### PR TITLE
Remove okta prefix from source fields

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,10 +39,10 @@ helm upgrade infra infrahq/infra --set-file config=./infra.yaml --recreate-pods
 ```yaml
 sources:
   - type: okta
-    oktaDomain: acme.okta.com
-    oktaClientId: 0oapn0qwiQPiMIyR35d6
-    oktaClientSecret: jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2
-    oktaApiToken: 001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
+    domain: acme.okta.com
+    clientId: 0oapn0qwiQPiMIyR35d6
+    clientSecret: jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2
+    apiToken: 001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
 
 users:
   - name: admin@example.com

--- a/docs/okta.md
+++ b/docs/okta.md
@@ -44,10 +44,10 @@ Edit your [Infra configuration](./configuration.md) (e.g. `infra.yaml`) to inclu
 ```yaml
 sources:
   - type: okta
-    oktaDomain: acme.okta.com
-    oktaClientId: 0oapn0qwiQPiMIyR35d6
-    oktaClientSecret: jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2
-    oktaApiToken: 001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
+    domain: acme.okta.com
+    clientId: 0oapn0qwiQPiMIyR35d6
+    clientSecret: jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2
+    apiToken: 001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
 
 users:
   - name: admin@example.com

--- a/internal/registry/_testdata/infra.yaml
+++ b/internal/registry/_testdata/infra.yaml
@@ -1,9 +1,9 @@
 sources:
   - type: okta
-    oktaDomain: acme.okta.com
-    oktaClientId: 0oapn0qwiQPiMIyR35d6
-    oktaClientSecret: jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2
-    oktaApiToken: 001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
+    domain: acme.okta.com
+    clientId: 0oapn0qwiQPiMIyR35d6
+    clientSecret: jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2
+    apiToken: 001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
 
 groups:
   - name: ios-developers

