### PR TITLE
Standardize SessionDuration Use

### DIFF
--- a/internal/registry/api.go
+++ b/internal/registry/api.go
@@ -32,10 +32,7 @@ type CustomJWTClaims struct {
 	Nonce       string `json:"nonce" validate:"required"`
 }
 
-var (
-	validate        *validator.Validate = validator.New()
-	SessionDuration time.Duration       = time.Hour * 24
-)
+var validate *validator.Validate = validator.New()
 
 func NewApiMux(db *gorm.DB, k8s *kubernetes.Kubernetes, okta Okta) *mux.Router {
 	a := Api{
@@ -415,7 +412,7 @@ func (a *Api) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secret, err := NewToken(a.db, user.Id, SessionDuration, &token)
+	secret, err := NewToken(a.db, user.Id, &token)
 	if err != nil {
 		logging.L.Debug(err.Error())
 		sendApiError(w, http.StatusInternalServerError, "could not create token")

--- a/internal/registry/api_test.go
+++ b/internal/registry/api_test.go
@@ -41,7 +41,7 @@ func addUser(db *gorm.DB, sessionDuration time.Duration) (tokenId string, tokenS
 			return err
 		}
 
-		secret, err = NewToken(tx, user.Id, sessionDuration, &token)
+		secret, err = NewToken(tx, user.Id, &token)
 		if err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ func TestBearerTokenMiddlewareExpiredToken(t *testing.T) {
 		db: db,
 	}
 
-	id, secret, err := addUser(db, time.Millisecond * 1)
+	id, secret, err := addUser(db, time.Millisecond*1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestBearerTokenMiddlewareValidToken(t *testing.T) {
 		db: db,
 	}
 
-	id, secret, err := addUser(db, time.Hour * 24)
+	id, secret, err := addUser(db, time.Hour*24)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/registry/data.go
+++ b/internal/registry/data.go
@@ -462,14 +462,14 @@ func (t *Token) CheckSecret(secret string) (err error) {
 	return nil
 }
 
-func NewToken(db *gorm.DB, userId string, sessionDuration time.Duration, token *Token) (secret string, err error) {
+func NewToken(db *gorm.DB, userId string, token *Token) (secret string, err error) {
 	secret = generate.RandString(TOKEN_SECRET_LEN)
 
 	h := sha256.New()
 	h.Write([]byte(secret))
 	token.UserId = userId
 	token.Secret = h.Sum(nil)
-	token.Expires = time.Now().Add(sessionDuration).Unix()
+	token.Expires = time.Now().Add(SessionDuration).Unix()
 
 	err = db.Create(token).Error
 	if err != nil {


### PR DESCRIPTION
- Standardize SessionDuration to declaration in data.go

SessionDuration was re-declared in the api file. This change makes sure we have a single source of truth.