### PR TITLE
maintain: move subjectNameFromGrants to cmd/grants.go

### DIFF
--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -308,3 +308,30 @@ func getIDByName(client *api.Client, name string, identityType identityType) (ui
 
 	return id, nil
 }
+
+func subjectNameFromGrant(client *api.Client, g api.Grant) (name string, err error) {
+	id, err := g.Subject.ID()
+	if err != nil {
+		return "", err
+	}
+
+	if g.Subject.IsIdentity() {
+		identity, err := client.GetIdentity(id)
+		if err != nil {
+			return "", err
+		}
+
+		return identity.Name, nil
+	}
+
+	if g.Subject.IsGroup() {
+		group, err := client.GetGroup(id)
+		if err != nil {
+			return "", err
+		}
+
+		return group.Name, nil
+	}
+
+	return "", fmt.Errorf("unrecognized grant subject")
+}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -136,30 +136,3 @@ func list() error {
 
 	return writeKubeconfig(destinations, grants)
 }
-
-func subjectNameFromGrant(client *api.Client, g api.Grant) (name string, err error) {
-	id, err := g.Subject.ID()
-	if err != nil {
-		return "", err
-	}
-
-	if g.Subject.IsIdentity() {
-		identity, err := client.GetIdentity(id)
-		if err != nil {
-			return "", err
-		}
-
-		return identity.Name, nil
-	}
-
-	if g.Subject.IsGroup() {
-		group, err := client.GetGroup(id)
-		if err != nil {
-			return "", err
-		}
-
-		return group.Name, nil
-	}
-
-	return "", fmt.Errorf("unrecognized grant subject")
-}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Move `subjectNameFromGrants` to `cmd/grants.go` since that's the only place it's being used.