### PR TITLE
build: use go 1.18rc1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          stable: 'false'
-          go-version: '1.18.0-beta1'
+          stable: false
+          go-version: 1.18.0-rc1
       - run: make test
 
   helm-lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: false
-          go-version: 1.18.0-beta1
+          go-version: 1.18.0-rc1
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.18beta1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.18rc1 AS builder
 RUN apt-get update && \
     apt-get install -y gcc-aarch64-linux-gnu gcc-x86-64-linux-gnu && \
     ln -s /usr/bin/aarch64-linux-gnu-gcc /usr/bin/arm64-linux-gnu-gcc  && \

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-1. Install [Go 1.18](https://go.dev/dl/#go1.18beta1)
+1. Install [Go 1.18](https://go.dev/dl/#go1.18rc1)
 1. Clone the project
 
     ```bash


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Bump to golang:1.18rc1