### PR TITLE
feat: add docker-compose.yml

### DIFF
--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -1,0 +1,5 @@
+version: "3.9"
+
+services:
+  server:
+    build: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: "3.9"
+
+services:
+  server:
+    image: infrahq/infra:${VERSION:-latest}
+    container_name: infra-server
+    ports:
+      - 8080:80
+      - 8443:443
+    environment:
+      - INFRA_LOG_LEVEL=${LOG_LEVEL:-}
+      - INFRA_SERVER_ADMIN_ACCESS_KEY=${ADMIN_ACCESS_KEY:-}
+      - INFRA_SERVER_ENABLE_TELEMETRY=${ENABLE_TELEMETRY:-}
+      - INFRA_SERVER_ENABLE_CRASH_REPORTING=${ENABLE_CRASH_REPORTING:-}
+      - INFRA_SERVER_ENABLE_SETUP=${ENABLE_SETUP:-}
+    volumes:
+      - data:/root/.infra
+volumes:
+  data: {}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

- Add a `docker-compose.yml` for Infra quick start

Pull and run latest infra image, use a randomly generated admin access key:

```bash
docker-compose up
```

Build an infra image from working directory, use a randomly generated admin access key:

```bash
docker-compose -f docker-compose.yaml -f docker-compose.build.yaml up
```

Pull and run latest infra image, use a predefined admin access key:

```bash
ADMIN_ACCESS_KEY=xxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxx docker-compose up
```

Debug:

```bash
LOG_LEVEL=debug docker-compose up
```


## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1053

[1]: https://www.conventionalcommits.org/en/v1.0.0/
