### PR TITLE
fix(helm): podAnnotation breaking helm templating

### DIFF
--- a/helm/charts/infra/charts/engine/templates/_helpers.tpl
+++ b/helm/charts/infra/charts/engine/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Pod annotations
 {{- define "engine.podAnnotations" -}}
 rollme: {{ include (print .Template.BasePath "/configmap.yaml") . | sha1sum }}
 {{- if or .Values.podAnnotations .Values.global.podAnnotations }}
-{{- .Values.global.podAnnotations | default dict | merge .Values.podAnnotations | toYaml }}
+{{ .Values.global.podAnnotations | default dict | merge .Values.podAnnotations | toYaml }}
 {{- end }}
 {{- end }}
 

--- a/helm/charts/infra/charts/server/templates/_helpers.tpl
+++ b/helm/charts/infra/charts/server/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Pod annotations
 {{- define "server.podAnnotations" -}}
 rollme: {{ include (print .Template.BasePath "/configmap.yaml") . | sha1sum }}
 {{- if or .Values.podAnnotations .Values.global.podAnnotations }}
-{{- .Values.global.podAnnotations | default dict | merge .Values.podAnnotations | toYaml }}
+{{ .Values.global.podAnnotations | default dict | merge .Values.podAnnotations | toYaml }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Fix template spacing so it doesn't produce something like

```yaml
podAnnotations:
  key1: val1
  key2: val2key3:val3
```

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1008 

[1]: https://www.conventionalcommits.org/en/v1.0.0/
