### PR TITLE
feat: infra view role

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -22,7 +22,7 @@ func currentAccessKey(c *gin.Context) *models.AccessKey {
 }
 
 func ListAccessKeys(c *gin.Context, identityID uid.ID, name string) ([]models.AccessKey, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole)
+	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/access/destination.go
+++ b/internal/access/destination.go
@@ -27,7 +27,7 @@ func SaveDestination(c *gin.Context, destination *models.Destination) error {
 }
 
 func GetDestination(c *gin.Context, id uid.ID) (*models.Destination, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraConnectorRole, models.InfraUserRole)
+	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole, models.InfraUserRole)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func GetDestination(c *gin.Context, id uid.ID) (*models.Destination, error) {
 }
 
 func ListDestinations(c *gin.Context, uniqueID, name string) ([]models.Destination, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraConnectorRole, models.InfraUserRole)
+	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole, models.InfraUserRole)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -18,7 +18,7 @@ func GetGrant(c *gin.Context, id uid.ID) (*models.Grant, error) {
 }
 
 func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, privilege string) ([]models.Grant, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraConnectorRole)
+	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 }
 
 func ListIdentityGrants(c *gin.Context, identityID uid.ID) ([]models.Grant, error) {
-	db, err := hasAuthorization(c, identityID, isIdentitySelf, models.InfraAdminRole)
+	db, err := hasAuthorization(c, identityID, isIdentitySelf, models.InfraAdminRole, models.InfraViewRole)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func ListIdentityGrants(c *gin.Context, identityID uid.ID) ([]models.Grant, erro
 }
 
 func ListGroupGrants(c *gin.Context, groupID uid.ID) ([]models.Grant, error) {
-	db, err := hasAuthorization(c, groupID, isUserInGroup, models.InfraAdminRole)
+	db, err := hasAuthorization(c, groupID, isUserInGroup, models.InfraAdminRole, models.InfraViewRole)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -31,7 +31,7 @@ func isUserInGroup(c *gin.Context, requestedResourceID uid.ID) (bool, error) {
 }
 
 func ListGroups(c *gin.Context, name string, providerID uid.ID) ([]models.Group, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraConnectorRole)
+	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func CreateGroup(c *gin.Context, group *models.Group) error {
 }
 
 func GetGroup(c *gin.Context, id uid.ID) (*models.Group, error) {
-	db, err := hasAuthorization(c, id, isUserInGroup, models.InfraAdminRole, models.InfraConnectorRole)
+	db, err := hasAuthorization(c, id, isUserInGroup, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func GetGroup(c *gin.Context, id uid.ID) (*models.Group, error) {
 }
 
 func ListIdentityGroups(c *gin.Context, userID uid.ID) ([]models.Group, error) {
-	db, err := hasAuthorization(c, userID, isIdentitySelf, models.InfraAdminRole)
+	db, err := hasAuthorization(c, userID, isIdentitySelf, models.InfraAdminRole, models.InfraViewRole)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -29,7 +29,7 @@ func CurrentIdentity(c *gin.Context) *models.Identity {
 }
 
 func GetIdentity(c *gin.Context, id uid.ID) (*models.Identity, error) {
-	db, err := hasAuthorization(c, id, isIdentitySelf, models.InfraAdminRole, models.InfraConnectorRole)
+	db, err := hasAuthorization(c, id, isIdentitySelf, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 }
 
 func ListIdentities(c *gin.Context, email string, providerID uid.ID) ([]models.Identity, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraConnectorRole)
+	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	InfraAdminRole     = "admin"
+	InfraViewRole      = "view"
 	InfraUserRole      = "user"
 	InfraConnectorRole = "connector"
 )


### PR DESCRIPTION
- allow identities with the view role read-only access to server state

## Summary
There should be a way to audit the state of infra. Add a "view" role to enable this.

Also added some specific role checking tests in passing.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1505
