### PR TITLE
Fix upgrade requests by placing query string in request body

### DIFF
--- a/internal/cmd/client.go
+++ b/internal/cmd/client.go
@@ -113,6 +113,10 @@ func RunLocalClient() error {
 
 		timer.Reset(ClientTimeoutDuration)
 
+		if r.Header.Get("Upgrade") != "" {
+			r.Header.Add("X-Infra-Query", r.URL.RawQuery)
+		}
+
 		r.Header.Add("X-Infra-Authorization", r.Header.Get("Authorization"))
 		r.Header.Set("Authorization", "Bearer "+saToken)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -176,6 +176,12 @@ func proxyHandler(ca []byte, bearerToken string, remote *url.URL) (http.HandlerF
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Sometimes the kubernetes proxy strips query string for Upgrade requests
+		// so we need to put that in the request body
+		if r.Header.Get("X-Infra-Query") != "" {
+			r.URL.RawQuery = r.Header.Get("X-Infra-Query")
+		}
+
 		email, ok := r.Context().Value(HttpContextKeyEmail{}).(string)
 		if !ok {
 			logging.L.Debug("Proxy handler unable to retrieve email from context")


### PR DESCRIPTION
Fixes #155 

For some background, the Kubernetes api proxy strips away query params for `Upgrade: xxxxx` requests, stopping `kubectl exec` and `kubectl proxy` from working. This fixes it by placing the query string in a request header