### PR TITLE
fix: re-index identities after de-duplication

### DIFF
--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -347,13 +347,6 @@ func migrate(db *gorm.DB) error {
 				}
 				identityTable := &Identity{}
 				logging.S.Debug("starting migration")
-				if tx.Migrator().HasIndex(identityTable, "idx_identities_name_provider_id") {
-					logging.S.Debug("has idx_identities_name_provider_id index")
-					err := tx.Migrator().DropIndex(identityTable, "idx_identities_name_provider_id")
-					if err != nil {
-						return err
-					}
-				}
 
 				logging.S.Debug("checking provider_id column")
 				if tx.Migrator().HasColumn(identityTable, "provider_id") {
@@ -420,6 +413,14 @@ func migrate(db *gorm.DB) error {
 					err = tx.Migrator().DropColumn(identityTable, "provider_id")
 					if err != nil {
 						return err
+					}
+				}
+
+				if tx.Migrator().HasIndex(identityTable, "idx_identities_name_provider_id") {
+					logging.S.Debug("has idx_identities_name_provider_id index")
+					err := tx.Migrator().DropIndex(identityTable, "idx_identities_name_provider_id")
+					if err != nil {
+						return fmt.Errorf("migrate identity index: %w", err)
 					}
 				}
 


### PR DESCRIPTION
## Summary
Move re-indexing identity names to after they are de-duplicated in migration.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1570 
