### PR TITLE
fix: update infra kube config tokens command

### DIFF
--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -166,7 +166,7 @@ func writeKubeconfig(destinations []api.Destination, grants []api.Grant) error {
 		kubeConfig.AuthInfos[context] = &clientcmdapi.AuthInfo{
 			Exec: &clientcmdapi.ExecConfig{
 				Command:         executable,
-				Args:            []string{"tokens", "create"},
+				Args:            []string{"tokens", "add"},
 				APIVersion:      "client.authentication.k8s.io/v1beta1",
 				InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
 			},


### PR DESCRIPTION
- tokens could not be created because the command in the kube config was out of date

## Summary
Kube commands were failing because the CLI was updated.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #

[1]: https://www.conventionalcommits.org/en/v1.0.0/
