### PR TITLE
docs: OpenAPI enum for oneof (#1496)

### DIFF
--- a/api/identity.go
+++ b/api/identity.go
@@ -10,7 +10,7 @@ type Identity struct {
 	Updated    Time   `json:"updated"`
 	LastSeenAt Time   `json:"lastSeenAt"`
 	Name       string `json:"name" validate:"required"`
-	Kind       string `json:"kind" validate:"required"`
+	Kind       string `json:"kind" validate:"required,oneof=user machine"`
 }
 
 type ListIdentitiesRequest struct {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -288,6 +288,10 @@
             "type": "string"
           },
           "kind": {
+            "enum": [
+              "user",
+              "machine"
+            ],
             "type": "string"
           },
           "lastSeenAt": {
@@ -1998,7 +2002,7 @@
         },
         "summary": "ListIdentities",
         "tags": [
-          "Misc"
+          "Identities"
         ]
       },
       "post": {
@@ -2010,6 +2014,10 @@
               "schema": {
                 "properties": {
                   "kind": {
+                    "enum": [
+                      "user",
+                      "machine"
+                    ],
                     "type": "string"
                   },
                   "name": {


### PR DESCRIPTION
- generate an enum for one-of tags in open api spec
- refactor some duplicated tag reading code
- add "one of" to identity api struct
- fix /v1/identites in the right category

## Summary
API structs that are validated to be "one of" set values should be enums in the OpenAPI spec.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Commit message conforms to [Conventional Commit][1]
- [ ] GitHub Actions are passing
- [ ] Considered data migrations for smooth upgrades

[1]: https://www.conventionalcommits.org/en/v1.0.0/

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1496
