### PR TITLE
logger middleware

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -132,9 +132,7 @@ func (w *filteredWriterSyncer) Sync() error {
 	return w.dest.Sync()
 }
 
-var (
-	ctxLoggerKey = "logger"
-)
+var ctxLoggerKey = "logger"
 
 // UserAwareLoggerMiddleware saves a request-specific logger to the context
 func UserAwareLoggerMiddleware(c *gin.Context) {
@@ -158,5 +156,6 @@ func Logger(c *gin.Context) *zap.SugaredLogger {
 			return logger
 		}
 	}
+
 	return S
 }

--- a/internal/registry/api.go
+++ b/internal/registry/api.go
@@ -465,7 +465,9 @@ func (a *API) ListAPIKeys(c *gin.Context) {
 	for _, k := range keys {
 		resKey, err := k.marshal()
 		if err != nil {
+			logging.Logger(c).Error(err)
 			sendAPIError(c, http.StatusInternalServerError, "unexpected value encountered while marshalling API key")
+
 			return
 		}
 
@@ -885,8 +887,7 @@ func marshalPermissions(permissions string) ([]api.InfraAPIPermission, error) {
 	for _, p := range storedPermissions {
 		apiPermission, err := api.NewInfraAPIPermissionFromValue(p)
 		if err != nil {
-			logging.Logger(c).Errorf("Error converting stored permission %q to API permission: %w", p, err)
-			return nil, err
+			return nil, fmt.Errorf("Error converting stored permission %q to API permission: %w", p, err)
 		}
 
 		apiPermissions = append(apiPermissions, *apiPermission)


### PR DESCRIPTION
injects the logger into context, which has the current user id as a field.

resolves #681
