### PR TITLE
fix: give users infra grant on creation

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -72,8 +72,6 @@ func (a *API) CreateUser(c *gin.Context, r *api.CreateUserRequest) (*api.CreateU
 		return nil, err
 	}
 
-	// by default the user role in infra can see all destinations
-	// #1084 - create grants for only destinations a user has access to
 	defaultGrant := &models.Grant{Identity: user.PolymorphicIdentifier(), Privilege: models.InfraUserRole, Resource: "infra"}
 	if err := access.CreateGrant(c, defaultGrant); err != nil {
 		return nil, err


### PR DESCRIPTION
- users need infra "users" role for the infra list endpoint

## Summary

When a user is created locally and they don't have a grant declared in config they didn't get the internal "user" role in Infra. This is needed for the `infra list` endpoint.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things.  Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]

## Related Issues

<!-- Link any related issues using `Resolves #1234`. -->

Resolves #1294 

[1]: https://www.conventionalcommits.org/en/v1.0.0/
