### PR TITLE
refactor: add a test for logout --purge

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -117,29 +117,3 @@ func readHostConfig(host string) (*ClientHostConfig, error) {
 
 	return nil, ErrConfigNotFound
 }
-
-func removeHostConfig(host string, purge bool) error {
-	cfg, err := readConfig()
-	if err != nil {
-		return err
-	}
-
-	for i, c := range cfg.Hosts {
-		if c.Host == host {
-			if purge {
-				cfg.Hosts = append(cfg.Hosts[:i], cfg.Hosts[i+1:]...)
-			} else {
-				cfg.Hosts[i].AccessKey = ""
-			}
-
-			break
-		}
-	}
-
-	err = writeConfig(cfg)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -18,10 +18,9 @@ func logout(purge bool) error {
 		return err
 	}
 
-	for _, hostConfig := range config.Hosts {
-		if err := removeHostConfig(hostConfig.Host, purge); err != nil {
-			logging.S.Warn(err.Error())
-			continue
+	for i, hostConfig := range config.Hosts {
+		if !purge {
+			config.Hosts[i].AccessKey = ""
 		}
 
 		client, err := apiClient(hostConfig.Host, hostConfig.AccessKey, hostConfig.SkipTLSVerify)
@@ -35,5 +34,11 @@ func logout(purge bool) error {
 		}
 	}
 
+	if purge {
+		config.Hosts = nil
+	}
+	if err := writeConfig(config); err != nil {
+		logging.S.Warnf("failed to write client host config: %v", err)
+	}
 	return clearKubeconfig()
 }

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -22,71 +22,61 @@ func TestLogout(t *testing.T) {
 	kubeConfigPath := filepath.Join(homeDir, "kube.config")
 	t.Setenv("KUBECONFIG", kubeConfigPath)
 
-	var count int32
-	handler := func(resp http.ResponseWriter, req *http.Request) {
-		if req.URL.Path != "/v1/logout" {
-			resp.WriteHeader(http.StatusBadRequest)
-			return
+	setup := func(t *testing.T) (ClientConfig, *int32) {
+		var count int32
+		handler := func(resp http.ResponseWriter, req *http.Request) {
+			if req.URL.Path != "/v1/logout" {
+				resp.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			atomic.AddInt32(&count, 1)
+			resp.WriteHeader(http.StatusOK)
+			_, _ = resp.Write([]byte(`{}`)) // API client requires a JSON response
 		}
-		atomic.AddInt32(&count, 1)
-		resp.WriteHeader(http.StatusOK)
-		_, _ = resp.Write([]byte(`{}`)) // API client requires a JSON response
-	}
 
-	srv := httptest.NewTLSServer(http.HandlerFunc(handler))
-	defer srv.Close()
-	srv2 := httptest.NewTLSServer(http.HandlerFunc(handler))
-	defer srv2.Close()
+		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(srv.Close)
+		srv2 := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(srv2.Close)
 
-	cfg := ClientConfig{
-		Version: "0.3",
-		Hosts: []ClientHostConfig{
-			{
-				Name:          "host1",
-				Host:          srv.Listener.Addr().String(),
-				AccessKey:     "the-access-key",
-				SkipTLSVerify: true,
+		cfg := ClientConfig{
+			Version: "0.3",
+			Hosts: []ClientHostConfig{
+				{
+					Name:          "host1",
+					Host:          srv.Listener.Addr().String(),
+					AccessKey:     "the-access-key",
+					SkipTLSVerify: true,
+				},
+				{
+					Name:          "host2",
+					Host:          srv2.Listener.Addr().String(),
+					AccessKey:     "the-access-key",
+					SkipTLSVerify: true,
+				},
 			},
-			{
-				Name:          "host2",
-				Host:          srv2.Listener.Addr().String(),
-				AccessKey:     "the-access-key",
-				SkipTLSVerify: true,
+		}
+		err := writeConfig(&cfg)
+		require.NoError(t, err)
+
+		kubeCfg := clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"keep:not-infra": {Server: "https://keep:8080"},
+				"infra:prod":     {Server: "https://infraprod:8080"},
 			},
-		},
+			Contexts: map[string]*clientcmdapi.Context{
+				"keep:not-infra": {Cluster: "keep:not-infra"},
+				"infra:prod":     {Cluster: "infra:prod"},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"keep:not-infra": {Token: "keep-token"},
+				"infra:prod":     {Token: "infra-token"},
+			},
+		}
+		err = clientcmd.WriteToFile(kubeCfg, kubeConfigPath)
+		require.NoError(t, err)
+		return cfg, &count
 	}
-	err := writeConfig(&cfg)
-	require.NoError(t, err)
-
-	kubeCfg := clientcmdapi.Config{
-		Clusters: map[string]*clientcmdapi.Cluster{
-			"keep:not-infra": {Server: "https://keep:8080"},
-			"infra:prod":     {Server: "https://infraprod:8080"},
-		},
-		Contexts: map[string]*clientcmdapi.Context{
-			"keep:not-infra": {Cluster: "keep:not-infra"},
-			"infra:prod":     {Cluster: "infra:prod"},
-		},
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"keep:not-infra": {Token: "keep-token"},
-			"infra:prod":     {Token: "infra-token"},
-		},
-	}
-	err = clientcmd.WriteToFile(kubeCfg, kubeConfigPath)
-	require.NoError(t, err)
-
-	err = newLogoutCmd().Execute()
-	require.NoError(t, err)
-
-	require.Equal(t, int32(2), atomic.LoadInt32(&count), "calls to API")
-
-	updatedCfg, err := readConfig()
-	require.NoError(t, err)
-
-	expected := cfg
-	expected.Hosts[0].AccessKey = ""
-	expected.Hosts[1].AccessKey = ""
-	require.Equal(t, &expected, updatedCfg)
 
 	expectedKubeCfg := clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
@@ -100,7 +90,43 @@ func TestLogout(t *testing.T) {
 		},
 	}
 
-	updatedKubeCfg, err := clientConfig().RawConfig()
-	require.NoError(t, err)
-	assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+	t.Run("default", func(t *testing.T) {
+		cfg, count := setup(t)
+		err := newLogoutCmd().Execute()
+		require.NoError(t, err)
+
+		require.Equal(t, int32(2), atomic.LoadInt32(count), "calls to API")
+
+		updatedCfg, err := readConfig()
+		require.NoError(t, err)
+
+		expected := cfg
+		expected.Hosts[0].AccessKey = ""
+		expected.Hosts[1].AccessKey = ""
+		require.Equal(t, &expected, updatedCfg)
+
+		updatedKubeCfg, err := clientConfig().RawConfig()
+		require.NoError(t, err)
+		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+	})
+
+	t.Run("with purge", func(t *testing.T) {
+		_, count := setup(t)
+		cmd := newLogoutCmd()
+		cmd.SetArgs([]string{"--purge"})
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		require.Equal(t, int32(2), atomic.LoadInt32(count), "calls to API")
+
+		updatedCfg, err := readConfig()
+		require.NoError(t, err)
+
+		expected := ClientConfig{Version: "0.3"}
+		require.Equal(t, &expected, updatedCfg)
+
+		updatedKubeCfg, err := clientConfig().RawConfig()
+		require.NoError(t, err)
+		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+	})
 }


### PR DESCRIPTION
## Summary

Follow up to #1373

Adds a test for `infra logout --purge`, and also improves the implementation by removing the need to read and write
the file multiple times.

Lots of whitespace changes, so best viewed with [hide whitespace](https://github.com/infrahq/infra/pull/1383/files?diff=split&w=1).