### PR TITLE
fix: show infra grants in list (#1515)

### DIFF
--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -66,10 +65,6 @@ func newGrantsListCmd() *cobra.Command {
 
 			var rows []row
 			for _, g := range grants {
-				if strings.HasPrefix(g.Resource, "infra") {
-					continue
-				}
-
 				identity, err := subjectNameFromGrant(client, g)
 				if err != nil {
 					return err


### PR DESCRIPTION
## Summary
When you run `infra grants list` the grants for infra roles should be listed also.

Grants created internally (for the admin/connector identities, and user role grants on login) are still hidden.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1515
