### PR TITLE
helm: s/persistentVolumeClaim/persistence/

### DIFF
--- a/helm/charts/infra/charts/engine/templates/deployment.yaml
+++ b/helm/charts/infra/charts/engine/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - name: conf
               mountPath: /etc/infrahq
               readOnly: true
-{{- if .Values.persistentVolumeClaim.enabled }}
+{{- if .Values.persistence.enabled }}
             - name: data
               mountPath: /var/lib/infrahq/infra
 {{- end }}
@@ -78,7 +78,7 @@ spec:
         - name: conf
           configMap:
             name: {{ include "engine.fullname" . }}
-{{- if .Values.persistentVolumeClaim.enabled }}
+{{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "engine.fullname" . }}

--- a/helm/charts/infra/charts/engine/templates/persistentvolumeclaim.yaml
+++ b/helm/charts/infra/charts/engine/templates/persistentvolumeclaim.yaml
@@ -1,21 +1,21 @@
-{{- if .Values.persistentVolumeClaim.enabled }}
+{{- if .Values.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "engine.fullname" . }}
   labels:
 {{- include "engine.labels" . | nindent 4 }}
-{{- if .Values.persistentVolumeClaim.labels }}
-{{- toYaml .Values.persistentVolumeClaim.labels | nindent 4 }}
+{{- if .Values.persistence.labels }}
+{{- toYaml .Values.persistence.labels | nindent 4 }}
 {{- end }}
   annotations:
-{{- toYaml .Values.persistentVolumeClaim.annotations | nindent 4 }}
+{{- toYaml .Values.persistence.annotations | nindent 4 }}
 spec:
