### PR TITLE
logger filter

### DIFF
--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -34,7 +34,7 @@ func TestConfigValidLevel(t *testing.T) {
 }
 
 func TestFiltersOutBearerTokenValue(t *testing.T) {
-	// remove this test after Go patches https://groups.google.com/g/golang-codereviews/c/BOSa6DE8tnI
+	// remove this test after Go patches https://github.com/golang/go/pull/48979
 	tests := []struct {
 		Input    string
 		Expected string
@@ -54,7 +54,8 @@ func TestFiltersOutBearerTokenValue(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		writeSyncer := &testWriterSyncer{}
-		defaultWriter = writeSyncer
+		defaultStdoutWriter = writeSyncer
+		defaultStderrWriter = writeSyncer
 
 		logger, err := Initialize(int(zap.InfoLevel))
 		require.NoError(t, err)


### PR DESCRIPTION
temporary change until we can figure out what versions are affected by this. I had some problems figuring that out, as none of the source I looked at had the text "for key" as part of the message. Not sure what I'm missing. 

Anyway this is the expensive way to fix it; every line written to the logger is checked for this header text and the line is modified if so. Unfortunately the line may be in JSON so that complicates it somewhat.

resolves #655

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Nothing sensitive logged
