### PR TITLE
Fix unreachable plaintext GRPC handler

### DIFF
--- a/helm/charts/infra/templates/deployment.yaml
+++ b/helm/charts/infra/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
                   key: defaultApiKey
                   optional: true
           ports:
+            - containerPort: 80
             - containerPort: 443
           volumeMounts:
             - name: data


### PR DESCRIPTION
We were missing a [`h2c`](https://pkg.go.dev/golang.org/x/net/http2/h2c) handler wrapper to support unencrypted grpc/http2 requests 