### PR TITLE
fix: run import in go routine to apply config

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -152,12 +152,14 @@ func Run(options Options) (err error) {
 		scope.SetContext("serverId", settings.ID)
 	})
 
+	go func() {
+		if err := server.importConfig(); err != nil {
+			logging.S.Error(fmt.Errorf("import config: %w", err))
+		}
+	}()
+
 	if err := server.runServer(); err != nil {
 		return fmt.Errorf("running server: %w", err)
-	}
-
-	if err := server.importConfig(); err != nil {
-		logging.S.Error(fmt.Errorf("import config: %w", err))
 	}
 
 	return logging.L.Sync()


### PR DESCRIPTION
- interim fix until server config is applied directly

## Summary
Config isn't applied if we do it after the server runs (it doesn't return until terminating). This is an interim fix so that Infra functions as expected until the config import just runs the database queries directly.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1115

[1]: https://www.conventionalcommits.org/en/v1.0.0/
