### PR TITLE
fix: recreate access key if parts differ

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -537,7 +537,7 @@ func (s *Server) importAccessKeys() error {
 			sum := sha256.Sum256([]byte(parts[1]))
 
 			// if token name, key, and secret checksum match input, skip recreating the token
-			if accessKey.Name == name && subtle.ConstantTimeCompare([]byte(accessKey.Key), []byte(parts[0])) != 1 && subtle.ConstantTimeCompare(accessKey.SecretChecksum, sum[:]) != 1 {
+			if accessKey.Name == name && subtle.ConstantTimeCompare([]byte(accessKey.Key), []byte(parts[0])) == 1 && subtle.ConstantTimeCompare(accessKey.SecretChecksum, sum[:]) == 1 {
 				logging.S.Debugf("%s: skip recreating token", k)
 				continue
 			}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/secrets"
 	"github.com/infrahq/infra/uid"
@@ -859,4 +860,8 @@ func TestImportAccessKeysUpdate(t *testing.T) {
 
 	err = s.importAccessKeys()
 	require.NoError(t, err)
+
+	accessKey, err := data.GetAccessKey(s.db, data.ByName("default admin access key"))
+	require.NoError(t, err)
+	require.Equal(t, accessKey.Key, "EKoHADINYX")
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

There is a bug in the subtle compare of key and secret.
subtle.ConstantTimeCompare returns 1 if contents are equal, and 0
otherwise. The code assumed the inverse.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [x] GitHub Actions are passing

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1334
