### PR TITLE
fix: wait to import until server is up

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -134,12 +134,7 @@ func Run(options Options) (err error) {
 		return fmt.Errorf("importing access keys: %w", err)
 	}
 
-	// TODO: this should instead happen after runserver and we should wait for the server to close
-	go func() {
-		if err := server.importConfig(); err != nil {
-			logging.S.Error(fmt.Errorf("import config: %w", err))
-		}
-	}()
+	go server.importConfig()
 
 	if err := server.runServer(); err != nil {
 		return fmt.Errorf("running server: %w", err)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Config import is started in a goroutine before the server actually starts. This means there's a race between the server and the import client. Because there's no retry, if the import fails, the configuration will never be imported. On slow systems, it may take a few tries to get a working instance.

Mitigate this problem by delaying import until the server is up. Do this by sending a TCP ping to the server at localhost:80. If the server is up, i.e. receiving connections, continue with the import. Otherwise, wait 1 second before trying again. Since the process is localhost, the connection timeout can be set very low, 1ms.

Once the server is known to be up, request import. Regardless of success or failure, the timer will be stopped. This means there's a single import attempt on start up. 

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1065

[1]: https://www.conventionalcommits.org/en/v1.0.0/
