### PR TITLE
Expose plaintext server for ingress

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -173,7 +173,10 @@ func Run(options Options) error {
 	}
 
 	go func() {
-		httpServer.ListenAndServe()
+		err := httpServer.ListenAndServe()
+		if err != nil {
+			zapLogger.Error(err.Error())
+		}
 	}()
 
 	tlsServer := &http.Server{


### PR DESCRIPTION
Several users have mentioned the need to use Infra behind Kubernetes `Ingress` configurations for TLS termination. To support this, we need (especially for GRPC traffic) to expose an alternative, plaintext port for users to connect to behind their own TLS-terminated load balancers or ingress controllers.