### PR TITLE
maintain: use json tag for openapi property names

### DIFF
--- a/api/login.go
+++ b/api/login.go
@@ -10,17 +10,17 @@ type LoginRequestOIDC struct {
 
 type LoginRequestPasswordCredentials struct {
 	Email    string `json:"email" validate:"required"`
-	Password string `json:"password"  validate:"required"`
+	Password string `json:"password" validate:"required"`
 }
 
 type LoginRequest struct {
-	OIDC                *LoginRequestOIDC                `json:"oidc" validate:"excluded_with=KeyExchange,excluded_with=PasswordCredentials"`
-	AccessKey           string                           `json:"accessKey"  validate:"excluded_with=OIDC,excluded_with=PasswordCredentials"`
+	AccessKey           string                           `json:"accessKey" validate:"excluded_with=OIDC,excluded_with=PasswordCredentials"`
 	PasswordCredentials *LoginRequestPasswordCredentials `json:"passwordCredentials" validate:"excluded_with=OIDC,excluded_with=AccessKey"`
+	OIDC                *LoginRequestOIDC                `json:"oidc" validate:"excluded_with=KeyExchange,excluded_with=PasswordCredentials"`
 }
 
 type LoginResponse struct {
-	PolymorphicID          uid.PolymorphicID `json:"polymorphicId"`
+	PolymorphicID          uid.PolymorphicID `json:"polymorphicID"`
 	Name                   string            `json:"name"`
 	AccessKey              string            `json:"accessKey"`
 	PasswordUpdateRequired bool              `json:"passwordUpdateRequired,omitempty"`

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -122,11 +122,11 @@
         "properties": {
           "connection": {
             "properties": {
-              "CA": {
+              "ca": {
                 "example": "-----BEGIN CERTIFICATE-----\nMIIDNTCCAh2gAwIBAgIRALRetnpcTo9O3V2fAK3ix+c\n-----END CERTIFICATE-----\n",
                 "type": "string"
               },
-              "URL": {
+              "url": {
                 "example": "aa60eexample.us-west-2.elb.amazonaws.com",
                 "type": "string"
               }
@@ -173,13 +173,13 @@
           "fieldErrors": {
             "items": {
               "properties": {
-                "Errors": {
+                "errors": {
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
-                "FieldName": {
+                "fieldName": {
                   "type": "string"
                 }
               },
@@ -344,7 +344,7 @@
           "passwordUpdateRequired": {
             "type": "boolean"
           },
-          "polymorphicId": {
+          "polymorphicID": {
             "example": "i:4yJ3n3D8E3",
             "format": "poly-uid",
             "pattern": "\\w:[\\da-zA-HJ-NP-Z]{1,11}",
@@ -805,11 +805,11 @@
                 "properties": {
                   "connection": {
                     "properties": {
-                      "CA": {
+                      "ca": {
                         "example": "-----BEGIN CERTIFICATE-----\nMIIDNTCCAh2gAwIBAgIRALRetnpcTo9O3V2fAK3ix+c\n-----END CERTIFICATE-----\n",
                         "type": "string"
                       },
-                      "URL": {
+                      "url": {
                         "example": "aa60eexample.us-west-2.elb.amazonaws.com",
                         "type": "string"
                       }
@@ -1095,11 +1095,11 @@
                 "properties": {
                   "connection": {
                     "properties": {
-                      "CA": {
+                      "ca": {
                         "example": "-----BEGIN CERTIFICATE-----\nMIIDNTCCAh2gAwIBAgIRALRetnpcTo9O3V2fAK3ix+c\n-----END CERTIFICATE-----\n",
                         "type": "string"
                       },
-                      "URL": {
+                      "url": {
                         "example": "aa60eexample.us-west-2.elb.amazonaws.com",
                         "type": "string"
                       }
@@ -2667,16 +2667,16 @@
                   },
                   "oidc": {
                     "properties": {
-                      "Code": {
+                      "code": {
                         "type": "string"
                       },
-                      "ProviderID": {
+                      "providerID": {
                         "example": "4yJ3n3D8E2",
                         "format": "uid",
                         "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
                         "type": "string"
                       },
-                      "RedirectURL": {
+                      "redirectURL": {
                         "type": "string"
                       }
                     },
@@ -2689,10 +2689,10 @@
                   },
                   "passwordCredentials": {
                     "properties": {
-                      "Email": {
+                      "email": {
                         "type": "string"
                       },
-                      "Password": {
+                      "password": {
                         "type": "string"
                       }
                     },

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -206,7 +206,7 @@ func buildProperty(f reflect.StructField, t, parent reflect.Type, parentSchema *
 
 		for i := 0; i < t.NumField(); i++ {
 			f2 := t.Field(i)
-			s.Properties[f2.Name] = buildProperty(f2, f2.Type, t, s)
+			s.Properties[getFieldName(f2, t)] = buildProperty(f2, f2.Type, t, s)
 		}
 	}
 

--- a/ui/store/AuthContext.js
+++ b/ui/store/AuthContext.js
@@ -82,7 +82,7 @@ export const AuthContextProvider = ({ children }) => {
 
   const redirectToDashboard = async (loginInfor) => {
     setUser({
-      id: loginInfor.polymorphicId,
+      id: loginInfor.polymorphicID,
       name: loginInfor.name
     })
     setAuthReady(true)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The openapi generator isn't using the json tag when setting property names 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1470
