### PR TITLE
Remove unused nonce from login flow

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -168,12 +168,7 @@ provider:
 			return err
 		}
 
-		nonce, err := generate.CryptoRandom(10)
-		if err != nil {
-			return err
-		}
-
-		authorizeURL := fmt.Sprintf("https://%s/oauth2/v1/authorize?redirect_uri=http://localhost:8301&client_id=%s&response_type=code&scope=openid+email+groups+offline_access&nonce=%s&state=%s", selectedProvider.Domain, selectedProvider.ClientID, nonce, state)
+		authorizeURL := fmt.Sprintf("https://%s/oauth2/v1/authorize?redirect_uri=http://localhost:8301&client_id=%s&response_type=code&scope=openid+email+groups+offline_access&state=%s", selectedProvider.Domain, selectedProvider.ClientID, state)
 
 		fmt.Fprintf(os.Stderr, "  Logging in with %s...\n", termenv.String("Okta").Bold().String())
 


### PR DESCRIPTION
<!-- Include a summary of the change and/or why it's necessary. -->
The nonce is used to mitigate replay on attacks on implicit OAuth login flows, we don't need it on our authorization code flow.

Around the time our login flow was implemented there was a typo in the Okta docs for the authorization code flow that said it was required:
https://devforum.okta.com/t/authorization-code-flow-is-the-nonce-parameter-necessary/12150

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->