### PR TITLE
cli: show default host option

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -288,7 +288,7 @@ func promptHost(hosts []string) (string, error) {
 	if len(hosts) > 0 {
 
 		prompt := &survey.Select{
-			Message: defaultOpt,
+			Message: "Select an Infra host:",
 			Options: hosts,
 		}
 


### PR DESCRIPTION
<!-- Include a summary of the change and/or why it's necessary. -->
No matter what user types, "Connect to an infra host" will always be available to select. This behaviour would be okay because this default option would always be listed last. 

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

-  ~~Wrote appropriate unit tests~~
-  ~~Considered security implications of the change~~
-  ~~Updated associated docs where necessary~~
-  ~~Updated associated configuration where necessary~~
-  ~~Change is backwards compatible if it needs to be (user can upgrade without manual steps?)~~
- [x] Nothing sensitive logged


Resources:
- https://github.com/AlecAivazis/survey
- https://github.com/AlecAivazis/survey/issues/254 (not used)
<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #931
