### PR TITLE
fix: k8s connector should ignore "connect" grants

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -267,6 +267,10 @@ func updateRoles(c *api.Client, k *kubernetes.Kubernetes, grants []api.Grant) er
 	for _, g := range grants {
 		var name, kind string
 
+		if g.Privilege == "connect" {
+			continue
+		}
+
 		id, err := g.Subject.ID()
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

k8s connector should ignore "connect" grants as they don't map to anything in k8s. This is used as a signal that the users are allowed to authenticate, and typically used to indicate that authorization is managed elsewhere.

## Checklist

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing

[1]: https://www.conventionalcommits.org/en/v1.0.0/
