### PR TITLE
remove redundant metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -105,72 +105,62 @@ go_memstats_sys_bytes 7.5580424e+07
 # HELP go_threads Number of OS threads created.
 # TYPE go_threads gauge
 go_threads 9
-# HELP http_requests_duration_seconds A histogram of the duration, in seconds, handling HTTP requests.
-# TYPE http_requests_duration_seconds histogram
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.001"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.002"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.004"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.008"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.016"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.032"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.064"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.128"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.256"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.512"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="1.024"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="2.048"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="4.096"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="8.192"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="16.384"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="+Inf"} 1
-http_requests_duration_seconds_sum{handler="/v1/destinations",method="GET",status="200"} 0.000855667
-http_requests_duration_seconds_count{handler="/v1/destinations",method="GET",status="200"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.001"} 0
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.002"} 0
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.004"} 0
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.008"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.016"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.032"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.064"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.128"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.256"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.512"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="1.024"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="2.048"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="4.096"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="8.192"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="16.384"} 1
-http_requests_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="+Inf"} 1
-http_requests_duration_seconds_sum{handler="/v1/destinations/:id",method="PUT",status="200"} 0.006805916
-http_requests_duration_seconds_count{handler="/v1/destinations/:id",method="PUT",status="200"} 1
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.001"} 2
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.002"} 6
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.004"} 11
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.008"} 11
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.016"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.032"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.064"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.128"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.256"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.512"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="1.024"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="2.048"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="4.096"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="8.192"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="16.384"} 12
-http_requests_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="+Inf"} 12
-http_requests_duration_seconds_sum{handler="/v1/grants",method="GET",status="200"} 0.031218166
-http_requests_duration_seconds_count{handler="/v1/grants",method="GET",status="200"} 12
-# HELP http_requests_in_progress Number of HTTP requests currently in progress.
-# TYPE http_requests_in_progress gauge
-http_requests_in_progress{handler="/v1/destinations",method="GET"} 0
-http_requests_in_progress{handler="/v1/destinations/:id",method="PUT"} 0
-http_requests_in_progress{handler="/v1/grants",method="GET"} 0
-# HELP http_requests_total Total number of HTTP requests served.
-# TYPE http_requests_total counter
-http_requests_total{handler="/v1/destinations",method="GET",status="200"} 1
-http_requests_total{handler="/v1/destinations/:id",method="PUT",status="200"} 1
-http_requests_total{handler="/v1/grants",method="GET",status="200"} 12
+# HELP http_request_duration_seconds A histogram of the duration, in seconds, handling HTTP requests.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.001"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.002"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.004"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.008"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.016"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.032"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.064"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.128"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.256"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="0.512"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="1.024"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="2.048"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="4.096"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="8.192"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="16.384"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations",method="GET",status="200",le="+Inf"} 1
+http_request_duration_seconds_sum{handler="/v1/destinations",method="GET",status="200"} 0.000855667
+http_request_duration_seconds_count{handler="/v1/destinations",method="GET",status="200"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.001"} 0
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.002"} 0
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.004"} 0
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.008"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.016"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.032"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.064"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.128"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.256"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="0.512"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="1.024"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="2.048"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="4.096"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="8.192"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="16.384"} 1
+http_request_duration_seconds_bucket{handler="/v1/destinations/:id",method="PUT",status="200",le="+Inf"} 1
+http_request_duration_seconds_sum{handler="/v1/destinations/:id",method="PUT",status="200"} 0.006805916
+http_request_duration_seconds_count{handler="/v1/destinations/:id",method="PUT",status="200"} 1
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.001"} 2
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.002"} 6
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.004"} 11
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.008"} 11
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.016"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.032"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.064"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.128"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.256"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="0.512"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="1.024"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="2.048"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="4.096"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="8.192"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="16.384"} 12
+http_request_duration_seconds_bucket{handler="/v1/grants",method="GET",status="200",le="+Inf"} 12
+http_request_duration_seconds_sum{handler="/v1/grants",method="GET",status="200"} 0.031218166
+http_request_duration_seconds_count{handler="/v1/grants",method="GET",status="200"} 12
 # HELP infra_destinations Number of destinations managed by Infra.
 # TYPE infra_destinations gauge
 infra_destinations 1

--- a/internal/registry/metrics.go
+++ b/internal/registry/metrics.go
@@ -11,26 +11,12 @@ import (
 	"github.com/infrahq/infra/internal/registry/models"
 )
 
-var (
-	requestInProgressGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "http",
-		Name:      "requests_in_progress",
-		Help:      "Number of HTTP requests currently in progress.",
-	}, []string{"method", "handler"})
-
-	requestCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "http",
-		Name:      "requests_total",
-		Help:      "Total number of HTTP requests served.",
-	}, []string{"method", "handler", "status"})
-
-	requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "http",
-		Name:      "requests_duration_seconds",
-		Help:      "A histogram of the duration, in seconds, handling HTTP requests.",
-		Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
-	}, []string{"method", "handler", "status"})
-)
+var requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "http",
+	Name:      "request_duration_seconds",
+	Help:      "A histogram of the duration, in seconds, handling HTTP requests.",
+	Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
+}, []string{"method", "handler", "status"})
 
 func SetupMetrics(db *gorm.DB) error {
 	promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/internal/registry/middleware.go
+++ b/internal/registry/middleware.go
@@ -80,21 +80,13 @@ func MetricsMiddleware(path string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		t := time.Now()
 
-		labels := prometheus.Labels{
-			"method":  c.Request.Method,
-			"handler": path,
-		}
-
-		requestInProgressGauge.With(labels).Inc()
-
 		c.Next()
 
-		requestInProgressGauge.With(labels).Dec()
-
-		labels["status"] = strconv.Itoa(c.Writer.Status())
-
-		requestCount.With(labels).Inc()
-		requestDuration.With(labels).Observe(time.Since(t).Seconds())
+		requestDuration.With(prometheus.Labels{
+			"method":  c.Request.Method,
+			"handler": path,
+			"status":  strconv.Itoa(c.Writer.Status()),
+		}).Observe(time.Since(t).Seconds())
 	}
 }
 


### PR DESCRIPTION
<!-- Include a summary of the change and/or why it's necessary. -->

- `in_progress` and `total` aren't useful metrics to capture. `total` is a duplicate of `request_duration_seconds_sum` which the histogram already captures
- `http_requests` -> `http_request`

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #
