### PR TITLE
fix: not logging api calls

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -22,12 +22,17 @@ type ReqResHandlerFunc[Req, Res any] func(c *gin.Context, req *Req) (Res, error)
 
 func (a *API) registerRoutes(router *gin.RouterGroup, promRegistry prometheus.Registerer) {
 	router.GET("/healthz", a.healthHandler)
+
+	router.Use(
+		logging.Middleware(),
+		RequestTimeoutMiddleware(),
+	)
+
 	router.GET("/.well-known/jwks.json", DatabaseMiddleware(a.server.db), a.wellKnownJWKsHandler)
 
 	router.Use(
 		sentrygin.New(sentrygin.Options{}),
 		metrics.Middleware(promRegistry),
-		logging.IdentityAwareMiddleware(),
 		DatabaseMiddleware(a.server.db),
 	)
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Server is not currently logging incoming requests. This was due to the logging middleware being (accidentally?) removed. 

Replacing the `IdentityAwareLoggingMiddleware` which doesn't work in the current state. It requires `identity` to exist in the context but `identity` is not set until much later in the `AuthenticationMiddleware`

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
