### PR TITLE
fix: cert generation

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -89,7 +89,7 @@ func SelfSignedOrLetsEncryptCert(manager *autocert.Manager, serverName string) f
 			serverName = hello.Conn.LocalAddr().String()
 		}
 
-		certBytes, err := manager.Cache.Get(context.TODO(), serverName)
+		certBytes, err := manager.Cache.Get(context.TODO(), serverName+".crt")
 		if err != nil {
 			logging.S.Warnf("cert: %w", err)
 		}
@@ -99,13 +99,14 @@ func SelfSignedOrLetsEncryptCert(manager *autocert.Manager, serverName string) f
 			logging.S.Warnf("key: %w", err)
 		}
 
-		if certBytes == nil && keyBytes == nil {
+		// if either cert or key is missing, create it
+		if certBytes == nil || keyBytes == nil {
 			certBytes, keyBytes, err = SelfSignedCert([]string{serverName})
 			if err != nil {
 				return nil, err
 			}
 
-			if err := manager.Cache.Put(context.TODO(), serverName, certBytes); err != nil {
+			if err := manager.Cache.Put(context.TODO(), serverName+".crt", certBytes); err != nil {
 				return nil, err
 			}
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Add back `.crt` extension to the cached certificate.

Change condition to if either cert or key is missing instead of missing
both as there may be edge cases where one of the two are missing which
puts the service into a weird, half-configured position. Add a comment
documenting this.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
