### PR TITLE
fix: do not force http2 on proxy transport

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -578,6 +578,7 @@ func Run(options Options) error {
 	}
 
 	proxyTransport := defaultHTTPTransport.Clone()
+	proxyTransport.ForceAttemptHTTP2 = false
 	proxyTransport.TLSClientConfig = &tls.Config{
 		RootCAs:    certPool,
 		MinVersion: tls.VersionTLS12,


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`kubectl exec` uses `Upgrade` headers in its requests which isn't supported in HTTP/2 so do not set `ForceAttemptHTTP2` for the proxy transport.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1365