### PR TITLE
BREAKING CHANGE: fix: update login flow for access key and multiple redirect URLs

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -441,7 +441,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 			require.True(t, ok)
 			mockOIDC := setupFunc(t, db)
 
-			u, sess, err := ExchangeAuthCodeForAccessKey(c, "123somecode", provider, mockOIDC, time.Minute)
+			u, sess, err := ExchangeAuthCodeForAccessKey(c, "123somecode", provider, mockOIDC, time.Minute, "example.com")
 
 			verifyFunc, ok := v["verify"].(func(*testing.T, *models.User, string, error))
 			require.True(t, ok)

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -93,7 +93,7 @@ func UpdateProviderToken(c *gin.Context, providerToken *models.ProviderToken) er
 	return data.UpdateProviderToken(db, providerToken)
 }
 
-func ExchangeAuthCodeForAccessKey(c *gin.Context, code string, provider *models.Provider, oidc authn.OIDC, sessionDuration time.Duration) (*models.User, string, error) {
+func ExchangeAuthCodeForAccessKey(c *gin.Context, code string, provider *models.Provider, oidc authn.OIDC, sessionDuration time.Duration, redirectURL string) (*models.User, string, error) {
 	db := getDB(c)
 
 	// exchange code for tokens from identity provider (these tokens are for the IDP, not Infra)
@@ -123,6 +123,7 @@ func ExchangeAuthCodeForAccessKey(c *gin.Context, code string, provider *models.
 	provToken := &models.ProviderToken{
 		UserID:       user.ID,
 		ProviderID:   provider.ID,
+		RedirectURL:  redirectURL,
 		AccessToken:  models.EncryptedAtRest(accessToken),
 		RefreshToken: models.EncryptedAtRest(refreshToken),
 		ExpiresAt:    expiry,

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -11,9 +11,9 @@ import (
 )
 
 type Client struct {
-	Url   string
-	Token string
-	Http  http.Client
+	Url       string
+	AccessKey string
+	Http      http.Client
 }
 
 func checkError(status int, body []byte) error {
@@ -45,7 +45,7 @@ func get[Res any](client Client, path string) (*Res, error) {
 		return nil, err
 	}
 
-	req.Header.Add("Authorization", "Bearer "+client.Token)
+	req.Header.Add("Authorization", "Bearer "+client.AccessKey)
 
 	resp, err := client.Http.Do(req)
 	if err != nil {
@@ -78,7 +78,7 @@ func list[Res any](client Client, path string, query map[string]string) ([]Res, 
 		return nil, err
 	}
 
-	req.Header.Add("Authorization", "Bearer "+client.Token)
+	req.Header.Add("Authorization", "Bearer "+client.AccessKey)
 
 	q := req.URL.Query()
 	for k, v := range query {
@@ -123,7 +123,7 @@ func request[Req, Res any](client Client, method string, path string, req *Req) 
 		return nil, err
 	}
 
-	httpReq.Header.Add("Authorization", "Bearer "+client.Token)
+	httpReq.Header.Add("Authorization", "Bearer "+client.AccessKey)
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Http.Do(httpReq)
@@ -165,7 +165,7 @@ func delete(client Client, path string) error {
 		return err
 	}
 
-	req.Header.Add("Authorization", "Bearer "+client.Token)
+	req.Header.Add("Authorization", "Bearer "+client.AccessKey)
 
 	resp, err := client.Http.Do(req)
 	if err != nil {

--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -3,12 +3,13 @@ package api
 import "github.com/infrahq/infra/uid"
 
 type LoginRequest struct {
-	ProviderID uid.ID `json:"providerID" validate:"required"`
-	Code       string `json:"code" validate:"required"`
+	ProviderID  uid.ID `json:"providerID" validate:"required"`
+	RedirectURL string `json:"redirectURL" validate:"required"`
+	Code        string `json:"code" validate:"required"`
 }
 
 type LoginResponse struct {
-	ID    uid.ID `json:"id"`
-	Name  string `json:"name"`
-	Token string `json:"token"`
+	ID        uid.ID `json:"id"`
+	Name      string `json:"name"`
+	AccessKey string `json:"accessKey"`
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -136,10 +136,10 @@ func defaultAPIClient() (*api.Client, error) {
 		return nil, err
 	}
 
-	return apiClient(config.Host, config.Token, config.SkipTLSVerify)
+	return apiClient(config.Host, config.AccessKey, config.SkipTLSVerify)
 }
 
-func apiClient(host string, token string, skipTLSVerify bool) (*api.Client, error) {
+func apiClient(host string, accessKey string, skipTLSVerify bool) (*api.Client, error) {
 	u, err := urlx.Parse(host)
 	if err != nil {
 		return nil, err
@@ -148,8 +148,8 @@ func apiClient(host string, token string, skipTLSVerify bool) (*api.Client, erro
 	u.Scheme = "https"
 
 	return &api.Client{
-		Url:   fmt.Sprintf("%s://%s", u.Scheme, u.Host),
-		Token: token,
+		Url:       fmt.Sprintf("%s://%s", u.Scheme, u.Host),
+		AccessKey: accessKey,
 		Http: http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -22,7 +22,7 @@ type ClientHostConfig struct {
 	PolymorphicID uid.PolymorphicID `json:"polymorphic-id"`
 	Name          string            `json:"name"`
 	Host          string            `json:"host"`
-	Token         string            `json:"token,omitempty"`
+	AccessKey     string            `json:"access-key,omitempty"`
 	SkipTLSVerify bool              `json:"skip-tls-verify"` // where is the other cert info stored?
 	ProviderID    uid.ID            `json:"provider-id"`
 	Current       bool              `json:"current"`
@@ -130,7 +130,7 @@ func removeHostConfig(host string, force bool) error {
 			if force {
 				cfg.Hosts = append(cfg.Hosts[:i], cfg.Hosts[i+1:]...)
 			} else {
-				cfg.Hosts[i].Token = ""
+				cfg.Hosts[i].AccessKey = ""
 			}
 
 			break

--- a/internal/cmd/config_migration.go
+++ b/internal/cmd/config_migration.go
@@ -54,7 +54,7 @@ func (c ClientConfigV0dot2) ToV0dot3() *ClientConfig {
 		conf.Hosts = append(conf.Hosts, ClientHostConfig{
 			Name:          h.Name,
 			Host:          h.Host,
-			Token:         h.Token,
+			AccessKey:     h.Token,
 			SkipTLSVerify: h.SkipTLSVerify,
 			ProviderID:    providerID,
 			Current:       h.Current,

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -24,7 +24,7 @@ func logout(force bool) error {
 			continue
 		}
 
-		client, err := apiClient(hostConfig.Host, hostConfig.Token, hostConfig.SkipTLSVerify)
+		client, err := apiClient(hostConfig.Host, hostConfig.AccessKey, hostConfig.SkipTLSVerify)
 		if err != nil {
 			logging.S.Warn(err.Error())
 			continue

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -405,8 +405,8 @@ func Run(options Options) error {
 		}
 
 		client := &api.Client{
-			Url:   u.String(),
-			Token: accessKey,
+			Url:       u.String(),
+			AccessKey: accessKey,
 			Http: http.Client{
 				Transport: &http.Transport{
 					TLSClientConfig: hostTLSConfig,

--- a/internal/server/authn/oidc.go
+++ b/internal/server/authn/oidc.go
@@ -32,13 +32,15 @@ type oidcImplementation struct {
 	Domain       string
 	ClientID     string
 	ClientSecret string
+	RedirectURL  string
 }
 
-func NewOIDC(domain, clientID, clientSecret string) OIDC {
+func NewOIDC(domain, clientID, clientSecret, redirectURL string) OIDC {
 	return &oidcImplementation{
 		Domain:       domain,
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
 	}
 }
 
@@ -53,7 +55,7 @@ func (o *oidcImplementation) clientConfig(ctx context.Context) (*oauth2.Config, 
 	conf := &oauth2.Config{
 		ClientID:     o.ClientID,
 		ClientSecret: o.ClientSecret,
-		RedirectURL:  "http://localhost:8301",
+		RedirectURL:  o.RedirectURL,
 		Scopes:       []string{oidc.ScopeOpenID, "email", "groups", oidc.ScopeOfflineAccess},
 		Endpoint:     provider.Endpoint(),
 	}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -47,8 +47,8 @@ func (s *Server) importConfig() error {
 	}
 
 	client := &api.Client{
-		Url:   "https://localhost:443",
-		Token: adminAccessKey,
+		Url:       "https://localhost:443",
+		AccessKey: adminAccessKey,
 		Http: http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{

--- a/internal/server/models/provider.go
+++ b/internal/server/models/provider.go
@@ -35,8 +35,9 @@ func (p *Provider) ToAPI() *api.Provider {
 type ProviderToken struct {
 	Model
 
-	UserID     uid.ID
-	ProviderID uid.ID
+	UserID      uid.ID
+	ProviderID  uid.ID
+	RedirectURL string `validate:"required"` // needs to match the redirect URL specified when the token was issued for refreshing
 
 	AccessToken  EncryptedAtRest
 	RefreshToken EncryptedAtRest


### PR DESCRIPTION
## Summary
Two changes:

1. When call is made to the login endpoint specify the redirect URL used. This is needed to support the UI with a different redirect URL. This is also a breaking change because the CLI needs to be updated to send this field along.
2. Update some `token` naming in the CLI to be `accessKey`

- specify a redirect URL on login to support UI redirects
- clean up some "token naming"

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1004 and #1007
