### PR TITLE
feat(helm): infer server.enabled

### DIFF
--- a/helm/charts/infra/templates/NOTES.txt
+++ b/helm/charts/infra/templates/NOTES.txt
@@ -2,7 +2,7 @@
 
                                 Welcome to Infra
 
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 
   Login to this cluster with infra-cli:
 

--- a/helm/charts/infra/templates/engine/configmap.yaml
+++ b/helm/charts/infra/templates/engine/configmap.yaml
@@ -14,7 +14,7 @@ data:
     accessKey: file:/var/run/secrets/infrahq.com/access-key/access-key
 {{- end }}
 
-{{- if and .Values.server.enabled (not (hasKey .Values.engine.config "server")) }}
+{{- if include "server.enabled" . | eq "true" }}
     server: {{ .Release.Name }}-server.{{ .Release.Namespace }}
 
 {{- if (not (hasKey .Values.engine.config "skipTLSVerify")) }}

--- a/helm/charts/infra/templates/server/_helpers.tpl
+++ b/helm/charts/infra/templates/server/_helpers.tpl
@@ -157,3 +157,10 @@ existing secret and use its password. If the secret does not exist, randomly gen
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Infer whether server should be deployed based on server.enabled and engine.config.server.
+*/}}
+{{- define "server.enabled" -}}
+{{- and .Values.server.enabled (not .Values.engine.config.server) }}
+{{- end }}

--- a/helm/charts/infra/templates/server/configmap.yaml
+++ b/helm/charts/infra/templates/server/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/charts/infra/templates/server/deployment.yaml
+++ b/helm/charts/infra/templates/server/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/charts/infra/templates/server/horizontalpodautoscaler.yaml
+++ b/helm/charts/infra/templates/server/horizontalpodautoscaler.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 {{- if .Values.server.autoscaling.enabled }}
 {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2beta2

--- a/helm/charts/infra/templates/server/ingress.yaml
+++ b/helm/charts/infra/templates/server/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 {{- if .Values.server.ingress.enabled }}
 {{- if and .Values.server.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
 {{- if not (hasKey .Values.server.ingress.annotations "kubernetes.io/ingress.class") }}

--- a/helm/charts/infra/templates/server/persistentvolumeclaim.yaml
+++ b/helm/charts/infra/templates/server/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 {{- if .Values.server.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/helm/charts/infra/templates/server/secret.yaml
+++ b/helm/charts/infra/templates/server/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 {{- $adminAccessKey := default "" .Values.server.config.adminAccessKey -}}
 {{- if or (not $adminAccessKey) (and (not (hasPrefix "file:" $adminAccessKey)) (not (hasPrefix "env:" $adminAccessKey))) }}
 apiVersion: v1

--- a/helm/charts/infra/templates/server/service.yaml
+++ b/helm/charts/infra/templates/server/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/charts/infra/templates/server/serviceaccount.yaml
+++ b/helm/charts/infra/templates/server/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 {{- if .Values.server.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/charts/infra/templates/server/servicemetrics.yaml
+++ b/helm/charts/infra/templates/server/servicemetrics.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 {{- if .Values.server.metrics.enabled }}
 apiVersion: v1
 kind: Service

--- a/helm/charts/infra/templates/server/servicemonitor.yaml
+++ b/helm/charts/infra/templates/server/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.server.enabled }}
+{{- if include "server.enabled" . | eq "true" }}
 {{- if and .Values.server.metrics.enabled .Values.server.metrics.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -101,7 +101,6 @@ func newDestinationsAddCmd() *cobra.Command {
 
 			var sb strings.Builder
 			sb.WriteString("    helm install infra infrahq/infra")
-			sb.WriteString(" --set server.enabled=false")
 
 			if len(args) > 1 {
 				fmt.Fprintf(&sb, " --set engine.config.name=%s", args[1])


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The server component is enabled if `server.enabled` and if `engine.config.server` is not defined. If `engine.config.server` is defined, the user probably want to install the just the engine component.

This change simplifies the command necessary to create an engine-only deployment by removing the need to manually specify `--set server.enabled=false`.

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #

[1]: https://www.conventionalcommits.org/en/v1.0.0/
