### PR TITLE
fix(server): elevate metrics middleware

### DIFF
--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -16,7 +16,7 @@ var requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:      "request_duration_seconds",
 	Help:      "A histogram of the duration, in seconds, handling HTTP requests.",
 	Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
-}, []string{"method", "handler", "status"})
+}, []string{"host", "method", "path", "status"})
 
 func SetupMetrics(db *gorm.DB) error {
 	promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -74,18 +74,17 @@ func AuthenticationMiddleware() gin.HandlerFunc {
 }
 
 // MetricsMiddleware wraps the request with a standard set of Prometheus metrics.
-// It has an additional responsibility of stripping out any unique identifiers as it will
-// drastically increase the cardinality, and cost, of produced metrics.
-func MetricsMiddleware(path string) gin.HandlerFunc {
+func MetricsMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		t := time.Now()
 
 		c.Next()
 
 		requestDuration.With(prometheus.Labels{
-			"method":  c.Request.Method,
-			"handler": path,
-			"status":  strconv.Itoa(c.Writer.Status()),
+			"host":   c.Request.Host,
+			"method": c.Request.Method,
+			"path":   c.FullPath(),
+			"status": strconv.Itoa(c.Writer.Status()),
 		}).Observe(time.Since(t).Seconds())
 	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -18,6 +18,7 @@ type (
 
 func (a *API) registerRoutes(router *gin.RouterGroup) {
 	router.Use(
+		MetricsMiddleware(),
 		RequestTimeoutMiddleware(),
 		DatabaseMiddleware(a.server.db),
 	)
@@ -80,7 +81,7 @@ func (a *API) registerRoutes(router *gin.RouterGroup) {
 }
 
 func get[Req, Res any](r *gin.RouterGroup, path string, handler ReqResHandlerFunc[Req, Res]) {
-	r.GET(path, MetricsMiddleware(path), func(c *gin.Context) {
+	r.GET(path, func(c *gin.Context) {
 		req := new(Req)
 		if err := bind(c, req); err != nil {
 			sendAPIError(c, fmt.Errorf("%w: %s", internal.ErrBadRequest, err))
@@ -100,7 +101,7 @@ func get[Req, Res any](r *gin.RouterGroup, path string, handler ReqResHandlerFun
 }
 
 func post[Req, Res any](r *gin.RouterGroup, path string, handler ReqResHandlerFunc[Req, Res]) {
-	r.POST(path, MetricsMiddleware(path), func(c *gin.Context) {
+	r.POST(path, func(c *gin.Context) {
 		req := new(Req)
 		if err := bind(c, req); err != nil {
 			sendAPIError(c, fmt.Errorf("%w: %s", internal.ErrBadRequest, err))
@@ -120,7 +121,7 @@ func post[Req, Res any](r *gin.RouterGroup, path string, handler ReqResHandlerFu
 }
 
 func put[Req, Res any](r *gin.RouterGroup, path string, handler ReqResHandlerFunc[Req, Res]) {
-	r.PUT(path, MetricsMiddleware(path), func(c *gin.Context) {
+	r.PUT(path, func(c *gin.Context) {
 		req := new(Req)
 		if err := bind(c, req); err != nil {
 			sendAPIError(c, fmt.Errorf("%w: %s", internal.ErrBadRequest, err))
@@ -140,7 +141,7 @@ func put[Req, Res any](r *gin.RouterGroup, path string, handler ReqResHandlerFun
 }
 
 func delete[Req any](r *gin.RouterGroup, path string, handler ReqHandlerFunc[Req]) {
-	r.DELETE(path, MetricsMiddleware(path), func(c *gin.Context) {
+	r.DELETE(path, func(c *gin.Context) {
 		req := new(Req)
 		if err := bind(c, req); err != nil {
 			sendAPIError(c, fmt.Errorf("%w: %s", internal.ErrBadRequest, err))


### PR DESCRIPTION
- metrics should be one of the first middlewares registered so any
  errors seen by later handlers can be exposed as metrics
- installing the metrics middleware as one of the last handlers negates much
  of the benefits of having a metrics middleware since it isn't able to catch
  errors like an unauthenticated request (raised in the AuthenticateionMiddleware)
- remove "handler", add "path" and "host"

<!-- Include a summary of the change and/or why it's necessary. -->

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #884 
