### PR TITLE
style(cli): remove some short flags from CLI commands

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -213,7 +213,7 @@ func newLogoutCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&force, "force", "f", false, "logout and remove context")
+	cmd.Flags().BoolVar(&force, "force", false, "logout and remove context")
 
 	return cmd
 }
@@ -431,7 +431,7 @@ func newServerCmd() *cobra.Command {
 	cmd.Flags().Bool("enable-crash-reporting", true, "Enable crash reporting")
 	cmd.Flags().Bool("enable-ui", false, "Enable Infra server UI")
 	cmd.Flags().String("ui-proxy-url", "", "Proxy upstream UI requests to this url")
-	cmd.Flags().DurationP("session-duration", "d", time.Hour*12, "User session duration")
+	cmd.Flags().Duration("session-duration", time.Hour*12, "User session duration")
 	cmd.Flags().Bool("enable-setup", true, "Enable one-time setup")
 
 	return cmd
@@ -609,8 +609,8 @@ func NewRootCmd() (*cobra.Command, error) {
 	rootCmd.AddCommand(newConnectorCmd())
 	rootCmd.AddCommand(newVersionCmd())
 
-	rootCmd.Flags().BoolP("version", "v", false, "Display Infra version")
-	rootCmd.Flags().BoolP("info", "i", false, "Display info about the current logged in session")
+	rootCmd.Flags().Bool("version", false, "Display Infra version")
+	rootCmd.Flags().Bool("info", false, "Display info about the current logged in session")
 
 	rootCmd.PersistentFlags().String("log-level", "info", "Show logs when running the command [error, warn, info, debug]")
 	rootCmd.PersistentFlags().Bool("non-interactive", false, "Disable all prompts for input")

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -52,8 +52,8 @@ infra keys create main wall-e 12h --extension-deadline=1h
 		},
 	}
 
-	cmd.Flags().StringP("ttl", "t", "", "The total time that an access key will be valid for")
-	cmd.Flags().StringP("extension-deadline", "e", "", "A specified deadline that an access key must be used within to remain valid")
+	cmd.Flags().String("ttl", "", "The total time that an access key will be valid for")
+	cmd.Flags().String("extension-deadline", "", "A specified deadline that an access key must be used within to remain valid")
 
 	return cmd
 }


### PR DESCRIPTION
## Background

Short flags are nice for convenience, but once we add them it is almost impossible to remove them. I think if we start with fewer short flags it will be easier to add them in the future, instead of adding them all now and regretting that we can't use them for other purposes later.

The risk of adding them all now is that we won't be able to use them for other CLI flags in the future, and the short flag for one command may be different from the short for a different command, which make the CLI less intuitive. For example the `-f` for logout was `--force`, which is much different than the `-f` for server or connector (`--config-file`). By removing these short flags for now we give ourselves more time to figure out if these differences are confusing, or not.

## Summary

This PR removes a bunch of short flags. It leaves some of them, but I think we should talk about if it makes sense to remove more.

I've marked this as a breaking change, but I'm not sure if users will be significantly impacted as they may not be using these short flags yet. Any short flags used by the helm charts are left as-is.

## Open questions

* Should we remove more of the short flags?
* Does `-f` make sense for `--config-file`? Often that would be `-c`. Should we remove the short flag for now since we expect that most of the time a server and connector will be started by some form of automation (ex: helm), which means the short flag provides very little value.