### PR TITLE
Standardize login terminology (#80)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ helm:
 .PHONY: docs
 docs:
 	go run ./internal/docgen
+	# Remove the $$HOME of the local system from the docs
+	# This probably only works on MacOS
+	grep -ilr $$HOME docs/* | xargs -I@ sed -i '' 's:'"$$HOME"':$$HOME:g' @
 
 clean:
 	rm -rf dist

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ scoop bucket add infrahq https://github.com/infrahq/scoop.git
 scoop install infra
 ```
 
-### Log in
+### Login
 
 ```
 infra login <EXTERNAL-IP>
 ```
 
-Great! You're now **logged in to the cluster via Infra**. 
+Great! You're now **logged into the cluster via Infra**. 
 
 ### Adding users
 * [Connect Okta](./docs/okta.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@
 
 ## `infra login`
 
-Log in to an Infra Registry
+Login to an Infra Registry
 
 ```
 infra login REGISTRY [flags]
@@ -38,7 +38,7 @@ $ infra login infra.example.com
 
 ## `infra logout`
 
-Log out of an Infra Registry
+Logout of an Infra Registry
 
 ```
 infra logout [flags]
@@ -154,8 +154,8 @@ $ infra source create okta \
 
 ```
       --api-token string       Api Token
-      --client-id string       Client ID for single sign on
-      --client-secret string   Client Secret for single sign on
+      --client-id string       Client ID for single sign-on
+      --client-secret string   Client Secret for single sign-on
       --domain string          Domain (e.g. example.okta.com)
   -h, --help                   help for create
 ```
@@ -206,10 +206,10 @@ infra registry [flags]
 
 ```
   -c, --config string           config file
-      --db string               path to database file (default "/Users/jmorgan/.infra/infra.db")
+      --db string               path to database file (default "$HOME/.infra/infra.db")
   -h, --help                    help for registry
       --initial-apikey string   initial api key for adding destinations
-      --tls-cache string        path to directory to cache tls self-signed and Let's Encrypt certificates (default "/Users/jmorgan/.infra/cache")
+      --tls-cache string        path to directory to cache tls self-signed and Let's Encrypt certificates (default "$HOME/.infra/cache")
 ```
 
 ## `infra engine`

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -23,7 +23,7 @@ Add the following DNS records to set up automatic LetsEncrypt certificates for y
 
 Note that some Load Balancers (e.g. on AWS) will require using a **CNAME** record instead.
 
-## Log in via the new domain
+## Login via the new domain
 
 ```
 infra login infra.example.com

--- a/docs/okta.md
+++ b/docs/okta.md
@@ -7,7 +7,7 @@
     * [Create an Okta App](#create-an-okta-app)
     * [Add Okta information to Infra registry](#add-okta-information-to-infra-registry)
 * [Usage](#usage)
-    * [Log in with Okta](#log-in-with-okta)
+    * [Login with Okta](#log-in-with-okta)
     * [List Okta users](#list-okta-users)
 
 ## Prerequisites
@@ -18,7 +18,7 @@
 
 ### Create an Okta App 
 
-1. Log in to the Okta administrative dashboard.
+1. Login to the Okta administrative dashboard.
 2. Under the left menu click **Applications > Applications**. Click **Create App Integration** then select **OIDC – OpenID Connect** and **Web Application**, and click **Next**.
 
 ![okta_applications](https://user-images.githubusercontent.com/5853428/124651126-67c9e780-de4f-11eb-98bd-def34bea95fd.png)
@@ -60,7 +60,7 @@ mark@example.com   	  okta    	  About a minute ago
 admin@example.com     infra       5 minutes ago         x
 ```
 
-### Log in with Okta
+### Login with Okta
 
 ```
 $ infra login <INFRA_REGISTRY_EXTERNAL_IP>

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -275,7 +275,7 @@ var rootCmd = &cobra.Command{
 
 var loginCmd = &cobra.Command{
 	Use:     "login REGISTRY",
-	Short:   "Log in to an Infra Registry",
+	Short:   "Login to an Infra Registry",
 	Args:    cobra.ExactArgs(1),
 	Example: "$ infra login infra.example.com",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -400,7 +400,7 @@ var loginCmd = &cobra.Command{
 			case v1.SourceType_OKTA:
 				// Start OIDC flow
 				// Get auth code from Okta
-				// Send auth code to Infra to log in as a user
+				// Send auth code to Infra to login as a user
 				state := generate.RandString(12)
 				authorizeUrl := "https://" + source.Okta.Domain + "/oauth2/v1/authorize?redirect_uri=" + "http://localhost:8301&client_id=" + source.Okta.ClientId + "&response_type=code&scope=openid+email&nonce=" + generate.RandString(10) + "&state=" + state
 
@@ -540,7 +540,7 @@ var loginCmd = &cobra.Command{
 
 var logoutCmd = &cobra.Command{
 	Use:   "logout",
-	Short: "Log out of an Infra Registry",
+	Short: "Logout of an Infra Registry",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config, err := readConfig()
 		if err != nil {
@@ -841,8 +841,8 @@ func newSourceCreateCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&apiToken, "api-token", "", "Api Token")
 	cmd.Flags().StringVar(&domain, "domain", "", "Domain (e.g. example.okta.com)")
-	cmd.Flags().StringVar(&clientID, "client-id", "", "Client ID for single sign on")
-	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "Client Secret for single sign on")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "Client ID for single sign-on")
+	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "Client Secret for single sign-on")
 
 	return cmd
 }


### PR DESCRIPTION
- Change instances of "log in" to "login"
- Regenerate docs
- Remove local $HOME from docs on make