### PR TITLE
maintain(ci): only include features and fixes in changelog

### DIFF
--- a/.github/release-please.json
+++ b/.github/release-please.json
@@ -4,6 +4,12 @@
   "pull-request-title-pattern": "maintain${scope}: release${component} ${version}",
   "label": "autorelease/pending",
   "release-label": "autorelease/tagged",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "improve", "section": "Improvement", "hidden": true },
+    { "type": "maintain", "section": "Maintenance", "hidden": true }
+  ],
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
## Summary

With the changes in tags it started including `improve` and `maintain` in the changelog, which is not what we wanted.

I found these:
* [docs reference](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile)
* [default config](https://github.com/conventional-changelog/conventional-changelog/blob/8076d4666c2a3ea728b95bf1e4e78d4c7189b1dc/packages/conventional-changelog-conventionalcommits/writer-opts.js#L171)