### PR TITLE
fix: nil error log when destination refreshed

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -648,8 +648,7 @@ func refreshDestination(client *api.Client, local *localDetails) error {
 		},
 	}
 
-	_, err := client.UpdateDestination(request)
-	if err != nil {
+	if _, err := client.UpdateDestination(request); err != nil {
 		return fmt.Errorf("error updating existing destination: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
This logged a nil error on destination refresh.

```
{"level":"error","ts":1647282784.513224,"caller":"engine/engine.go:483","msg":"initializing destination: %!w(*errors.errorString=&{error updating existing destination: %!w(<nil>)})"}
```

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
