### PR TITLE
change user key to "email" from "name" (#224)

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -20,7 +20,7 @@ groups:
               - web
 
 users:
-  - name: admin@example.com   # user email
+  - email: admin@example.com   # user email
     groups:                   # manually assign groups this user belongs to
       - developers
     roles:

--- a/internal/registry/_testdata/infra.yaml
+++ b/internal/registry/_testdata/infra.yaml
@@ -61,11 +61,11 @@ groups:
           - name: cluster-CCC
 
 users:
-  - name: woz@example.com
+  - email: woz@example.com
     groups:
       - ios-developers
       - mac-admins
-  - name: admin@example.com
+  - email: admin@example.com
     roles:
       - name: admin
         kind: cluster-role
@@ -85,7 +85,7 @@ users:
           - name: cluster-CCC
             namespaces: 
               - infrahq
-  - name: user@example.com
+  - email: user@example.com
     groups:
       - ios-developers
     roles:
@@ -94,7 +94,7 @@ users:
         clusters:
           - name: cluster-AAA
           - name: cluster-UNKNOWN
-  - name: unknown@example.com
+  - email: unknown@example.com
     groups:
       - adversaries
     roles:

--- a/internal/registry/config.go
+++ b/internal/registry/config.go
@@ -34,7 +34,7 @@ type ConfigGroupMapping struct {
 }
 
 type ConfigUserMapping struct {
-	Name   string                 `yaml:"name"`
+	Email  string                 `yaml:"email"`
 	Roles  []ConfigRoleKubernetes `yaml:"roles"`
 	Groups []string               `yaml:"groups"`
 }
@@ -143,7 +143,7 @@ func ApplyGroupMappings(db *gorm.DB, configGroups []ConfigGroupMapping) (groupId
 func ApplyUserMapping(db *gorm.DB, users []ConfigUserMapping) error {
 	for _, u := range users {
 		var user User
-		usrReadErr := db.Where(&User{Email: u.Name}).First(&user).Error
+		usrReadErr := db.Where(&User{Email: u.Email}).First(&user).Error
 		if usrReadErr != nil {
 			if errors.Is(usrReadErr, gorm.ErrRecordNotFound) {
 				// skip this user, if they're created these roles will be added later


### PR DESCRIPTION
- change configuration user key from name to email to match the API

Previously I used `name` as a user identifier in configuration to match the other configuration objects, but we are making sure the configuration and API have a consistent experience now so this changes the config user's `name` field to `email` to match the API.

Standardizing on email because it is a standard OIDC claim:
https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims

If we standardize on name it makes identity providers a bit confusing since the name claim is a user's first/last names, rather than a unique identifier.