### PR TITLE
fix: HTTP request logging

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -161,7 +161,7 @@ func UserAwareLoggerMiddleware() gin.HandlerFunc {
 					Type:   zapcore.StringType,
 					String: userID,
 				})
-			c.Set(ctxLoggerKey, logger.Sugar())
+			c.Set(ctxLoggerKey, logger)
 		}
 
 		c.Next()
@@ -169,12 +169,29 @@ func UserAwareLoggerMiddleware() gin.HandlerFunc {
 }
 
 // Logger gets the request-specific logger from the context
-func Logger(c *gin.Context) *zap.SugaredLogger {
+// If a request-specific logger cannot be found, use the default logger
+func Logger(c *gin.Context) *zap.Logger {
 	if loggerInf, ok := c.Get(ctxLoggerKey); ok {
-		if logger, ok := loggerInf.(*zap.SugaredLogger); ok {
+		if logger, ok := loggerInf.(*zap.Logger); ok {
 			return logger
 		}
 	}
 
-	return S
+	return L
+}
+
+// Sugared variant of Logger
+func SugarLogger(c *gin.Context) *zap.SugaredLogger {
+	return Logger(c).Sugar()
+}
+
+// WrappedLogger skips the most recent caller
+// Useful for functions that logs for callers
+func WrappedLogger(c *gin.Context) *zap.Logger {
+	return Logger(c).WithOptions(zap.AddCallerSkip(1))
+}
+
+// Sugared variant of WrappedLogger
+func WrappedSugarLogger(c *gin.Context) *zap.SugaredLogger {
+	return WrappedLogger(c).Sugar()
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -44,29 +44,29 @@ func sendAPIError(c *gin.Context, err error) {
 	case errors.Is(err, internal.ErrUnauthorized):
 		code = http.StatusUnauthorized
 		message = "unauthorized"
-		logging.Logger(c).Debugw(err.Error(), "statusCode", code)
+		logging.WrappedSugarLogger(c).Debugw(err.Error(), "statusCode", code)
 	case errors.Is(err, internal.ErrForbidden):
 		code = http.StatusForbidden
 		message = "forbidden"
-		logging.Logger(c).Debugw(err.Error(), "statusCode", code)
+		logging.WrappedSugarLogger(c).Debugw(err.Error(), "statusCode", code)
 	case errors.Is(err, internal.ErrDuplicate):
 		code = http.StatusConflict
 		message = err.Error()
-		logging.Logger(c).Debugw(err.Error(), "statusCode", code)
+		logging.WrappedSugarLogger(c).Debugw(err.Error(), "statusCode", code)
 	case errors.Is(err, internal.ErrNotFound):
 		code = http.StatusNotFound
 		message = err.Error()
-		logging.Logger(c).Debugw(err.Error(), "statusCode", code)
+		logging.WrappedSugarLogger(c).Debugw(err.Error(), "statusCode", code)
 	case errors.Is(err, internal.ErrBadRequest):
 		code = http.StatusBadRequest
 		message = err.Error()
-		logging.Logger(c).Debugw(err.Error(), "statusCode", code)
+		logging.WrappedSugarLogger(c).Debugw(err.Error(), "statusCode", code)
 	case errors.Is(err, (*validator.InvalidValidationError)(nil)):
 		code = http.StatusBadRequest
 		message = err.Error()
-		logging.Logger(c).Debugw(err.Error(), "statusCode", code)
+		logging.WrappedSugarLogger(c).Debugw(err.Error(), "statusCode", code)
 	default:
-		logging.Logger(c).Errorw(err.Error(), "statusCode", code)
+		logging.WrappedSugarLogger(c).Errorw(err.Error(), "statusCode", code)
 	}
 
 	c.JSON(code, &api.Error{


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

skip one caller in `sendAPIError` so it logs the source of the error

e.g.
```
{"level":"debug","ts":1646263628.9533913,"caller":"server/middleware.go:66","msg":"unauthorized","statusCode":401}
```

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

[1]: https://www.conventionalcommits.org/en/v1.0.0/
