### PR TITLE
refactor: set authorization from cookie (#1049)

### DIFF
--- a/internal/server/cookie.go
+++ b/internal/server/cookie.go
@@ -8,20 +8,18 @@ import (
 )
 
 var (
-	CookieTokenName = "token"
-	CookieLoginName = "login"
-	CookieDomain    = ""
-	CookiePath      = "/"
+	CookieAuthorizationName = "auth"
+	CookieLoginName         = "login"
+	CookieDomain            = ""
+	CookiePath              = "/"
 	// while these vars look goofy, they avoid "magic number" arguments to SetCookie
-	CookieHTTPOnlyJavascriptAccessible    = false   // setting HttpOnly to false means JS can access it.
 	CookieHTTPOnlyNotJavascriptAccessible = true    // setting HttpOnly to true means JS can't access it.
 	CookieSecureHTTPSOnly                 = true    // setting Secure to true means the cookie is only sent over https connections
-	CookieSecureHttpOrHTTPS               = false   // setting Secure to false means the cookie will be sent over http or https connections
 	CookieMaxAgeDeleteImmediately         = int(-1) // <0: delete immediately
 	CookieMaxAgeNoExpiry                  = int(0)  // zero has special meaning of "no expiry"
 )
 
-func setAuthCookie(c *gin.Context, token string, sessionDuration time.Duration) {
+func setAuthCookie(c *gin.Context, key string, sessionDuration time.Duration) {
 	expires := time.Now().Add(sessionDuration)
 
 	maxAge := int(time.Until(expires).Seconds())
@@ -31,11 +29,11 @@ func setAuthCookie(c *gin.Context, token string, sessionDuration time.Duration) 
 
 	c.SetSameSite(http.SameSiteStrictMode)
 
-	c.SetCookie(CookieTokenName, token, maxAge, CookiePath, CookieDomain, CookieSecureHTTPSOnly, CookieHTTPOnlyNotJavascriptAccessible)
+	c.SetCookie(CookieAuthorizationName, key, maxAge, CookiePath, CookieDomain, CookieSecureHTTPSOnly, CookieHTTPOnlyNotJavascriptAccessible)
 	c.SetCookie(CookieLoginName, "1", maxAge, CookiePath, CookieDomain, CookieSecureHTTPSOnly, CookieHTTPOnlyNotJavascriptAccessible)
 }
 
 func deleteAuthCookie(c *gin.Context) {
-	c.SetCookie(CookieTokenName, "", CookieMaxAgeDeleteImmediately, CookiePath, CookieDomain, CookieSecureHTTPSOnly, CookieHTTPOnlyNotJavascriptAccessible)
+	c.SetCookie(CookieAuthorizationName, "", CookieMaxAgeDeleteImmediately, CookiePath, CookieDomain, CookieSecureHTTPSOnly, CookieHTTPOnlyNotJavascriptAccessible)
 	c.SetCookie(CookieLoginName, "", CookieMaxAgeDeleteImmediately, CookiePath, CookieDomain, CookieSecureHTTPSOnly, CookieHTTPOnlyNotJavascriptAccessible)
 }


### PR DESCRIPTION
## Summary
Bring back the check for user authentication from cookies in the request. This allows us to securely store access keys in UI. 

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1049

[1]: https://www.conventionalcommits.org/en/v1.0.0/
