### PR TITLE
Clean up destination naming in infra list

### DIFF
--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -53,17 +53,17 @@ func list() error {
 			Name:   d.Name,
 			Status: "💻 → ❌ Can't reach internet",
 		}
+
 		if kube, ok := d.GetKubernetesOk(); ok {
 			row.Endpoint = kube.Endpoint
 			row.CertificateAuthorityData = []byte(kube.Ca)
-			row.Type = "k8s"
-			row.Name = "infra:" + row.Name
+			row.Type = "kubernetes"
 
 			if kubeConfig.CurrentContext == row.Name {
 				row.CurrentlySelected = "*"
 			}
 		}
-		// other dest types?
+
 		rows = append(rows, row)
 	}
 


### PR DESCRIPTION
Before:

```
  CURRENT  NAME                      TYPE  STATUS  
  *        infra:infrahq-production  k8s   ✅ OK  
```

After:
```
  CURRENT  NAME                TYPE        STATUS  
  *        infrahq-production  kubernetes  ✅ OK
```