### PR TITLE
Update images in okta.md to be easily readable (#50)

### DIFF
--- a/docs/okta.md
+++ b/docs/okta.md
@@ -28,7 +28,7 @@
 
 ![okta_new_web_app_integration](https://user-images.githubusercontent.com/5853428/124652225-b88e1000-de50-11eb-8da3-36af6ba28bd8.png)
 
-4. On the **General** tab, **note** the **Client ID** and **Client Secret** for the next step.
+4. On the **General** tab, **note** the **Client ID** and **Client Secret** for the next step. Note the **Okta domain** for adding your Okta information to Infra registry later.
 
 ![okta_client_credentials](https://user-images.githubusercontent.com/5853428/124652384-f12de980-de50-11eb-86bb-67f0c0b16d2f.png)
 


### PR DESCRIPTION
https://github.com/infrahq/infra/blob/okta-instructions/docs/okta.md
Added some new images to the Okta setup process that should be easier to read. I removed all confidential info from the screenshot. The URL has my Okta ID removed, my account info is removed for the UI, and the API access token is a fake one.

People that use light mode (do these people still exist?) can also see the fancy drop-shadow effect.
<img width="632" alt="Screen Shot 2021-07-06 at 12 08 47 PM" src="https://user-images.githubusercontent.com/5853428/124654654-ab265500-de53-11eb-805f-197b6f84a38c.png">

Changes:
- Add new images demonstrating the Okta integration process
- Minor grammar modifications