### PR TITLE
maintain: remove a couple items from PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,11 +14,8 @@ Checklists help us remember things. Change [ ] to [x] to show completion.
 - [ ] Updated associated configuration where necessary
 - [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
 - [ ] Nothing sensitive logged
-- [ ] Commit message conforms to [Conventional Commit][1]
-- [ ] GitHub Actions are passing
 - [ ] Considered data migrations for smooth upgrades
 
-[1]: https://www.conventionalcommits.org/en/v1.0.0/
 
 ## Related Issues
 


### PR DESCRIPTION

## Summary

We use branch protection rules now, so github will tell us if actions are not run.
We also lint the commit message in CI, so our CI checks the commit conforms to our rules.