### PR TITLE
Organize Github labels into categories

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,87 @@
+# The labels in this file will be synced to Github by the Github workflow in
+# .github/workflows/manage-labels.yaml
+#
+# All labels are organized by category using a <category>/ prefix
+
+
+- name: "kind/bug"
+  color: "d73a4a"
+  description: A report or a fix for a problem with functional correctness.
+  from_name: "bug"
+- name: "kind/feature"
+  color: "a2eeef"
+  description: A request or change that improves functional suitability.
+  from_name: "enhancement"
+- name: "kind/improvement"
+  color: "d8d468"
+  description: A report of a quality problem, or a change that addresses a quality problem.
+- name: "kind/maintenance"
+  color: "605f11"
+  description: A change related to the maintenance of the project.
+  from_name: "tech debt"
+- name: "kind/question"
+  color: "d876e3"
+  description: A request for more information.
+  from_name: "question"
+
+
+- name: "area/documentation"
+  color: "0075ca"
+  description: Improvements or additions to documentation.
+  from_name: "documentation"
+- name: "area/api"
+  color: "11dd3d"
+  description: Issue or PR related to the Infra API.
+  from_name: "api"
+- name: "area/ui"
+  color: "0246D8"
+  from_name: "ui"
+- name: "area/deploy"
+  color: "BFA38D"
+  description: Issue or PR related to deploying Infra.
+  from_name: "helm"
+- name: "area/release"
+  color: "FBCA04"
+  from_name: "release"
+- name: "area/cli"
+  color: "ca10ac"
+  description: Issue or PR related to the command-line interface.
+  from_name: "cli"
+- name: "area/destinations"
+  color: "AC82DA"
+  from_name: "destinations"
+- name: "area/destinations/kubernetes"
+  color: "E2057A"
+  from_name: "kubernetes"
+- name: "area/providers"
+  color: "71EDD1"
+  from_name: "providers"
+- name: "area/providers/okta"
+  color: "07269E"
+  from_name: "okta"
+- name: "area/providers/infra"
+  color: "B3B781"
+- name: "area/ci"
+  color: "000000"
+  description: Issue or PR related to Github actions, and other CI automation.
+  from_name: "github_actions"
+- name: "area/observability"
+  color: "9CED24"
+  description: Issue or PR related to observability.
+  from_name: "observability"
+
+
+- name: "priority/high"
+  color: "d93f0b"
+  description: The issue is high priority.
+  from_name: "high"
+
+
+- name: "status/idea"
+  color: "ffffff"
+  description: The issue is an idea that may require more research.
+  from_name: "idea"
+- name: "status/blocked"
+  color: "B60205"
+  description: The issue is blocked on out-of-repository dependencies.
+  from_name: "blocked"

--- a/.github/workflows/manage-labels.yaml
+++ b/.github/workflows/manage-labels.yaml
@@ -1,0 +1,24 @@
+name: "Manage github labels"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/manage-labels.yaml"
+      - ".github/labels.yaml"
+  pull_request:
+    paths:
+      - ".github/workflows/manage-labels.yaml"
+      - ".github/labels.yaml"
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Apply github labels from config
+        uses: crazy-max/ghaction-github-labeler@v3
+        with:
+          yaml-file: .github/labels.yaml
+          skip-delete: true
+          dry-run: "${{ github.event_name == 'pull_request' }}"


### PR DESCRIPTION
## Summary

This PR adds a Github workflow that uses https://github.com/marketplace/actions/github-labeler to sync the labels from a config file to Github. I tested the action here: [dry run on PR](https://github.com/dnephin/actions-test/runs/5759115176#step:3:30) so that we can preview changes in a PR, and [apply the labels on merge to main](https://github.com/dnephin/actions-test/runs/5759129929?check_suite_focus=true#step:3:30). The workflow will not delete any existing labels, so we can still manage some manually, but the idea would be that for most label changes we would add them to the config file and open a PR.

The config file organizes many of our existing labels into categories. Looking at other popular open source Go projects ([see notes here](https://gist.github.com/dnephin/0f4ca66251c87022478e2581e72eb3ed)), the `kind` and `area` categories are very popular choices. The `kind/` labels should roughly match what we use for commit messages in #1390.

Any label in the config with `from_name` will be renamed to the new categorized name. The changes can be seen in the github check status for "Manage github labels / labeler" in the "Apply labels from config "step. For example: https://github.com/infrahq/infra/runs/5760544060?check_suite_focus=true#step:3:153