### PR TITLE
Store secrets in Kubernetes rather than config (#152)

### DIFF
--- a/docs/okta.md
+++ b/docs/okta.md
@@ -1,10 +1,21 @@
 # Okta
 
+This guide will walk you through the process of setting up Okta as an identity provider for Infra. At the end of this process you will have updated your Infra configuration with an Okta source that looks something like this:
+```
+sources:
+  - type: okta
+    domain: acme.okta.com
+    clientId: 0oapn0qwiQPiMIyR35d6
+    clientSecret: infra-okta/clientSecret
+    apiToken: infra-okta/apiToken
+```
+
 ## Contents
 
 * [Prerequisites](#prerequisites)
 * [Setup](#setup)
     * [Create an Okta App](#create-an-okta-app)
+    * [Add Okta secrets to the Infra registry deployment](#add-okta-secrets-to-the-infra-registry-deployment)
     * [Add Okta information to Infra registry](#add-okta-information-to-infra-registry)
 * [Usage](#usage)
     * [Login with Okta](#log-in-with-okta)
@@ -28,14 +39,27 @@
 
 ![okta_new_web_app_integration](https://user-images.githubusercontent.com/5853428/124652225-b88e1000-de50-11eb-8da3-36af6ba28bd8.png)
 
-4. On the **General** tab, **note** the **Client ID** and **Client Secret** for the next step. Note the **Okta domain** for adding your Okta information to Infra registry later.
+4. On the **General** tab, **note** the **Client ID**, **Client Secret**, and **Okta domain** for adding your Okta information to Infra registry later.
 
 ![okta_application](https://user-images.githubusercontent.com/5853428/125355241-a3febb80-e319-11eb-8fc6-84df2509f621.png)
 
-5. Navigate to **Security > API**, then click the **Tokens** tab. Create a new Token by clicking **Create Token**. Name it **infra**.
+5. Navigate to **Security > API**, then click the **Tokens** tab. Create a new Token by clicking **Create Token**. Name it **infra**. Note this token value for later.
 
 ![okta_create_token](https://user-images.githubusercontent.com/5853428/124652451-0276f600-de51-11eb-9d22-92262de76371.png)
 ![okta_api_token](https://user-images.githubusercontent.com/5853428/124652864-787b5d00-de51-11eb-81d8-e503babfdbca.png)
+
+### Add Okta secrets to the Infra registry deployment
+The Okta client secret and API token are sensitive information which cannot be stored in the Infra configuration file. In order for Infra to access these secret values they must be stored in Kubernetes Secret objects.
+
+Create [Kubernetes Secret objects](https://kubernetes.io/docs/tasks/configmap-secret/) to store the Okta client secret and API token (noted in steps 4 and 5 of `Create an Okta App` respectively). You can name these Secrets as you desire, these names will be specified in the Infra configuration.
+
+#### Example Secret Creation
+Store the Okta client secret and API token on the same Kubernetes Secret object.
+```
+kubectl create secret generic infra-okta /
+--from-literal=clientSecret=jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2 /
+--from-literal=apiToken=001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd /
+```
 
 ### Add Okta information to Infra registry
 
@@ -46,8 +70,8 @@ sources:
   - type: okta
     domain: acme.okta.com
     clientId: 0oapn0qwiQPiMIyR35d6
-    clientSecret: jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2
-    apiToken: 001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
+    clientSecret: infra-okta/clientSecret # <kubernetes secret object name>/<key of the secret>
+    apiToken: infra-okta/apiToken
 
 users:
   - name: admin@example.com

--- a/internal/kubernetes/secret.go
+++ b/internal/kubernetes/secret.go
@@ -1,0 +1,43 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type SecretReader interface {
+	Get(secretName string, client *kubernetes.Clientset) (string, error)
+}
+
+type KubeSecretReader struct {
+	Namespace string
+}
+
+func NewSecretReader(namespace string) SecretReader {
+	return &KubeSecretReader{Namespace: namespace}
+}
+
+// Get returns a K8s secret object with the specified name from a Kubernetes configuration if it exists
+func (ksr *KubeSecretReader) Get(secretName string, client *kubernetes.Clientset) (string, error) {
+	secretParts := strings.Split(secretName, "/")
+	if len(secretParts) != 2 {
+		return "", errors.New("invalid Kubernetes secret path seperated, expected exactly 2 parts but was " + fmt.Sprint(len(secretParts)))
+	}
+	objName := secretParts[0]
+	key := secretParts[1]
+
+	retrieved, err := client.CoreV1().Secrets(ksr.Namespace).Get(context.TODO(), objName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	secretVal := retrieved.Data[key]
+	if string(secretVal) == "" {
+		return "", errors.New("secret could not be found in kubernetes: " + secretName)
+	}
+	return string(secretVal), nil
+}

--- a/internal/kubernetes/secret_test.go
+++ b/internal/kubernetes/secret_test.go
@@ -1,0 +1,32 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	rest "k8s.io/client-go/rest"
+)
+
+func TestInvalidSecretFormats(t *testing.T) {
+	testConfig := &rest.Config{
+		Host: "https://localhost",
+	}
+	testSecretReader := NewSecretReader("test-namespace")
+	testK8s := &Kubernetes{Config: testConfig, SecretReader: testSecretReader}
+
+	_, err := testK8s.GetSecret("invalid-secret-format")
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid Kubernetes secret path seperated, expected exactly 2 parts but was 1", err.Error())
+
+	_, err = testK8s.GetSecret("")
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid Kubernetes secret path seperated, expected exactly 2 parts but was 1", err.Error())
+
+	_, err = testK8s.GetSecret("/")
+	assert.NotNil(t, err)
+	assert.Equal(t, "resource name may not be empty", err.Error())
+
+	_, err = testK8s.GetSecret("invalid/number/path")
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid Kubernetes secret path seperated, expected exactly 2 parts but was 3", err.Error())
+}

--- a/internal/registry/_testdata/infra.yaml
+++ b/internal/registry/_testdata/infra.yaml
@@ -2,8 +2,8 @@ sources:
   - type: okta
     domain: acme.okta.com
     clientId: 0oapn0qwiQPiMIyR35d6
-    clientSecret: jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2
-    apiToken: 001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
+    clientSecret: okta-secrets/clientSecret
+    apiToken: okta-secrets/apiToken
 
 groups:
   - name: ios-developers

--- a/internal/registry/config_test.go
+++ b/internal/registry/config_test.go
@@ -12,7 +12,7 @@ import (
 
 var db *gorm.DB
 
-var fakeOktaSource = Source{Type: "okta", Domain: "test.example.com"}
+var fakeOktaSource = Source{Type: "okta", Domain: "test.example.com", ClientSecret: "okta-secrets/client-secret", ApiToken: "okta-secrets/api-token"}
 var adminUser = User{Email: "admin@example.com"}
 var standardUser = User{Email: "user@example.com"}
 var iosDevUser = User{Email: "woz@example.com"}


### PR DESCRIPTION
This change allows for config files to refer to secrets using a string with the format `secretObject/secretKey`. These strings are not converted to the actual secrets until they are used. 

- Move Kubernetes to a shared package
- Registry now relies on Kubernetes for getting secrets
- Fix unrelated bug when there are no group IDs to keep
- Update config sources to expect the secretObj/secretKey format
- Add secret reader to get secrets from the current kube environment
- Update tests
- Update config examples
- Update docs