### PR TITLE
Fix delete logic for sources & groups

### DIFF
--- a/internal/registry/data.go
+++ b/internal/registry/data.go
@@ -205,7 +205,7 @@ func (r *Destination) BeforeCreate(tx *gorm.DB) (err error) {
 }
 
 func (d *Destination) AfterCreate(tx *gorm.DB) error {
-	if err := ApplyGroupMappings(tx, initialConfig.Groups); err != nil {
+	if _, err := ApplyGroupMappings(tx, initialConfig.Groups); err != nil {
 		return err
 	}
 	return ApplyUserMapping(tx, initialConfig.Users)


### PR DESCRIPTION
Fixes #185 by using the `.Where("1 = 1")` trick documented in the gorm docs.