### PR TITLE
fix: hide infra provider from login CLI

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -20,6 +20,7 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -162,8 +163,15 @@ func login(host string) error {
 	}
 
 	var options []string
+	var oidcProviders []api.Provider
+
 	for _, p := range providers {
-		options = append(options, fmt.Sprintf("%s (%s)", p.Name, p.URL))
+		if p.Name == models.InternalInfraProviderName {
+			// TODO
+		} else {
+			options = append(options, fmt.Sprintf("%s (%s)", p.Name, p.URL))
+			oidcProviders = append(oidcProviders, p)
+		}
 	}
 
 	options = append(options, "Login with Access Key")
@@ -189,7 +197,7 @@ func login(host string) error {
 
 		loginReq.AccessKey = accessKey
 	} else {
-		provider := providers[option]
+		provider := oidcProviders[option]
 		providerID = provider.ID
 
 		fmt.Fprintf(os.Stderr, "  Logging in with %s...\n", termenv.String(provider.Name).Bold().String())

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -266,7 +266,7 @@ func setTagInfo(f reflect.StructField, t, parent reflect.Type, schema, parentSch
 				if err != nil {
 					panic("unexpected min length: " + err.Error())
 				}
-				parentSchema.MinLength = len
+				schema.MinLength = len
 			}
 			if val == "email" {
 				schema.Example = "email@example.com"


### PR DESCRIPTION
## Summary
Hiding the Infra provider from the CLI login until the username/password stuff is in (soon).

Also small tweak for OpenAPI doc generation.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #

[1]: https://www.conventionalcommits.org/en/v1.0.0/
