### PR TITLE
fix: do not recreate connector cert if exists

### DIFF
--- a/helm/charts/infra/templates/connector/secret.yaml
+++ b/helm/charts/infra/templates/connector/secret.yaml
@@ -12,7 +12,8 @@ data:
 {{- end }}
 ---
 {{- if and (not .Values.connector.config.tlsCert) (not .Values.connector.config.tlsKey) }}
-{{- $tlsName := printf "%s.%s" (include "connector.fullname" .) .Release.Namespace }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-tls" (include "connector.fullname" .)) -}}
+{{- $tlsName := printf "%s.%s" (include "connector.fullname" .) .Release.Namespace -}}
 {{- $cert := genSelfSignedCert $tlsName nil (list $tlsName) 3650 -}}
 apiVersion: v1
 kind: Secret
@@ -23,8 +24,16 @@ metadata:
 type: kubernetes.io/tls
 data:
   tls.crt: |
+{{- if $secret.data }}
+{{- get $secret.data "tls.crt" | nindent 4 }}
+{{- else }}
 {{- $cert.Cert | b64enc | nindent 4 }}
+{{- end }}
   tls.key: |
+{{- if $secret.data }}
+{{- get $secret.data "tls.key" | nindent 4 }}
+{{- else }}
 {{- $cert.Key | b64enc | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Connector certificates should not be recreated if they already exist. Check existence before templating out certificates

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1371
