### PR TITLE
secrets: return not found error if secret is not set

### DIFF
--- a/secrets/awssecretsmanager.go
+++ b/secrets/awssecretsmanager.go
@@ -108,7 +108,7 @@ func (s *AWSSecretsManager) GetSecret(name string) (secret []byte, err error) {
 		var aerr awserr.Error
 		if errors.As(err, &aerr) {
 			if aerr.Code() == secretsmanager.ErrCodeResourceNotFoundException {
-				return nil, nil
+				return nil, ErrNotFound
 			}
 		}
 

--- a/secrets/awsssm.go
+++ b/secrets/awsssm.go
@@ -99,7 +99,7 @@ func (s *AWSSSM) GetSecret(name string) (secret []byte, err error) {
 		var aerr awserr.Error
 		if errors.As(err, &aerr) {
 			if aerr.Code() == ssm.ErrCodeParameterNotFound {
-				return nil, nil
+				return nil, ErrNotFound
 			}
 		}
 

--- a/secrets/env.go
+++ b/secrets/env.go
@@ -58,6 +58,11 @@ func (fp *EnvSecretProvider) GetSecret(name string) (secret []byte, err error) {
 		b = []byte(os.Getenv(name))
 	}
 
+	_, present := os.LookupEnv(name)
+	if !present {
+		return nil, ErrNotFound
+	}
+
 	var result []byte
 	if fp.Base64 {
 		result = make([]byte, fp.encoder().DecodedLen(len(b)))

--- a/secrets/file.go
+++ b/secrets/file.go
@@ -75,7 +75,7 @@ func (fp *FileSecretProvider) GetSecret(name string) (secret []byte, err error) 
 	f, err := os.Open(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, ErrNotFound
 		}
 
 		return nil, fmt.Errorf("opening file %q: %w", fullPath, err)

--- a/secrets/kubernetes.go
+++ b/secrets/kubernetes.go
@@ -122,7 +122,7 @@ func (k *KubernetesSecretProvider) GetSecret(name string) (secret []byte, err er
 	retrieved, err := k.client.CoreV1().Secrets(k.Namespace).Get(context.TODO(), objName, metav1.GetOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			return nil, nil
+			return nil, ErrNotFound
 		}
 
 		return nil, err
@@ -130,7 +130,7 @@ func (k *KubernetesSecretProvider) GetSecret(name string) (secret []byte, err er
 
 	secretVal, ok := retrieved.Data[key]
 	if !ok {
-		return nil, fmt.Errorf("secret could not be found in kubernetes: %s", name)
+		return nil, ErrNotFound
 	}
 
 	return secretVal, nil

--- a/secrets/native.go
+++ b/secrets/native.go
@@ -1,6 +1,9 @@
 package secrets
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	infraKeyNamespace   = "infra-x"                         // k8s doesn't like names that start or end with _
@@ -30,7 +33,9 @@ func (n *NativeSecretProvider) GenerateDataKey(rootKeyID string) (*SymmetricKey,
 
 	rootKey, err := n.SecretStorage.GetSecret(rootKeyID)
 	if err != nil {
-		return nil, fmt.Errorf("getting root key: %w", err)
+		if !errors.Is(err, ErrNotFound) {
+			return nil, fmt.Errorf("getting root key: %w", err)
+		}
 	}
 
 	if len(rootKey) == 0 {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 )
 
+var ErrNotFound = fmt.Errorf("secret not found")
+
 // SecretStorage is implemented by a provider if the provider gives a mechanism for storing arbitrary secrets.
 type SecretStorage interface {
 	// Use secrets when you don't want to store the underlying data, eg secret tokens

--- a/secrets/vault.go
+++ b/secrets/vault.go
@@ -78,11 +78,11 @@ func (v *VaultSecretProvider) GetSecret(name string) ([]byte, error) {
 	}
 
 	if sec == nil || sec.Data == nil {
-		return nil, nil
+		return nil, ErrNotFound
 	}
 
 	if _, ok := sec.Data["data"]; !ok {
-		return nil, nil
+		return nil, ErrNotFound
 	}
 
 	data, ok := sec.Data["data"].(map[string]interface{})


### PR DESCRIPTION
`GetSecret` now returns a new error type, `secrets.ErrNotFound` if the secret is not found (i.e. file does not exist, Kubernetes secret does not exist, etc)

Passes `make test-all`

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
