### PR TITLE
improve(cli): do not use a default path for config file

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -42,13 +42,6 @@ func mustBeLoggedIn() error {
 func parseOptions(cmd *cobra.Command, options interface{}, envPrefix string) error {
 	v := viper.New()
 
-	v.SetConfigName("infra")
-	v.SetConfigType("yaml")
-
-	v.AddConfigPath("/etc/infrahq")
-	v.AddConfigPath("$HOME/.infra")
-	v.AddConfigPath(".")
-
 	if configFileFlag := cmd.Flags().Lookup("config-file"); configFileFlag != nil {
 		if configFile := configFileFlag.Value.String(); configFile != "" {
 			v.SetConfigFile(configFile)


### PR DESCRIPTION
## Summary

Related to the problem described in #1407

Multiple commands are using the same default path, which can cause a lot of confusion. At this point we don't need a default path. We expect most people to install via helm which sets the path to the config with a command line flag. Other CLI commands (short lived ones run by users) don't need a config file. They accept arguments from command line flags or env vars.
