### PR TITLE
docs: add docs for ALB ingress

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -107,6 +107,8 @@ server:
     hosts:
       - infra.example.com # edit me
     className: alb
+    paths:
+      - '/*'
     annotations:
       alb.ingress.kubernetes.io/scheme: internet-facing         # (optional: use "internal" for non-internet facing)
       alb.ingress.kubernetes.io/backend-protocol: HTTP


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Update AWS Load Balancer Controller example for ingress to override `server.ingress.paths`.

Resolves #1224

[1]: https://www.conventionalcommits.org/en/v1.0.0/
