### PR TITLE
Fix engine working in cluster with no dns service

### DIFF
--- a/helm/charts/engine/templates/deployment.yaml
+++ b/helm/charts/engine/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       automountServiceAccountToken: true
       serviceAccountName: infra-engine
+      dnsPolicy: Default
       containers:
         - name: engine
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/helm/charts/registry/templates/deployment.yaml
+++ b/helm/charts/registry/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       automountServiceAccountToken: true
       serviceAccountName: infra-registry
+      dnsPolicy: Default
       containers:
         - name: registry
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 
@@ -591,7 +592,12 @@ func (k *Kubernetes) Endpoint() (string, error) {
 		InsecureSkipVerify: true,
 	}
 
-	conn, err := tls.Dial("tcp", "kubernetes.default.svc:443", conf)
+	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	if len(host) == 0 || len(port) == 0 {
+		return "", errors.New("not in cluster")
+	}
+
+	conn, err := tls.Dial("tcp", host+":"+port, conf)
 	if err != nil {
 		return "", err
 	}
@@ -657,7 +663,6 @@ func (k *Kubernetes) Endpoint() (string, error) {
 		return "", err
 	}
 
-	var port string
 	for _, p := range kubernetesService.Spec.Ports {
 		if p.Name == "https" {
 			port = p.TargetPort.String()


### PR DESCRIPTION
Fixes engines not working in clusters with no DNS service add-ons (e.g. `kube-dns` or `coredns`). This also fixes issues where those add-ons are running in different subnets than the cluster dns service.