### PR TITLE
Mention waiting for load balancer during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ helm install infra-registry infrahq/registry --namespace infrahq --create-namesp
 
 ### Connect Kubernetes cluster to Infra Registry
 
-Run the following commands to retrieve Infra Registry information and its API key:
+Once the load balancer for the Infra Registry is available, run the following commands to retrieve Infra Registry information and its API key:
 
 ```bash
 INFRA_REGISTRY=$(kubectl --namespace infrahq get services infra-registry -o jsonpath="{.status.loadBalancer.ingress[*]['ip', 'hostname']}")


### PR DESCRIPTION
If the user is just copy/pasting during initial install (like I do) they won't see that their registry environment variable has not been set, this causes problems later with the engine not have a registry to connect to.

A better long-term solution is an `infra deploy` command that waits for this load balancer to come up.