### PR TITLE
make: add build/openapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ openapi: openapi/clean
 	# manually post process some files since openapi-generator forgot
 	find internal/api -name '*.go' -exec $(GO_POST_PROCESS_FILE) {} \;
 
+build/openapi:
+	npx @redocly/openapi-cli bundle -o openapi-bundled.yaml openapi.yaml
+
 openapi/clean:
 	$(RM) -r internal/api/*.go
 	$(RM) -r internal/api/api internal/api/.openapi-generator


### PR DESCRIPTION
<!-- include a summary of the change and/or why it's necessary -->

Add Makefile target to bundle and dereference OpenAPI specification into a single file, openapi-bundled.yaml

<!-- 
Checklists help us remember things. 
Change [ ] to [x] to show completion, or whatever :D 
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged

<!-- you can link to the issue it closes using a keyword like "resolves #1234" -->

Resolves #665 
