### PR TITLE
improve(cli): better interface for testing CLI commands

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -21,6 +22,14 @@ import (
 	"github.com/infrahq/infra/internal/connector"
 	"github.com/infrahq/infra/internal/logging"
 )
+
+// Run the main CLI command with the given args. The args should not contain
+// the name of the binary (ex: os.Args[1:]).
+func Run(ctx context.Context, args ...string) error {
+	cmd := NewRootCmd()
+	cmd.SetArgs(args)
+	return cmd.ExecuteContext(ctx)
+}
 
 func mustBeLoggedIn() error {
 	config, err := currentHostConfig()
@@ -263,7 +272,7 @@ func newConnectorCmd() *cobra.Command {
 
 			options.TLSCache = tlsCache
 
-			return connector.Run(options)
+			return connector.Run(cmd.Context(), options)
 		},
 	}
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -130,12 +131,9 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 	}
 
 	t.Run("UseClusterWithoutPrefix", func(t *testing.T) {
-		_ = setup(t)
+		setup(t)
 
-		useCmd := newUseCmd()
-		useCmd.SetArgs([]string{"cluster"})
-
-		err := useCmd.Execute()
+		err := Run(context.Background(), "use", "cluster")
 		assert.NilError(t, err)
 
 		kubeconfig, err := clientConfig().RawConfig()
@@ -148,12 +146,9 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 	})
 
 	t.Run("UseClusterWithPrefix", func(t *testing.T) {
-		_ = setup(t)
+		setup(t)
 
-		useCmd := newUseCmd()
-		useCmd.SetArgs([]string{"kubernetes.cluster"})
-
-		err := useCmd.Execute()
+		err := Run(context.Background(), "use", "kubernetes.cluster")
 		assert.NilError(t, err)
 
 		kubeconfig, err := clientConfig().RawConfig()
@@ -166,12 +161,9 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 	})
 
 	t.Run("UseNamespaceWithoutPrefix", func(t *testing.T) {
-		_ = setup(t)
+		setup(t)
 
-		useCmd := newUseCmd()
-		useCmd.SetArgs([]string{"cluster.namespace"})
-
-		err := useCmd.Execute()
+		err := Run(context.Background(), "use", "cluster.namespace")
 		assert.NilError(t, err)
 
 		kubeconfig, err := clientConfig().RawConfig()
@@ -184,12 +176,9 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 	})
 
 	t.Run("UseNamespaceWithPrefix", func(t *testing.T) {
-		_ = setup(t)
+		setup(t)
 
-		useCmd := newUseCmd()
-		useCmd.SetArgs([]string{"kubernetes.cluster.namespace"})
-
-		err := useCmd.Execute()
+		err := Run(context.Background(), "use", "kubernetes.cluster.namespace")
 		assert.NilError(t, err)
 
 		kubeconfig, err := clientConfig().RawConfig()
@@ -202,12 +191,9 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 	})
 
 	t.Run("UseUnknown", func(t *testing.T) {
-		_ = setup(t)
+		setup(t)
 
-		useCmd := newUseCmd()
-		useCmd.SetArgs([]string{"unknown"})
-
-		err := useCmd.Execute()
+		err := Run(context.Background(), "use", "unknown")
 		assert.ErrorContains(t, err, "context not found")
 	})
 }

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -364,7 +364,7 @@ func verifyTLS(host string) error {
 	url.Scheme = "https"
 	urlString := url.String()
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, urlString, nil)
+	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, urlString, nil)
 	if err != nil {
 		logging.S.Debugf("Cannot create request: %v", err)
 		return err

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -91,7 +92,7 @@ func TestLogout(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		cfg, count := setup(t)
-		err := newLogoutCmd().Execute()
+		err := Run(context.Background(), "logout")
 		assert.NilError(t, err)
 
 		assert.Equal(t, int32(2), atomic.LoadInt32(count), "calls to API")
@@ -111,9 +112,7 @@ func TestLogout(t *testing.T) {
 
 	t.Run("with purge", func(t *testing.T) {
 		_, count := setup(t)
-		cmd := newLogoutCmd()
-		cmd.SetArgs([]string{"--purge"})
-		err := cmd.Execute()
+		err := Run(context.Background(), "logout", "--purge")
 		assert.NilError(t, err)
 
 		assert.Equal(t, int32(2), atomic.LoadInt32(count), "calls to API")

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -54,7 +53,7 @@ func newServerCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("creating server: %w", err)
 			}
-			return srv.Run(context.Background())
+			return srv.Run(cmd.Context())
 		},
 	}
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -63,7 +63,7 @@ func (j *jwkCache) getJWK() (*jose.JSONWebKey, error) {
 		return j.key, nil
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("%s/.well-known/jwks.json", j.baseURL), nil)
+	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, fmt.Sprintf("%s/.well-known/jwks.json", j.baseURL), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func updateRoles(c *api.Client, k *kubernetes.Kubernetes, grants []api.Grant) er
 	return nil
 }
 
-func Run(options Options) error {
+func Run(ctx context.Context, options Options) error {
 	k8s, err := kubernetes.NewKubernetes()
 	if err != nil {
 		return err
@@ -408,7 +408,7 @@ func Run(options Options) error {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	repeat.Start(ctx, 5*time.Second, func(context.Context) {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 
@@ -11,7 +12,7 @@ import (
 )
 
 func main() {
-	if err := cmd.NewRootCmd().Execute(); err != nil {
+	if err := cmd.Run(context.Background(), os.Args[1:]...); err != nil {
 		if !errors.Is(err, terminal.InterruptErr) {
 			logging.S.Error(err.Error())
 		}


### PR DESCRIPTION
## Summary

This change is being made to expose a better interface for testing CLI commands. This new interface has a few advantages:

1. it accepts a `context.Context`. This allows us to pass in a context from a test, to cancel long running commands (server, connector)
2. it accepts args, removing the need for a separate `SetArgs` call
3. it hides more of the cobra command details. We could change how the CLI is constructed and these tests should continue to work.

This commit also removes a few calls to `context.Background`. In a couple places they are replaced with a context passed from the command, and in others they are replaced with a `context.TODO`, to indicate we should accept the context from the command.