### PR TITLE
fix: clean up tls cert error display in cli

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/infrahq/infra/internal/api"
 	"github.com/infrahq/infra/internal/generate"
+	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -347,13 +348,15 @@ func promptShouldSkipTLSVerify(host string) (shouldSkipTLSVerify bool, proceed b
 			return false, false, err
 		}
 
-		proceed := false
+		logging.S.Debug(err)
 
-		fmt.Fprintf(os.Stderr, "Could not verify certificate for host %q: %s\n", host, err)
+		fmt.Printf("  The authenticity of host '%s' can't be established.\n", host)
 
 		prompt := &survey.Confirm{
-			Message: "Are you sure you want to continue?",
+			Message: fmt.Sprintf("Are you sure you want to continue?"),
 		}
+
+		proceed := false
 
 		err := survey.AskOne(prompt, &proceed, survey.WithStdio(os.Stdin, os.Stderr, os.Stderr))
 		if err != nil {


### PR DESCRIPTION
## Summary
When there was an error in TLS certificate validation we output the error, which looks confusing to the user with the trace:
```
  Logging in to 137.184.245.223
Could not verify certificate for host "137.184.245.223": Get "https://137.184.245.223": x509: “Infra” certificate is not trusted
? Are you sure you want to continue? Yes
? Select a login method: Okta (tmlw.okta.com)
  Logging in with Okta...
```

Output a human friendly one-liner instead:
```
$ infra login localhost
  Logging in to localhost
? “Infra” certificate is not trusted, are you sure you want to continue? Yes
? Select a login method:  [Use arrows to move, type to filter]
> okta (dev.okta.com)
  Login with Access Key
```
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves # 936

[1]: https://www.conventionalcommits.org/en/v1.0.0/
