### PR TITLE
 Standardize Struct Validation (#202) (#444)

### DIFF
--- a/docker-desktop.yaml.in
+++ b/docker-desktop.yaml.in
@@ -15,6 +15,7 @@ config:
       apiToken: kubernetes:$OKTA_SECRET/apiToken
   groups:
     - name: Everyone
+      provider: okta
       roles:
         - kind: cluster-role
           name: cluster-admin

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -65,10 +65,10 @@ Secrets Manager takes configuration, like so:
 ```yaml
 secrets:
   - name: awssm # can optionally provide a custom name
-    kind: awssm
+    kind: awssecretsmanager
     endpoint: https://kms.endpoint
     region: us-west-2
-    accessKeyId: env:AWS_ACCESS_KEY_ID # secret config can even reference other built-in secret types, like env
+    accessKeyID: env:AWS_ACCESS_KEY_ID # secret config can even reference other built-in secret types, like env
     secretAccessKey: env:AWS_SECRET_ACCESS_KEY
 ```
 
@@ -84,10 +84,10 @@ SSM takes configuration, like so:
 secrets:
   - name: awsssm # can optionally provide a custom name
     kind: awsssm
-    keyId: 1234abcd-12ab-34cd-56ef-1234567890ab # optional, if set it's the KMS key that should be used for decryption
+    keyID: 1234abcd-12ab-34cd-56ef-1234567890ab # optional, if set it's the KMS key that should be used for decryption
     endpoint: https://kms.endpoint
     region: us-west-2
-    accessKeyId: env:AWS_ACCESS_KEY_ID # secret config can even reference other built-in secret types, like env
+    accessKeyID: env:AWS_ACCESS_KEY_ID # secret config can even reference other built-in secret types, like env
     secretAccessKey: env:AWS_SECRET_ACCESS_KEY
 ```
 

--- a/internal/registry/_testdata/infra.yaml
+++ b/internal/registry/_testdata/infra.yaml
@@ -92,6 +92,8 @@ users:
           - labels:
               - us-west-1
               - us-east-1
+            namespaces:
+              - infrahq
   - email: unknown@example.com
     roles:
       - name: writer

--- a/internal/registry/api.go
+++ b/internal/registry/api.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-playground/validator/v10"
 	"github.com/gorilla/mux"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/api"
@@ -34,8 +33,6 @@ type CustomJWTClaims struct {
 	Destination string `json:"dest" validate:"required"`
 	Nonce       string `json:"nonce" validate:"required"`
 }
-
-var validate *validator.Validate = validator.New()
 
 func NewAPIMux(reg *Registry) *mux.Router {
 	a := API{

--- a/internal/registry/config_test.go
+++ b/internal/registry/config_test.go
@@ -347,7 +347,7 @@ func TestClusterRolesAreAppliedWithNamespacesToUsers(t *testing.T) {
 }
 
 func TestCleanupDomain(t *testing.T) {
-	p := ConfigIdentityProvider{Domain: "dev123123-admin.okta.com "}
+	p := ConfigProvider{Domain: "dev123123-admin.okta.com "}
 	p.cleanupDomain()
 
 	expected := "dev123123.okta.com"

--- a/internal/registry/validator.go
+++ b/internal/registry/validator.go
@@ -1,0 +1,5 @@
+package registry
+
+import "github.com/go-playground/validator/v10"
+
+var validate *validator.Validate = validator.New()

--- a/secrets/aws.go
+++ b/secrets/aws.go
@@ -1,8 +1,8 @@
 package secrets
 
 type AWSConfig struct {
-	Endpoint        string `yaml:"endpoint"`
-	Region          string `yaml:"region"`
-	AccessKeyID     string `yaml:"accessKeyId"`
-	SecretAccessKey string `yaml:"secretAccessKey"`
+	Endpoint        string `yaml:"endpoint" validate:"required"`
+	Region          string `yaml:"region" validate:"required"`
+	AccessKeyID     string `yaml:"accessKeyID" validate:"required"`
+	SecretAccessKey string `yaml:"secretAccessKey" validate:"required"`
 }

--- a/secrets/awsssm.go
+++ b/secrets/awsssm.go
@@ -23,7 +23,7 @@ type AWSSSM struct {
 
 type AWSSSMConfig struct {
 	AWSConfig
-	KeyID string `yaml:"keyId"` // KMS key to use for decryption
+	KeyID string `yaml:"keyID" validate:"required"` // KMS key to use for decryption
 }
 
 func NewAWSSSMSecretProviderFromConfig(cfg AWSSSMConfig) (*AWSSSM, error) {

--- a/secrets/file.go
+++ b/secrets/file.go
@@ -18,7 +18,7 @@ type GenericConfig struct {
 
 type FileConfig struct {
 	GenericConfig
-	Path string `yaml:"path"`
+	Path string `yaml:"path" validate:"required"`
 }
 
 type FileSecretProvider struct {

--- a/secrets/vault.go
+++ b/secrets/vault.go
@@ -22,11 +22,11 @@ type VaultSecretProvider struct {
 }
 
 type VaultConfig struct {
-	TransitMount string `yaml:"transitMount"` // mounting point. defaults to /transit
-	SecretMount  string `yaml:"secretMount"`  // mounting point. defaults to /secret
-	Token        string `yaml:"token"`        // vault token... should authenticate as machine to vault instead?
+	TransitMount string `yaml:"transitMount"`              // mounting point. defaults to /transit
+	SecretMount  string `yaml:"secretMount"`               // mounting point. defaults to /secret
+	Token        string `yaml:"token" validate:"required"` // vault token... should authenticate as machine to vault instead?
 	Namespace    string `yaml:"namespace"`
-	Address      string `yaml:"address"`
+	Address      string `yaml:"address" validate:"required"`
 }
 
 func NewVaultConfig() VaultConfig {


### PR DESCRIPTION
Closes: #202 and #444

Description:
When required keys are not valid (ex: present, and email, or an expected kind) fail fast and log an error. This change standardizes on the `go-playground/validator` package for validating structs.

When a config keys doesn't meet requirements an error log is output in the registry:
> Error: loading config from file: invalid config: Key: 'Config.Secrets[1].Config.AWSConfig.AccessKeyID' Error:Field validation for 'AccessKeyID' failed on the 'required' tag

Changes:
- validate config file keys
- fail fast on invalid config rather than logging
- refactor struct names now that they are visible in errors
- use a package-wide validator
- mark config fields as required
- standardize config keys to capital `ID`
- update developer config to specify group provider

@ssoroka, I definitely need your opinion on what is required in secret configurations.