### PR TITLE
improve: log identity name for logged in API request

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -148,35 +148,7 @@ func (w *filteredWriterSyncer) Sync() error {
 	return w.dest.Sync()
 }
 
-// Logger gets the request-specific logger from the context
-// If a request-specific logger cannot be found, use the default logger
-func Logger(c *gin.Context) *zap.Logger {
-	if loggerInf, ok := c.Get("logger"); ok {
-		if logger, ok := loggerInf.(*zap.Logger); ok {
-			return logger
-		}
-	}
-
-	return L
-}
-
-// Sugared variant of Logger
-func SugarLogger(c *gin.Context) *zap.SugaredLogger {
-	return Logger(c).Sugar()
-}
-
-// WrappedLogger skips the most recent caller
-// Useful for functions that logs for callers
-func WrappedLogger(c *gin.Context) *zap.Logger {
-	return Logger(c).WithOptions(zap.AddCallerSkip(1))
-}
-
-// Sugared variant of WrappedLogger
-func WrappedSugarLogger(c *gin.Context) *zap.SugaredLogger {
-	return WrappedLogger(c).Sugar()
-}
-
-// Middleware logs incoming requests using configured logger
+// Middleware logs incoming requests using configured logger.
 func Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Next()
@@ -193,19 +165,19 @@ func Middleware() gin.HandlerFunc {
 			c.Request.ContentLength,
 		)
 
-		logger := SugarLogger(c)
+		logger := L
 		if raw, ok := c.Get("identity"); ok {
 			if identity, ok := raw.(*models.Identity); ok {
-				logger = logger.With("identity", identity.ID.String())
+				logger = logger.With(zap.Stringer("identity", identity.ID))
 			}
 		}
 
-		logger.Infow(
+		logger.Info(
 			msg,
-			"method", c.Request.Method,
-			"path", c.Request.URL.Path,
-			"statusCode", c.Writer.Status(),
-			"remoteAddr", c.Request.RemoteAddr,
+			zap.String("method", c.Request.Method),
+			zap.String("path", c.Request.URL.Path),
+			zap.Int("statusCode", c.Writer.Status()),
+			zap.String("remoteAddr", c.Request.RemoteAddr),
 		)
 	}
 }


### PR DESCRIPTION
## Summary

Removes the IdentityAwareMiddleware as it did not work, and because we
can do this with a single middleware. It did not work for a few reasons.
It attempted to read an identity from the context before it existed, and
because the identity in the context is a model.Identity, not just an ID.

This new approach works because we read the identity out after the
request handler runs.

Tested manually and saw authenticated requests with an identity field,
and unauthenticated requests without.