### PR TITLE
When logout it should redirect back to login page

### DIFF
--- a/ui/store/AuthContext.tsx
+++ b/ui/store/AuthContext.tsx
@@ -133,11 +133,10 @@ export const AuthContextProvider = ({ children }:any) => {
   // TODO: it is not working right now
   const logout = () => {
     axios.post('/v1/logout', {}, { headers: { Authorization: `Bearer ${cookie.accessKey}` }})
-    .then((response) => {
-      removeCookies('accessKey', { path: '/' })
-
-      // redirect based on provider[]
+    .then(() => {
+      setAuthReady(false)
       redirectAccountPage(providers)
+      removeCookies('accessKey', { path: '/' })
     })
   }
 


### PR DESCRIPTION
## Summary
- a bug that when user clicks logout, the page does not redirect back to the login page. The reason why it is because we need to set the `authReady` be false so it will redirect back to the login page when it is trying to render the dashboard page

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1088 

[1]: https://www.conventionalcommits.org/en/v1.0.0/
