### PR TITLE
Automatically set helm release versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 tag := $(shell git describe --tags)
-repo := infrahq/infra
 
 generate:
 	go generate ./...
@@ -13,7 +12,7 @@ test:
 
 .PHONY: helm
 helm:
-	helm package -d ./helm helm/charts/infra helm/charts/infra/charts/engine
+	helm package --version $(tag:v%=%) --app-version $(tag:v%=%) -d ./helm helm/charts/infra helm/charts/infra/charts/engine
 	helm repo index ./helm
 
 .PHONY: docs

--- a/helm/charts/infra/Chart.yaml
+++ b/helm/charts/infra/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: infra
 description: Infra
 type: application
-version: 0.0.10
-appVersion: "0.0.10"
+version: 0.0.0-development
+appVersion: 0.0.0-development

--- a/helm/charts/infra/charts/engine/Chart.yaml
+++ b/helm/charts/infra/charts/engine/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: engine
 description: Infra Engine
 type: application
-version: 0.0.10
-appVersion: "0.0.10"
+version: 0.0.0-development
+appVersion: 0.0.0-development

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is set on build
 // Release build version is the git tag (set in the .goreleaser ldflags and the Dockerfile BUILDVERSION arg)
-var Version = "development"
+var Version = "0.0.0-development"


### PR DESCRIPTION
This changes the `make/helm` target to automatically fill the version via the current git tag instead of us having to bump it manually.

It also sets the default version on both Helm and the Go binary to `0.0.0-development` since Helm requires a semver string as the version.