### PR TITLE
bug: do not require an access key name (#1005)

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -25,7 +25,7 @@ func ListAccessKeys(c *gin.Context, machineID uid.ID, name string) ([]models.Acc
 	return data.ListAccessKeys(db, data.ByMachineIDIssuedFor(machineID), data.ByName(name))
 }
 
-func CreateAccessKey(c *gin.Context, token *models.AccessKey, machineID uid.ID) (body string, err error) {
+func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey, machineID uid.ID) (body string, err error) {
 	db, err := requireAuthorization(c, PermissionAccessKeyCreate)
 	if err != nil {
 		return "", err
@@ -36,7 +36,7 @@ func CreateAccessKey(c *gin.Context, token *models.AccessKey, machineID uid.ID) 
 		return "", fmt.Errorf("get access key machine: %w", err)
 	}
 
-	body, err = data.CreateAccessKey(db, token)
+	body, err = data.CreateAccessKey(db, accessKey)
 	if err != nil {
 		return "", fmt.Errorf("create token: %w", err)
 	}

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -164,14 +164,14 @@ func ExchangeAuthCodeForAccessKey(c *gin.Context, code string, provider *models.
 		return nil, "", fmt.Errorf("update info on login: %w", err)
 	}
 
-	token := &models.AccessKey{
+	key := &models.AccessKey{
 		IssuedFor: user.PolymorphicIdentifier(),
 		ExpiresAt: time.Now().Add(sessionDuration),
 	}
 
-	body, err := data.CreateAccessKey(db, token)
+	body, err := data.CreateAccessKey(db, key)
 	if err != nil {
-		return nil, body, fmt.Errorf("create token: %w", err)
+		return nil, body, fmt.Errorf("create access key: %w", err)
 	}
 
 	user.LastSeenAt = time.Now()


### PR DESCRIPTION
A users authentication would break on second login. This was due to access keys requiring a unique name when being created for a machine, but keys being created for users do not have a name set.

Fix is to require access keys created through the external API to have a name, rather than in the data model.

- do not require access keys in data model to have name
- require name on access keys created through the API
- require name of API created access key to be unique

<!-- Include a summary of the change and/or why it's necessary. -->

<!-- 
Checklists help us remember things.
Change [ ] to [x] to show completion, or whatever :D
Add to .github/pull_request_template.md if you think there's something we should consider before merging.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged

<!-- You can link to the issue it closes using a keyword like "Resolves #1234". -->

Resolves #1005 
