### PR TITLE
fix: better client error messages

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -633,7 +633,7 @@ func Run() error {
 func printError(err error) {
 	if err != nil {
 		if !errors.Is(err, terminal.InterruptErr) {
-			fmt.Fprint(os.Stderr, err.Error())
+			fmt.Fprintln(os.Stderr, "error: "+err.Error())
 		}
 	}
 }


### PR DESCRIPTION
resolves #918 

Sample:
```sh
$ ./infra destinations list
error: GET "/v1/destinations" responded 401: unauthorized
```