### PR TITLE
fix: allow use by name alone

### DIFF
--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -40,8 +40,8 @@ $ infra list
 
 # You can switch clusters using your existing tools
 # Infra also includes a CLI command for switching clusters
-$ infra use kubernetes.production.web
-Switched to context "infra:production:web".
+$ infra use production.web
+Switched to context "production.web".
 
 $ kubectl get pods
 NAME                  READY   STATUS    RESTARTS   AGE
@@ -89,4 +89,4 @@ Data stored and transmitted by Infra is always encrypted. Read more about our [s
 
 ## What's next
 
-Get up and running with the [Quickstart](./quickstart.md) guide or read about the [Key concepts](./key-concepts.md).
+Get up and running with the [Quickstart](./quickstart.md) guide or read about the [Key Concepts](./key-concepts.md).

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -125,12 +125,11 @@ infra use DESTINATION [flags]
 
 ```
 
-# Connect to a Kubernetes cluster
-$ infra use kubernetes.development
+# Use a Kubernetes context
+$ infra use development
 
-# Connect to a Kubernetes namespace
-$ infra use kubernetes.development.kube-system
-		
+# Use a Kubernetes namespace context
+$ infra use development.kube-system
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,0 +1,213 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/uid"
+)
+
+func TestUse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
+
+	// k8s.io/tools/clientcmd reads HOME at import time, so this must be patched too
+	t.Setenv("KUBECONFIG", filepath.Join(home, "config"))
+
+	userID := uid.New()
+	destinationID := uid.New()
+	ca := `-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUETRDuZAQHGhiH11GNsXn16n9t48wDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMjA0MTIyMTAzMDhaFw0yNDA0
+MTEyMTAzMDhaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQC6GBhadDfSLlgXsL7sWOExlOboQYAQh2pjfjUjMjgW
+ZNQhguRnA4iDCXeBVJnrlTxJvBUJpZ5Wd3h6Tp3Yf9o8teJCvRqX99uuD1P/4P2O
+gcEpiXxEmnAgsNeZfUVCQJhhHM9BGUEn+3FRL6yuSVi+6F6Xu+FmQ0xERu3M7Gv8
+dtXdn1y8rSxNPME8+VFAon47phGAa4aACZOo5dqbfkKNSJlLK2B7B6MYuVtI14kk
+GuVtLy/sEJlH1ZROPE7zeyh7ZXsGXr8O/sCmXTZNAe98mTUxZX0IxT6drgcwzFdK
+6BJNAxvgBsJltpAGrVo+m+pm8HWmnAS0NTXYPUofYD0NAgMBAAGjUzBRMB0GA1Ud
+DgQWBBT/khk5FFePHZ7v5tT/3QeHggVHETAfBgNVHSMEGDAWgBT/khk5FFePHZ7v
+5tT/3QeHggVHETAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCx
+XQyY89xU9XA29JSn96oOQQRNVDl1PmhNiIrJI7FCn5vK1+do00i5teO8mAb49IMt
+DGA8pCAllFTiz6ibf8IuVnCype4lLbJ19am648IllV97Dwo/gnlF08ozWai2mx6l
+5rOqg0YSpEWB88xbulVPWpjwAzYsXh8Y7kem7TXd9MICsIkl1+BXjgG7LSaIwa60
+swYRJSf2bpBsW0Hiqx6WlLUETieVJF9gld0FZSG5Vix0y0IdPEZD5ACbM5G2X4QB
+XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
+7Crix1N6DuA9FeukBz2M
+-----END CERTIFICATE-----`
+
+	setup := func(t *testing.T) *ClientConfig {
+		handler := func(resp http.ResponseWriter, req *http.Request) {
+			switch {
+			case req.URL.Path == "/v1/destinations":
+				destinations := []api.Destination{
+					{
+						ID:       destinationID,
+						UniqueID: "uniqueID",
+						Name:     "kubernetes.cluster",
+						Connection: api.DestinationConnection{
+							URL: "kubernetes.docker.local",
+							CA:  ca,
+						},
+					},
+				}
+
+				bytes, err := json.Marshal(destinations)
+				assert.NilError(t, err)
+
+				_, err = resp.Write(bytes)
+				assert.NilError(t, err)
+			case req.URL.Path == fmt.Sprintf("/v1/identities/%s/grants", userID):
+				grants := []api.Grant{
+					{
+						ID:        uid.New(),
+						Subject:   uid.NewIdentityPolymorphicID(userID),
+						Resource:  "kubernetes.cluster",
+						Privilege: "admin",
+					},
+					{
+						ID:        uid.New(),
+						Subject:   uid.NewIdentityPolymorphicID(userID),
+						Resource:  "kubernetes.cluster.namespace",
+						Privilege: "admin",
+					},
+				}
+
+				bytes, err := json.Marshal(grants)
+				assert.NilError(t, err)
+
+				_, err = resp.Write(bytes)
+				assert.NilError(t, err)
+			case req.URL.Path == fmt.Sprintf("/v1/identities/%s/groups", userID):
+				groups := []api.Group{}
+
+				bytes, err := json.Marshal(groups)
+				assert.NilError(t, err)
+
+				_, err = resp.Write(bytes)
+				assert.NilError(t, err)
+			default:
+				resp.WriteHeader(http.StatusBadRequest)
+			}
+		}
+
+		svc := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(svc.Close)
+
+		cfg := ClientConfig{
+			Version: "0.3",
+			Hosts: []ClientHostConfig{
+				{
+					PolymorphicID: uid.NewIdentityPolymorphicID(userID),
+					Name:          "test",
+					Host:          svc.Listener.Addr().String(),
+					SkipTLSVerify: true,
+					AccessKey:     "access-key",
+					Expires:       api.Time(time.Now().Add(time.Hour)),
+					Current:       true,
+				},
+			},
+		}
+
+		err := writeConfig(&cfg)
+		assert.NilError(t, err)
+
+		err = clearKubeconfig()
+		assert.NilError(t, err)
+
+		return &cfg
+	}
+
+	t.Run("UseClusterWithoutPrefix", func(t *testing.T) {
+		_ = setup(t)
+
+		useCmd := newUseCmd()
+		useCmd.SetArgs([]string{"cluster"})
+
+		err := useCmd.Execute()
+		assert.NilError(t, err)
+
+		kubeconfig, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+
+		assert.Equal(t, len(kubeconfig.Clusters), 2)
+		assert.Equal(t, len(kubeconfig.Contexts), 2)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 2)
+		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster")
+	})
+
+	t.Run("UseClusterWithPrefix", func(t *testing.T) {
+		_ = setup(t)
+
+		useCmd := newUseCmd()
+		useCmd.SetArgs([]string{"kubernetes.cluster"})
+
+		err := useCmd.Execute()
+		assert.NilError(t, err)
+
+		kubeconfig, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+
+		assert.Equal(t, len(kubeconfig.Clusters), 2)
+		assert.Equal(t, len(kubeconfig.Contexts), 2)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 2)
+		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster")
+	})
+
+	t.Run("UseNamespaceWithoutPrefix", func(t *testing.T) {
+		_ = setup(t)
+
+		useCmd := newUseCmd()
+		useCmd.SetArgs([]string{"cluster.namespace"})
+
+		err := useCmd.Execute()
+		assert.NilError(t, err)
+
+		kubeconfig, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+
+		assert.Equal(t, len(kubeconfig.Clusters), 2)
+		assert.Equal(t, len(kubeconfig.Contexts), 2)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 2)
+		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster:namespace")
+	})
+
+	t.Run("UseNamespaceWithPrefix", func(t *testing.T) {
+		_ = setup(t)
+
+		useCmd := newUseCmd()
+		useCmd.SetArgs([]string{"kubernetes.cluster.namespace"})
+
+		err := useCmd.Execute()
+		assert.NilError(t, err)
+
+		kubeconfig, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+
+		assert.Equal(t, len(kubeconfig.Clusters), 2)
+		assert.Equal(t, len(kubeconfig.Contexts), 2)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 2)
+		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster:namespace")
+	})
+
+	t.Run("UseUnknown", func(t *testing.T) {
+		_ = setup(t)
+
+		useCmd := newUseCmd()
+		useCmd.SetArgs([]string{"unknown"})
+
+		err := useCmd.Execute()
+		assert.ErrorContains(t, err, "context not found")
+	})
+}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`infra use` should allow referencing by name, i.e. without the `kubernetes.` prefix

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1552