### PR TITLE
fix: set infra provider on created access key

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -490,6 +490,11 @@ func (s *Server) setupBuiltinIdentity(name, role string) (*models.Identity, erro
 			return nil, fmt.Errorf("create identity: %w", err)
 		}
 
+		_, err = data.CreateProviderUser(s.db, data.InfraProvider(s.db), id)
+		if err != nil {
+			return nil, fmt.Errorf("create identity: %w", err)
+		}
+
 		grant := &models.Grant{
 			Subject:   id.PolyID(),
 			Privilege: role,

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -388,6 +388,7 @@ func (a *API) CreateAccessKey(c *gin.Context, r *api.CreateAccessKeyRequest) (*a
 	accessKey := &models.AccessKey{
 		IssuedFor:         r.IdentityID,
 		Name:              r.Name,
+		ProviderID:        access.InfraProvider(c).ID,
 		ExpiresAt:         time.Now().Add(time.Duration(r.TTL)).UTC(),
 		Extension:         time.Duration(r.ExtensionDeadline),
 		ExtensionDeadline: time.Now().Add(time.Duration(r.ExtensionDeadline)).UTC(),


### PR DESCRIPTION
- set infra provider on directly created access keys

- create infra provider users for default identities

## Summary
Some tweaks for the user reference unification in grants.

The change broke the `infra keys add` command because access keys now need a provider associated with their creation. In this case we just have to set it to the Infra provider.

The other fix is to create Infra "ProviderUser" entities for the default identities created on infra install. This is needed for them to be able to create tokens.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues
#1494 
<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
--