-{{- if .Values.persistentVolumeClaim.className }}
-  storageClassName: {{ .Values.persistentVolumeClaim.className | quote }}
+{{- if .Values.persistence.className }}
+  storageClassName: {{ .Values.persistence.className | quote }}
 {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:
-{{- toYaml .Values.persistentVolumeClaim.resources | nindent 6 }}
+{{- toYaml .Values.persistence.resources | nindent 6 }}
 {{- end }}

--- a/helm/charts/infra/charts/engine/values.yaml
+++ b/helm/charts/infra/charts/engine/values.yaml
@@ -222,22 +222,22 @@ ingress:
   #   hosts:
   #     - infra.example.com
 
-## Engine persistent volume claim configurations
-persistentVolumeClaim:
+## Engine persistence configurations
+persistence:
 
-  ## Enable server persistent volume claim
+  ## Enable server persistence
   enabled: true
 
-  ## Persistent volume claim labels
+  ## persistence labels
   labels: {}
 
-  ## Persistent volume claim annotations
+  ## persistence annotations
   annotations: {}
 
   ## Name of the storage controller that will implement this resource
   className: ""
 
-  ## Resource requests and limits for the persistent volume claim
+  ## Resource requests and limits for the persistence
   resources:
     requests:
       storage: 2Gi

--- a/helm/charts/infra/charts/server/templates/configmap.yaml
+++ b/helm/charts/infra/charts/server/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
 {{- end }}
 {{- end }}
 
-{{- if .Values.persistentVolumeClaim.enabled }}
+{{- if .Values.persistence.enabled }}
 {{- if not (hasKey .Values.config "tlsCache") }}
     tlsCache: /var/lib/infrahq/server/tls.cache
 {{- end }}

--- a/helm/charts/infra/charts/server/templates/deployment.yaml
+++ b/helm/charts/infra/charts/server/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - name: conf
               mountPath: /etc/infrahq
               readOnly: true
-{{- if .Values.persistentVolumeClaim.enabled }}
+{{- if .Values.persistence.enabled }}
             - name: data
               mountPath: /var/lib/infrahq/server
 {{- end }}
@@ -84,7 +84,7 @@ spec:
         - name: conf
           configMap:
             name: {{ include "server.fullname" . }}
-{{- if .Values.persistentVolumeClaim.enabled }}
+{{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "server.fullname" . }}

--- a/helm/charts/infra/charts/server/templates/persistentvolumeclaim.yaml
+++ b/helm/charts/infra/charts/server/templates/persistentvolumeclaim.yaml
@@ -1,21 +1,21 @@
-{{- if .Values.persistentVolumeClaim.enabled }}
+{{- if .Values.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "server.fullname" . }}
   labels:
 {{- include "server.labels" . | nindent 4 }}
-{{- if .Values.persistentVolumeClaim.labels }}
-{{- toYaml .Values.persistentVolumeClaim.labels | nindent 4 }}
+{{- if .Values.persistence.labels }}
+{{- toYaml .Values.persistence.labels | nindent 4 }}
 {{- end }}
   annotations:
-{{- toYaml .Values.persistentVolumeClaim.annotations | nindent 4 }}
+{{- toYaml .Values.persistence.annotations | nindent 4 }}
 spec:
-{{- if .Values.persistentVolumeClaim.className }}
-  storageClassName: {{ .Values.persistentVolumeClaim.className | quote }}
+{{- if .Values.persistence.className }}
+  storageClassName: {{ .Values.persistence.className | quote }}
 {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:
-{{- toYaml .Values.persistentVolumeClaim.resources | nindent 6 }}
+{{- toYaml .Values.persistence.resources | nindent 6 }}
 {{- end }}

--- a/helm/charts/infra/charts/server/values.yaml
+++ b/helm/charts/infra/charts/server/values.yaml
@@ -264,22 +264,22 @@ ingress:
   #   hosts:
   #     - infra.example.com
 
-## Server persistent volume claim configurations
-persistentVolumeClaim:
+## Server persistence configurations
+persistence:
 
-  ## Enable server persistent volume claim
+  ## Enable server persistence
   enabled: true
 
-  ## Persistent volume claim labels
+  ## persistence labels
   labels: {}
 
-  ## Persistent volume claim annotations
+  ## persistence annotations
   annotations: {}
 
   ## Name of the storage controller that will implement this resource
   className: ""
 
-  ## Resource requests and limits for the persistent volume claim
+  ## Resource requests and limits for the persistence
   resources:
     requests:
       storage: 2Gi

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -310,22 +310,22 @@ server:
     #   hosts:
     #     - infra.example.com
 
-  ## Server persistent volume claim configurations
-  persistentVolumeClaim:
+  ## Server persistence configurations
+  persistence:
 
-    ## Enable server persistent volume claim
+    ## Enable server persistence
     enabled: true
 
-    ## Persistent volume claim labels
+    ## persistence labels
     labels: {}
 
-    ## Persistent volume claim annotations
+    ## persistence annotations
     annotations: {}
 
     ## Name of the storage controller that will implement this resource
     className: ""
 
-    ## Resource requests and limits for the persistent volume claim
+    ## Resource requests and limits for the persistence
     resources:
       requests:
         storage: 2Gi
@@ -618,22 +618,22 @@ engine:
     #   hosts:
     #     - infra.example.com
 
-  ## Engine persistent volume claim configurations
-  persistentVolumeClaim:
+  ## Engine persistence configurations
+  persistence:
 
-    ## Enable server persistent volume claim
+    ## Enable server persistence
     enabled: true
 
-    ## Persistent volume claim labels
+    ## persistence labels
     labels: {}
 
-    ## Persistent volume claim annotations
+    ## persistence annotations
     annotations: {}
 
     ## Name of the storage controller that will implement this resource
     className: ""
 
-    ## Resource requests and limits for the persistent volume claim
+    ## Resource requests and limits for the persistence
     resources:
       requests:
         storage: 2Gi


### PR DESCRIPTION
<!-- Include a summary of the change and/or why it's necessary. -->

while `persistentVolumeClaim` is the resource backing persistence, it's not a descriptor of the configuration value. another candidate is `persistentVolume`

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #
