### PR TITLE
chore: upgrade to golang:1.18

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           stable: false
-          go-version: 1.18.0-rc1
+          go-version: '1.18'
       - run: make test
 
   helm-lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           stable: false
-          go-version: 1.18.0-rc1
+          go-version: '1.18'
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.18rc1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.18 AS builder
 RUN apt-get update && \
     apt-get install -y gcc-aarch64-linux-gnu gcc-x86-64-linux-gnu && \
     ln -s /usr/bin/aarch64-linux-gnu-gcc /usr/bin/arm64-linux-gnu-gcc  && \

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-1. Install [Go 1.18](https://go.dev/dl/#go1.18rc1)
+1. Install [Go 1.18](https://go.dev/dl/#go1.18)
 1. Clone the project
 
     ```bash


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Go 1.18 is here!