### PR TITLE
clean helm packages before building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ helm: helm/engine.tgz helm/infra.tgz
 	helm repo index helm
 
 helm/%.tgz: helm/charts/%
+	$(RM) $(@D)/$*-*.tgz
 	helm package -d $(@D) $< --version $(tag) --app-version $(tag)
 
 helm/charts/infra/charts/:


### PR DESCRIPTION
Can't use Makefile dependencies because Makefile contents get scanned once. This causes Makefile to evaluate the dependency as existing which means it won't get built but it then removes it so dependent rules fail as the dependency no longer exists.