### PR TITLE
registry: remove sync destination timer

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -194,12 +194,6 @@ func (r *Registry) scheduleSyncJobs() {
 	syncProvidersTimer.Start(r.options.ProvidersSyncInterval, func() {
 		syncProviders(r)
 	})
-
-	// schedule destination sync job
-	syncDestinationsTimer := timer.NewTimer()
-	syncDestinationsTimer.Start(r.options.DestinationsSyncInterval, func() {
-		syncDestinations(r.db, time.Hour*1)
-	})
 }
 
 func (r *Registry) configureTelemetry() error {


### PR DESCRIPTION
- remove it temporarily because destinations no longer periodically
  get updated. this causes the timer to erroneously remove a destination
  that may still be up and running
- once we have destination identities, we can bring back this timer
  because any request will act as a heartbeat from the destination and
  refresh the updated timestamp

<!-- Include a summary of the change and/or why it's necessary. -->

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #
