### PR TITLE
refactor(helm): use LoadBalancer by default

### DIFF
--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -173,7 +173,7 @@ server:
 
     ## Service type
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-    type: ClusterIP
+    type: LoadBalancer
 
     ## Service labels
     labels: {}
@@ -575,7 +575,7 @@ engine:
 
     ## Service type
     ## Ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-    type: ClusterIP
+    type: LoadBalancer
 
     ## Service labels
     labels: {}
@@ -594,7 +594,7 @@ engine:
     nodePort: 30080
 
     ## HTTPS service port
-    securePort: 443
+    securePort: 8443
 
     ## HTTPS service port name
     securePortName: https


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Set engine port to 8443 to not collide with server port 443

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1212

[1]: https://www.conventionalcommits.org/en/v1.0.0/
