### PR TITLE
Removing Root API Token instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,15 +115,6 @@ helm repo add infrahq https://helm.infrahq.com/
 helm install -n infrahq --create-namespace infra infrahq/infra --set-file config.import=infra.yaml
 ```
 
-You'll need the Infra Root API Token to log into Infra. Please generate this token by running the following commands: 
-
-```
-ROOT_API_TOKEN=$(kubectl -n infrahq get secrets infra -o jsonpath='{.data.root-api-token}' | base64 --decode)
-echo $ROOT_API_TOKEN
-```
-
-**Please store this in a safe place.** 
-
 Next, you'll need to find the URL of Infra Server to log into Infra. 
 
 <details>


### PR DESCRIPTION
Removing the Root API Token instructions as users setting up using IaC do not need to use it if an Infra Administrator has been configured.