### PR TITLE
remove architecture pic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Infra is **identity and access management** for Kubernetes. Provide any user fin
 * Onboard & offboard users via Okta (Azure AD, Google, GitHub coming soon)
 * Audit logs for who did what, when (coming soon)
 
-<p align="center">
-  <img width="838" src="./docs/images/arch.svg" />
-</p>
-
 ## Quickstart
 
 1. Create `infra.yaml` 


### PR DESCRIPTION
removing it since users currently get confused on the fact that this shows Infra as a single app, but we require them to install registry + engine (on the cluster). In the future, there are plans to better reflect this. 
- Config file currently on the quickstart might be a better way to show users what Infra is like