### PR TITLE
improve(docs): add brew link in case infra cask is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ helm install infra infrahq/infra
 
   ```bash
   brew install infrahq/tap/infra
+  brew link infrahq/tap/infra
   ```
 
 </details>

--- a/docs/Getting Started/quickstart.md
+++ b/docs/Getting Started/quickstart.md
@@ -23,6 +23,7 @@ helm install infra infrahq/infra
 
 ```bash
 brew install infrahq/tap/infra
+brew link infrahq/tap/infra
 ```
 
 </details>

--- a/docs/User Guides/accessing-infra.md
+++ b/docs/User Guides/accessing-infra.md
@@ -7,6 +7,7 @@
 
 ```bash
 brew install infrahq/tap/infra
+brew link infrahq/tap/infra
 ```
 
 </details>


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

When a cask of the same name is installed, Homebrew will not
automatically link binaries installed from a keg. Since there's a
infra.app cask also called infra[^1], install Infra CLI through
Homebrew may need the additional step of manually linking `infra`.

Resolves #1336 

[^1]: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/infra.rb