### PR TITLE
fix(cli): check min requirement for new password

### DIFF
--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -361,6 +361,7 @@ func updateUser(name, newPassword string) error {
 			}
 			return err
 		}
+		// Todo otp: update term to temporary password (https://github.com/infrahq/infra/issues/1441)
 		fmt.Fprintf(os.Stderr, "  Updated one time password for user %s.\n", user.Email)
 	}
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -370,7 +370,8 @@ func updateUserPassword(client *api.Client, pid uid.PolymorphicID, oldPassword s
 		panic("updateUserPassword called with a non-user PID")
 	}
 
-	fmt.Println("\n  One time password was used. If you fail to set a new password, contact your admin to reset your password.")
+	// Todo otp: update term to temporary password (https://github.com/infrahq/infra/issues/1441)
+	fmt.Println("\n  One time password was used.")
 
 	newPassword, err := promptUpdatePassword(oldPassword)
 	if err != nil {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->
When user types in a new password during reset, it will check if it's a valid password. 
Blocked by pr https://github.com/infrahq/infra/pull/1409

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1375
