### PR TITLE
improve(api): move /debug/pprof to /v1/debug/pprof

### DIFF
--- a/internal/server/debug.go
+++ b/internal/server/debug.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net/http"
 	"net/http/pprof"
 
 	"github.com/gin-gonic/gin"
@@ -22,6 +23,6 @@ func (a *API) pprofHandler(c *gin.Context) {
 		pprof.Profile(c.Writer, c.Request)
 	default:
 		// All other types of profiles are served from Index
-		pprof.Index(c.Writer, c.Request)
+		http.StripPrefix("/v1", http.HandlerFunc(pprof.Index)).ServeHTTP(c.Writer, c.Request)
 	}
 }

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -31,7 +31,7 @@ func TestAPI_PProfHandler(t *testing.T) {
 	assert.NilError(t, err)
 
 	run := func(t *testing.T, tc testCase) {
-		req, err := http.NewRequest(http.MethodGet, "/debug/pprof/heap?debug=1", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/debug/pprof/heap?debug=1", nil)
 		assert.NilError(t, err)
 
 		if tc.setupRequest != nil {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -89,8 +89,7 @@ func (a *API) registerRoutes(router *gin.RouterGroup, promRegistry prometheus.Re
 		get(a, unauthorized, "/version", a.Version)
 	}
 
-	// pprof.Index does not work with a /v1 prefix
-	debug := router.Group("/debug/pprof", AuthenticationMiddleware(a))
+	debug := v1.Group("/debug/pprof", AuthenticationMiddleware(a))
 	debug.GET("/*profile", a.pprofHandler)
 
 	// TODO: remove after a couple version.


### PR DESCRIPTION
## Summary

I found this `http.StripPrefix` which makes it easy to move the pprof handlers to `/v1`. This is probably good because any paths that start with a different prefix are assumed to be paths for serving the UI.

Would be a breaking change if anyone was using these, but I don't think anyone has a use for them yet.