### PR TITLE
maintain: update actions/stale config and labels

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -69,10 +69,22 @@
   color: "b60205"
   description: The issue is blocked on out-of-repository dependencies.
 
+# we could remove status/wip when we have access to draft PRs
+- name: "status/wip"
+  color: "dddddd"
+  description: The pull request is a work in progress.
+  from_name: "wip"
+
 - name: "autorelease/pending"
   color: "dddddd"
   description: Used by release-please to mark a pending release PR.
 - name: "autorelease/tagged"
   color: "dddddd"
   description: Used by release-please to mark a PR that has been released.
-
+- name: "status/stale"
+  description: Used by actions/stale to mark an issue or PR as stale.
+  color: "dddddd"
+  from_name: "Stale"
+- name: "status/never-stale"
+  color: "dddddd"
+  description: Indicates to actions/stale that the issue or PR should never be marked stale.

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,12 +10,22 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: Message to comment on stale issues. If none provided, will not mark issues stale.
-          stale-pr-message: Message to comment on stale PRs. If none provided, will not mark PRs stale.
-          close-issue-message: This issue was closed because it has been stalled for 5 days with no activity.
-          close-pr-message: This PR was closed because it has been stalled for 10 days with no activity.
+          stale-issue-message: |
+            This issue has not seen any activity in a while. Add a comment if this issue is still relevant,
+            otherwise it will be closed in 7 days.
+          stale-pr-message: |
+            This pull request has not seen any activity in a while. Add a comment if this pull request is
+            relevant, otherwise it will be closed in 14 days.
+          close-issue-message: |
+            This issue was closed because it is inactive.
+          close-pr-message: |
+            This pull request was closed because it is inactive.
           days-before-issue-stale: 60
           days-before-issue-close: 7
           days-before-pr-stale: 90
           days-before-pr-close: 14
           exempt-all-pr-assignees: true
+          stale-issue-label: status/stale
+          stale-pr-label: status/stale
+          exempt-issue-labels: status/never-stale
+          exempt-pr-labels: status/never-stale


### PR DESCRIPTION
## Summary

It looks like we were using the description of the config field as the message added to github issues (ex: #674).

This PR:
* Set the message used to comment on stale issues/PRs to something a bit more helpful to someone reading the issue.
* Uses a label that matches our convention (`status/stale`)
* Adds a label for marking issues/PRs as excluded from being stale (`status/never-stale`)
* Adds the labels to labels.yaml to manage them.
* Also adds status/wip to the config


