### PR TITLE
engine: short name by default

### DIFF
--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -614,7 +614,8 @@ func (k *Kubernetes) Name() (string, string, error) {
 
 	logging.L.Debug("could not fetch cluster name, resorting to hashed cluster CA")
 
-	return chksm, chksm, nil
+	// truncated checksum will be used as default name if one could not be found
+	return chksm[:12], chksm, nil
 }
 
 func (k *Kubernetes) Namespace() (string, error) {


### PR DESCRIPTION
if falling back to using checksum as the cluster name, use a truncated form instead of the full checksum.