### PR TITLE
fix: cli required parameter validation (#948) (#949)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,7 +107,7 @@ infra list [flags]
 Connect to a destination
 
 ```
-infra use [DESTINATION] [flags]
+infra use DESTINATION [flags]
 ```
 
 ### Examples
@@ -115,10 +115,10 @@ infra use [DESTINATION] [flags]
 ```
 
 # Connect to a Kubernetes cluster
-infra use kubernetes.development
+$ infra use kubernetes.development
 
 # Connect to a Kubernetes namespace
-infra use kubernetes.development.kube-system
+$ infra use kubernetes.development.kube-system
 		
 ```
 
@@ -167,13 +167,13 @@ infra access grant DESTINATION [flags]
 ```
 
 # Grant user admin access to a cluster
-infra access grant -u suzie@acme.com -r admin kubernetes.production
+$ infra access grant -u suzie@acme.com -r admin kubernetes.production
 
 # Grant group admin access to a namespace
-infra access grant -g Engineering -r admin kubernetes.production.default
+$ infra access grant -g Engineering -r admin kubernetes.production.default
 
 # Grant user admin access to infra itself
-infra access grant -u admin@acme.com -r admin infra
+$ infra access grant -u admin@acme.com -r admin infra
 
 ```
 
@@ -207,6 +207,7 @@ infra access revoke DESTINATION [flags]
 ```
   -g, --group string      Group to revoke access from
   -h, --help              help for revoke
+  -m, --machine string    Machine to revoke access from
   -p, --provider string   Provider from which to revoke access from
   -r, --role string       Role to revoke
   -u, --user string       User to revoke access from
@@ -244,7 +245,7 @@ infra keys list [flags]
 Create an access key for authentication
 
 ```
-infra keys create [ACCESS_KEY_NAME] [MACHINE_NAME] [flags]
+infra keys create ACCESS_KEY_NAME MACHINE_NAME [flags]
 ```
 
 ### Examples
@@ -275,7 +276,7 @@ infra keys create main wall-e 12h --extension-deadline=1h
 Delete access keys
 
 ```
-infra keys delete [ACCESS_KEY_NAME] [flags]
+infra keys delete ACCESS_KEY_NAME [flags]
 ```
 
 ### Options
@@ -372,19 +373,27 @@ infra providers list [flags]
 
 ## `infra providers add`
 
-Connect an identity provider
+Add an identity provider
+
+### Synopsis
+
+
+Add an identity provider for users to authenticate.
+
+NAME: The name of the identity provider (e.g. okta)
+URL: The base URL of the domain used to login with the identity provider (e.g. acme.okta.com)
+CLIENT_ID: The Infra application OpenID Connect client ID
+CLIENT_SECRET: The Infra application OpenID Connect client secret
+		
 
 ```
-infra providers add NAME [flags]
+infra providers add NAME URL CLIENT_ID CLIENT_SECRET [flags]
 ```
 
 ### Options
 
 ```
-      --client-id string       OpenID Client ID
-      --client-secret string   OpenID Client Secret
-  -h, --help                   help for add
-      --url string             url or domain (e.g. acme.okta.com)
+  -h, --help   help for add
 ```
 
 ### Options inherited from parent commands
@@ -418,7 +427,7 @@ infra providers remove PROVIDER [flags]
 Create a machine identity, e.g. a service that needs to access infrastructure
 
 ```
-infra machines create [NAME] [flags]
+infra machines create NAME [flags]
 ```
 
 ### Options
@@ -497,10 +506,10 @@ infra tokens create [flags]
 
 ## `infra import`
 
-Import an infra server configuration
+Import an Infra server configuration
 
 ```
-infra import [FILE] [flags]
+infra import FILE [flags]
 ```
 
 ### Options

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -216,14 +216,14 @@ func newListCmd() *cobra.Command {
 
 func newUseCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "use [DESTINATION]",
+		Use:   "use DESTINATION",
 		Short: "Connect to a destination",
 		Example: `
 # Connect to a Kubernetes cluster
-infra use kubernetes.development
+$ infra use kubernetes.development
 
 # Connect to a Kubernetes namespace
-infra use kubernetes.development.kube-system
+$ infra use kubernetes.development.kube-system
 		`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -429,7 +429,7 @@ func newTokensCmd() *cobra.Command {
 func newProvidersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "providers",
-		Short: "Connect & manage identity providers",
+		Short: "Add & manage identity providers",
 	}
 
 	cmd.AddCommand(newProvidersListCmd())
@@ -528,7 +528,7 @@ func newImportCmd() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "import [FILE]",
+		Use:   "import FILE",
 		Short: "Import an Infra server configuration",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -51,7 +51,7 @@ func newDestinationsAddCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "add TYPE NAME",
 		Short: "Connect a destination",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := defaultAPIClient()
 			if err != nil {

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -14,7 +14,7 @@ type keyCreateOptions struct {
 
 func newKeysCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create [ACCESS_KEY_NAME] [MACHINE_NAME]",
+		Use:   "create ACCESS_KEY_NAME MACHINE_NAME",
 		Short: "Create an access key for authentication",
 		Example: `
 # Create an access key for the machine "wall-e" called main that expires in 12 hours and must be used every hour to remain valid
@@ -59,7 +59,7 @@ infra keys create main wall-e 12h --extension-deadline=1h
 
 func newKeysDeleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete [ACCESS_KEY_NAME]",
+		Use:   "delete ACCESS_KEY_NAME",
 		Short: "Delete access keys",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -57,7 +57,6 @@ func updateKubeconfig(client *api.Client, identityPolymorphicID uid.PolymorphicI
 
 	var grants []api.Grant
 	if identityPolymorphicID.IsUser() {
-		// infer that this is a user
 		grants, err = client.ListUserGrants(id)
 		if err != nil {
 			return err

--- a/internal/cmd/machines.go
+++ b/internal/cmd/machines.go
@@ -16,7 +16,7 @@ type machineOptions struct {
 
 func newMachinesCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create [NAME]",
+		Use:   "create NAME",
 		Short: "Create a machine identity, e.g. a service that needs to access infrastructure",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -47,9 +47,17 @@ func newProvidersListCmd() *cobra.Command {
 
 func newProvidersAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "add NAME",
-		Short: "Connect an identity provider",
-		Args:  cobra.ExactArgs(1),
+		Use:   "add NAME URL CLIENT_ID CLIENT_SECRET",
+		Short: "Add an identity provider",
+		Long: `
+Add an identity provider for users to authenticate.
+
+NAME: The name of the identity provider (e.g. okta)
+URL: The base URL of the domain used to login with the identity provider (e.g. acme.okta.com)
+CLIENT_ID: The Infra application OpenID Connect client ID
+CLIENT_SECRET: The Infra application OpenID Connect client secret
+		`,
+		Args: cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var options providerOptions
 			if err := parseOptions(cmd, &options, "INFRA_PROVIDER"); err != nil {
@@ -63,9 +71,9 @@ func newProvidersAddCmd() *cobra.Command {
 
 			_, err = client.CreateProvider(&api.CreateProviderRequest{
 				Name:         args[0],
-				URL:          options.URL,
-				ClientID:     options.ClientID,
-				ClientSecret: options.ClientSecret,
+				URL:          args[1],
+				ClientID:     args[2],
+				ClientSecret: args[3],
 			})
 			if err != nil {
 				return err
@@ -74,10 +82,6 @@ func newProvidersAddCmd() *cobra.Command {
 			return nil
 		},
 	}
-
-	cmd.Flags().String("url", "", "url or domain (e.g. acme.okta.com)")
-	cmd.Flags().String("client-id", "", "OpenID Client ID")
-	cmd.Flags().String("client-secret", "", "OpenID Client Secret")
 
 	return cmd
 }


### PR DESCRIPTION
Standardizing some CLI patterns and fixing a bug around revoking machine grants through the CLI in passing.

- standardize examples to start with $
- do not require provider to be configured for machine grants
- add machine flag to grant revoke
- required cli params should not have square brackets
- long providers description
- typos

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #948 and #949

[1]: https://www.conventionalcommits.org/en/v1.0.0/
