### PR TITLE
improve: ask user to confirm new password

### DIFF
--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -103,7 +103,7 @@ func newIdentitiesEditCmd() *cobra.Command {
 					return errors.New("specify the --password flag to update the password")
 				}
 
-				newPassword, err := promptUpdatePassword("")
+				newPassword, err := promptUpdatePassword()
 				if err != nil {
 					return err
 				}
@@ -111,6 +111,8 @@ func newIdentitiesEditCmd() *cobra.Command {
 				if err = updateUser(name, newPassword); err != nil {
 					return err
 				}
+
+				fmt.Println("user identity updated")
 			}
 
 			return nil
@@ -342,7 +344,7 @@ func updateUser(name, newPassword string) error {
 			}
 			return err
 		}
-		fmt.Fprintf(os.Stderr, "  Updated one time password for user %s\n", user.Email)
+		fmt.Println("setting one time password")
 	}
 
 	if _, err := client.UpdateUser(&api.UpdateUserRequest{ID: user.ID, Password: newPassword}); err != nil {
@@ -386,39 +388,22 @@ func getUserFromName(client *api.Client, name string, provider *api.Provider) (*
 	return &users[0], nil
 }
 
-func promptUpdatePassword(oldPassword string) (string, error) {
-	fmt.Fprintf(os.Stderr, "Enter a new password (min 8 characters)")
-
+func promptUpdatePassword() (string, error) {
 PROMPT:
 	newPassword := ""
-	if err := survey.AskOne(&survey.Password{Message: "New password:"}, &newPassword, survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)); err != nil {
+	if err := survey.AskOne(&survey.Password{Message: "New Password:"}, &newPassword, survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)); err != nil {
 		return "", err
 	}
 
-	if err := checkPasswordRequirements(newPassword, oldPassword); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
-		goto PROMPT
-	}
-
 	confirmNewPassword := ""
-	if err := survey.AskOne(&survey.Password{Message: "Re-enter new password:"}, &confirmNewPassword, survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)); err != nil {
+	if err := survey.AskOne(&survey.Password{Message: "Confirm New Password:"}, &confirmNewPassword, survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)); err != nil {
 		return "", err
 	}
 
 	if confirmNewPassword != newPassword {
-		fmt.Println("  Passwords do not match")
+		fmt.Println("passwords do not match")
 		goto PROMPT
 	}
 
 	return newPassword, nil
-}
-
-func checkPasswordRequirements(newPassword string, oldPassword string) error {
-	if len(newPassword) < 8 {
-		return errors.New("  Password cannot be less than 8 characters")
-	}
-	if newPassword == oldPassword {
-		return errors.New("  New password cannot equal your old password.")
-	}
-	return nil
 }


### PR DESCRIPTION
- CLI prompt to confirm new password before setting

## Summary
When a new password is set in the CLI you'll typically see a confirmation prompt immediately afterwards in case the password has a typo. This enforces that.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [x] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1280 
