### PR TITLE
Fix loading of secret providers from config file

### DIFF
--- a/docs/install/configure/secrets.md
+++ b/docs/install/configure/secrets.md
@@ -30,7 +30,8 @@ Kubernetes takes configuration, like so:
 secrets:
   - name: kubernetes # can optionally provide a custom name
     kind: kubernetes
-    namespace: mynamespace
+    config:
+      namespace: mynamespace
 ```
 
 namespace defaults to whatever is defined in `/var/run/secrets/kubernetes.io/serviceaccount/namespace`, or the `default` namespace.
@@ -49,11 +50,12 @@ Vault takes configuration, like so:
 secrets:
   - name: vault # can optionally provide a custom name
     kind: vault
-    transitMount: /transit
-    secretMount: /secret
-    token: env:VAULT_TOKEN # secret config can even reference other built-in secret types, like env
-    namespace: mynamespace
-    address: https://vault
+    config:
+      transitMount: /transit
+      secretMount: /secret
+      token: env:VAULT_TOKEN # secret config can even reference other built-in secret types, like env
+      namespace: mynamespace
+      address: https://vault
 ```
 
 ### AWS Secrets Manager
@@ -68,10 +70,11 @@ Secrets Manager takes configuration, like so:
 secrets:
   - name: awssm # can optionally provide a custom name
     kind: awssecretsmanager
-    endpoint: https://kms.endpoint
-    region: us-west-2
-    accessKeyID: env:AWS_ACCESS_KEY_ID # secret config can even reference other built-in secret types, like env
-    secretAccessKey: env:AWS_SECRET_ACCESS_KEY
+    config:
+      endpoint: https://kms.endpoint
+      region: us-west-2
+      accessKeyID: env:AWS_ACCESS_KEY_ID # secret config can even reference other built-in secret types, like env
+      secretAccessKey: env:AWS_SECRET_ACCESS_KEY
 ```
 
 ### AWS SSM (Systems Manager Parameter Store)
@@ -86,11 +89,12 @@ SSM takes configuration, like so:
 secrets:
   - name: awsssm # can optionally provide a custom name
     kind: awsssm
-    keyID: 1234abcd-12ab-34cd-56ef-1234567890ab # optional, if set it's the KMS key that should be used for decryption
-    endpoint: https://kms.endpoint
-    region: us-west-2
-    accessKeyID: env:AWS_ACCESS_KEY_ID # secret config can even reference other built-in secret types, like env
-    secretAccessKey: env:AWS_SECRET_ACCESS_KEY
+    config:
+      keyID: 1234abcd-12ab-34cd-56ef-1234567890ab # optional, if set it's the KMS key that should be used for decryption
+      endpoint: https://kms.endpoint
+      region: us-west-2
+      accessKeyID: env:AWS_ACCESS_KEY_ID # secret config can even reference other built-in secret types, like env
+      secretAccessKey: env:AWS_SECRET_ACCESS_KEY
 ```
 
 ### Environment variables
@@ -105,9 +109,10 @@ secrets:
 secrets:
   - name: base64env
     kind: env
-    base64: true
-    base64UrlEncoded: false
-    base64Raw: false
+    config:
+      base64: true
+      base64UrlEncoded: false
+      base64Raw: false
 ```
 
 which you would then use like this. First create the environment variable:
@@ -136,10 +141,11 @@ It's a common pattern to write secrets to a set of files on disk and then have a
 secrets:
   - name: base64file
     kind: file
-    base64: true
-    base64UrlEncoded: false
-    base64Raw: false
-    path: /var/secrets # optional: assume all files mentioned are in this root directory
+    config:
+      base64: true
+      base64UrlEncoded: false
+      base64Raw: false
+      path: /var/secrets # optional: assume all files mentioned are in this root directory
 ```
 
 which you would then use as follows. First base64 encode a string and write it to a file:
@@ -174,9 +180,10 @@ Optionally for plaintext secrets, you can leave off the secret back-end name:
 secrets:
   - name: base64text
     kind: plain
