### PR TITLE
feat: k8s connector: allow disabling provider-name prefixing on users

### DIFF
--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -713,6 +713,3 @@ connector:
 
   ## Skip verify server TLS certificate
   #   skipTLSVerify: true
-
-  ## Disable provider-name prefixing on matching kubernetes user emails.
-  #   disableProviderNamePrefix: false


### PR DESCRIPTION
## Summary

See #1367. allow disabling prefixing of user emails in k8s. `okta:joe@example.com` to become `joe@example.com`. Assists with users managing their own authorization.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [x] GitHub Actions are passing
- [x] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1367
