### PR TITLE
configuration validation (#178)

### DIFF
--- a/internal/kubernetes/secret.go
+++ b/internal/kubernetes/secret.go
@@ -26,7 +26,7 @@ func NewSecretReader(namespace string) SecretReader {
 func (ksr *KubeSecretReader) Get(secretName string, client *kubernetes.Clientset) (string, error) {
 	secretParts := strings.Split(secretName, "/")
 	if len(secretParts) != 2 {
-		return "", errors.New("invalid Kubernetes secret path seperated, expected exactly 2 parts but was " + fmt.Sprint(len(secretParts)))
+		return "", errors.New("invalid Kubernetes secret path specified, expected exactly 2 parts but was " + fmt.Sprint(len(secretParts)))
 	}
 	objName := secretParts[0]
 	key := secretParts[1]

--- a/internal/kubernetes/secret_test.go
+++ b/internal/kubernetes/secret_test.go
@@ -16,11 +16,11 @@ func TestInvalidSecretFormats(t *testing.T) {
 
 	_, err := testK8s.GetSecret("invalid-secret-format")
 	assert.NotNil(t, err)
-	assert.Equal(t, "invalid Kubernetes secret path seperated, expected exactly 2 parts but was 1", err.Error())
+	assert.Equal(t, "invalid Kubernetes secret path specified, expected exactly 2 parts but was 1", err.Error())
 
 	_, err = testK8s.GetSecret("")
 	assert.NotNil(t, err)
-	assert.Equal(t, "invalid Kubernetes secret path seperated, expected exactly 2 parts but was 1", err.Error())
+	assert.Equal(t, "invalid Kubernetes secret path specified, expected exactly 2 parts but was 1", err.Error())
 
 	_, err = testK8s.GetSecret("/")
 	assert.NotNil(t, err)
@@ -28,5 +28,5 @@ func TestInvalidSecretFormats(t *testing.T) {
 
 	_, err = testK8s.GetSecret("invalid/number/path")
 	assert.NotNil(t, err)
-	assert.Equal(t, "invalid Kubernetes secret path seperated, expected exactly 2 parts but was 3", err.Error())
+	assert.Equal(t, "invalid Kubernetes secret path specified, expected exactly 2 parts but was 3", err.Error())
 }

--- a/internal/registry/_testdata/infra.yaml
+++ b/internal/registry/_testdata/infra.yaml
@@ -1,6 +1,11 @@
 sources:
   - type: okta
-    domain: acme.okta.com
+    domain: overwrite.example.com
+    clientId: 0oapn0qwiQPiMIyR35d6
+    clientSecret: okta-secrets/clientSecret
+    apiToken: okta-secrets/apiToken
+  - type: okta
+    domain: test.example.com
     clientId: 0oapn0qwiQPiMIyR35d6
     clientSecret: okta-secrets/clientSecret
     apiToken: okta-secrets/apiToken

--- a/internal/registry/config_test.go
+++ b/internal/registry/config_test.go
@@ -12,6 +12,7 @@ import (
 
 var db *gorm.DB
 
+var overriddenOktaSource = Source{Type: "okta", Domain: "overwrite.example.com", ClientSecret: "okta-secrets/client-secret", ApiToken: "okta-secrets/api-token"}
 var fakeOktaSource = Source{Type: "okta", Domain: "test.example.com", ClientSecret: "okta-secrets/client-secret", ApiToken: "okta-secrets/api-token"}
 var adminUser = User{Email: "admin@example.com"}
 var standardUser = User{Email: "user@example.com"}
@@ -171,6 +172,16 @@ func TestImportRolesForUnknownDestinationsAreIgnored(t *testing.T) {
 			t.Errorf("Created role for destination which does not exist: " + role.DestinationId)
 		}
 	}
+}
+
+func TestExistingSourceIsOverridden(t *testing.T) {
+	// this source comes second in the config so it will override the one before it
+	var importedOkta Source
+	err := db.Where(&Source{Type: SOURCE_TYPE_OKTA}).First(&importedOkta).Error
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, fakeOktaSource.Domain, importedOkta.Domain)
 }
 
 func containsUserRoleForDestination(db *gorm.DB, user User, destinationId string, roleName string) (bool, error) {

--- a/internal/registry/grpc.go
+++ b/internal/registry/grpc.go
@@ -601,7 +601,7 @@ func (v *V1Server) Login(ctx context.Context, in *v1.LoginRequest) (*v1.LoginRes
 		clientSecret, err := v.k8s.GetSecret(source.ClientSecret)
 		if err != nil {
 			grpc_zap.Extract(ctx).Error("Could not retrieve okta client secret from kubernetes: " + err.Error())
-			return nil, err
+			return nil, status.Errorf(codes.Unauthenticated, "invalid okta login information")
 		}
 
 		email, err := v.okta.EmailFromCode(


### PR DESCRIPTION
Some quality of life improvements around validation of an imported config file.

- Log problems when importing configuration
- Fix typo in secret formatting error
- Add configuration source override test
- Validate okta configuration from imported file works
- Do not return secret errors to RPC calls