### PR TITLE
improve(cli): login with --key will skip setup and login instead

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -112,10 +112,7 @@ func login(options loginCmdOptions) error {
 	if err != nil {
 		return err
 	}
-	if setupRequired.Required {
-		if options.AccessKey != "" {
-			return fmt.Errorf(`Infra has not been setup. To setup, run the following without any additional args: 'infra login [SERVER]'`)
-		}
+	if setupRequired.Required && options.AccessKey == "" {
 		options.AccessKey, err = runSetupForLogin(client)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

If user provides `--key`, it will skip setup and attempt to login. 
This is because if user provides `--key`, user is expecting to login. 
_However, note that_: 
1. user will always fail this flow. If setup is required, key will never work.
2. user will have to figure out why their --key is not working. We are not letting them know that setup needs to be run. 


## Related Issues

Resolves #1374