### PR TITLE
Machine Access Key Authentication 🔑 

### DIFF
--- a/docker-desktop.yaml.in
+++ b/docker-desktop.yaml.in
@@ -14,6 +14,9 @@ server:
     - group: Everyone
       role: cluster-admin
       resource: kubernetes.docker-desktop
+    - machine: admin
+      role: cluster-admin
+      resource: kubernetes.docker-desktop
 
 engine:
   config:

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -44,8 +44,8 @@ func GetGroup(c *gin.Context, id uid.ID) (*models.Group, error) {
 }
 
 func ListUserGroups(c *gin.Context, userID uid.ID) ([]models.Group, error) {
-	db, err := requireAuthorizationWithCheck(c, PermissionGroupRead, func(user *models.User) bool {
-		return userID == user.ID
+	db, err := requireAuthorizationWithCheck(c, PermissionGroupRead, func(id uid.ID) bool {
+		return userID == id
 	})
 	if err != nil {
 		return nil, err

--- a/internal/access/machine.go
+++ b/internal/access/machine.go
@@ -18,6 +18,20 @@ const (
 	PermissionMachineDelete Permission = "infra.machine.delete"
 )
 
+func CurrentMachine(c *gin.Context) *models.Machine {
+	machineObj, exists := c.Get("machine")
+	if !exists {
+		return nil
+	}
+
+	machine, ok := machineObj.(*models.Machine)
+	if !ok {
+		return nil
+	}
+
+	return machine
+}
+
 func CreateMachine(c *gin.Context, machine *models.Machine) error {
 	db, err := requireAuthorization(c, PermissionMachineCreate)
 	if err != nil {
@@ -40,6 +54,15 @@ func CreateMachine(c *gin.Context, machine *models.Machine) error {
 	}
 
 	return nil
+}
+
+func GetMachine(c *gin.Context, id uid.ID) (*models.Machine, error) {
+	db, err := requireAuthorization(c, PermissionMachineRead)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.GetMachine(db, data.ByID(id))
 }
 
 func ListMachines(c *gin.Context, name string) ([]models.Machine, error) {

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -165,7 +165,7 @@ func ExchangeAuthCodeForAccessKey(c *gin.Context, code string, provider *models.
 	}
 
 	token := &models.AccessKey{
-		UserID:    user.ID,
+		IssuedFor: user.PolymorphicIdentifier(),
 		ExpiresAt: time.Now().Add(sessionDuration),
 	}
 

--- a/internal/access/token.go
+++ b/internal/access/token.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 const (
@@ -16,17 +17,33 @@ const (
 
 func CreateUserToken(c *gin.Context) (token *models.Token, err error) {
 	user := CurrentUser(c)
-
 	if user == nil {
 		return nil, fmt.Errorf("no active user")
 	}
 
-	db, err := requireAuthorizationWithCheck(c, PermissionTokenCreate, func(currentUser *models.User) bool {
-		return currentUser.ID == user.ID
+	db, err := requireAuthorizationWithCheck(c, PermissionTokenCreate, func(id uid.ID) bool {
+		return user.ID == id
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return data.CreateToken(db, user.ID)
+	return data.CreateUserToken(db, user.ID)
+}
+
+func CreateMachineToken(c *gin.Context) (token *models.Token, err error) {
+	machine := CurrentMachine(c)
+
+	if machine == nil {
+		return nil, fmt.Errorf("no active machine")
+	}
+
+	db, err := requireAuthorizationWithCheck(c, PermissionTokenCreate, func(id uid.ID) bool {
+		return machine.ID == id
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return data.CreateMachineToken(db, machine.ID)
 }

--- a/internal/access/user.go
+++ b/internal/access/user.go
@@ -37,10 +37,10 @@ func CurrentUser(c *gin.Context) *models.User {
 }
 
 func GetUser(c *gin.Context, id uid.ID) (*models.User, error) {
-	db, err := requireAuthorizationWithCheck(c, PermissionUserRead, func(currentUser *models.User) bool {
+	db, err := requireAuthorizationWithCheck(c, PermissionUserRead, func(tokenUserID uid.ID) bool {
 		// current user is allowed to fetch their own record,
 		// even without the infra.users.read permission
-		return currentUser.ID == id
+		return tokenUserID == id
 	})
 	if err != nil {
 		return nil, err
@@ -74,9 +74,7 @@ func CreateUser(c *gin.Context, user *models.User) error {
 }
 
 func ListUsers(c *gin.Context, email string, providerID uid.ID) ([]models.User, error) {
-	db, err := requireAuthorizationWithCheck(c, PermissionUserRead, func(currentUser *models.User) bool {
-		return currentUser.Email == email
-	})
+	db, err := requireAuthorization(c, PermissionUserRead)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/access_key.go
+++ b/internal/api/access_key.go
@@ -6,26 +6,33 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-// InfraAccessKey struct for InfraAccessKey
 type AccessKey struct {
-	ID          uid.ID    `json:"id"`
-	Created     time.Time `json:"created"`
-	Expires     time.Time `json:"expires,omitempty"`
-	Name        string    `json:"name"`
-	Permissions []string  `json:"permissions"`
+	ID                uid.ID            `json:"id"`
+	Created           time.Time         `json:"created"`
+	Name              string            `json:"name"`
+	IssuedFor         uid.PolymorphicID `json:"issuedFor"`
+	Expires           time.Time         `json:"expires,omitempty"`
+	ExtensionDeadline time.Time         `json:"extensionDeadline"`
+}
+
+type ListAccessKeysRequest struct {
+	MachineID uid.ID `form:"machineID"`
+	Name      string `form:"name"`
 }
 
 type CreateAccessKeyRequest struct {
-	Name        string        `json:"name"`
-	Permissions []string      `json:"permissions"`
-	Ttl         time.Duration `json:"ttl,omitempty"`
+	MachineID         uid.ID `json:"machineID" validate:"required"`
+	Name              string `json:"name"`
+	TTL               string `json:"ttl"`                         // maximum time valid
+	ExtensionDeadline string `json:"extensionDeadline,omitempty"` // the access key must be used within this amount of time to renew validity
 }
 
 type CreateAccessKeyResponse struct {
-	AccessKey   string    `json:"access-key"`
-	ID          uid.ID    `json:"id"`
-	Created     time.Time `json:"created"`
-	Expires     time.Time `json:"expires,omitempty"`
-	Name        string    `json:"name"`
-	Permissions []string  `json:"permissions"`
+	ID                uid.ID            `json:"id"`
+	Created           time.Time         `json:"created"`
+	Name              string            `json:"name"`
+	IssuedFor         uid.PolymorphicID `json:"issuedFor"`
+	Expires           time.Time         `json:"expires"`           // after this deadline the key is no longer valid
+	ExtensionDeadline time.Time         `json:"extensionDeadline"` // the key must be used by this time to remain valid
+	AccessKey         string            `json:"accessKey"`
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -247,7 +247,7 @@ func (c Client) DeleteProvider(id uid.ID) error {
 }
 
 func (c Client) ListGrants(req ListGrantsRequest) ([]Grant, error) {
-	return list[Grant](c, "/v1/grants", map[string]string{"resource": req.Resource, "identity": req.Identity, "privilege": req.Privilege})
+	return list[Grant](c, "/v1/grants", map[string]string{"resource": req.Resource, "identity": string(req.Identity), "privilege": req.Privilege})
 }
 
 func (c Client) CreateGrant(req *CreateGrantRequest) (*Grant, error) {
@@ -270,8 +270,24 @@ func (c Client) DeleteDestination(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/v1/destinations/%s", id))
 }
 
+func (c Client) Introspect() (*Introspect, error) {
+	return get[Introspect](c, "/v1/introspect")
+}
+
 func (c Client) CreateAccessKey(req *CreateAccessKeyRequest) (*CreateAccessKeyResponse, error) {
 	return post[CreateAccessKeyRequest, CreateAccessKeyResponse](c, "/v1/access-keys", req)
+}
+
+func (c Client) ListAccessKeys(req ListAccessKeysRequest) ([]AccessKey, error) {
+	return list[AccessKey](c, "/v1/access-keys", map[string]string{"machineID": req.MachineID.String(), "name": req.Name})
+}
+
+func (c Client) DeleteAccessKey(id uid.ID) error {
+	return delete(c, fmt.Sprintf("/v1/access-keys/%s", id))
+}
+
+func (c Client) GetMachine(id uid.ID) (*Machine, error) {
+	return get[Machine](c, fmt.Sprintf("/v1/machines/%s", id))
 }
 
 func (c Client) CreateMachine(req *CreateMachineRequest) (*Machine, error) {
@@ -284,6 +300,10 @@ func (c Client) ListMachines(req ListMachinesRequest) ([]Machine, error) {
 
 func (c Client) DeleteMachine(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/v1/machines/%s", id))
+}
+
+func (c Client) ListMachineGrants(id uid.ID) ([]Grant, error) {
+	return list[Grant](c, fmt.Sprintf("/v1/machines/%s/grants", id), nil)
 }
 
 func (c Client) CreateToken(req *CreateTokenRequest) (*CreateTokenResponse, error) {

--- a/internal/api/grant.go
+++ b/internal/api/grant.go
@@ -11,21 +11,21 @@ type Grant struct {
 	CreatedBy uid.ID `json:"created_by"` // id of user who created the grant
 	Updated   int64  `json:"updated"`    // updated time in seconds since 1970-01-01 00:00:00 UTC
 
-	Identity  string `json:"identity"`  // format is "u:<idstr>" for users, "g:<idstr>" for groups
-	Privilege string `json:"privilege"` // role or permission
-	Resource  string `json:"resource"`  // Universal Resource Notation
+	Identity  uid.PolymorphicID `json:"identity"`
+	Privilege string            `json:"privilege"` // role or permission
+	Resource  string            `json:"resource"`  // Universal Resource Notation
 
 	ExpiresAt *int64 `json:"expires_at"` // time this grant expires at in seconds since 1970-01-01 00:00:00 UTC
 }
 
 type ListGrantsRequest struct {
-	Identity  string `form:"identity"`
-	Resource  string `form:"resource"`
-	Privilege string `form:"privilege"`
+	Identity  uid.PolymorphicID `form:"identity"`
+	Resource  string            `form:"resource"`
+	Privilege string            `form:"privilege"`
 }
 
 type CreateGrantRequest struct {
-	Identity  string `json:"identity" validate:"required"`
-	Resource  string `json:"resource" validate:"required"`
-	Privilege string `json:"privilege" validate:"required"`
+	Identity  uid.PolymorphicID `json:"identity" validate:"required"`
+	Resource  string            `json:"resource" validate:"required"`
+	Privilege string            `json:"privilege" validate:"required"`
 }

--- a/internal/api/introspect.go
+++ b/internal/api/introspect.go
@@ -1,0 +1,10 @@
+package api
+
+import "github.com/infrahq/infra/uid"
+
+// Introspect returns information about the party that the calling token was issued for
+type Introspect struct {
+	ID           uid.ID `json:"id"`
+	Name         string `json:"name"`         // the machine name or the user email
+	IdentityType string `json:"identityType"` // user or machine
+}

--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -1,7 +1,8 @@
 package claims
 
 type Custom struct {
-	Email  string   `json:"email" validate:"required"`
-	Groups []string `json:"groups" validate:"required"`
-	Nonce  string   `json:"nonce" validate:"required"`
+	Email   string   `json:"email" validate:"required_without=Machine,excluded_with=Machine"`
+	Machine string   `json:"machine" validate:"required_without=Email,excluded_with=User,excluded_with=Group"`
+	Groups  []string `json:"groups" validate:"excluded_with=Machine"`
+	Nonce   string   `json:"nonce" validate:"required"`
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -18,13 +18,14 @@ type ClientConfig struct {
 
 // current: v0.3
 type ClientHostConfig struct {
-	ID            uid.ID `json:"id"`
-	Name          string `json:"name"`
-	Host          string `json:"host"`
-	Token         string `json:"token,omitempty"`
-	SkipTLSVerify bool   `json:"skip-tls-verify"` // where is the other cert info stored?
-	ProviderID    uid.ID `json:"provider-id"`
-	Current       bool   `json:"current"`
+	ID            uid.ID            `json:"id"`
+	PolymorphicID uid.PolymorphicID `json:"polymorphic-id"`
+	Name          string            `json:"name"`
+	Host          string            `json:"host"`
+	Token         string            `json:"token,omitempty"`
+	SkipTLSVerify bool              `json:"skip-tls-verify"` // where is the other cert info stored?
+	ProviderID    uid.ID            `json:"provider-id"`
+	Current       bool              `json:"current"`
 }
 
 //lint:ignore ST1005, user facing error

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/infrahq/infra/internal/api"
+	"github.com/spf13/cobra"
+)
+
+type keyCreateOptions struct {
+	TTL               string `mapstructure:"ttl"`
+	ExtensionDeadline string `mapstructure:"extension-deadline"`
+}
+
+func newKeysCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create [ACCESS_KEY_NAME] [MACHINE_NAME]",
+		Short: "Create an access key for authentication",
+		Example: `
+# Create an access key for the machine "wall-e" called main that expires in 12 hours and must be used every hour to remain valid
+infra keys create main wall-e 12h --extension-deadline=1h
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var options keyCreateOptions
+			if err := parseOptions(cmd, &options, "INFRA_KEYS"); err != nil {
+				return err
+			}
+
+			keyName := args[0]
+			machineName := args[1]
+
+			client, err := defaultAPIClient()
+			if err != nil {
+				return err
+			}
+
+			machine, err := getMachineFromName(client, machineName)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.CreateAccessKey(&api.CreateAccessKeyRequest{MachineID: machine.ID, Name: keyName, TTL: options.TTL, ExtensionDeadline: options.ExtensionDeadline})
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("key: %s \n", resp.AccessKey)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("ttl", "t", "", "The total time that an access key will be valid for")
+	cmd.Flags().StringP("extension-deadline", "e", "", "A specified deadline that an access key must be used within to remain valid")
+
+	return cmd
+}
+
+func newKeysDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete [ACCESS_KEY_NAME]",
+		Short: "Delete access keys",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := defaultAPIClient()
+			if err != nil {
+				return err
+			}
+
+			keys, err := client.ListAccessKeys(api.ListAccessKeysRequest{Name: args[0]})
+			if err != nil {
+				return err
+			}
+
+			if len(keys) == 0 {
+				return fmt.Errorf("no access key found with this name")
+			}
+
+			if len(keys) != 1 {
+				return fmt.Errorf("invalid access key response, there should only be one access key that matches a name, but multiple were found")
+			}
+
+			err = client.DeleteAccessKey(keys[0].ID)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}
+
+type keyListOptions struct {
+	MachineName string `mapstructure:"machine"`
+}
+
+func newKeysListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List access keys",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var options keyListOptions
+			if err := parseOptions(cmd, &options, "INFRA_KEYS"); err != nil {
+				return err
+			}
+
+			client, err := defaultAPIClient()
+			if err != nil {
+				return err
+			}
+
+			var keys []api.AccessKey
+			if options.MachineName != "" {
+				machine, err := getMachineFromName(client, options.MachineName)
+				if err != nil {
+					return err
+				}
+
+				keys, err = client.ListAccessKeys(api.ListAccessKeysRequest{MachineID: machine.ID})
+				if err != nil {
+					return err
+				}
+			} else {
+				keys, err = client.ListAccessKeys(api.ListAccessKeysRequest{})
+				if err != nil {
+					return err
+				}
+			}
+
+			type row struct {
+				ID                string `header:"ID"`
+				Name              string `header:"NAME"`
+				IssuedFor         string `header:"ISSUED FOR"`
+				Created           string `header:"CREATED"`
+				Expires           string `header:"EXPIRES"`
+				ExtensionDeadline string `header:"EXTENSION DEADLINE"`
+			}
+
+			var rows []row
+			for _, k := range keys {
+				rows = append(rows, row{
+					ID:                k.ID.String(),
+					Name:              k.Name,
+					IssuedFor:         string(k.IssuedFor),
+					Created:           k.Created.String(),
+					Expires:           k.Expires.String(),
+					ExtensionDeadline: k.ExtensionDeadline.String(),
+				})
+			}
+
+			printTable(rows)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("machine", "m", "", "The name of a machine to list access keys for")
+
+	return cmd
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,8 +105,9 @@ func Import(c *api.Client, config Config, replace bool) error {
 			}
 		}
 
-		// create user if it doesn't exist
-		var identityID string
+		// create identifier if it doesn't exist
+		var identityID uid.PolymorphicID
+
 		if g.User != "" {
 			users, err := c.ListUsers(api.ListUsersRequest{Email: g.User})
 			if err != nil {
@@ -126,7 +127,7 @@ func Import(c *api.Client, config Config, replace bool) error {
 				user = &users[0]
 			}
 
-			identityID = "u:" + user.ID.String()
+			identityID = uid.NewUserPolymorphicID(user.ID)
 		}
 
 		// create group if it doesn't exist
@@ -149,12 +150,12 @@ func Import(c *api.Client, config Config, replace bool) error {
 				group = &groups[0]
 			}
 
-			identityID = "g:" + group.ID.String()
+			identityID = uid.NewGroupPolymorphicID(group.ID)
 		}
 
 		// create machine if it doesn't exist
 		if g.Machine != "" {
-			machines, err := c.ListMachines(api.ListMachinesRequest{g.Machine})
+			machines, err := c.ListMachines(api.ListMachinesRequest{Name: g.Machine})
 			if err != nil {
 				return fmt.Errorf("error importing grant: %w", err)
 			}
@@ -171,7 +172,7 @@ func Import(c *api.Client, config Config, replace bool) error {
 				machine = &machines[0]
 			}
 
-			identityID = "m:" + machine.ID.String()
+			identityID = uid.NewMachinePolymorphicID(machine.ID)
 		}
 
 		// create grant if it doesn't exist

--- a/internal/context.go
+++ b/internal/context.go
@@ -2,6 +2,8 @@ package internal
 
 type HttpContextKeyEmail struct{}
 
+type HttpContextKeyMachine struct{}
+
 type HttpContextKeyGroups struct{}
 
 type HttpContextKeyDestination struct{}

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -19,11 +19,18 @@ func GetGrant(db *gorm.DB, selectors ...SelectorFunc) (*models.Grant, error) {
 }
 
 func ListUserGrants(db *gorm.DB, userID uid.ID) (result []models.Grant, err error) {
-	return list[models.Grant](db, ByIdentityUserID(userID))
+	polymorphicID := uid.NewUserPolymorphicID(userID)
+	return ListGrants(db, ByIdentity(polymorphicID))
+}
+
+func ListMachineGrants(db *gorm.DB, machineID uid.ID) (result []models.Grant, err error) {
+	polymorphicID := uid.NewMachinePolymorphicID(machineID)
+	return ListGrants(db, ByIdentity(polymorphicID))
 }
 
 func ListGroupGrants(db *gorm.DB, groupID uid.ID) (result []models.Grant, err error) {
-	return list[models.Grant](db, ByIdentityGroupID(groupID))
+	polymorphicID := uid.NewGroupPolymorphicID(groupID)
+	return ListGrants(db, ByIdentity(polymorphicID))
 }
 
 func ListGrants(db *gorm.DB, selectors ...SelectorFunc) ([]models.Grant, error) {
@@ -44,7 +51,7 @@ func DeleteGrants(db *gorm.DB, selectors ...SelectorFunc) error {
 	return deleteAll[models.Grant](db, ByIDs(ids))
 }
 
-func Can(db *gorm.DB, identity, privilege, resource string) (bool, error) {
+func Can(db *gorm.DB, identity uid.PolymorphicID, privilege, resource string) (bool, error) {
 	grants, err := list[models.Grant](db, ByIdentity(identity), ByPrivilege(privilege), ByResource(resource))
 	if err != nil {
 		return false, err

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 var tom = &models.User{Email: "tom@infrahq.com"}
@@ -16,19 +17,19 @@ func TestBasicGrant(t *testing.T) {
 	err := CreateUser(db, tom)
 	require.NoError(t, err)
 
-	grant(t, db, tom, "steven", "read", "infra.groups.1")
+	grant(t, db, tom, "u:steven", "read", "infra.groups.1")
 
-	can(t, db, "steven", "read", "infra.groups.1")
-	cant(t, db, "steven", "read", "infra.groups.2")
-	cant(t, db, "steven", "write", "infra.groups.1")
+	can(t, db, "u:steven", "read", "infra.groups.1")
+	cant(t, db, "u:steven", "read", "infra.groups.2")
+	cant(t, db, "u:steven", "write", "infra.groups.1")
 
-	grant(t, db, tom, "steven", "read", "infra.groups.*")
-	can(t, db, "steven", "read", "infra.groups.1")
-	can(t, db, "steven", "read", "infra.groups.2")
-	cant(t, db, "steven", "write", "infra.groups.1")
+	grant(t, db, tom, "u:steven", "read", "infra.groups.*")
+	can(t, db, "u:steven", "read", "infra.groups.1")
+	can(t, db, "u:steven", "read", "infra.groups.2")
+	cant(t, db, "u:steven", "write", "infra.groups.1")
 }
 
-func grant(t *testing.T, db *gorm.DB, currentUser *models.User, identity, privilege, resource string) {
+func grant(t *testing.T, db *gorm.DB, currentUser *models.User, identity uid.PolymorphicID, privilege, resource string) {
 	err := CreateGrant(db, &models.Grant{
 		Identity:  identity,
 		Privilege: privilege,
@@ -38,13 +39,13 @@ func grant(t *testing.T, db *gorm.DB, currentUser *models.User, identity, privil
 	require.NoError(t, err)
 }
 
-func can(t *testing.T, db *gorm.DB, identity, privilege, resource string) {
+func can(t *testing.T, db *gorm.DB, identity uid.PolymorphicID, privilege, resource string) {
 	canAccess, err := Can(db, identity, privilege, resource)
 	require.NoError(t, err)
 	require.True(t, canAccess)
 }
 
-func cant(t *testing.T, db *gorm.DB, identity, privilege, resource string) {
+func cant(t *testing.T, db *gorm.DB, identity uid.PolymorphicID, privilege, resource string) {
 	canAccess, err := Can(db, identity, privilege, resource)
 	require.NoError(t, err)
 	require.False(t, canAccess)

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -47,7 +47,7 @@ func DeleteGroups(db *gorm.DB, selectors ...SelectorFunc) error {
 	for _, g := range toDelete {
 		ids = append(ids, g.ID)
 
-		err := DeleteGrants(db, ByIdentityGroupID(g.ID))
+		err := DeleteGrants(db, ByIdentity(g.PolymorphicIdentifier()))
 		if err != nil {
 			return err
 		}

--- a/internal/server/data/machine.go
+++ b/internal/server/data/machine.go
@@ -11,6 +11,10 @@ func CreateMachine(db *gorm.DB, machine *models.Machine) error {
 	return add(db, machine)
 }
 
+func SaveMachine(db *gorm.DB, machine *models.Machine) error {
+	return save(db, machine)
+}
+
 func ListMachines(db *gorm.DB, selectors ...SelectorFunc) ([]models.Machine, error) {
 	return list[models.Machine](db, selectors...)
 }

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -76,33 +76,23 @@ func ByURL(url string) SelectorFunc {
 	}
 }
 
-func ByIdentity(identity string) SelectorFunc {
+func ByIdentity(polymorphicID uid.PolymorphicID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
-		if identity == "" {
+		if polymorphicID == "" {
 			return db
 		}
 
-		return db.Where("identity = ?", identity)
+		return db.Where("identity = ?", string(polymorphicID))
 	}
 }
 
-func ByIdentityUserID(userID uid.ID) SelectorFunc {
+func ByMachineIDIssuedFor(machineID uid.ID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
-		if userID == 0 {
+		if machineID == 0 {
 			return db
 		}
 
-		return db.Where("identity = ?", "u:"+userID.String())
-	}
-}
-
-func ByIdentityGroupID(groupID uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		if groupID == 0 {
-			return db
-		}
-
-		return db.Where("identity = ?", "g:"+groupID.String())
+		return db.Where("issued_for = ?", "m:"+machineID.String())
 	}
 }
 

--- a/internal/server/data/token_test.go
+++ b/internal/server/data/token_test.go
@@ -19,8 +19,25 @@ func createAccessKey(t *testing.T, db *gorm.DB, sessionDuration time.Duration) (
 	require.NoError(t, err)
 
 	token := &models.AccessKey{
-		UserID:    user.ID,
+		IssuedFor: user.PolymorphicIdentifier(),
 		ExpiresAt: time.Now().Add(sessionDuration),
+	}
+
+	body, err := CreateAccessKey(db, token)
+	require.NoError(t, err)
+
+	return body, token
+}
+
+func createAccessKeyWithExtensionDeadline(t *testing.T, db *gorm.DB, ttl, exensionDeadline time.Duration) (string, *models.AccessKey) {
+	machine := &models.Machine{Name: "Wall-E"}
+	err := CreateMachine(db, machine)
+	require.NoError(t, err)
+
+	token := &models.AccessKey{
+		IssuedFor:         machine.PolymorphicIdentifier(),
+		ExpiresAt:         time.Now().Add(ttl),
+		ExtensionDeadline: time.Now().Add(exensionDeadline),
 	}
 
 	body, err := CreateAccessKey(db, token)
@@ -33,13 +50,13 @@ func TestCheckAccessKeySecret(t *testing.T) {
 	db := setup(t)
 	body, _ := createAccessKey(t, db, time.Hour*5)
 
-	_, err := LookupAccessKey(db, body)
+	_, err := ValidateAccessKey(db, body)
 	require.NoError(t, err)
 
 	random := generate.MathRandom(models.AccessKeySecretLength)
 	authorization := fmt.Sprintf("%s.%s", strings.Split(body, ".")[0], random)
 
-	_, err = LookupAccessKey(db, authorization)
+	_, err = ValidateAccessKey(db, authorization)
 	require.EqualError(t, err, "access key invalid secret")
 }
 
@@ -64,6 +81,14 @@ func TestCheckAccessKeyExpired(t *testing.T) {
 	db := setup(t)
 	body, _ := createAccessKey(t, db, -1*time.Hour)
 
-	_, err := LookupAccessKey(db, body)
+	_, err := ValidateAccessKey(db, body)
 	require.EqualError(t, err, "token expired")
+}
+
+func TestCheckAccessKeyPastExtensionDeadline(t *testing.T) {
+	db := setup(t)
+	body, _ := createAccessKeyWithExtensionDeadline(t, db, 1*time.Hour, -1*time.Hour)
+
+	_, err := ValidateAccessKey(db, body)
+	require.EqualError(t, err, "token extension deadline exceeded")
 }

--- a/internal/server/data/user.go
+++ b/internal/server/data/user.go
@@ -39,7 +39,7 @@ func DeleteUsers(db *gorm.DB, selectors ...SelectorFunc) error {
 	for _, u := range toDelete {
 		ids = append(ids, u.ID)
 
-		err := DeleteGrants(db, ByIdentityUserID(u.ID))
+		err := DeleteGrants(db, ByIdentity(u.PolymorphicIdentifier()))
 		if err != nil {
 			return err
 		}

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -14,12 +14,12 @@ var (
 // AccessKey is a session token presented to the Infra server as proof of authentication
 type AccessKey struct {
 	Model
-	Name      string // optional name
-	UserID    uid.ID
-	ExpiresAt time.Time
+	Name      string            `gorm:"uniqueIndex:,where:deleted_at is NULL"`
+	IssuedFor uid.PolymorphicID `validate:"required"`
 
-	// TODO: remove me with machine identities
-	Permissions string
+	ExpiresAt         time.Time     `validate:"required"`
+	Extension         time.Duration // how long to increase the lifetime extension deadline by
+	ExtensionDeadline time.Time
 
 	Key            string `gorm:"<-;uniqueIndex:,where:deleted_at is NULL"`
 	Secret         string `gorm:"-"`

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -28,9 +28,9 @@ import (
 type Grant struct {
 	Model
 
-	Identity  string `validate:"required"` // polymorphic reference. Format is "u:<idstr>" for users, "g:<idstr>" for groups, "m:<idstr>" for machines
-	Privilege string `validate:"required"` // role or permission
-	Resource  string `validate:"required"` // Universal Resource Notation
+	Identity  uid.PolymorphicID `validate:"required"`
+	Privilege string            `validate:"required"` // role or permission
+	Resource  string            `validate:"required"` // Universal Resource Notation
 
 	CreatedBy uid.ID
 
@@ -59,7 +59,7 @@ func (r *Grant) ToAPI() api.Grant {
 	return result
 }
 
-func (g *Grant) Matches(identity, privilege, resource string) bool {
+func (g *Grant) Matches(identity uid.PolymorphicID, privilege, resource string) bool {
 	if identity != g.Identity {
 		return false
 	}

--- a/internal/server/models/group.go
+++ b/internal/server/models/group.go
@@ -24,3 +24,7 @@ func (g *Group) ToAPI() *api.Group {
 		ProviderID: g.ProviderID,
 	}
 }
+
+func (g *Group) PolymorphicIdentifier() uid.PolymorphicID {
+	return uid.NewGroupPolymorphicID(g.ID)
+}

--- a/internal/server/models/machine.go
+++ b/internal/server/models/machine.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/api"
+	"github.com/infrahq/infra/uid"
 )
 
 type Machine struct {
@@ -46,4 +47,8 @@ func (m *Machine) FromAPI(from interface{}) error {
 	}
 
 	return fmt.Errorf("%w: unknown request", internal.ErrBadRequest)
+}
+
+func (m *Machine) PolymorphicIdentifier() uid.PolymorphicID {
+	return uid.NewMachinePolymorphicID(m.ID)
 }

--- a/internal/server/models/user.go
+++ b/internal/server/models/user.go
@@ -33,3 +33,7 @@ func (u *User) ToAPI() *api.User {
 
 	return result
 }
+
+func (u *User) PolymorphicIdentifier() uid.PolymorphicID {
+	return uid.NewUserPolymorphicID(u.ID)
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -37,7 +37,15 @@ func (a *API) registerRoutes(router *gin.RouterGroup) {
 
 		get(authorized, "/machines", a.ListMachines)
 		post(authorized, "/machines", a.CreateMachine)
+		get(authorized, "/machines/:id", a.GetMachine)
 		delete(authorized, "/machines/:id", a.DeleteMachine)
+		get(authorized, "/machines/:id/grants", a.ListMachineGrants)
+
+		get(authorized, "/access-keys", a.ListAccessKeys)
+		post(authorized, "/access-keys", a.CreateAccessKey)
+		delete(authorized, "/access-keys/:id", a.DeleteAccessKey)
+
+		get(authorized, "/introspect", a.Introspect)
 
 		get(authorized, "/groups", a.ListGroups)
 		post(authorized, "/groups", a.CreateGroup)
@@ -60,10 +68,6 @@ func (a *API) registerRoutes(router *gin.RouterGroup) {
 		delete(authorized, "/destinations/:id", a.DeleteDestination)
 
 		post(authorized, "/tokens", a.CreateToken)
-
-		get(authorized, "/access-keys", a.ListAccessKeys)
-		post(authorized, "/access-keys", a.CreateAccessKey)
-		delete(authorized, "/access-keys/:id", a.DeleteAccessKey)
 
 		post(authorized, "/logout", a.Logout)
 	}

--- a/uid/polymorphic.go
+++ b/uid/polymorphic.go
@@ -1,0 +1,42 @@
+package uid
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PolymorphicID is a reference of the format "u:<idstr>" for users, "m:<idstr>" for machines, and "g:<idstr>" for groups
+type PolymorphicID string
+
+func (p PolymorphicID) ID() (ID, error) {
+	id := string(p)[2:]
+	return ParseString(id)
+}
+
+func (p PolymorphicID) IsMachine() bool {
+	return strings.HasPrefix(string(p), "m:")
+}
+
+func (p PolymorphicID) IsUser() bool {
+	return strings.HasPrefix(string(p), "u:")
+}
+
+func (p PolymorphicID) IsGroup() bool {
+	return strings.HasPrefix(string(p), "g:")
+}
+
+func NewMachinePolymorphicID(id ID) PolymorphicID {
+	return newPolymorphicID("m", id)
+}
+
+func NewUserPolymorphicID(id ID) PolymorphicID {
+	return newPolymorphicID("u", id)
+}
+
+func NewGroupPolymorphicID(id ID) PolymorphicID {
+	return newPolymorphicID("g", id)
+}
+
+func newPolymorphicID(prefix string, id ID) PolymorphicID {
+	return PolymorphicID(fmt.Sprintf("%s:%s", prefix, id))
+}

--- a/uid/polymorphic_test.go
+++ b/uid/polymorphic_test.go
@@ -1,0 +1,30 @@
+package uid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolyMorphicIDToSnowflakeID(t *testing.T) {
+	mID := New()
+	mPID := NewMachinePolymorphicID(mID)
+	fromMachinePID, err := mPID.ID()
+	assert.NoError(t, err)
+
+	assert.Equal(t, mID, fromMachinePID)
+
+	uID := New()
+	uPID := NewUserPolymorphicID(uID)
+	fromUserPID, err := uPID.ID()
+	assert.NoError(t, err)
+
+	assert.Equal(t, uID, fromUserPID)
+
+	gID := New()
+	gPID := NewGroupPolymorphicID(gID)
+	fromGroupPID, err := gPID.ID()
+	assert.NoError(t, err)
+
+	assert.Equal(t, gID, fromGroupPID)
+}

--- a/uid/snowflake.go
+++ b/uid/snowflake.go
@@ -51,6 +51,10 @@ func ParseString(s string) (ID, error) {
 	return Parse([]byte(s))
 }
 
+func ParsePolymorphicID(pid PolymorphicID) (ID, error) {
+	return ParseString(string(pid))
+}
+
 func (u *ID) UnmarshalText(b []byte) error {
 	id, err := Parse(b)
 	if err != nil {


### PR DESCRIPTION
<!-- Include a summary of the change and/or why it's necessary. -->
Allow machines to authentication using an access key, this means machines can access destinations if they have a grant.

This change removes API access keys as a top level concept. Now an access key must be bound to a machine identity.

(gonna be a few structural changes  to the CLI commands after I rebase main into this, but nothing too big)
<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


- [x] Add a credential based authentication mechanism (currently only for machines)
- [x] Bind this credential to a machine identity
- [x] Login via presentation of credential at `/v1/login`
- [x] Login  via presentation of credential in the CLI
- [x] Update root, and engine connections to be credential based rather than API keys
- [x] GET /v1/machines/{ID}/keys
- [x] POST /v1/machines/{ID}/keys
- [x] DELETE /v1/machines/{ID}/keys/{ID}

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #851
