### PR TITLE
Grants for machines (#852)

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -274,12 +274,12 @@ func (c Client) CreateAccessKey(req *CreateAccessKeyRequest) (*CreateAccessKeyRe
 	return post[CreateAccessKeyRequest, CreateAccessKeyResponse](c, "/v1/access-keys", req)
 }
 
-func (c Client) CreateMachine(req *MachineCreateRequest) (*Machine, error) {
-	return post[MachineCreateRequest, Machine](c, "/v1/machines", req)
+func (c Client) CreateMachine(req *CreateMachineRequest) (*Machine, error) {
+	return post[CreateMachineRequest, Machine](c, "/v1/machines", req)
 }
 
-func (c Client) ListMachines(name string) ([]Machine, error) {
-	return list[Machine](c, "/v1/machines", map[string]string{"name": name})
+func (c Client) ListMachines(req ListMachinesRequest) ([]Machine, error) {
+	return list[Machine](c, "/v1/machines", map[string]string{"name": req.Name})
 }
 
 func (c Client) DeleteMachine(id uid.ID) error {

--- a/internal/api/model_machine.go
+++ b/internal/api/model_machine.go
@@ -16,11 +16,11 @@ type Machine struct {
 }
 
 type ListMachinesRequest struct {
-	MachineName string `form:"name"`
+	Name string `form:"name"`
 }
 
-// MachineCreateRequest struct for MachineCreateRequest
-type MachineCreateRequest struct {
+// CreateMachineRequest struct for CreateMachineRequest
+type CreateMachineRequest struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	Permissions []string `json:"permissions"`

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -974,7 +974,7 @@ var machinesListCmd = &cobra.Command{
 			return err
 		}
 
-		machines, err := client.ListMachines("")
+		machines, err := client.ListMachines(api.ListMachinesRequest{})
 		if err != nil {
 			return err
 		}
@@ -1009,7 +1009,7 @@ var machinesDeleteCmd = &cobra.Command{
 			return err
 		}
 
-		machines, err := client.ListMachines(args[0])
+		machines, err := client.ListMachines(api.ListMachinesRequest{Name: args[0]})
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/machines.go
+++ b/internal/cmd/machines.go
@@ -56,7 +56,7 @@ func createMachine(options *MachinesCreateOptions) error {
 		return err
 	}
 
-	_, err = client.CreateMachine(&api.MachineCreateRequest{Name: options.Name, Description: options.Description, Permissions: strings.Split(options.Permissions, " ")})
+	_, err = client.CreateMachine(&api.CreateMachineRequest{Name: options.Name, Description: options.Description, Permissions: strings.Split(options.Permissions, " ")})
 	if err != nil {
 		return err
 	}

--- a/internal/registry/api.go
+++ b/internal/registry/api.go
@@ -275,7 +275,7 @@ func (a *API) ListDestinations(c *gin.Context, r *api.ListDestinationsRequest) (
 	return results, nil
 }
 
-func (a *API) CreateMachine(c *gin.Context, r *api.MachineCreateRequest) (*api.Machine, error) {
+func (a *API) CreateMachine(c *gin.Context, r *api.CreateMachineRequest) (*api.Machine, error) {
 	machine := &models.Machine{}
 	if err := machine.FromAPI(r); err != nil {
 		return nil, err
@@ -290,7 +290,7 @@ func (a *API) CreateMachine(c *gin.Context, r *api.MachineCreateRequest) (*api.M
 }
 
 func (a *API) ListMachines(c *gin.Context, r *api.ListMachinesRequest) ([]api.Machine, error) {
-	machines, err := access.ListMachines(c, r.MachineName)
+	machines, err := access.ListMachines(c, r.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/registry/models/machine.go
+++ b/internal/registry/models/machine.go
@@ -37,7 +37,7 @@ func (m *Machine) ToAPI() *api.Machine {
 }
 
 func (m *Machine) FromAPI(from interface{}) error {
-	if createRequest, ok := from.(*api.MachineCreateRequest); ok {
+	if createRequest, ok := from.(*api.CreateMachineRequest); ok {
 		m.Name = createRequest.Name
 		m.Description = createRequest.Description
 		m.Permissions = strings.Join(createRequest.Permissions, " ")


### PR DESCRIPTION
<!-- Include a summary of the change and/or why it's necessary. -->
Grants can only be written for users and groups. With machine identities they should be able to have grants also. 

Pretty simple change here. I looked at adding a general "identifier" type for convenience rather than the `u:dfsfds...` string, but it seemed like this simple change was better for now.
<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #852 
