### PR TITLE
feat: check cli version against server version on login

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: make docker tag=next
+      - run: make next/docker
         env:
           TELEMETRY_WRITE_KEY: ${{ secrets.TELEMETRY_WRITE_KEY }}
           CRASH_REPORTING_DSN: ${{ secrets.CRASH_REPORTING_DSN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}-checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: "{{ .Tag }}-devel"
 blobs:
   - provider: s3
     region: us-east-2

--- a/docker-desktop.yaml.in
+++ b/docker-desktop.yaml.in
@@ -1,6 +1,6 @@
 global:
   image:
-    tag: $IMAGE_TAG
+    tag: build
     pullPolicy: Never
 
 server:
@@ -22,7 +22,3 @@ server:
 connector:
   config:
     name: docker-desktop
-
-  image:
-    tag: $IMAGE_TAG
-    pullPolicy: Never

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/spf13/afero v1.8.2
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
+	golang.org/x/mod v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1236,6 +1236,7 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.5.0 h1:UG21uOlmZabA4fW5i7ZX6bjw1xELEGg/ZLgZq9auk/Q=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -42,6 +42,10 @@ func relogin() error {
 		return err
 	}
 
+	if err := checkVersion(client); err != nil {
+		return err
+	}
+
 	if currentConfig.ProviderID == 0 {
 		return errors.New("can not renew login without provider")
 	}
@@ -133,6 +137,10 @@ func login(host string) error {
 
 	client, err := apiClient(host, "", skipTLSVerify)
 	if err != nil {
+		return err
+	}
+
+	if err := checkVersion(client); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Inform the user of a version mismatch if the build version is not in sync. When there is a version mismatch, inform the user as early as possible.

Example:

```
$ infra login infra.local
  Logging in to infra.local
  The authenticity of host 'infra.local' can't be established.
? Are you sure you want to continue? Yes
  WARN: Version mismatch between Infra CLI (v0.6.1) and Infra (v0.7.0)
? Select a login method:  [Use arrows to move, type to filter]
```

Update docker build targets to attach the appropriate values to image tags and build versions:

  - Rename build/docker to devel/docker which outputs <version>-devel and devel images
  - Rename docker to next/docker which outputs <version>-next and next images
  - release/docker remains unchanged

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1322
