### PR TITLE
ci: run go tests using -race and gotestsum

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,9 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-      - run: make test
+      - run: go install gotest.tools/gotestsum@v1.7.0
+      - run: go mod tidy
+      - run: ~/go/bin/gotestsum --no-color=false -ftestname -- -short -race ./...
 
   go-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Previously the github action used the Makefile but I think we'll often want to run tests in a slightly different way in CI.

Also uses `gotestsum` to run the tests, so that we get a summary of which tests were skipped.

Enables `-race` so that we can catch data races in CI.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [x] GitHub Actions are passing

[1]: https://www.conventionalcommits.org/en/v1.0.0/