-    base64: true
-    base64UrlEncoded: false
-    base64Raw: false
+    config:
+      base64: true
+      base64UrlEncoded: false
+      base64Raw: false
 ```
 
 Which you would then use in the `infra.yaml` file as shown:

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -418,44 +418,50 @@ server:
   additionalSecrets: []
   # - kind: ""  # required, kind of secret provider. one of ['plaintext', 'env', 'file', 'kubernetes', 'vault', 'awssecretmanager', 'awsssm']
   #   name: ""  # optional, to be referenced when accessing secrets. defaults to 'kind'
-  #   ...:      # additional configuration options are available and may be required for certain secret providers, e.g. 'vault'. see below.
+  #   config:
+  #     ...      # additional configuration options are available and may be required for certain secret providers, e.g. 'vault'. see below.
 
   ## Example
   # Configure Kubernetes as a secret provider
   # - name: kubernetes                      # optional, used when referencing secrets, e.g. kubernetes:infra/secret, where 'infra' is the name of the secret in Kubernetes and `secret` is the field in that secret
   #   kind: kubernetes                      # required
-  #   namespace: ""                         # required if secret exists in a namespace separate from the one infra is deployed to
+  #   config:
+  #     namespace: ""                       # required if secret exists in a namespace separate from the one infra is deployed to
 
   # Configure Vault as a secret provider
   # - name: vault                           # optional, used when referencing secrets, e.g. vault:infra-secret, where 'infra-secret' is the name of the secret in Vault
   #   kind: vault                           # required
-  #   address: https://vault.example.com    # required
-  #   token: env:VAULT_TOKEN                # required
-  #   namespace: ""                         # optional
-  #   transitMount: ""                      # optional, default '/transit'
-  #   secretMount: ""                       # optional, default '/secret'
+  #   config:
+  #     address: https://vault.example.com  # required
+  #     token: env:VAULT_TOKEN              # required
+  #     namespace: ""                       # optional
+  #     transitMount: ""                    # optional, default '/transit'
+  #     secretMount: ""                     # optional, default '/secret'
 
   # Configure AWS Secret Manager as a secret provider
   # - name: awssm                                               # optional, used when referencing secrets, e.g. awssm:infra-secret, where 'infra-secret' is the name of the secret in AWS Secret Manager
   #   kind: awssecretmanager                                    # required
-  #   endpoint: https://secretsmanager.us-east-2.amazonaws.com  # required
-  #   region: us-east-2                                         # required
-  #   accessKeyID: env:AWS_ACCESS_KEY_ID                        # required
-  #   secretAccessKey: env:AWS_SECRET_ACCESS_KEY                # required
+  #   config:
+  #     endpoint: https://secretsmanager.us-east-2.amazonaws.com  # required
+  #     region: us-east-2                                         # required
+  #     accessKeyID: env:AWS_ACCESS_KEY_ID                        # required
+  #     secretAccessKey: env:AWS_SECRET_ACCESS_KEY                # required
 
   # Configure AWS Systems Manager Parameter Store as a secret provider
   # - name: awsssm                                  # optional, used when referencing secrets, e.g. awsssm:infra-secret, where 'infra-secret' is the name of the secret in AWS SSM
   #   kind: awsssm                                  # required
-  #   endpoint: https://ssm.us-east-2.amazonaws.com # required
-  #   region: us-east-2                             # required
-  #   accessKeyID: env:AWS_ACCESS_KEY_ID            # required
-  #   secretAccessKey: env:AWS_SECRET_ACCESS_KEY    # required
-  #   keyID: ""                                     # optional, if set, this key will be used for decryption
+  #   config:
+  #     endpoint: https://ssm.us-east-2.amazonaws.com # required
+  #     region: us-east-2                             # required
+  #     accessKeyID: env:AWS_ACCESS_KEY_ID            # required
+  #     secretAccessKey: env:AWS_SECRET_ACCESS_KEY    # required
+  #     keyID: ""                                     # optional, if set, this key will be used for decryption
 
   # Configure base64-encoded environment variable as a secret provider
   # - name: based64env  # required to differentiate betweent built-in plaintext 'env' secret provider
   #   kind: env         # required
-  #   base64: true      # required
+  #   config:
+  #     base64: true    # required
 
   ## Additional identity providers to configure
   additionalProviders: []

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/connector"
+	"github.com/infrahq/infra/internal/decode"
 	"github.com/infrahq/infra/internal/logging"
 )
 
@@ -107,7 +108,12 @@ func parseOptions(cmd *cobra.Command, options interface{}, envPrefix string) err
 		}
 	}
 
-	return v.Unmarshal(options)
+	hooks := mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+		decode.HookPrepareForDecode,
+	)
+	return v.Unmarshal(options, viper.DecodeHook(hooks))
 }
 
 func infraHomeDir() (string, error) {

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -91,7 +91,7 @@ func defaultServerOptions() server.Options {
 	}
 }
 
-// shim for testing
+// runServer is a shim for testing.
 var runServer = func(ctx context.Context, srv *server.Server) error {
 	return srv.Run(ctx)
 }

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -53,7 +54,7 @@ func newServerCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("creating server: %w", err)
 			}
-			return srv.Run(cmd.Context())
+			return runServer(cmd.Context(), srv)
 		},
 	}
 
@@ -88,4 +89,9 @@ func defaultServerOptions() server.Options {
 			Metrics: ":9090",
 		},
 	}
+}
+
+// shim for testing
+var runServer = func(ctx context.Context, srv *server.Server) error {
+	return srv.Run(ctx)
 }

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
+	"github.com/infrahq/infra/internal/server"
+	"github.com/infrahq/infra/secrets"
+)
+
+func TestParseOptions_WithServerOptions(t *testing.T) {
+	type testCase struct {
+		name        string
+		setup       func(t *testing.T, cmd *cobra.Command)
+		expectedErr string
+		expected    func(t *testing.T) server.Options
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		cmd := newServerCmd()
+
+		if tc.setup != nil {
+			tc.setup(t, cmd)
+		}
+
+		options := defaultServerOptions()
+		err := parseOptions(cmd, &options, "INFRA_SERVER")
+		if tc.expectedErr != "" {
+			assert.ErrorContains(t, err, tc.expectedErr)
+			return
+		}
+
+		assert.NilError(t, err)
+		expected := tc.expected(t)
+		assert.DeepEqual(t, expected, options)
+	}
+
+	var testCases = []testCase{
+		{
+			name: "secret providers",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				content := `
+                    secrets:
+                      - kind: env
+                        name: base64env
+                        config:
+                          base64: true`
+
+				dir := fs.NewDir(t, t.Name(),
+					fs.WithFile("cfg.yaml", content))
+				err := cmd.Flags().Set("config-file", dir.Join("cfg.yaml"))
+				assert.NilError(t, err)
+			},
+			expected: func(t *testing.T) server.Options {
+				expected := serverOptionsWithDefaults()
+				expected.Secrets = []server.SecretProvider{
+					{
+						Kind:   "env",
+						Name:   "base64env",
+						Config: secrets.GenericConfig{Base64: true},
+					},
+				}
+				return expected
+			},
+		},
+		{
+			name: "config filename specified as env var",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				t.Skip("does not work yet")
+				content := `
+                    addr:
+                      http: "127.0.0.1:1455"`
+
+				dir := fs.NewDir(t, t.Name(),
+					fs.WithFile("cfg.yaml", content))
+
+				t.Setenv("INFRA_SERVER_CONFIG_FILE", dir.Join("cfg.yaml"))
+			},
+			expected: func(t *testing.T) server.Options {
+				expected := serverOptionsWithDefaults()
+				expected.Addr.HTTP = "127.0.0.1:1455"
+				return expected
+			},
+		},
+		{
+			name: "env var can set a value outside of the top level",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				t.Skip("does not work yet")
+				t.Setenv("INFRA_SERVER_ADDR_HTTP", "127.0.0.1:1455")
+			},
+			expected: func(t *testing.T) server.Options {
+				expected := serverOptionsWithDefaults()
+				expected.Addr.HTTP = "127.0.0.1:1455"
+				return expected
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+// serverOptionsWithDefaults returns all the default values. Many defaults are
+// specified in command line flags, which makes them difficult to access without
+// specifying them again here.
+func serverOptionsWithDefaults() server.Options {
+	o := defaultServerOptions()
+	o.TLSCache = "$HOME/.infra/cache"
+	o.DBFile = "$HOME/.infra/sqlite3.db"
+	o.DBEncryptionKey = "$HOME/.infra/sqlite3.db.key"
+	o.DBEncryptionKeyProvider = "native"
+	o.EnableTelemetry = true
+	o.EnableCrashReporting = true
+	o.SessionDuration = 12 * time.Hour
+	o.EnableSetup = true
+	return o
+}

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -40,7 +40,7 @@ func TestParseOptions_WithServerOptions(t *testing.T) {
 		assert.DeepEqual(t, expected, options)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			name: "secret providers",
 			setup: func(t *testing.T, cmd *cobra.Command) {

--- a/internal/decode/decode.go
+++ b/internal/decode/decode.go
@@ -1,0 +1,33 @@
+package decode
+
+import (
+	"reflect"
+)
+
+type Decoder func(target interface{}, source interface{}) error
+
+type PrepareForDecoder interface {
+	PrepareForDecode(data interface{}) error
+}
+
+// HookPrepareForDecode is a mapstructure.DecodeHookFuncValue that enables decoding
+// of any type that implements the PrepareForDecoder interface.
+//
+// Types that implement PrepareForDecoder can use the passed in data to set
+// concrete types on any polymorphic fields, which will allow mapstructure.Decode
+// to properly decode the config into the expected type.
+func HookPrepareForDecode(from reflect.Value, to reflect.Value) (interface{}, error) {
+	source := from.Interface()
+	unmapper, ok := to.Interface().(PrepareForDecoder)
+	if !ok {
+		if to.CanAddr() {
+			unmapper, ok = to.Addr().Interface().(PrepareForDecoder)
+		}
+		if !ok {
+			return source, nil
+		}
+	}
+
+	err := unmapper.PrepareForDecode(source)
+	return source, err
+}

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -1,0 +1,232 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/mitchellh/mapstructure"
+	"gopkg.in/yaml.v2"
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/decode"
+	"github.com/infrahq/infra/secrets"
+)
+
+func TestSecretProvider_PrepareForDecode_IntegrationWithDecode_FullConfig(t *testing.T) {
+	content := `
+secrets:
+
+  - name: the-vault
+    kind: vault
+    config:
+      token: the-token
+      namespace: the-namespace
+      secretMount: secret-mount
+      address: https://vault:12345
+
+  - name: the-aws
+    kind: awsssm
+    config:
+      keyID: the-key-id
+      endpoint: the-endpoint
+      region: the-region
+      accessKeyID: the-access-key
+      secretAccessKey: the-secret-key
+
+  - name: aws-2
+    kind: awssecretsmanager
+    config:
+      useSecretMaps: true
+      endpoint: the-endpoint-2
+      region: the-region-2
+      accessKeyID: the-access-key-2
+      secretAccessKey: the-secret-key-2
+
+  - name: the-kubes
+    kind: kubernetes
+    config:
+      namespace: the-namespace
+
+  - name: the-env
+    kind: env
+    config:
+      base64: true
+      base64UrlEncoded: true
+      base64Raw: true
+
+  - name: the-file
+    kind: file
+    config:
+      path: /the-path
+      base64: true
+
+  - name: the-plaintext
+    kind: plaintext
+    config:
+      base64Raw: true
+`
+	raw := map[string]interface{}{}
+	err := yaml.Unmarshal([]byte(content), &raw)
+	assert.NilError(t, err)
+
+	actual := Options{}
+	err = decodeConfig(&actual, raw)
+	assert.NilError(t, err)
+
+	expected := Options{
+		Secrets: []SecretProvider{
+			{
+				Kind: "vault",
+				Name: "the-vault",
+				Config: secrets.VaultConfig{
+					TransitMount: "/transit",
+					SecretMount:  "secret-mount",
+					Token:        "the-token",
+					Namespace:    "the-namespace",
+					Address:      "https://vault:12345",
+				},
+			},
+			{
+				Kind: "awsssm",
+				Name: "the-aws",
+				Config: secrets.AWSSSMConfig{
+					KeyID: "the-key-id",
+					AWSConfig: secrets.AWSConfig{
+						Endpoint:        "the-endpoint",
+						Region:          "the-region",
+						AccessKeyID:     "the-access-key",
+						SecretAccessKey: "the-secret-key",
+					},
+				},
+			},
+			{
+				Kind: "awssecretsmanager",
+				Name: "aws-2",
+				Config: secrets.AWSSecretsManagerConfig{
+					UseSecretMaps: true,
+					AWSConfig: secrets.AWSConfig{
+						Endpoint:        "the-endpoint-2",
+						Region:          "the-region-2",
+						AccessKeyID:     "the-access-key-2",
+						SecretAccessKey: "the-secret-key-2",
+					},
+				},
+			},
+			{
+				Kind: "kubernetes",
+				Name: "the-kubes",
+				Config: secrets.KubernetesConfig{
+					Namespace: "the-namespace",
+				},
+			},
+			{
+				Kind: "env",
+				Name: "the-env",
+				Config: secrets.GenericConfig{
+					Base64:           true,
+					Base64URLEncoded: true,
+					Base64Raw:        true,
+				},
+			},
+			{
+				Kind: "file",
+				Name: "the-file",
+				Config: secrets.FileConfig{
+					Path: "/the-path",
+					GenericConfig: secrets.GenericConfig{
+						Base64: true,
+					},
+				},
+			},
+			{
+				Kind: "plaintext",
+				Name: "the-plaintext",
+				Config: secrets.GenericConfig{
+					Base64Raw: true,
+				},
+			},
+		},
+	}
+	assert.DeepEqual(t, expected, actual)
+}
+
+func decodeConfig(target interface{}, source interface{}) error {
+	// Copied from viper defaultDecoderConfig
+	config := &mapstructure.DecoderConfig{
+		Result:           target,
+		WeaklyTypedInput: true,
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.StringToSliceHookFunc(","),
+			decode.HookPrepareForDecode,
+		),
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(source)
+}
+
+type rawConfig map[interface{}]interface{}
+
+func TestSecretProvider_PrepareForDecode_IntegrationWithDecode(t *testing.T) {
+	type testCase struct {
+		name        string
+		source      rawConfig
+		expectedErr string
+		expected    SecretProvider
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		actual := SecretProvider{}
+		err := decodeConfig(&actual, tc.source)
+		if tc.expectedErr != "" {
+			assert.ErrorContains(t, err, tc.expectedErr)
+			return
+		}
+
+		assert.NilError(t, err)
+		assert.DeepEqual(t, actual, tc.expected)
+	}
+
+	testCases := []testCase{
+		{
+			name: "minimal config",
+			expected: SecretProvider{
+				Kind:   "plaintext",
+				Config: secrets.GenericConfig{},
+			},
+		},
+		{
+			name:   "missing kind",
+			source: rawConfig{"name": "custom"},
+			expected: SecretProvider{
+				Kind:   "plaintext",
+				Name:   "custom",
+				Config: secrets.GenericConfig{},
+			},
+		},
+		{
+			name:        "wrong type for name",
+			source:      rawConfig{"name": map[string]int{}},
+			expectedErr: `'name' expected type 'string'`,
+		},
+		{
+			name:        "wrong type for kind",
+			source:      rawConfig{"kind": map[string]int{}},
+			expectedErr: `'kind' expected type 'string'`,
+		},
+		{
+			name:        "wrong type for config",
+			source:      rawConfig{"config": true},
+			expectedErr: `expected a map, got 'bool'`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,6 +105,7 @@ type Addrs struct {
 func New(options Options) (*Server, error) {
 	server := &Server{
 		options: options,
+		secrets: map[string]secrets.SecretStorage{},
 	}
 
 	if err := validate.Struct(options); err != nil {
@@ -117,7 +118,7 @@ func New(options Options) (*Server, error) {
 		return nil, fmt.Errorf("configure sentry: %w", err)
 	}
 
-	if err := server.importSecrets(); err != nil {
+	if err := importSecrets(options.Secrets, server.secrets); err != nil {
 		return nil, fmt.Errorf("secrets config: %w", err)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,7 +73,7 @@ type Options struct {
 	InitialRootCAPublicKey      string `mapstructure:"initialRootCAPublicKey"`
 	FullKeyRotationInDays       int    `mapstructure:"fullKeyRotationInDays"` // 365 default
 
-	Addr ListenerOptions `mapstructure:"addr"`
+	Addr ListenerOptions
 }
 
 type ListenerOptions struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -28,7 +28,10 @@ import (
 func setupServer(t *testing.T) *Server {
 	db := setupDB(t)
 
-	s := &Server{db: db}
+	s := &Server{
+		db:      db,
+		secrets: map[string]secrets.SecretStorage{},
+	}
 
 	err := s.setupInternalInfraIdentityProvider()
 	assert.NilError(t, err)
@@ -43,7 +46,7 @@ func setupServer(t *testing.T) *Server {
 		assert.NilError(t, err)
 	}
 
-	err = s.importSecrets()
+	err = loadDefaultSecretConfig(s.secrets)
 	assert.NilError(t, err)
 
 	return s

--- a/secrets/awssecretsmanager.go
+++ b/secrets/awssecretsmanager.go
@@ -22,9 +22,9 @@ type AWSSecretsManager struct {
 }
 
 type AWSSecretsManagerConfig struct {
-	AWSConfig
+	AWSConfig `mapstructure:",squash"`
 
-	UseSecretMaps bool `yaml:"useSecretMaps"` // TODO: support storing to json maps if this is enabled.
+	UseSecretMaps bool `mapstructure:"useSecretMaps"` // TODO: support storing to json maps if this is enabled.
 }
 
 func NewAWSSecretsManagerFromConfig(cfg AWSSecretsManagerConfig) (*AWSSecretsManager, error) {

--- a/secrets/awsssm.go
+++ b/secrets/awsssm.go
@@ -22,8 +22,8 @@ type AWSSSM struct {
 }
 
 type AWSSSMConfig struct {
-	AWSConfig
-	KeyID string `yaml:"keyID" validate:"required"` // KMS key to use for decryption
+	AWSConfig `mapstructure:",squash"`
+	KeyID     string `mapstructure:"keyID" validate:"required"` // KMS key to use for decryption
 }
 
 func NewAWSSSMSecretProviderFromConfig(cfg AWSSSMConfig) (*AWSSSM, error) {

--- a/secrets/file.go
+++ b/secrets/file.go
@@ -11,14 +11,14 @@ import (
 // implements file storage for secret config
 
 type GenericConfig struct {
-	Base64           bool `yaml:"base64"`
-	Base64URLEncoded bool `yaml:"base64UrlEncoded"`
-	Base64Raw        bool `yaml:"base64Raw"`
+	Base64           bool `mapstructure:"base64"`
+	Base64URLEncoded bool `mapstructure:"base64UrlEncoded"`
+	Base64Raw        bool `mapstructure:"base64Raw"`
 }
 
 type FileConfig struct {
-	GenericConfig
-	Path string `yaml:"path" validate:"required"`
+	GenericConfig `mapstructure:",squash"`
+	Path          string `mapstructure:"path" validate:"required"`
 }
 
 type FileSecretProvider struct {

--- a/secrets/kubernetes.go
+++ b/secrets/kubernetes.go
@@ -23,7 +23,7 @@ type KubernetesSecretProvider struct {
 }
 
 type KubernetesConfig struct {
-	Namespace string `yaml:"namespace"`
+	Namespace string `mapstructure:"namespace"`
 }
 
 func NewKubernetesConfig() KubernetesConfig {

--- a/secrets/vault.go
+++ b/secrets/vault.go
@@ -22,11 +22,11 @@ type VaultSecretProvider struct {
 }
 
 type VaultConfig struct {
-	TransitMount string `yaml:"transitMount"`              // mounting point. defaults to /transit
-	SecretMount  string `yaml:"secretMount"`               // mounting point. defaults to /secret
-	Token        string `yaml:"token" validate:"required"` // vault token... should authenticate as machine to vault instead?
-	Namespace    string `yaml:"namespace"`
-	Address      string `yaml:"address" validate:"required"`
+	TransitMount string `mapstructure:"transitMount"`              // mounting point. defaults to /transit
+	SecretMount  string `mapstructure:"secretMount"`               // mounting point. defaults to /secret
+	Token        string `mapstructure:"token" validate:"required"` // vault token... should authenticate as machine to vault instead?
+	Namespace    string `mapstructure:"namespace"`
+	Address      string `mapstructure:"address" validate:"required"`
 }
 
 func NewVaultConfig() VaultConfig {


### PR DESCRIPTION
## Summary

Initially I thought the problem was simply the structure (a missing `config:` field), so the first few commits fix that problem and the docs. Then I realized it was the `UnmarshalYAML` methods, so I started converting those.

This PR changes the UnmarshalYAML hook to one that mapstructure understands.

## Related Issues


Related to #1519 (but keys need the same fix, which I will do in a follow up PR)
