### PR TITLE
ci: disable wsl linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,5 @@ linters:
     - unused
     - varcheck
     - wastedassign
-    - wsl
   disable:
     - scopelint


### PR DESCRIPTION
## Summary

This linter seems to be mostly concerned with adding or removing newlines, and grouping things into blocks.

https://github.com/bombsimon/wsl/blob/master/doc/rules.md

I looked over those rules to see if there were any we should keep, but it seems like a lot of work to customize. I'm not sure there is enough value here to warrant spending the time on it. I'd like to propose we disable this linter for now. If there are rules that we find useful, we can try to re-enable it and disable the rules we don't like.

`gofmt -s` already does a good job of applying a consistent format, and we still have that formatting after `wsl` is disabled.

## Checklist

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]