--- a/internal/registry/config.go
+++ b/internal/registry/config.go
@@ -9,11 +9,11 @@ import (
 )
 
 type ConfigSource struct {
-	Type             string `yaml:"type"`
-	OktaDomain       string `yaml:"oktaDomain"`
-	OktaClientId     string `yaml:"oktaClientId"`
-	OktaClientSecret string `yaml:"oktaClientSecret"`
-	OktaApiToken     string `yaml:"oktaApiToken"`
+	Type         string `yaml:"type"`
+	Domain       string `yaml:"domain"`
+	ClientId     string `yaml:"clientId"`
+	ClientSecret string `yaml:"clientSecret"`
+	ApiToken     string `yaml:"apiToken"`
 }
 
 type ConfigRoleKubernetes struct {
@@ -49,14 +49,14 @@ func ImportSources(db *gorm.DB, sources []ConfigSource) error {
 		switch s.Type {
 		case SOURCE_TYPE_OKTA:
 			var source Source
-			err := db.FirstOrCreate(&source, &Source{Type: s.Type, OktaDomain: s.OktaDomain}).Error
+			err := db.FirstOrCreate(&source, &Source{Type: s.Type, Domain: s.Domain}).Error
 			if err != nil {
 				return err
 			}
 
-			source.OktaClientId = s.OktaClientId
-			source.OktaClientSecret = s.OktaClientSecret
-			source.OktaApiToken = s.OktaApiToken
+			source.ClientId = s.ClientId
+			source.ClientSecret = s.ClientSecret
+			source.ApiToken = s.ApiToken
 			source.FromConfig = true
 
 			err = db.Save(&source).Error

--- a/internal/registry/config_test.go
+++ b/internal/registry/config_test.go
@@ -12,7 +12,7 @@ import (
 
 var db *gorm.DB
 
-var fakeOktaSource = Source{Type: "okta", OktaDomain: "test.example.com"}
+var fakeOktaSource = Source{Type: "okta", Domain: "test.example.com"}
 var adminUser = User{Email: "admin@example.com"}
 var standardUser = User{Email: "user@example.com"}
 var iosDevUser = User{Email: "woz@example.com"}

--- a/internal/registry/data.go
+++ b/internal/registry/data.go
@@ -54,10 +54,10 @@ type Source struct {
 	Updated int64  `gorm:"autoUpdateTime"`
 	Type    string `yaml:"type"`
 
-	OktaDomain       string `gorm:"unique"`
-	OktaClientId     string
-	OktaClientSecret string
-	OktaApiToken     string
+	Domain       string `gorm:"unique"`
+	ClientId     string
+	ClientSecret string
+	ApiToken     string
 
 	Users  []User  `gorm:"many2many:users_sources"`
 	Groups []Group `gorm:"many2many:groups_sources"`
@@ -347,7 +347,7 @@ func (s *Source) SyncUsers(db *gorm.DB, okta Okta) error {
 
 	switch s.Type {
 	case "okta":
-		emails, err = okta.Emails(s.OktaDomain, s.OktaClientId, s.OktaApiToken)
+		emails, err = okta.Emails(s.Domain, s.ClientId, s.ApiToken)
 		if err != nil {
 			return err
 		}

--- a/internal/registry/grpc.go
+++ b/internal/registry/grpc.go
@@ -311,8 +311,8 @@ func dbToProtoSource(in *Source) *v1.Source {
 	case SOURCE_TYPE_OKTA:
 		out.Type = v1.SourceType_OKTA
 		out.Okta = &v1.Source_Okta{
-			Domain:   in.OktaDomain,
-			ClientId: in.OktaClientId,
+			Domain:   in.Domain,
+			ClientId: in.ClientId,
 		}
 	}
 
@@ -349,10 +349,10 @@ func (v *V1Server) CreateSource(ctx context.Context, in *v1.CreateSourceRequest)
 		}
 
 		source.Type = "okta"
-		source.OktaApiToken = in.Okta.ApiToken
-		source.OktaDomain = in.Okta.Domain
-		source.OktaClientId = in.Okta.ClientId
-		source.OktaClientSecret = in.Okta.ClientSecret
+		source.ApiToken = in.Okta.ApiToken
+		source.Domain = in.Okta.Domain
+		source.ClientId = in.Okta.ClientId
+		source.ClientSecret = in.Okta.ClientSecret
 
 		if err := v.db.Create(&source).Error; err != nil {
 			return nil, err
@@ -585,16 +585,16 @@ func (v *V1Server) Login(ctx context.Context, in *v1.LoginRequest) (*v1.LoginRes
 		}
 
 		var source Source
-		if err := v.db.Where(&Source{Type: SOURCE_TYPE_OKTA, OktaDomain: in.Okta.Domain}).First(&source).Error; err != nil {
+		if err := v.db.Where(&Source{Type: SOURCE_TYPE_OKTA, Domain: in.Okta.Domain}).First(&source).Error; err != nil {
 			grpc_zap.Extract(ctx).Debug("Could not retrieve okta source from db: " + err.Error())
 			return nil, status.Errorf(codes.Unauthenticated, "invalid okta login information")
 		}
 
 		email, err := v.okta.EmailFromCode(
 			in.Okta.Code,
-			source.OktaDomain,
-			source.OktaClientId,
-			source.OktaClientSecret,
+			source.Domain,
+			source.ClientId,
+			source.ClientSecret,
 		)
 		if err != nil {
 			grpc_zap.Extract(ctx).Debug("Could not extract email from okta info: " + err.Error())

--- a/internal/registry/grpc_test.go
+++ b/internal/registry/grpc_test.go
@@ -520,10 +520,10 @@ func TestLoginMethodOkta(t *testing.T) {
 
 	var source Source
 	source.Type = "okta"
-	source.OktaApiToken = "test-api-token"
-	source.OktaDomain = "test.okta.com"
-	source.OktaClientId = "test-client-id"
-	source.OktaClientSecret = "test-client-secret"
+	source.ApiToken = "test-api-token"
+	source.Domain = "test.okta.com"
+	source.ClientId = "test-client-id"
+	source.ClientSecret = "test-client-secret"
 	if err := db.Create(&source).Error; err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Cleaning up the source field naming, we specify the `type` as `okta` so this prefix isn't needed.