### PR TITLE
maintain(ci): use slash labels for release-please

### DIFF
--- a/.github/release-please.json
+++ b/.github/release-please.json
@@ -2,6 +2,8 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "pull-request-title-pattern": "maintain${scope}: release${component} ${version}",
+  "label": "autorelease/pending",
+  "release-label": "autorelease/tagged",
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
These labels default to `autorelease: pending` and `autorelease: tagged` and we'd like them to match the other github labels which use `<category>/<label>`.