### PR TITLE
Update destination fields on create, in case they were modifed (#656)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -365,6 +365,8 @@ func Run(options *Options) error {
 					logging.L.Error(err.Error())
 					return
 				}
+
+				return
 			} else {
 				logging.S.Errorf("cache get: %s", err.Error())
 				return

--- a/internal/registry/data.go
+++ b/internal/registry/data.go
@@ -191,11 +191,7 @@ func (d *Destination) BeforeCreate(tx *gorm.DB) (err error) {
 	return nil
 }
 
-func (d *Destination) AfterCreate(tx *gorm.DB) error {
-	if err := tx.Model(&d).Association("Labels").Replace(d.Labels); err != nil {
-		return err
-	}
-
+func (d *Destination) AfterSave(tx *gorm.DB) error {
 	if _, err := ApplyGroupMappings(tx, initialConfig.Groups); err != nil {
 		return fmt.Errorf("group apply after destination create: %w", err)
 	}


### PR DESCRIPTION
Loading an existing destination from the database overrode the incoming fields. This meant that updating a destination from the POST `/destination` endpoint was not possible. Fix is to apply the incoming request destination fields after loading the destination.

- [X] Wrote appropriate unit tests
- [X] Considered security implications of the change
- [X] Updated associated docs where necessary
- [X] Updated associated configuration where necessary
- [X] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [X] Nothing sensitive logged

resolves #656