### PR TITLE
fix: note that connector takes time to initialize (#1343)

### DIFF
--- a/helm/charts/infra/templates/NOTES.txt
+++ b/helm/charts/infra/templates/NOTES.txt
@@ -90,7 +90,9 @@
 {{- end }}
 
   Connector installed. It may take some time to initialize.
-  Once this cluster has been successfully registered with Infra it will appear in the output of the following command:
+  
+  Once this cluster has been successfully registered with Infra
+  it will appear in the output of the following command:
 
   $ infra destinations list | grep {{ .Values.connector.config.name | default "my-cluster" }}
 


### PR DESCRIPTION
## Summary

It is confusing that the output of the helm install on the connector tells you to run the `infra list` command, when doing so immediately will result in an empty output. Mitigate this by adding some context that the connector takes time to initialize. 

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1343
