### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,22 +7,43 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what the bug is. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Expected behavior
 
-**Environment**
-* Infra client and server versions (use `infra version`)
-* Kubernetes version (use `kubectl version`)
-* Where you are running Kubernetes (e.g. EKS, AKS, GKE, Docker Desktop, Minikube, etc.)
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Relevant Infra Logs**
-Use `kubectl logs deployment/infra-connector` and `kubectl logs deployment/infra-server` and add any suspicious logs here (do not post any sensitive information, and only post small snippets!).
+## Screenshots
 
-**Additional context**
-Add any other context about the problem here.
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Environment
+
+<!-- Infra client and server versions using `infra version` -->
+
+```
+$ infra version
+```
+
+<!-- Kubernetes version using `kubectl version` -->
+
+```
+$ kubectl version
+```
+
+<!-- Where you are running Kubernetes (e.g. EKS, AKS, GKE, Docker Desktop, Minikube, etc.) -->
+
+## Relevant Infra Logs
+
+<!--
+Use `kubectl logs deployment/infra-server` and `kubectl logs deployment/infra-connector` and
+add any suspicious logs here. Try to keep snippets short and concise.
+
+Sensitive information should be masked/redacted.
+-->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,19 +7,34 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Is your feature request related to a problem? Please describe.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what the problem is. Example: I'm always frustrated when [...] -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Describe the solution you'd like
 
-**Environment Details**
-* Infra client and server versions (use infra version)
-* Kubernetes version (use kubectl version)
-* Where you are running Kubernetes (e.g. EKS, AKS, GKE, Docker Desktop, Minikube, etc.)
+<!-- A clear and concise description of what you want to happen. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Describe alternatives you've considered
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+## Environment Details
+
+<!-- Infra client and server versions using `infra version` -->
+
+```
+$ infra version
+```
+
+<!-- Kubernetes version using `kubectl version` -->
+
+```
+$ kubectl version
+```
+
+<!-- Where you are running Kubernetes (e.g. EKS, AKS, GKE, Docker Desktop, Minikube, etc.) -->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Updating issue templates with more formatting.

Use headers `##` instead of bolding `**` to more clearly establish sections in the final issue.
Wrap prompts in comments such that they aren't rendered in the final markdown. This allows the user to leave the prompts in the issue in edit mode while omitting them in the rendered view.