### PR TITLE
More robust error checking for TLS verify on first login

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -32,7 +32,6 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	grpcMetadata "google.golang.org/grpc/metadata"
@@ -278,7 +277,7 @@ var rootCmd = &cobra.Command{
 
 func promptShouldSkipTLSVerify(host string) (skipTlsVerify bool, proceed bool, err error) {
 	httpClient := &http.Client{}
-	httpClient.Transport = &http2.Transport{
+	httpClient.Transport = &http.Transport{
 		TLSClientConfig: &tls.Config{},
 	}
 	url, err := urlx.Parse(host)
@@ -287,9 +286,6 @@ func promptShouldSkipTLSVerify(host string) (skipTlsVerify bool, proceed bool, e
 	}
 	url.Scheme = "https"
 	urlString := url.String()
-	if url.Port() == "" {
-		urlString += ":443"
-	}
 
 	_, err = httpClient.Get(urlString)
 	if err != nil {
@@ -303,13 +299,11 @@ func promptShouldSkipTLSVerify(host string) (skipTlsVerify bool, proceed bool, e
 		fmt.Print(termenv.String(host).Bold())
 		fmt.Println()
 		prompt := &survey.Confirm{
-			Message: "Are you sure you want to continue (yes/no)?",
+			Message: "Are you sure you want to continue?",
 		}
 
-		p := termenv.ColorProfile()
-
 		err := survey.AskOne(prompt, &proceed, survey.WithIcons(func(icons *survey.IconSet) {
-			icons.Question.Text = termenv.String("?").Bold().Foreground(p.Color("#0155F9")).String()
+			icons.Question.Text = blue("?")
 		}))
 		if err != nil {
 			fmt.Println(err.Error())


### PR DESCRIPTION
This change factors out the TLS verify check on initial login. Before we would look at the error string for a potential certificate error, but this only checked against one of many possible certificate errors. With this change, we make a raw http2 request to the registry to verify certificates, checking against the two types of certificate verification errors in `crypto/x509`

An alternative would have been to look at the errors being returned from the grpc client, but grpc clients unfortunately lose error type data (by converting them to strings) before they are surfaced to us. I tried a few workarounds with no luck, so decided to just do a quick check with a raw http2 client.