### PR TITLE
Helm secret reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ sources:
   - type: okta
     domain: acme.okta.com
     clientId: 0oapn0qwiQPiMIyR35d6
-    clientSecret: infra-okta/clientSecret 
-    apiToken: infra-okta/apiToken
+    clientSecret: infra-registry-okta/clientSecret
+    apiToken: infra-registry-okta/apiToken
 
 # Map groups or individual users pulled from identity providers
 # Roles refer to available roles or cluster-roles currently 
@@ -54,7 +54,6 @@ helm repo add infrahq https://helm.infrahq.com
 
 helm install infra-registry infrahq/registry --namespace infrahq --create-namespace --set-file config=./infra.yaml 
 ```
-**Note:** You should not deploy the Infra registry in your cluster's default namespace. Deploying it in its own namespace allows you to securely grant secret access.
 
 3. Connect Kubernetes Cluster(s)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,8 +41,8 @@ sources:
   - type: okta
     domain: acme.okta.com
     clientId: 0oapn0qwiQPiMIyR35d6
-    clientSecret: infrahq/oktaClientSecret
-    apiToken: infrahq/oktaClientSecret
+    clientSecret: infra-registry-okta/clientSecret
+    apiToken: infra-registry-okta/apiToken
 
 users:
   - name: admin@example.com

--- a/docs/okta.md
+++ b/docs/okta.md
@@ -6,8 +6,8 @@ sources:
   - type: okta
     domain: acme.okta.com
     clientId: 0oapn0qwiQPiMIyR35d6
-    clientSecret: infrahq/oktaClientSecret
-    apiToken: infrahq/oktaAPIToken
+    clientSecret: infra-registry-okta/clientSecret
+    apiToken: infra-registry-okta/apiToken
 ```
 
 ## Contents
@@ -56,10 +56,10 @@ Create [Kubernetes Secret objects](https://kubernetes.io/docs/tasks/configmap-se
 #### Example Secret Creation
 Store the Okta client secret and API token on the same Kubernetes Secret object in the namespace that Infra registry is running in.
 ```
-kubectl create secret generic infrahq \
+kubectl create secret generic infra-registry-okta \
 --namespace=infrahq \
---from-literal=oktaClientSecret=jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2 \
---from-literal=oktaAPIToken=001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
+--from-literal=clientSecret=jfpn0qwiQPiMIfs408fjs048fjpn0qwiQPiMajsdf08j10j2 \
+--from-literal=apiToken=001XJv9xhv899sdfns938haos3h8oahsdaohd2o8hdao82hd
 ```
 
 ### Add Okta information to Infra registry
@@ -71,8 +71,8 @@ sources:
   - type: okta
     domain: acme.okta.com
     clientId: 0oapn0qwiQPiMIyR35d6
-    clientSecret: infrahq/oktaClientSecret # <kubernetes secret object name>/<key of the secret>
-    apiToken: infrahq/oktaAPIToken
+    clientSecret: infra-registry-okta/clientSecret # <kubernetes secret object name>/<key of the secret>
+    apiToken: infra-registry-okta/apiToken
 
 users:
   - name: admin@example.com

--- a/helm/charts/registry/templates/deployment.yaml
+++ b/helm/charts/registry/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
         app: infra-registry
     spec:
       automountServiceAccountToken: true
+      serviceAccountName: infra-registry
       containers:
         - name: registry
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/helm/charts/registry/templates/role.yaml
+++ b/helm/charts/registry/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: infra-pod-secret-access
+  name: infra-registry-secret-reader
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]

--- a/helm/charts/registry/templates/rolebinding.yaml
+++ b/helm/charts/registry/templates/rolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: infra-pod-secret-access
+  name: infra-registry-secret-reader
   namespace: {{ .Release.Namespace }}
 subjects:
-- kind: User
-  name: system:serviceaccount:{{ .Release.Namespace }}:default
+- kind: ServiceAccount
+  name: infra-registry
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: infra-pod-secret-access
+  name: infra-registry-secret-reader

--- a/helm/charts/registry/templates/serviceaccount.yaml
+++ b/helm/charts/registry/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: infra-registry
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Fix #187 

The service account used by the registry is now given access to secrets in its current namespace. I added some notes around **not** deploying the registry in the default namespace for this reason. If the registry was in the default namespace this would grant the default namespace service account the ability to read all secrets, which would mean any pods in the default namespace could read secrets and potentially escalate their privileges. Keeping Infra in its own namespace means that it can only access the secrets it is supposed to. 

- Update the registry helm chart to grant the service account permission to read secrets in the current namespace
- Specify that infra should not run in the default namespace in the docs