### PR TITLE
fix(engine): remove Recovery middleware

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -528,7 +528,6 @@ func Run(options Options) error {
 	gin.SetMode(gin.ReleaseMode)
 
 	router := gin.New()
-	router.Use(gin.Recovery())
 	router.GET("/healthz", func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})


### PR DESCRIPTION
gin.Recovery middleware is used to recover from panics which is new
behaviour added during the gin move. Previously, panics were not
recovered.

This new middleware produces the recovery message seen when requests
are aborted, which is common with requests with `watch=true` or, using
kubectl, `kubectl get pods -w` or log following. Aborts in this case
should not be considered an error.

## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1186

[1]: https://www.conventionalcommits.org/en/v1.0.0/
