### PR TITLE
models: use partial index for unique constraints

### DIFF
--- a/internal/registry/data/destination_test.go
+++ b/internal/registry/data/destination_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	destinationDevelop    = models.Destination{Name: "develop", Kind: "kubernetes", Endpoint: "dev.kubernetes.com", Kubernetes: models.DestinationKubernetes{CA: "notsosecret"}, NodeID: "one"}
-	destinationProduction = models.Destination{Name: "production", Kind: "kubernetes", Endpoint: "prod.kubernetes.com", Kubernetes: models.DestinationKubernetes{CA: "supersecret"}, NodeID: "two"}
+	destinationDevelop    = models.Destination{Name: "develop", Kind: "kubernetes", Endpoint: "dev.kubernetes.com", Kubernetes: models.DestinationKubernetes{CA: "notsosecret"}, NodeID: "develop"}
+	destinationProduction = models.Destination{Name: "production", Kind: "kubernetes", Endpoint: "prod.kubernetes.com", Kubernetes: models.DestinationKubernetes{CA: "supersecret"}, NodeID: "production"}
 
 	labelUSWest1 = models.Label{Value: "us-west-1"}
 	labelUSEast1 = models.Label{Value: "us-east-1"}
@@ -295,5 +295,16 @@ func TestDeleteDestinations(t *testing.T) {
 
 	// deleting a destination should not delete unrelated destinations
 	_, err = GetDestination(db, &models.Destination{Name: "production"})
+	require.NoError(t, err)
+}
+
+func TestRecreateDestinationSameNodeID(t *testing.T) {
+	db := setup(t)
+	createDestinations(t, db, destinationDevelop, destinationProduction)
+
+	err := DeleteDestinations(db, &models.Destination{NodeID: "develop"})
+	require.NoError(t, err)
+
+	_, err = CreateDestination(db, &models.Destination{NodeID: "develop"})
 	require.NoError(t, err)
 }

--- a/internal/registry/data/group_test.go
+++ b/internal/registry/data/group_test.go
@@ -326,3 +326,14 @@ func TestDeleteGroup(t *testing.T) {
 	_, err = GetGroup(db, &models.Group{Name: engineers.Name})
 	require.NoError(t, err)
 }
+
+func TestRecreateGroupSameName(t *testing.T) {
+	db := setup(t)
+	createGroups(t, db, everyone, engineers, product)
+
+	err := DeleteGroups(db, &models.Group{Name: everyone.Name})
+	require.NoError(t, err)
+
+	_, err = CreateGroup(db, &models.Group{Name: everyone.Name})
+	require.NoError(t, err)
+}

--- a/internal/registry/data/provider_test.go
+++ b/internal/registry/data/provider_test.go
@@ -338,3 +338,16 @@ func TestDeleteProviders(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(okta))
 }
+
+func TestRecreateProviderSameDomain(t *testing.T) {
+	db := setup(t)
+	createProviders(t, db, providerDevelop, providerProduction)
+
+	err := DeleteProviders(db, func(db *gorm.DB) *gorm.DB {
+		return db.Where(&models.Provider{Domain: "dev.okta.com"})
+	})
+	require.NoError(t, err)
+
+	_, err = CreateProvider(db, &models.Provider{Domain: "dev.okta.com"})
+	require.NoError(t, err)
+}

--- a/internal/registry/data/user_test.go
+++ b/internal/registry/data/user_test.go
@@ -241,3 +241,14 @@ func TestDeleteUser(t *testing.T) {
 	_, err = GetUser(db, &models.User{Email: bourne.Email})
 	require.NoError(t, err)
 }
+
+func TestRecreateUserSameEmail(t *testing.T) {
+	db := setup(t)
+	createUsers(t, db, bond, bourne, bauer)
+
+	err := DeleteUsers(db, &models.User{Email: bond.Email})
+	require.NoError(t, err)
+
+	_, err = CreateUser(db, &models.User{Email: bond.Email})
+	require.NoError(t, err)
+}

--- a/internal/registry/models/destination.go
+++ b/internal/registry/models/destination.go
@@ -17,7 +17,7 @@ type Destination struct {
 
 	Name     string
 	Kind     DestinationKind
-	NodeID   string `gorm:"uniqueIndex" validate:"required"`
+	NodeID   string `gorm:"uniqueIndex:,where:deleted_at is NULL" validate:"required"`
 	Endpoint string
 
 	Labels []Label

--- a/internal/registry/models/group.go
+++ b/internal/registry/models/group.go
@@ -9,7 +9,7 @@ import (
 type Group struct {
 	Model
 
-	Name string
+	Name string `gorm:"uniqueIndex:,where:deleted_at is NULL"`
 
 	Grants    []Grant    `gorm:"many2many:groups_grants"`
 	Providers []Provider `gorm:"many2many:groups_providers"`

--- a/internal/registry/models/model.go
+++ b/internal/registry/models/model.go
@@ -11,7 +11,7 @@ type Model struct {
 	ID        uuid.UUID
 	CreatedAt time.Time
 	UpdatedAt time.Time
-	DeletedAt gorm.DeletedAt `gorm:"index"`
+	DeletedAt gorm.DeletedAt
 }
 
 // Set an ID if one does not already exist. Unfortunately, we can use `gorm:"default"`

--- a/internal/registry/models/provider.go
+++ b/internal/registry/models/provider.go
@@ -17,7 +17,7 @@ type Provider struct {
 
 	Kind ProviderKind
 
-	Domain       string `gorm:"unique"`
+	Domain       string `gorm:"uniqueIndex:,where:deleted_at is NULL"`
 	ClientID     string
 	ClientSecret EncryptedAtRest
 

--- a/internal/registry/models/token.go
+++ b/internal/registry/models/token.go
@@ -25,7 +25,7 @@ type Token struct {
 	APIToken   APIToken
 	APITokenID uuid.UUID
 
-	Key      string `gorm:"<-:create;uniqueIndex"`
+	Key      string `gorm:"<-:create;uniqueIndex:,where:deleted_at is NULL"`
 	Secret   string `gorm:"-"`
 	Checksum []byte
 
@@ -45,7 +45,7 @@ func (t *Token) SessionToken() string {
 type APIToken struct {
 	Model
 
-	Name        string `gorm:"unique"`
+	Name        string `gorm:"uniqueIndex:,where:deleted_at is NULL"`
 	Permissions string
 	TTL         time.Duration
 }

--- a/internal/registry/models/user.go
+++ b/internal/registry/models/user.go
@@ -10,7 +10,7 @@ type User struct {
 	Model
 
 	Name        string
-	Email       string `gorm:"uniqueIndex"`
+	Email       string `gorm:"uniqueIndex:,where:deleted_at is NULL"`
 	Permissions string
 
 	Grants    []Grant    `gorm:"many2many:users_grants"`


### PR DESCRIPTION
<!-- Include a summary of the change and/or why it's necessary. -->

Allow soft deletes while keeping unique constraints by creating an unique index using both deleted_at and the tables' unique field.

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #
