### PR TITLE
Test creating an Okta client before persisting (#70)

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -848,6 +848,7 @@ func newSourceCreateCmd() *cobra.Command {
 					},
 				})
 				if err != nil {
+					fmt.Println(blue("✕") + " Source creation aborted")
 					return err
 				}
 			}

--- a/internal/okta/okta.go
+++ b/internal/okta/okta.go
@@ -8,6 +8,12 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
+// ValidateOktaConnection requests the client from Okta to check for errors on the response
+func ValidateOktaConnection(domain string, clientID string, apiToken string) error {
+	_, _, err := okta.NewClient(context.TODO(), okta.WithOrgUrl("https://"+domain), okta.WithRequestTimeout(30), okta.WithRateLimitMaxRetries(3), okta.WithToken(apiToken))
+	return err
+}
+
 func Emails(domain string, clientID string, apiToken string) ([]string, error) {
 	ctx, client, err := okta.NewClient(context.TODO(), okta.WithOrgUrl("https://"+domain), okta.WithRequestTimeout(30), okta.WithRateLimitMaxRetries(3), okta.WithToken(apiToken))
 	if err != nil {

--- a/internal/registry/grpc.go
+++ b/internal/registry/grpc.go
@@ -336,6 +336,9 @@ func (v *V1Server) CreateSource(ctx context.Context, in *v1.CreateSourceRequest)
 		if err := in.Okta.Validate(); err != nil {
 			return nil, err
 		}
+		if err := okta.ValidateOktaConnection(in.Okta.Domain, in.Okta.ClientId, in.Okta.ApiToken); err != nil {
+			return nil, err
+		}
 
 		source.Type = "okta"
 		source.OktaApiToken = in.Okta.ApiToken


### PR DESCRIPTION
Connect to Okta to check the provided credentials before persisting the source.