### PR TITLE
refactor: call gin.SetMode in fewer places

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -18,10 +18,6 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func init() {
-	gin.SetMode(gin.TestMode)
-}
-
 func setupDB(t *testing.T) *gorm.DB {
 	driver, err := data.NewSQLiteDriver("file::memory:")
 	require.NoError(t, err)

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -28,6 +28,7 @@ import (
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/certs"
 	"github.com/infrahq/infra/internal/claims"
+	"github.com/infrahq/infra/internal/ginutil"
 	"github.com/infrahq/infra/internal/kubernetes"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/repeat"
@@ -527,8 +528,7 @@ func Run(options Options) error {
 		}
 	})
 
-	gin.SetMode(gin.ReleaseMode)
-
+	ginutil.SetMode()
 	router := gin.New()
 	router.GET("/healthz", func(c *gin.Context) {
 		c.Status(http.StatusOK)

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -20,10 +20,6 @@ import (
 	"github.com/infrahq/infra/internal/claims"
 )
 
-func init() {
-	gin.SetMode(gin.TestMode)
-}
-
 func TestJWTMiddlewareNoAuthHeader(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/apis", nil)
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/internal/ginutil/mode.go
+++ b/internal/ginutil/mode.go
@@ -1,0 +1,18 @@
+package ginutil
+
+import (
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SetMode from the GIN_MODE environment variable. Unlike the init function
+// in gin, this function defaults to ReleaseMode when the environment variable
+// has no value.
+func SetMode() {
+	mode := os.Getenv(gin.EnvGinMode)
+	if mode == "" {
+		mode = gin.ReleaseMode
+	}
+	gin.SetMode(mode)
+}

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestSendAPIError(t *testing.T) {
-	gin.SetMode(gin.ReleaseMode)
-
 	tests := []struct {
 		err    error
 		result api.Error

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -61,7 +61,6 @@ func TestRequestTimeoutError(t *testing.T) {
 	requestTimeout = 100 * time.Millisecond
 
 	router := gin.New()
-	gin.SetMode(gin.ReleaseMode)
 	router.Use(RequestTimeoutMiddleware())
 	router.GET("/", func(c *gin.Context) {
 		time.Sleep(110 * time.Millisecond)
@@ -77,7 +76,6 @@ func TestRequestTimeoutSuccess(t *testing.T) {
 	requestTimeout = 60 * time.Second
 
 	router := gin.New()
-	gin.SetMode(gin.ReleaseMode)
 	router.Use(RequestTimeoutMiddleware())
 	router.GET("/", func(c *gin.Context) {
 		require.NoError(t, c.Request.Context().Err())
@@ -88,8 +86,6 @@ func TestRequestTimeoutSuccess(t *testing.T) {
 }
 
 func TestRequireAuthentication(t *testing.T) {
-	gin.SetMode(gin.ReleaseMode)
-
 	cases := map[string]map[string]interface{}{
 		"AccessKeyValid": {
 			"authFunc": func(t *testing.T, db *gorm.DB, c *gin.Context) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/certs"
+	"github.com/infrahq/infra/internal/ginutil"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/repeat"
 	"github.com/infrahq/infra/internal/server/data"
@@ -79,10 +80,6 @@ type Server struct {
 	secrets             map[string]secrets.SecretStorage
 	keys                map[string]secrets.SymmetricKeyProvider
 	certificateProvider pki.CertificateProvider
-}
-
-func init() {
-	gin.SetMode(gin.ReleaseMode)
 }
 
 func Run(options Options) (err error) {
@@ -369,6 +366,7 @@ func (s *Server) GenerateRoutes() *gin.Engine {
 }
 
 func (s *Server) runServer() error {
+	ginutil.SetMode()
 	router := s.GenerateRoutes()
 
 	if err := s.ui(router); err != nil {


### PR DESCRIPTION
## Summary

I noticed we were calling `gin.SetMode` in few places. Sometimes in `init()` sometimes right before creating the router, and sometimes in tests.

When I was adding new routes I found it helpful to be able to turn on debug mode with an environment variable, but all of these calls to `gin.SetMode` made it difficult.

Also looking over the code, and seeing https://github.com/gin-gonic/gin/issues/2984, it seems that `TestMode` does nothing. It is effectively equivalent to `ReleaseMode`. Only `DebugMode` changes what is logged.

The new behaviour works as follows:
1. `gin` itself defaults to `DebugMode` in `mode.go:init()`
2. the two packages that use gin (server and connector) both call `ginutil.SetMode` before starting a gin router.
3. `ginutil.SetMode` will attempt to use the same environment variable as `gin` would have used, but instead defaults to `ReleaseMode` when not set.

I believe this gives us the correct behaviour. We should always be in `ReleaseMode`. A developer debugging locally or an operator running a binary can set `GIN_MODE=debug` if they need to.

I could not find an appropriate place to put this new function, so I had to create the `ginutil` package. I'm happy to move it somewhere else if anyone has suggestions.