### PR TITLE
fix(cmd): use single field to cache client identity

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -18,7 +18,6 @@ type ClientConfig struct {
 
 // current: v0.3
 type ClientHostConfig struct {
-	ID            uid.ID            `json:"id"`
 	PolymorphicID uid.PolymorphicID `json:"polymorphic-id"`
 	Name          string            `json:"name"`
 	Host          string            `json:"host"`

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -228,12 +228,6 @@ func finishLogin(host string, polymorphicID uid.PolymorphicID, name string, acce
 
 	var hostConfig ClientHostConfig
 
-	id, err := polymorphicID.ID()
-	if err != nil {
-		return err
-	}
-
-	hostConfig.ID = id
 	hostConfig.PolymorphicID = polymorphicID
 	hostConfig.Current = true
 	hostConfig.Host = host

--- a/internal/cmd/tokens.go
+++ b/internal/cmd/tokens.go
@@ -40,13 +40,21 @@ func tokensCreate() error {
 		return err
 	}
 
-	if config.ID == 0 {
-		return fmt.Errorf("no active user")
+	id := config.PolymorphicID
+	if id == "" {
+		return fmt.Errorf("no active identity")
 	}
 
-	token, err := client.CreateToken(&api.CreateTokenRequest{
-		UserID: config.ID,
-	})
+	if !id.IsUser() && !id.IsMachine() {
+		return fmt.Errorf("unsupported identity for operation: %s", id)
+	}
+
+	userID, err := id.ID()
+	if err != nil {
+		return err
+	}
+
+	token, err := client.CreateToken(&api.CreateTokenRequest{UserID: userID})
 	if err != nil {
 		if errors.Is(err, api.ErrForbidden) {
 			fmt.Fprintln(os.Stderr, "Session has expired.")


### PR DESCRIPTION
## Summary

client identity is duplicated between config.ID and
config.PolymorphicID. since config.PolymorphicID supersedes ID, it is
sufficient to only cache the PolymorphicID value.

refactor: rename config.PolymorphicID to config.ID

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1146

[1]: https://www.conventionalcommits.org/en/v1.0.0/
