### PR TITLE
api: more robust structure for building routes

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
 	"github.com/goware/urlx"
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/acme/autocert"
 	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
@@ -359,24 +358,6 @@ func (s *Server) registerUIRoutes(router *gin.Engine) error {
 	})
 
 	return nil
-}
-
-func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) (*gin.Engine, error) {
-	router := gin.New()
-
-	router.Use(gin.Recovery())
-	a := &API{
-		t:      s.tel,
-		server: s,
-	}
-
-	a.registerRoutes(router.Group("/"), promRegistry)
-
-	if err := s.registerUIRoutes(router); err != nil {
-		return nil, err
-	}
-
-	return router, nil
 }
 
 func (s *Server) listen() error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -336,27 +336,6 @@ func (s *Server) registerUIRoutes(router *gin.Engine) error {
 
 	staticFS := &StaticFileSystem{base: http.FS(assetFS)}
 	router.Use(gzip.Gzip(gzip.DefaultCompression), static.Serve("/", staticFS))
-
-	// 404
-	router.NoRoute(func(c *gin.Context) {
-		if strings.HasPrefix(c.Request.URL.Path, "/v1") {
-			c.Status(404)
-			c.Writer.WriteHeaderNow()
-			return
-		}
-
-		c.Status(http.StatusNotFound)
-		buf, err := assetFS.ReadFile("ui/404.html")
-		if err != nil {
-			logging.S.Error(err)
-		}
-
-		_, err = c.Writer.Write(buf)
-		if err != nil {
-			logging.S.Error(err)
-		}
-	})
-
 	return nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -981,7 +981,11 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 		{
 			name: "/v1 path prefix",
 			path: "/v1/not/found",
-			// TODO: should have a JSON response body
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				contentType := resp.Header().Get("Content-Type")
+				expected := "application/json; charset=utf-8"
+				assert.Equal(t, contentType, expected)
+			},
 		},
 		{
 			name: "ui path",


### PR DESCRIPTION
(Best viewed by individual commit because it required moving a function to a different file).

## Summary

We've had a couple regressions with the API middleware either applying to the wrong routes (ui routes), or not being applied to routes (missing logging on API routes). Even when we notice the problem it has been a challenge to fix it properly (requiring lots of back-and-forth or pairing).

I think there are a few constraints that make this challenging:
1. Our UI routes are applied as catch-all middleware with no path prefix. This makes it really easily to accidentally add a middleware to those routes without noticing.
2. The interface gin providers for constructing these routes is overly flexible and not well documented (I had to read the source to understand how/when middleware would be applied to a route. See the godoc I added for details).
3. It's very difficult to test things are constructed properly in any meaningful way. We could potentially write a test that checks the number or list of middleware applied (although I'm not sure if that is possible with Gin), however that is just mirroring the implementation. Testing that a crash middleware or timeout middleware is applied to the routes we want is challenging at best.

The approach I've taken here is to:
1. consolidate - move all of the HTTP handler building to a single function. This makes it easier to reason about because we can see it all together (instead of it being split between 2+ functions across 2 files.
2. document - both the godoc on the function and inline comments should help clarify why things are this way, and what to look out for when it changes.

There is already some pretty reasonable test coverage of the "not found" route,  the UI routes, and the healthz endpoint. We should be adding tests for all the other endpoints which will further improve our confidence that at least all the routes exist (but we still don't have a good way of testing the middleware is applied correctly). Changes like #1609 will make it easier to test the logging middleware at least.
