### PR TITLE
fix `rollme` pod annotations

### DIFF
--- a/helm/charts/engine/templates/deployment.yaml
+++ b/helm/charts/engine/templates/deployment.yaml
@@ -13,9 +13,9 @@ spec:
     metadata:
       labels:
 {{- include "engine.selectorLabels" . | nindent 8 }}
-{{- with .Values.pod.annotations }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
+{{- with .Values.pod.annotations }}
   {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:

--- a/helm/charts/registry/templates/deployment.yaml
+++ b/helm/charts/registry/templates/deployment.yaml
@@ -13,9 +13,9 @@ spec:
     metadata:
       labels:
 {{- include "registry.selectorLabels" . | nindent 8 }}
-{{- with .Values.pod.annotations }}
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
+{{- with .Values.pod.annotations }}
   {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:


### PR DESCRIPTION
Fixes #470 by always annotating pod templates with `rollme`. 