### PR TITLE
refactor: return a friendly PID parse error (#1338)

### DIFF
--- a/uid/polymorphic.go
+++ b/uid/polymorphic.go
@@ -13,6 +13,9 @@ func (p PolymorphicID) String() string {
 }
 
 func (p PolymorphicID) ID() (ID, error) {
+	if len(p) < 2 {
+		return ID(0), fmt.Errorf("invalid polymorphic ID encountered: %v", p)
+	}
 	return ParseString(string(p)[2:])
 }
 


### PR DESCRIPTION
## Summary
A recent migration bug brought this unfriendly error to light. Rather than returning a slice out of range error we should return this more descriptive error.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1338 
