### PR TITLE
Log Infra client errors to a file (#38)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,4 +68,3 @@ dev:
 
 make dev/clean:
 	helm uninstall infra || true
-	helm uninstall infra-engine || true

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/gon v0.2.3
 	github.com/muesli/termenv v0.8.1
+	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect
 	github.com/okta/okta-sdk-golang/v2 v2.3.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,8 @@ github.com/muesli/termenv v0.8.1/go.mod h1:kzt/D/4a88RoheZmwfqorY3A+tnsSMA9HJC/f
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4UpgHp07nNdFX7mqFfM=
+github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/okta/okta-sdk-golang/v2 v2.3.0 h1:+IGDlvIKD0iotCuhlcrJsTOdz6ZI+WTelqipaUhJibg=


### PR DESCRIPTION
This change appends errors in the proxy handler to a `~/.infra/client/proxy_error.log` file so they can be viewed in the future. The log file is capped at 1MB, when it reaches this limit a new file is created and the current one has its name rolled with a timestamp. One timestamped file is preserved at a time.

This part of the code does not seem to be testable where it just starts a server. Let me know if you have any ideas there beyond future integration tests.

Changes:
- Log errors in the infra client to `~/.infra/client/proxy_error.log`
- Add lumberjack for log rolling
- Move reused dir names to constants
- Remove unused helm namespace from dev cleanup