### PR TITLE
refactor: implement additional http handlers as gin middlewares

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-playground/validator/v10 v10.10.0
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/goreleaser/goreleaser v1.5.0
-	github.com/gorilla/handlers v1.5.1
 	github.com/goware/urlx v0.3.1
 	github.com/hashicorp/vault/api v1.4.1
 	github.com/jackc/pgconn v1.11.0
@@ -133,7 +132,6 @@ require (
 	github.com/envoyproxy/go-control-plane v0.10.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.6.2 // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,6 @@ github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
-github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -616,8 +614,6 @@ github.com/goreleaser/goreleaser v1.5.0 h1:l4BxBt2Rrk5Tngmzyrcp7H/CszXSA0guzL4mP
 github.com/goreleaser/goreleaser v1.5.0/go.mod h1:4Y0nT+ZtJnzRiEcMZ+A9SsppqoPQMuuP0QA1gBU6fQM=
 github.com/goreleaser/nfpm/v2 v2.13.0 h1:SeASFH+AeFBoVRCIrzzYhvydvK5lSB1GdVcDvBfpOqs=
 github.com/goreleaser/nfpm/v2 v2.13.0/go.mod h1:/1nEaaBKHLY2Vn8RtSLaV/Vst0VhIWF4ARynuIqJv6Q=
-github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
-github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -18,7 +17,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
-	"github.com/gorilla/handlers"
 	"github.com/goware/urlx"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/crypto/acme/autocert"
@@ -584,7 +582,7 @@ func Run(options Options) error {
 
 	metricsServer := &http.Server{
 		Addr:     ":9090",
-		Handler:  handlers.CustomLoggingHandler(io.Discard, metrics, logging.ZapLogFormatter),
+		Handler:  metrics,
 		ErrorLog: logging.StandardErrorLog(),
 	}
 
@@ -597,7 +595,7 @@ func Run(options Options) error {
 	tlsServer := &http.Server{
 		Addr:      ":443",
 		TLSConfig: tlsConfig,
-		Handler:   handlers.CustomLoggingHandler(io.Discard, router, logging.ZapLogFormatter),
+		Handler:   router,
 		ErrorLog:  logging.StandardErrorLog(),
 	}
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	sentrygin "github.com/getsentry/sentry-go/gin"
 	"github.com/gin-gonic/gin"
 
 	"github.com/infrahq/infra/internal"
@@ -17,14 +18,16 @@ type ReqResHandlerFunc[Req, Res any] func(c *gin.Context, req *Req) (Res, error)
 
 func (a *API) registerRoutes(router *gin.RouterGroup) {
 	router.Use(
+		sentrygin.New(sentrygin.Options{}),
 		metrics.Middleware(),
+		logging.IdentityAwareMiddleware(),
+		logging.Middleware(),
 		RequestTimeoutMiddleware(),
 		DatabaseMiddleware(a.server.db),
 	)
 
 	authorized := router.Group("/",
 		AuthenticationMiddleware(),
-		logging.UserAwareLoggerMiddleware(),
 	)
 
 	{


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

- infra is using a combination of gin middleware and http handler
  chaining which is unnecessary. instead, intermediate handlers like
  logging and sentry can be implemented as gin middleware
- fix an issue with identity aware logger so it can use the correct context key/values
- UserAwareLoggerMiddware used key `userID` which is no longer being
  set. Instead, change it to IdentityAwareLoggerMiddleware to reflect
  both user and machine access

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #

[1]: https://www.conventionalcommits.org/en/v1.0.0/
