### PR TITLE
fix(cli): small if-statement flip for machine validation options

### DIFF
--- a/internal/cmd/access.go
+++ b/internal/cmd/access.go
@@ -102,7 +102,7 @@ $ infra access grant -u admin@acme.com -r admin infra
 
 			var providers []api.Provider
 
-			if options.Machine != "" {
+			if options.Machine == "" {
 				providers, err = client.ListProviders(options.Provider)
 				if err != nil {
 					return err


### PR DESCRIPTION
Looks like the if statement was flipped 