### PR TITLE
fix: client should skip json parse body on unknown errors

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,6 +39,10 @@ func checkError(status int, body []byte) error {
 		return fmt.Errorf("%w: %s", ErrBadRequest, apiError.Message)
 	case http.StatusInternalServerError:
 		return ErrInternal
+	}
+
+	if status >= 400 {
+		return errors.New(http.StatusText(status))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

previously we only error on known returned errors, but unknown errors (like 503/504 gateway problems) should also prevent us from parsing the response.

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to Conventional Commit
