### PR TITLE
quickstart: Reorder some steps, and add a little more detail

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,19 +1,20 @@
 ## Quickstart
 
-**Prerequisites:**
-* Install [Helm](https://helm.sh/) (v3+)
-* Install [Kubernetes](https://kubernetes.io/) (v1.14+)
+Follow these steps to install and setup Infra on Kubernetes.
+
+### Prerequisites
+
+To use this quickstart guide you will need `helm` and `kubectl` installed.
+
+* Install [helm](https://helm.sh/docs/intro/install/) (v3+)
+* Install Kubernetes [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) (v1.14+)
+
+You will also need a Kubernetes cluster.
 
 
-### 1. Self-host Infra
+### 1. Install Infra CLI
 
-```
-helm repo add infrahq https://helm.infrahq.com/
-helm repo update
-helm install infra infrahq/infra
-```
-
-### 2. Install Infra CLI
+The Infra CLI is used to connect to the Infra server.
 
 <details>
   <summary><strong>macOS</strong></summary>
@@ -54,7 +55,18 @@ helm install infra infrahq/infra
   ```
 </details>
 
-### 3. Login to Infra
+
+### 2. Setup an Infra server
+
+Deploy an Infra server to kubernetes using helm.
+
+```
+helm repo add infrahq https://helm.infrahq.com/
+helm repo update
+helm install infra infrahq/infra
+```
+
+Once the Infra server is deployed, login to the server to complete the setup.
 
 ```
 infra login INFRA_URL --skip-tls-verify
@@ -73,33 +85,22 @@ kubectl get service infra-server -o jsonpath="{.status.loadBalancer.ingress[*]['
 
 This will output the admin access key which you can use to login in cases of emergency recovery. Please store this in a safe place as you will not see this again.
 
-### 4. Connect your first Kubernetes cluster
 
-In order to add connectors to Infra, you will need to set three pieces of information:
+### 3. Setup a local user
 
-* `connector.config.name` is a name you give to identify this cluster. For the purposes of this Quickstart, the name will be `example-name`
-* `connector.config.server` is the value in the previous step used to login to Infra
-* `connector.config.accessKey` is the access key the connector will use to communicate with the server. You can use an existing access key or generate a new access key with `infra keys add KEY_NAME connector`
-
-```bash
-helm upgrade --install infra-connector infrahq/infra --set connector.config.server=INFRA_URL --set connector.config.accessKey=ACCESS_KEY --set connector.config.name=example-name --set connector.config.skipTLSVerify=true
-```
-
-### 5. Create the first local user
+Now that the Infra server is setup you can create a user.  The `infra id add` command creates a one-time password for the user.
 
 ```
 infra id add name@example.com
 ```
 
-This creates a one-time password for the created user.
-
-### 6. Grant Infra administrator privileges to the first user
+Grant the user Infra administrator privileges.
 
 ```
 infra grants add --user name@example.com --role admin infra
 ```
 
-### 7. Grant Kubernetes cluster administrator privileges to the first user
+Grant the user Kubernetes cluster administrator privileges.
 
 ```
 infra grants add --user name@example.com --role cluster-admin kubernetes.example-name
@@ -130,15 +131,31 @@ This role does not allow viewing Secrets, since reading the contents of Secrets 
 </details>
 
 
-### 8. Login to Infra with the newly created user
+### 4. Login to Infra with the newly created user
+
+Login again to switch from admin to your newly created user.
 
 ```
 infra login
 ```
 
-Select the Infra instance, and login with username/password.
+Select the Infra instance, and login with username `name@example.com`, and the password
+from the previous step.
 
-### 9. Use your Kubernetes clusters
+### 5. Connect your first Kubernetes cluster
+
+In order to add connectors to Infra, you will need to set three pieces of information:
+
+* `connector.config.name` is a name you give to identify this cluster. For the purposes of this Quickstart, the name will be `example-name`
+* `connector.config.server` is the hostname or IP address the connector will use to communicate with the Infra server. This will be the same INFRA_URL value from step 2.
+* `connector.config.accessKey` is the access key the connector will use to communicate with the server. You can use an existing access key or generate a new access key with `infra keys add KEY_NAME connector`
+
+```bash
+helm upgrade --install infra-connector infrahq/infra --set connector.config.server=INFRA_URL --set connector.config.accessKey=ACCESS_KEY --set connector.config.name=example-name --set connector.config.skipTLSVerify=true
+```
+
+
+### 6. Use your Kubernetes clusters
 
 You can now access the connected Kubernetes clusters via your favorite tools directly. Infra in the background automatically synchronizes your Kubernetes configuration file (kubeconfig).
 
@@ -170,6 +187,6 @@ infra grants add --user name@example.com --role admin infra
 ```
 </details>
 
-### 10. Share the cluster(s) with other developers
+### 7. Share the cluster(s) with other developers
 
 To share access with Infra, developers will need to install Infra CLI, and be provided the login URL. If using local users, please share the one-time password.

--- a/helm/charts/infra/templates/NOTES.txt
+++ b/helm/charts/infra/templates/NOTES.txt
@@ -6,7 +6,7 @@
 
   Login to this cluster with infra-cli:
 
-    https://github.com/infrahq/infra#2-install-infra-cli
+    https://github.com/infrahq/infra#1-install-infra-cli
 
 {{- if .Values.server.ingress.enabled }}
 {{- with first .Values.server.ingress.hosts }}


### PR DESCRIPTION
This is mostly just polish, the steps remain entirely the same.

High level summary of the changes:
* give a brief explanation of the purpose of  the guide
* add a little more narrative text to a few of the sections to explain the commands
* re-order the sections a bit (install the CLI before deploying the server, and move "adding the connector" to the bottom so that connect and use are together). The goal here was to try and keep related operations together.
* combine a few of the steps to show some of the grouping of operations