### PR TITLE
docs: add a toplevel contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thank you so much for wanting to help make Infra successful. Community contributions are really important and help
+us make Infra better.
+
+## Types of Contributions
+
+### Report Bugs or Suggest Enhancements
+
+We use [GitHub Issues](https://github.com/infrahq/infra/issues) to track bug reports and feature requests. We're always
+looking for ways to improve the project, and well written issues help us find things we may have missed. Before filing an issue though,
+please check to see if it has been filed before.
+
+When filing the issue, we ask that you use good bug/feature etiquette. Make sure that you:
+ * Use a clear and descriptive title
+ * Include a description of what you expected to happen
+ * Attach a screenshot if relevant
+ * Include the Infra and Kubernetes versions you're using
+ * Describe where you're running Kubernetes
+
+
+### Fix a Bug or Implement a Feature
+
+If you'd like to help fix any bugs or contribute a new feature, please first make sure there is an [issue](https://github.com/infrahq/infra/issues) filed.
+
+Any issues tagged with `bug` or `good first issue` make great places to start. Issues tagged with `enhancement` are
+changes that we're thinking of making in the future. If you want to talk about an issue more, check out our [discussions page](https://github.com/infrahq/infra/discussions).
+
+Our repository follows GitHub's normal forking model. If you have never forked a repository before, follow GitHub's
+documentation which describes how to:
+  * [Fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+  * [Contribute to projects](https://docs.github.com/en/get-started/quickstart/contributing-to-projects)
+
+When you are ready to commit your change, follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+for your commit message.
+
+
+


### PR DESCRIPTION
## Summary

We removed the other contributing guide from the docs directory, so this puts a rudimentary one back.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [x] GitHub Actions are passing
- [x] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1320 
