### PR TITLE
add docs on running infra server in docker

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,6 +23,31 @@
 go run .
 ```
 
+## Run Infra Server (Docker)
+
+### Setup
+
+* Install [Docker](https://docker.com/)
+  * (macOS, Windows) [Docker Desktop](https://www.docker.com/products/docker-desktop)
+  * (Linux) [Docker Engine](https://docs.docker.com/engine/install)
+
+### Steps
+
+1. Build or pull the Infra Docker image
+1. Generate an admin access key
+
+```bash
+randascii() { python -c "import random, string; print(''.join([random.choice(string.ascii_letters) for _ in range($1)]))"; }
+ADMIN_ACCESS_KEY=$(echo $(randascii 10).$(randascii 24))
+docker run -d -p 8080:80/tcp -p 8443:443/tcp --name infra-server infrahq/infra server --admin-access-key $ADMIN_ACCESS_KEY
+```
+
+1. Access the API server
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_ACCESS_KEY" localhost:8080/v1/users
+```
+
 ## Run a full local setup
 
 ### Setup


### PR DESCRIPTION
<!-- Include a summary of the change and/or why it's necessary. -->

It's possible to run infra in a container but it requires some bootstrapping, specifically configuring it enough to get access to privileged APIs

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #
