### PR TITLE
fix: remove user token by issued for on logout

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -61,5 +61,5 @@ func DeleteAllUserAccessKeys(c *gin.Context) error {
 
 	db := getDB(c)
 
-	return data.DeleteAccessKeys(db, data.ByUserID(user.ID))
+	return data.DeleteAccessKeys(db, data.ByUserIDIssuedFor(user.ID))
 }

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -92,7 +92,17 @@ func ByMachineIDIssuedFor(machineID uid.ID) SelectorFunc {
 			return db
 		}
 
-		return db.Where("issued_for = ?", "m:"+machineID.String())
+		return db.Where("issued_for = ?", uid.NewMachinePolymorphicID(machineID))
+	}
+}
+
+func ByUserIDIssuedFor(userID uid.ID) SelectorFunc {
+	return func(db *gorm.DB) *gorm.DB {
+		if userID == 0 {
+			return db
+		}
+
+		return db.Where("issued_for = ?", uid.NewUserPolymorphicID(userID))
 	}
 }
 


### PR DESCRIPTION
## Summary
When a user logs out we need to delete the authorization based on who the key was issued for. There was some old code here that was looking to delete keys by user ID which no longer worked.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1060

[1]: https://www.conventionalcommits.org/en/v1.0.0/
