### PR TITLE
fix(ci): use personal access token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           command: manifest
           config-file: .github/release-please.json
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   binaries:
     needs: release-please


### PR DESCRIPTION
Use infrahq-ci personal access token to trigger pull request workflows

See https://github.com/google-github-actions/release-please-action/issues/404 for more details