### PR TITLE
fix: use a more human readable format for logs from the CLI

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/goware/urlx"
 	"github.com/iancoleman/strcase"
 	"github.com/lensesio/tableprinter"
@@ -361,6 +360,8 @@ func newServerCmd() *cobra.Command {
 		Short:  "Start Infra server",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logging.SetServerLogger()
+
 			// override default strcase.ToLowerCamel behaviour
 			strcase.ConfigureAcronym("enable-ui", "enableUI")
 			strcase.ConfigureAcronym("ui-proxy-url", "uiProxyURL")
@@ -424,6 +425,8 @@ func newConnectorCmd() *cobra.Command {
 		Short:  "Start the Infra connector",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			logging.SetServerLogger()
+
 			// override default strcase.ToLowerCamel behaviour
 			strcase.ConfigureAcronym("skip-tls-verify", "skipTLSVerify")
 
@@ -539,7 +542,7 @@ var rootOptions struct {
 	Version        bool   `mapstructure:"version"`
 }
 
-func NewRootCmd() (*cobra.Command, error) {
+func NewRootCmd() *cobra.Command {
 	cobra.EnableCommandSorting = false
 
 	rootCmd := &cobra.Command{
@@ -600,27 +603,7 @@ func NewRootCmd() (*cobra.Command, error) {
 
 	rootCmd.SetHelpCommandGroup("Other commands:")
 	rootCmd.SetUsageTemplate(usageTemplate())
-	return rootCmd, nil
-}
-
-func Run() error {
-	cmd, err := NewRootCmd()
-	if err != nil {
-		return err
-	}
-
-	err = cmd.Execute()
-	printError(err)
-
-	return err
-}
-
-func printError(err error) {
-	if err != nil {
-		if !errors.Is(err, terminal.InterruptErr) {
-			fmt.Fprintln(os.Stderr, "error: "+err.Error())
-		}
-	}
+	return rootCmd
 }
 
 func usageTemplate() string {

--- a/internal/docgen/main.go
+++ b/internal/docgen/main.go
@@ -15,12 +15,7 @@ func main() {
 	}
 	defer f.Close()
 
-	rootCmd, err := cmd.NewRootCmd()
-	if err != nil {
-		log.Println(err.Error())
-		return
-	}
-
+	rootCmd := cmd.NewRootCmd()
 	err = GenMarkdownFile(rootCmd, f)
 	if err != nil {
 		log.Println(err.Error())

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -28,22 +28,20 @@ func TestFiltersOutBearerTokenValue(t *testing.T) {
 		},
 	}
 	for _, testCase := range tests {
-		writeSyncer := &testWriterSyncer{}
-		defaultStdoutWriter = writeSyncer
-		defaultStderrWriter = writeSyncer
+		t.Run("", func(t *testing.T) {
+			writeSyncer := &testWriterSyncer{}
 
-		logger, err := NewLogger(zapcore.InfoLevel)
-		require.NoError(t, err)
+			logger := newServerLogger(zapcore.InfoLevel, writeSyncer, writeSyncer)
+			logger.Sugar().Info(testCase.Input)
 
-		logger.Sugar().Info(testCase.Input)
+			m := map[string]interface{}{}
+			err := json.Unmarshal(writeSyncer.data, &m)
+			require.NoError(t, err, string(writeSyncer.data))
 
-		m := map[string]interface{}{}
-		err = json.Unmarshal(writeSyncer.data, &m)
-		require.NoError(t, err)
-
-		msg, ok := m["msg"].(string)
-		require.True(t, ok)
-		require.Equal(t, testCase.Expected, msg)
+			msg, ok := m["msg"].(string)
+			require.True(t, ok)
+			require.Equal(t, testCase.Expected, msg)
+		})
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,13 +1,20 @@
 package main
 
 import (
+	"errors"
 	"os"
 
+	"github.com/AlecAivazis/survey/v2/terminal"
+
 	"github.com/infrahq/infra/internal/cmd"
+	"github.com/infrahq/infra/internal/logging"
 )
 
 func main() {
-	if err := cmd.Run(); err != nil {
+	if err := cmd.NewRootCmd().Execute(); err != nil {
+		if !errors.Is(err, terminal.InterruptErr) {
+			logging.S.Error(err.Error())
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

Previously we were using the same logger for both long running processes (server and connector) and short lived ones (other CLI commands).

The logger did use a text format (non-json) when stdin was a terminal, but the log would contain a long date+time and function name+line number, which is probably not what users want to see from a CLI.

This commit keeps the existing logger for long running processes, but uses a less verbose format for CLI commands. The new format is always text, and removes the timestamp and function name + line number.

Also changed the logging of error from the CLI to use the logger so that output of warnings and errors is more consistent.

Also removed some unnecessary error return values, and removed some very short functions to make the code easier to trace.