### PR TITLE
fix(ci): fix release_created/name output path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release-please.release_created }}
-      release_name: ${{ steps.release-please.tag_name }}
+      release_created: ${{ steps.release-please.outputs.release_created }}
+      release_name: ${{ steps.release-please.outputs.tag_name }}
     steps:
       - id: release-please
         uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

variable path missing `outputs`, e.g. `steps.release-please.outputs.release_created` 