### PR TITLE
improve(cli): move newCmd functions

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -171,87 +171,6 @@ func apiClient(host string, accessKey string, skipTLSVerify bool) (*api.Client, 
 	}, nil
 }
 
-func newLoginCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "login [SERVER]",
-		Short: "Login to Infra",
-		Example: `
-# By default, login will prompt for all required information. 
-$ infra login 
-
-# Login to a specified server
-$ infra login SERVER
-$ infra login --server SERVER
-
-# Login with an access key 
-$ infra login --key KEY 
-
-# Login with a specified provider
-$ infra login --provider NAME
-
-# Use the '--non-interactive' flag to error out instead of prompting. 
-`,
-		Args:  cobra.MaximumNArgs(1),
-		Group: "Core commands:",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			var options loginCmdOptions
-			strcase.ConfigureAcronym("skip-tls-verify", "skipTLSVerify")
-
-			if err := parseOptions(cmd, &options, "INFRA"); err != nil {
-				return err
-			}
-
-			if len(args) == 1 {
-				if options.Server != "" {
-					fmt.Fprintf(os.Stderr, "SERVER is specified twice. Ignoring --server and proceeding with %s\n", options.Server)
-				}
-				options.Server = args[0]
-			}
-
-			return login(options)
-		},
-	}
-
-	cmd.Flags().String("key", "", "Login with an access key")
-	cmd.Flags().String("server", "", "Infra server to login to")
-	cmd.Flags().String("provider", "", "Login with an identity provider")
-	cmd.Flags().Bool("skip-tls-verify", false, "Skip verifying server TLS certificates")
-	return cmd
-}
-
-func newLogoutCmd() *cobra.Command {
-	var purge bool
-
-	cmd := &cobra.Command{
-		Use:     "logout",
-		Short:   "Log out of Infra",
-		Example: "$ infra logout",
-		Group:   "Core commands:",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return logout(purge)
-		},
-	}
-
-	cmd.Flags().BoolVar(&purge, "purge", false, "remove Infra host from config")
-
-	return cmd
-}
-
-func newListCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "List accessible destinations",
-		Group:   "Core commands:",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return mustBeLoggedIn()
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return list()
-		},
-	}
-}
-
 func newUseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "use DESTINATION",
@@ -299,25 +218,6 @@ $ infra use kubernetes.development.kube-system
 			return kubernetesSetContext("infra:" + parts[1] + ":" + parts[2])
 		},
 	}
-}
-
-func newKeysCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "keys",
-		Short:   "Manage access keys",
-		Long:    "Manage access keys for machine identities to authenticate with Infra and call the API",
-		Aliases: []string{"key"},
-		Group:   "Management commands:",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			return mustBeLoggedIn()
-		},
-	}
-
-	cmd.AddCommand(newKeysListCmd())
-	cmd.AddCommand(newKeysAddCmd())
-	cmd.AddCommand(newKeysRemoveCmd())
-
-	return cmd
 }
 
 func newDestinationsCmd() *cobra.Command {

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -9,6 +9,25 @@ import (
 	"github.com/infrahq/infra/api"
 )
 
+func newKeysCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "keys",
+		Short:   "Manage access keys",
+		Long:    "Manage access keys for machine identities to authenticate with Infra and call the API",
+		Aliases: []string{"key"},
+		Group:   "Management commands:",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return mustBeLoggedIn()
+		},
+	}
+
+	cmd.AddCommand(newKeysListCmd())
+	cmd.AddCommand(newKeysAddCmd())
+	cmd.AddCommand(newKeysRemoveCmd())
+
+	return cmd
+}
+
 type keyCreateOptions struct {
 	TTL               string `mapstructure:"ttl"`
 	ExtensionDeadline string `mapstructure:"extension-deadline"`

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -5,9 +5,25 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
+	"github.com/spf13/cobra"
 
 	"github.com/infrahq/infra/api"
 )
+
+func newListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List accessible destinations",
+		Group:   "Core commands:",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return mustBeLoggedIn()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return list()
+		},
+	}
+}
 
 func list() error {
 	client, err := defaultAPIClient()

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -3,8 +3,28 @@ package cmd
 import (
 	"errors"
 
+	"github.com/spf13/cobra"
+
 	"github.com/infrahq/infra/internal/logging"
 )
+
+func newLogoutCmd() *cobra.Command {
+	var purge bool
+
+	cmd := &cobra.Command{
+		Use:     "logout",
+		Short:   "Log out of Infra",
+		Example: "$ infra logout",
+		Group:   "Core commands:",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return logout(purge)
+		},
+	}
+
+	cmd.Flags().BoolVar(&purge, "purge", false, "remove Infra host from config")
+
+	return cmd
+}
 
 func logout(purge bool) error {
 	config, err := readConfig()


### PR DESCRIPTION
## Summary

Continuing the work from #1410, and #1412, this PR moves 4 more of the `new<CommandName>Cmd` functions into the files with the implementation of the command (ex: `newloginCmd` moved to `login.go`). I'll do a few in each PR to hopefully reduce conflicts and allow these to be reviewed and merged quickly. No functional changes, just a copy/paste move of the functions.

This is being done to match the convention established by most Go CLIs. Generally the file structure of the sources files will match the CLI structure, which makes it easy to find the entrypoint, flags, help text, etc of the commands.

Some examples of this pattern:
* https://github.com/docker/cli/tree/master/cli/command
* https://github.com/influxdata/influxdb/tree/master/cmd/influxd