### PR TITLE
improve: sort infra list outputs

### DIFF
--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -86,13 +87,13 @@ func list() error {
 
 	var rows []row
 
-	for k, v := range gs {
+	keys := make([]string, 0, len(gs))
+	for k := range gs {
 		if strings.HasPrefix(k, "infra") {
 			continue
 		}
 
 		var exists bool
-
 		for _, d := range destinations {
 			if strings.HasPrefix(k, d.Name) {
 				exists = true
@@ -102,6 +103,18 @@ func list() error {
 
 		if !exists {
 			continue
+		}
+
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v, ok := gs[k]
+		if !ok {
+			// should not be possible
+			return fmt.Errorf("unexpected value in grants: %s", k)
 		}
 
 		access := make([]string, 0, len(v))


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Sort `infra list` outputs so it's stable. Without sorting, the ordering may change significantly between runs which will unexpected for the user