### PR TITLE
refactor: minor, no logical changes

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -525,25 +525,6 @@ func newInfoCmd() *cobra.Command {
 	}
 }
 
-func newIdentitiesCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "identities",
-		Aliases: []string{"id", "identity"},
-		Short:   "Manage identities (users & machines)",
-		Group:   "Management commands:",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return mustBeLoggedIn()
-		},
-	}
-
-	cmd.AddCommand(newIdentitiesAddCmd())
-	cmd.AddCommand(newIdentitiesEditCmd())
-	cmd.AddCommand(newIdentitiesListCmd())
-	cmd.AddCommand(newIdentitiesRemoveCmd())
-
-	return cmd
-}
-
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:    "version",

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -16,6 +16,25 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+func newIdentitiesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "identities",
+		Aliases: []string{"id", "identity"},
+		Short:   "Manage identities (users & machines)",
+		Group:   "Management commands:",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return mustBeLoggedIn()
+		},
+	}
+
+	cmd.AddCommand(newIdentitiesAddCmd())
+	cmd.AddCommand(newIdentitiesEditCmd())
+	cmd.AddCommand(newIdentitiesListCmd())
+	cmd.AddCommand(newIdentitiesRemoveCmd())
+
+	return cmd
+}
+
 type identityOptions struct {
 	Description string `mapstructure:"description"`
 	Password    bool   `mapstructure:"password"`

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -390,7 +390,7 @@ func runSetupForLogin(client *api.Client) (string, error) {
 	return setupRes.AccessKey, nil
 }
 
-// Only used when logging in to a new session, since user has no credentials. Otherwise, use defaultAPIClient().
+// Only used when logging in or switching to a new session, since user has no credentials. Otherwise, use defaultAPIClient().
 func newAPIClient(server string, skipTLSVerify bool) (*api.Client, error) {
 	if !skipTLSVerify {
 		// Prompt user only if server fails the TLS verification


### PR DESCRIPTION
Pushing in increments so the logical DIFFs are easier to compare. 
We are moving each cmd to its own file, rather than declaring it in the parent cmd file. 