### PR TITLE
Remove unnecessary step in Okta setup docs

### DIFF
--- a/docs/okta.md
+++ b/docs/okta.md
@@ -44,9 +44,7 @@ sources:
 
 ![okta_application](https://user-images.githubusercontent.com/5853428/125355241-a3febb80-e319-11eb-8fc6-84df2509f621.png)
 
-5. At this time you may also navigate to the **Assignments** tab on your application and assign any groups that Infra will read users from in order to map access and role assignments.
-
-6. Navigate to **Security > API**, then click the **Tokens** tab. Create a new Token by clicking **Create Token**. Name it **infra**. Note this token value for later.
+5. Navigate to **Security > API**, then click the **Tokens** tab. Create a new Token by clicking **Create Token**. Name it **infra**. Note this token value for later.
 
 ![okta_create_token](https://user-images.githubusercontent.com/5853428/124652451-0276f600-de51-11eb-9d22-92262de76371.png)
 ![okta_api_token](https://user-images.githubusercontent.com/5853428/124652864-787b5d00-de51-11eb-81d8-e503babfdbca.png)


### PR DESCRIPTION
Step 5 here is not needed, groups are assigned in step 3.

Closes:
#407 