### PR TITLE
Remove the infra user role

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -104,17 +104,13 @@ func TestUsersGroupGrant(t *testing.T) {
 	c.Set("db", db)
 	c.Set("identity", tom)
 
-	grant(t, db, tom, tomsGroup.PolyID(), models.InfraUserRole, "infra")
-
-	authDB, err := RequireInfraRole(c, models.InfraUserRole)
-	assert.NilError(t, err)
-	assert.Assert(t, authDB != nil)
-
-	authDB, err = RequireInfraRole(c, models.InfraAdminRole)
+	authDB, err := RequireInfraRole(c, models.InfraAdminRole)
 	assert.ErrorIs(t, err, internal.ErrForbidden)
 	assert.Assert(t, authDB == nil)
 
-	authDB, err = RequireInfraRole(c, models.InfraAdminRole, models.InfraUserRole)
+	grant(t, db, tom, tomsGroup.PolyID(), models.InfraAdminRole, "infra")
+
+	authDB, err = RequireInfraRole(c, models.InfraAdminRole)
 	assert.NilError(t, err)
 	assert.Assert(t, authDB != nil)
 }

--- a/internal/access/destination.go
+++ b/internal/access/destination.go
@@ -27,20 +27,12 @@ func SaveDestination(c *gin.Context, destination *models.Destination) error {
 }
 
 func GetDestination(c *gin.Context, id uid.ID) (*models.Destination, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole, models.InfraUserRole)
-	if err != nil {
-		return nil, err
-	}
-
+	db := getDB(c)
 	return data.GetDestination(db, data.ByID(id))
 }
 
 func ListDestinations(c *gin.Context, uniqueID, name string) ([]models.Destination, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole, models.InfraUserRole)
-	if err != nil {
-		return nil, err
-	}
-
+	db := getDB(c)
 	return data.ListDestinations(db, data.ByOptionalUniqueID(uniqueID), data.ByOptionalName(name))
 }
 

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -109,13 +109,6 @@ func ExchangeAuthCodeForAccessKey(c *gin.Context, code string, provider *models.
 		if err := data.CreateIdentity(db, user); err != nil {
 			return nil, "", fmt.Errorf("create user: %w", err)
 		}
-
-		// by default the user role in infra can see all destinations
-		// #1084 - create grants for only destinations a user has access to
-		roleGrant := &models.Grant{Subject: user.PolyID(), Privilege: models.InfraUserRole, Resource: "infra"}
-		if err := data.CreateGrant(db, roleGrant); err != nil {
-			return nil, "", fmt.Errorf("user role grant: %w", err)
-		}
 	}
 
 	providerUser, err := data.CreateProviderUser(db, provider, user)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -67,11 +67,6 @@ func (a *API) CreateIdentity(c *gin.Context, r *api.CreateIdentityRequest) (*api
 		return nil, err
 	}
 
-	defaultGrant := &models.Grant{Subject: identity.PolyID(), Privilege: models.InfraUserRole, Resource: access.ResourceInfraAPI}
-	if err := access.CreateGrant(c, defaultGrant); err != nil {
-		return nil, err
-	}
-
 	resp := &api.CreateIdentityResponse{
 		ID:         identity.ID,
 		Name:       identity.Name,

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -8,7 +8,6 @@ import (
 const (
 	InfraAdminRole     = "admin"
 	InfraViewRole      = "view"
-	InfraUserRole      = "user"
 	InfraConnectorRole = "connector"
 )
 


### PR DESCRIPTION
## Summary

Instead of a user role that we grant to all identities, we can allow authenticated requests to list and get destinations.

This is effectively the same behaviour, without showing the extra grant in the list of grants.

## Related Issues

Resolves #1585

## Open questions

* Do we need a migration for this to remove any existing grants for "infra user role" ?