### PR TITLE
http: error logging through zap

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -444,6 +444,7 @@ func Run(options *Options) error {
 		Addr:      ":443",
 		TLSConfig: tlsConfig,
 		Handler:   handlers.CustomLoggingHandler(io.Discard, mux, logging.ZapLogFormatter),
+		ErrorLog:  logging.StandardErrorLog(),
 	}
 
 	logging.L.Info("serving on port 443")

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -3,6 +3,7 @@ package logging
 
 import (
 	"io"
+	"log"
 	"os"
 
 	"github.com/gorilla/handlers"
@@ -57,4 +58,13 @@ func ZapLogFormatter(_ io.Writer, params handlers.LogFormatterParams) {
 		zap.String("path", params.URL.Path),
 		zap.Int("status", params.StatusCode),
 		zap.Int("size", params.Size))
+}
+
+func StandardErrorLog() *log.Logger {
+	errorLog, err := zap.NewStdLogAt(L, zapcore.ErrorLevel)
+	if err != nil {
+		return nil
+	}
+
+	return errorLog
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -350,8 +350,9 @@ func (r *Registry) runServer() error {
 	sentryHandler := sentryhttp.New(sentryhttp.Options{})
 
 	plaintextServer := http.Server{
-		Addr:    ":80",
-		Handler: handlers.CustomLoggingHandler(io.Discard, sentryHandler.Handle(mux), logging.ZapLogFormatter),
+		Addr:     ":80",
+		Handler:  handlers.CustomLoggingHandler(io.Discard, sentryHandler.Handle(mux), logging.ZapLogFormatter),
+		ErrorLog: logging.StandardErrorLog(),
 	}
 
 	go func() {
@@ -375,6 +376,7 @@ func (r *Registry) runServer() error {
 		Addr:      ":443",
 		TLSConfig: tlsConfig,
 		Handler:   handlers.CustomLoggingHandler(io.Discard, sentryHandler.Handle(mux), logging.ZapLogFormatter),
+		ErrorLog:  logging.StandardErrorLog(),
 	}
 
 	if err := tlsServer.ListenAndServeTLS("", ""); err != nil {


### PR DESCRIPTION
Push HTTP error logs through zap otherwise errors like the one below will look very out of place and highly visible to the user. 

```
2021/09/28 23:44:42 http: TLS handshake error from 192.168.1.245:28650: EOF
```

Now we get more benign error messages which blends in better with non-HTTP error.

```
{"level":"error","ts":1635902690.406826,"caller":"http/server.go:3117","msg":"http: TLS handshake error from 192.168.65.3:59266: EOF"}
```

We could technically use debug to hide these even more but it seems unwise to ignore legitimate errors.

Fixes #353 