### PR TITLE
chore: remove github.com/mcuadros/go-defaults

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	github.com/gin-contrib/static v0.0.1
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/spf13/afero v1.8.2
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -894,8 +894,6 @@ github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mcuadros/go-defaults v1.2.0 h1:FODb8WSf0uGaY8elWJAkoLL0Ri6AlZ1bFlenk56oZtc=
-github.com/mcuadros/go-defaults v1.2.0/go.mod h1:WEZtHEVIGYVDqkKSWBdWKUVdRyKlMfulPaGDWIVeCWY=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -14,7 +14,6 @@ import (
 	"github.com/goware/urlx"
 	"github.com/iancoleman/strcase"
 	"github.com/lensesio/tableprinter"
-	"github.com/mcuadros/go-defaults"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -97,8 +96,6 @@ func parseOptions(cmd *cobra.Command, options interface{}, envPrefix string) err
 
 		return errors.New(sb.String())
 	}
-
-	defaults.SetDefaults(options)
 
 	if err := v.ReadInConfig(); err != nil {
 		var errNotFound *viper.ConfigFileNotFoundError


### PR DESCRIPTION
## Summary

I believe this dependency was added along with viper. Searching for `default:"` returns no results. I think this means the library is not used. We can set defaults on the struct before passing it in. I don't think we need to set them as struct fields tags.

Is this used in some other way that I've missed?

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/