### PR TITLE
improve(ci): check go.mod is tidy

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,17 +48,22 @@ jobs:
         if: steps.cache-commitlint.cache-hit != true
       - run: ./node_modules/.bin/commitlint --from origin/$GITHUB_BASE_REF --to @ --verbose --config .github/commitlint.config.js
 
-  check-docs:
+  check-generated:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-      - run: |
+      - name: Check generated docs are updated
+        run: |
           go run ./internal/docgen
           go run ./internal/openapigen docs/api/openapi3.json
           git diff --exit-code
+      - name: Check go mod is tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
 
   docker:
     if: startsWith(github.head_ref, 'release-please-') == true


### PR DESCRIPTION
## Summary

So that the next person to branch from main doesn't have to apply unrelated changes to go.mod or go.sum.

This could also be a separate job, but `go mod tidy` runs quickly so probably faster to make it a step instead of having to spin up a whole machine to run for a few milliseconds.

## Related Issues

Related to #1302, but does not resolve it yet.