### PR TITLE
remove registry pod affinity

### DIFF
--- a/helm/charts/registry/templates/deployment.yaml
+++ b/helm/charts/registry/templates/deployment.yaml
@@ -73,16 +73,6 @@ spec:
               port: {{ .targetPort }}
               {{- end }}
             periodSeconds: 3
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - infra-registry
-            topologyKey: kubernetes.io/hostname
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
Removing pod affinity since it isn't necessary and it's causing issues with the registry not starting due to label mismatch

> it was originally for the sqlite database, to redeploy new pods on the same node as old ones

Fixes #479 
