### PR TITLE
fix: infra keys command details (#1501) (#1502)

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -370,7 +370,7 @@ infra keys add ACCESS_KEY_NAME MACHINE_NAME [flags]
 
 ```
 
-# Add an access key for the machine "bot" called "first-key" that expires in 12 hours and must be used every hour to remain valid
+# Create an access key for the machine "bot" called "first-key" that expires in 12 hours and must be used every hour to remain valid
 infra keys add first-key bot --ttl=12h --extension-deadline=1h
 
 ```

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -43,7 +43,7 @@ func newKeysAddCmd() *cobra.Command {
 		Use:   "add ACCESS_KEY_NAME MACHINE_NAME",
 		Short: "Create an access key for authentication",
 		Example: `
-# Add an access key for the machine "bot" called "first-key" that expires in 12 hours and must be used every hour to remain valid
+# Create an access key for the machine "bot" called "first-key" that expires in 12 hours and must be used every hour to remain valid
 infra keys add first-key bot --ttl=12h --extension-deadline=1h
 `,
 		Args: cobra.ExactArgs(2),


### PR DESCRIPTION
- update infra keys add example
- make default key lifetime and deadline 30 days

## Summary
The example for `infra keys add ...` was out of date, update it to match the expected format.

The default key lifetimes were too short, default them to 30 days instead.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1501
Resolves #1502
