### PR TITLE
feat(engine): add prometheus metrics and service monitor

### DIFF
--- a/helm/charts/infra/charts/engine/templates/deployment.yaml
+++ b/helm/charts/infra/charts/engine/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm/charts/infra/charts/engine/templates/servicemetrics.yaml
+++ b/helm/charts/infra/charts/engine/templates/servicemetrics.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "server.fullname" . }}-metrics
+  labels:
+{{- include "server.labels" . | nindent 4 }}
+{{- if .Values.metrics.service.labels }}
+{{- toYaml .Values.metrics.service.labels | nindent 4 }}
+{{- end }}
+  annotations:
+{{- toYaml .Values.metrics.service.annotations | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.metrics.service.port }}
+      name: {{ .Values.metrics.service.portName }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+{{- include "server.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/charts/infra/charts/engine/templates/servicemonitor.yaml
+++ b/helm/charts/infra/charts/engine/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "server.fullname" . }}
+  labels:
+{{- include "server.labels" . | nindent 4 }}
+{{- if .Values.metrics.serviceMonitor.labels }}
+{{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+{{- end }}
+  annotations:
+{{- toYaml .Values.metrics.serviceMonitor.annotations | nindent 4 }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: {{ .Values.metrics.service.portName }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      relabelings:
+{{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 8 }}
+      metricRelabelings:
+{{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
+  selector:
+    matchLabels:
+{{- include "server.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/helm/charts/infra/charts/engine/values.yaml
+++ b/helm/charts/infra/charts/engine/values.yaml
@@ -172,6 +172,48 @@ service:
   ## Supports `ClientIP` or `None`
   sessionAffinity: ""
 
+## Metrics configurations
+metrics:
+
+  ## Enable engine metrics
+  enabled: false
+
+  ## Metrics service configurations
+  service:
+
+    ## Metrics service labels
+    labels: {}
+
+    ## Metrics service annotations
+    annotations: {}
+
+    ## Metrics service port
+    port: 9090
+
+    ## Metrics service port name
+    portName: metrics
+
+  ## Service monitor configurations
+  serviceMonitor:
+
+    ## Enable service monitor
+    enabled: false
+
+    ## Service monitor labels
+    labels: {}
+
+    ## Service monitor annotations
+    annotations: {}
+
+    ## Service monitor scrape interval
+    interval: 30s
+
+    ## Prometheus relabel configs to apply to samples before scraping
+    relabelings: []
+
+    ## Prometheus metric relabel configs to apply to samples before ingesting
+    metricRelabelings: []
+
 ## Engine ingress configurations
 ingress:
 

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -606,6 +606,48 @@ engine:
     ## Supports `ClientIP` or `None`
     sessionAffinity: ""
 
+  ## Metrics configurations
+  metrics:
+
+    ## Enable engine metrics
+    enabled: false
+
+    ## Metrics service configurations
+    service:
+
+      ## Metrics service labels
+      labels: {}
+
+      ## Metrics service annotations
+      annotations: {}
+
+      ## Metrics service port
+      port: 9090
+
+      ## Metrics service port name
+      portName: metrics
+
+    ## Service monitor configurations
+    serviceMonitor:
+
+      ## Enable service monitor
+      enabled: false
+
+      ## Service monitor labels
+      labels: {}
+
+      ## Service monitor annotations
+      annotations: {}
+
+      ## Service monitor scrape interval
+      interval: 30s
+
+      ## Prometheus relabel configs to apply to samples before scraping
+      relabelings: []
+
+      ## Prometheus metric relabel configs to apply to samples before ingesting
+      metricRelabelings: []
+
   ## Engine ingress configurations
   ingress:
 

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -143,7 +143,7 @@ func writeKubeconfig(destinations []api.Destination, grants []api.Grant) error {
 		logging.S.Debugf("creating kubeconfig for %s", context)
 
 		kubeConfig.Clusters[context] = &clientcmdapi.Cluster{
-			Server:                   fmt.Sprintf("%s/proxy", u.String()),
+			Server:                   u.String(),
 			CertificateAuthorityData: []byte(ca),
 		}
 

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	NamespaceFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-	CaFilePath        = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	namespaceFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	caFilePath        = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
 
 type Kubernetes struct {
@@ -529,7 +529,7 @@ END:
 }
 
 func (k *Kubernetes) Namespace() (string, error) {
-	contents, err := ioutil.ReadFile(NamespaceFilePath)
+	contents, err := ioutil.ReadFile(namespaceFilePath)
 	if err != nil {
 		return "", err
 	}
@@ -538,7 +538,7 @@ func (k *Kubernetes) Namespace() (string, error) {
 }
 
 func (k *Kubernetes) CA() ([]byte, error) {
-	contents, err := ioutil.ReadFile(CaFilePath)
+	contents, err := ioutil.ReadFile(caFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -11,13 +11,6 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-var requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "http",
-	Name:      "request_duration_seconds",
-	Help:      "A histogram of the duration, in seconds, handling HTTP requests.",
-	Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
-}, []string{"host", "method", "path", "status"})
-
 func SetupMetrics(db *gorm.DB) error {
 	promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "build",

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
@@ -71,22 +69,6 @@ func AuthenticationMiddleware() gin.HandlerFunc {
 		}
 
 		c.Next()
-	}
-}
-
-// MetricsMiddleware wraps the request with a standard set of Prometheus metrics.
-func MetricsMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		t := time.Now()
-
-		c.Next()
-
-		requestDuration.With(prometheus.Labels{
-			"host":   c.Request.Host,
-			"method": c.Request.Method,
-			"path":   c.FullPath(),
-			"status": strconv.Itoa(c.Writer.Status()),
-		}).Observe(time.Since(t).Seconds())
 	}
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/metrics"
 )
 
 type (
@@ -18,7 +19,7 @@ type (
 
 func (a *API) registerRoutes(router *gin.RouterGroup) {
 	router.Use(
-		MetricsMiddleware(),
+		metrics.Middleware(),
 		RequestTimeoutMiddleware(),
 		DatabaseMiddleware(a.server.db),
 	)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,33 @@
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "http",
+	Name:      "request_duration_seconds",
+	Help:      "A histogram of duration, in seconds, handling HTTP requests.",
+	Buckets:   prometheus.ExponentialBuckets(0.001, 2, 15),
+}, []string{"host", "method", "path", "status"})
+
+// MetricsMiddleware wraps the request with a standard set of Prometheus metrics.
+func Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		t := time.Now()
+
+		c.Next()
+
+		requestDuration.With(prometheus.Labels{
+			"host":   c.Request.Host,
+			"method": c.Request.Method,
+			"path":   c.FullPath(),
+			"status": strconv.Itoa(c.Writer.Status()),
+		}).Observe(time.Since(t).Seconds())
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Add Prometheus metrics to the engine so it can be monitored.

- Refactor metrics middleware into a separate, top-level module since it will be shared between the server and the engine
- Refactor engine to use gin so it's more consistent with the server
  - Gin also provides a much nicer interface for adding additional handlers which cleans up the reverse proxying and JWT significantly
  - One side effect is removing `/proxy`
- The generated metrics doesn't reveal _too_ much about the engine, just enough to know if/when there are issues

## Checklist

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #829
