### PR TITLE
fix: generation of openapi spec when there are no changes

### DIFF
--- a/.github/release-please.json
+++ b/.github/release-please.json
@@ -5,7 +5,8 @@
     ".": {
       "release-type": "go",
       "extra-files": [
-        "helm/charts/infra/Chart.yaml"
+        "helm/charts/infra/Chart.yaml",
+        "internal/version.go"
       ]
     }
   }

--- a/Makefile
+++ b/Makefile
@@ -94,5 +94,6 @@ openapi-lint: docs/api/openapi3.json
 	@command -v openapi --version >/dev/null || { echo "openapi missing, try: npm install -g @redocly/openapi-cli" && exit 1; }
 	openapi lint $<
 
+.PHONY: docs/api/openapi3.json
 docs/api/openapi3.json:
 	go run ./internal/openapigen $@

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -409,7 +409,7 @@
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
     "title": "Infra API",
-    "version": "2022-03-24"
+    "version": "0.6.1"
   },
   "paths": {
     "/v1/access-keys": {

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,8 +1,10 @@
 package internal
 
 var (
-	Branch  = "main"
-	Version = "0.0.0-development"
-	Commit  = ""
-	Date    = ""
+	Branch = "main"
+	// {x-release-please-start-version}
+	Version = "0.6.1"
+	// {x-release-please-end}
+	Commit = ""
+	Date   = ""
 )


### PR DESCRIPTION
## Summary

I noticed the date update problem was happening again after #1290.

Using reflect.Equal does not appear to work, there must be differences between how the spec is decoded from a file, and generated from types.

This PR replaces the the date with the product version. Thanks to @mxyng , we can set this version from the please-release github action.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing

[1]: https://www.conventionalcommits.org/en/v1.0.0/

Builds on #1290