### PR TITLE
fix: do not fail on no groups or ref from oidc (#1225)

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -129,7 +129,7 @@ func (o *mockOIDCImplementation) RefreshAccessToken(providerTokens *models.Provi
 }
 
 func (m *mockOIDCImplementation) GetUserInfo(providerTokens *models.ProviderToken) (*authn.UserInfo, error) {
-	return &authn.UserInfo{Email: m.UserEmailResp, Groups: m.UserGroupsResp}, nil
+	return &authn.UserInfo{Email: m.UserEmailResp, Groups: &m.UserGroupsResp}, nil
 }
 
 func TestExchangeAuthCodeForProviderTokens(t *testing.T) {


### PR DESCRIPTION
- warn if no refresh token on oidc response and continue
- warn if no groups in user info response and continue

## Summary

If an operator misconfigured their OIDC client Infra would just fail on login completely even though the sign-in was a success. Updated the behavior to proceed if the refresh token isn't present or there are no groups from the user info command, and just warn of this bad state.

Failure states:
- No refresh token -> continues as normal, but the user's session will only last as long as the access token is valid with the IDP (probably 1 hour)
- No groups in user info response -> user's provider groups are cleared and their direct user grants can still be used

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1225 

[1]: https://www.conventionalcommits.org/en/v1.0.0/
