### PR TITLE
Fix loading of key providers from config

### DIFF
--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -136,9 +136,15 @@ func TestServerCmd_WithSecretsConfig(t *testing.T) {
         - kind: env
           name: base64env
           config:
-            base64: true`
+            base64: true
+      keys:
+        - kind: native
+          config:
+            secretProvider: env
+`
 
 	dir := fs.NewDir(t, t.Name(), fs.WithFile("cfg.yaml", content))
+	t.Setenv("HOME", dir.Path())
 
 	// TODO: change to Run(ctx, args) once that is merged
 	cmd := newServerCmd()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -102,11 +102,18 @@ type Addrs struct {
 	Metrics net.Addr
 }
 
-func New(options Options) (*Server, error) {
-	server := &Server{
+// newServer creates a Server with base dependencies initialized to zero values.
+func newServer(options Options) *Server {
+	return &Server{
 		options: options,
 		secrets: map[string]secrets.SecretStorage{},
+		keys:    map[string]secrets.SymmetricKeyProvider{},
 	}
+}
+
+// New creates a Server, and initializes it. The returned Server is ready to run.
+func New(options Options) (*Server, error) {
+	server := newServer(options)
 
 	if err := validate.Struct(options); err != nil {
 		return nil, fmt.Errorf("invalid options: %w", err)
@@ -122,7 +129,7 @@ func New(options Options) (*Server, error) {
 		return nil, fmt.Errorf("secrets config: %w", err)
 	}
 
-	if err := server.importSecretKeys(); err != nil {
+	if err := importKeyProviders(options.Keys, server.secrets, server.keys); err != nil {
 		return nil, fmt.Errorf("key config: %w", err)
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -26,12 +26,8 @@ import (
 )
 
 func setupServer(t *testing.T) *Server {
-	db := setupDB(t)
-
-	s := &Server{
-		db:      db,
-		secrets: map[string]secrets.SecretStorage{},
-	}
+	s := newServer(Options{})
+	s.db = setupDB(t)
 
 	err := s.setupInternalInfraIdentityProvider()
 	assert.NilError(t, err)
@@ -65,7 +61,7 @@ func setupLogging(t *testing.T) {
 func TestGetPostgresConnectionURL(t *testing.T) {
 	setupLogging(t)
 
-	r := &Server{options: Options{}, secrets: make(map[string]secrets.SecretStorage)}
+	r := newServer(Options{})
 
 	f := secrets.NewPlainSecretProviderFromConfig(secrets.GenericConfig{})
 	r.secrets["plaintext"] = f

--- a/secrets/aws.go
+++ b/secrets/aws.go
@@ -1,8 +1,8 @@
 package secrets
 
 type AWSConfig struct {
-	Endpoint        string `yaml:"endpoint" validate:"required"`
-	Region          string `yaml:"region" validate:"required"`
-	AccessKeyID     string `yaml:"accessKeyID" validate:"required"`
-	SecretAccessKey string `yaml:"secretAccessKey" validate:"required"`
+	Endpoint        string `mapstructure:"endpoint" validate:"required"`
+	Region          string `mapstructure:"region" validate:"required"`
+	AccessKeyID     string `mapstructure:"accessKeyID" validate:"required"`
+	SecretAccessKey string `mapstructure:"secretAccessKey" validate:"required"`
 }

--- a/secrets/awskms.go
+++ b/secrets/awskms.go
@@ -20,9 +20,9 @@ type AWSKMSSecretProvider struct {
 }
 
 type AWSKMSConfig struct {
-	AWSConfig
+	AWSConfig `mapstructure:",squash"`
 
-	EncryptionAlgorithm string `yaml:"encryptionAlgorithm"`
+	EncryptionAlgorithm string `mapstructure:"encryptionAlgorithm"`
 	// aws tags?
 }
 


### PR DESCRIPTION
Branched from #1520, so that will have to merge first.

## Summary

Similar to #1520, this PR fixes loading of key providers from config. When we switched from yaml config to using viper and mapstructure the custom unmarshal method no longer worked.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues


Resolves #https://github.com/infrahq/infra/issues/1519
