### PR TITLE
improve: remove error return from registerUIRoutes

### DIFF
--- a/internal/cmd/about.go
+++ b/internal/cmd/about.go
@@ -14,7 +14,6 @@ type triangle struct {
 	B     *point3D
 	C     *point3D
 	Color rune
-	surf  *sprite.Surface
 }
 
 func newAboutCmd() *cobra.Command {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -112,6 +112,7 @@ func parseOptions(cmd *cobra.Command, options interface{}, envPrefix string) err
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
 		decode.HookPrepareForDecode,
+		decode.HookSetFromString,
 	)
 	return v.Unmarshal(options, viper.DecodeHook(hooks))
 }

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -45,7 +45,7 @@ func newServerCmd() *cobra.Command {
 
 			options.DBEncryptionKey = dbEncryptionKey
 
-			srv, err := server.New(options)
+			srv, err := newServer(options)
 			if err != nil {
 				return fmt.Errorf("creating server: %w", err)
 			}
@@ -69,7 +69,7 @@ func newServerCmd() *cobra.Command {
 	cmd.Flags().Bool("enable-telemetry", true, "Enable telemetry")
 	cmd.Flags().Bool("enable-crash-reporting", true, "Enable crash reporting")
 	cmd.Flags().BoolVar(&options.UI.Enabled, "enable-ui", false, "Enable Infra server UI")
-	cmd.Flags().StringVar(&options.UI.ProxyURL, "ui-proxy-url", "", "Proxy upstream UI requests to this url")
+	cmd.Flags().Var(&options.UI.ProxyURL, "ui-proxy-url", "Proxy upstream UI requests to this url")
 	cmd.Flags().Duration("session-duration", time.Hour*12, "User session duration")
 	cmd.Flags().Bool("enable-setup", true, "Enable one-time setup")
 
@@ -90,3 +90,6 @@ func defaultServerOptions() server.Options {
 var runServer = func(ctx context.Context, srv *server.Server) error {
 	return srv.Run(ctx)
 }
+
+// newServer is a shim for testing.
+var newServer = server.New

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/iancoleman/strcase"
 	"github.com/spf13/cobra"
 
 	"github.com/infrahq/infra/internal/logging"
@@ -13,6 +12,7 @@ import (
 )
 
 func newServerCmd() *cobra.Command {
+	options := defaultServerOptions()
 	cmd := &cobra.Command{
 		Use:    "server",
 		Short:  "Start Infra server",
@@ -20,11 +20,6 @@ func newServerCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logging.SetServerLogger()
 
-			// override default strcase.ToLowerCamel behaviour
-			strcase.ConfigureAcronym("enable-ui", "enableUI")
-			strcase.ConfigureAcronym("ui-proxy-url", "uiProxyURL")
-
-			options := defaultServerOptions()
 			if err := parseOptions(cmd, &options, "INFRA_SERVER"); err != nil {
 				return err
 			}
@@ -73,8 +68,8 @@ func newServerCmd() *cobra.Command {
 	cmd.Flags().String("db-encryption-key-provider", "native", "Database encryption key provider")
 	cmd.Flags().Bool("enable-telemetry", true, "Enable telemetry")
 	cmd.Flags().Bool("enable-crash-reporting", true, "Enable crash reporting")
-	cmd.Flags().Bool("enable-ui", false, "Enable Infra server UI")
-	cmd.Flags().String("ui-proxy-url", "", "Proxy upstream UI requests to this url")
+	cmd.Flags().BoolVar(&options.UI.Enabled, "enable-ui", false, "Enable Infra server UI")
+	cmd.Flags().StringVar(&options.UI.ProxyURL, "ui-proxy-url", "", "Proxy upstream UI requests to this url")
 	cmd.Flags().Duration("session-duration", time.Hour*12, "User session duration")
 	cmd.Flags().Bool("enable-setup", true, "Enable one-time setup")
 

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -117,6 +117,28 @@ func TestServerCmd_ParseOptions(t *testing.T) {
 				return expected
 			},
 		},
+		{
+			name: "parse ui-proxy-url from config file",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				content := `
+                  ui:
+                    enabled: true
+                    proxyURL: https://127.0.1.2:34567
+`
+				dir := fs.NewDir(t, t.Name(),
+					fs.WithFile("cfg.yaml", content))
+				cmd.SetArgs([]string{"--config-file", dir.Join("cfg.yaml")})
+			},
+			expected: func(t *testing.T) server.Options {
+				expected := serverOptionsWithDefaults()
+				expected.UI.ProxyURL = types.URL{
+					Scheme: "https",
+					Host:   "127.0.1.2:34567",
+				}
+				expected.UI.Enabled = true
+				return expected
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -9,11 +9,12 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 
+	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/server"
 	"github.com/infrahq/infra/secrets"
 )
 
-func TestParseOptions_WithServerOptions(t *testing.T) {
+func TestServerCmd_ParseOptions(t *testing.T) {
 	type testCase struct {
 		name        string
 		setup       func(t *testing.T, cmd *cobra.Command)
@@ -22,14 +23,18 @@ func TestParseOptions_WithServerOptions(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		cmd := newServerCmd()
+		patchRunServer(t, noServerRun)
+		var actual server.Options
+		patchNewServer(t, &actual)
+		t.Setenv("HOME", "/home/user")
+		t.Setenv("USERPROFILE", "/home/user") // Windows
 
+		cmd := newServerCmd()
 		if tc.setup != nil {
 			tc.setup(t, cmd)
 		}
 
-		options := defaultServerOptions()
-		err := parseOptions(cmd, &options, "INFRA_SERVER")
+		err := cmd.Execute()
 		if tc.expectedErr != "" {
 			assert.ErrorContains(t, err, tc.expectedErr)
 			return
@@ -37,7 +42,7 @@ func TestParseOptions_WithServerOptions(t *testing.T) {
 
 		assert.NilError(t, err)
 		expected := tc.expected(t)
-		assert.DeepEqual(t, expected, options)
+		assert.DeepEqual(t, expected, actual)
 	}
 
 	testCases := []testCase{
@@ -53,8 +58,7 @@ func TestParseOptions_WithServerOptions(t *testing.T) {
 
 				dir := fs.NewDir(t, t.Name(),
 					fs.WithFile("cfg.yaml", content))
-				err := cmd.Flags().Set("config-file", dir.Join("cfg.yaml"))
-				assert.NilError(t, err)
+				cmd.SetArgs([]string{"--config-file", dir.Join("cfg.yaml")})
 			},
 			expected: func(t *testing.T) server.Options {
 				expected := serverOptionsWithDefaults()
@@ -99,6 +103,20 @@ func TestParseOptions_WithServerOptions(t *testing.T) {
 				return expected
 			},
 		},
+		{
+			name: "parse ui-proxy-url from command line flag",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				cmd.SetArgs([]string{"--ui-proxy-url", "https://127.0.1.2:34567"})
+			},
+			expected: func(t *testing.T) server.Options {
+				expected := serverOptionsWithDefaults()
+				expected.UI.ProxyURL = types.URL{
+					Scheme: "https",
+					Host:   "127.0.1.2:34567",
+				}
+				return expected
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -113,9 +131,9 @@ func TestParseOptions_WithServerOptions(t *testing.T) {
 // specifying them again here.
 func serverOptionsWithDefaults() server.Options {
 	o := defaultServerOptions()
-	o.TLSCache = "$HOME/.infra/cache"
-	o.DBFile = "$HOME/.infra/sqlite3.db"
-	o.DBEncryptionKey = "$HOME/.infra/sqlite3.db.key"
+	o.TLSCache = "/home/user/.infra/cache"
+	o.DBFile = "/home/user/.infra/sqlite3.db"
+	o.DBEncryptionKey = "/home/user/.infra/sqlite3.db.key"
 	o.DBEncryptionKeyProvider = "native"
 	o.EnableTelemetry = true
 	o.EnableCrashReporting = true
@@ -146,10 +164,8 @@ func TestServerCmd_WithSecretsConfig(t *testing.T) {
 	dir := fs.NewDir(t, t.Name(), fs.WithFile("cfg.yaml", content))
 	t.Setenv("HOME", dir.Path())
 
-	// TODO: change to Run(ctx, args) once that is merged
-	cmd := newServerCmd()
-	cmd.SetArgs([]string{"--config-file", dir.Join("cfg.yaml")})
-	err := cmd.Execute()
+	ctx := context.Background()
+	err := Run(ctx, "server", "--config-file", dir.Join("cfg.yaml"))
 	assert.NilError(t, err)
 }
 
@@ -163,4 +179,16 @@ func patchRunServer(t *testing.T, fn func(context.Context, *server.Server) error
 
 func noServerRun(context.Context, *server.Server) error {
 	return nil
+}
+
+func patchNewServer(t *testing.T, target *server.Options) {
+	orig := newServer
+	t.Cleanup(func() {
+		newServer = orig
+	})
+
+	newServer = func(options server.Options) (*server.Server, error) {
+		*target = options
+		return &server.Server{}, nil
+	}
 }

--- a/internal/cmd/types/url.go
+++ b/internal/cmd/types/url.go
@@ -1,0 +1,35 @@
+package types
+
+import (
+	"net/url"
+
+	"github.com/goware/urlx"
+)
+
+// URL is an alias for url.URL that allows it to be parsed from a command line
+// flag, or config file.
+type URL url.URL
+
+func (u *URL) Set(raw string) error {
+	v, err := urlx.Parse(raw)
+	if err != nil {
+		return err
+	}
+	*u = URL(*v)
+	return nil
+}
+
+func (u *URL) String() string {
+	if u == nil {
+		return ""
+	}
+	return (*url.URL)(u).String()
+}
+
+func (u *URL) Type() string {
+	return "url"
+}
+
+func (u *URL) Value() *url.URL {
+	return (*url.URL)(u)
+}

--- a/internal/decode/decode.go
+++ b/internal/decode/decode.go
@@ -31,3 +31,33 @@ func HookPrepareForDecode(from reflect.Value, to reflect.Value) (interface{}, er
 	err := unmapper.PrepareForDecode(source)
 	return source, err
 }
+
+type FromString interface {
+	Set(string) error
+}
+
+// HookSetFromString allows any complex type that implements FromString to
+// set its value from a string.
+//
+// This same interface is accepted by spf13/pflag, which allows us to use the
+// same type for command line flags, env vars, and config files.
+func HookSetFromString(from reflect.Value, to reflect.Value) (interface{}, error) {
+	source := from.Interface()
+	v, ok := source.(string)
+	if !ok {
+		return source, nil
+	}
+
+	fromString, ok := to.Interface().(FromString)
+	if !ok {
+		if to.CanAddr() {
+			fromString, ok = to.Addr().Interface().(FromString)
+		}
+		if !ok {
+			return source, nil
+		}
+	}
+
+	err := fromString.Set(v)
+	return to, err
+}

--- a/internal/openapigen/main.go
+++ b/internal/openapigen/main.go
@@ -23,7 +23,7 @@ func run(args []string) error {
 	filename := args[0]
 
 	s := server.Server{}
-	_, _ = s.GenerateRoutes(prometheus.NewRegistry())
+	s.GenerateRoutes(prometheus.NewRegistry())
 
 	return server.WriteOpenAPISpecToFile(filename)
 }

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -219,6 +219,7 @@ func decodeConfig(target interface{}, source interface{}) error {
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
 			decode.HookPrepareForDecode,
+			decode.HookSetFromString,
 		),
 	}
 

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -27,8 +27,7 @@ func TestAPI_PProfHandler(t *testing.T) {
 	}
 
 	s := &Server{db: setupDB(t)}
-	routes, err := s.GenerateRoutes(prometheus.NewRegistry())
-	assert.NilError(t, err)
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
 	run := func(t *testing.T, tc testCase) {
 		req, err := http.NewRequest(http.MethodGet, "/v1/debug/pprof/heap?debug=1", nil)

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -25,7 +25,7 @@ func TestListProviders(t *testing.T) {
 	err := s.importAccessKeys()
 	assert.NilError(t, err)
 
-	routes, err := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
 	assert.NilError(t, err)
 
 	testProvider := &models.Provider{
@@ -66,7 +66,7 @@ func TestDeleteProvider(t *testing.T) {
 	err := s.importAccessKeys()
 	assert.NilError(t, err)
 
-	routes, err := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
 	assert.NilError(t, err)
 
 	testProvider := &models.Provider{
@@ -97,7 +97,7 @@ func TestDeleteProvider_NoDeleteInternalProvider(t *testing.T) {
 	err := s.importAccessKeys()
 	assert.NilError(t, err)
 
-	routes, err := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
 	assert.NilError(t, err)
 
 	route := fmt.Sprintf("/v1/providers/%s", s.InternalProvider.ID)
@@ -121,7 +121,7 @@ func TestDeleteIdentity(t *testing.T) {
 	err := s.importAccessKeys()
 	assert.NilError(t, err)
 
-	routes, err := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
 	assert.NilError(t, err)
 
 	testUser := &models.Identity{
@@ -153,7 +153,7 @@ func TestDeleteIdentity_NoDeleteInternalIdentities(t *testing.T) {
 	err := s.importAccessKeys()
 	assert.NilError(t, err)
 
-	routes, err := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
 	assert.NilError(t, err)
 
 	for name := range s.InternalIdentities {
@@ -175,15 +175,14 @@ func TestDeleteIdentity_NoDeleteInternalIdentities(t *testing.T) {
 func TestDeleteIdentity_NoDeleteSelf(t *testing.T) {
 	s := setupServer(t)
 
-	routes, err := s.GenerateRoutes(prometheus.NewRegistry())
-	assert.NilError(t, err)
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
 	testUser := &models.Identity{
 		Name: "test",
 		Kind: models.UserKind,
 	}
 
-	err = data.CreateIdentity(s.db, testUser)
+	err := data.CreateIdentity(s.db, testUser)
 	assert.NilError(t, err)
 
 	testAccessKey, err := data.CreateAccessKey(s.db, &models.AccessKey{Name: "test", IssuedFor: testUser.ID, ExpiresAt: time.Now().Add(time.Hour), ProviderID: s.InternalProvider.ID})

--- a/internal/server/openapi_test.go
+++ b/internal/server/openapi_test.go
@@ -13,7 +13,7 @@ import (
 // file in git matches the source code.
 func TestWriteOpenAPISpec(t *testing.T) {
 	s := Server{}
-	_, _ = s.GenerateRoutes(prometheus.NewRegistry())
+	s.GenerateRoutes(prometheus.NewRegistry())
 
 	filename := "../../docs/api/openapi3.json"
 	err := WriteOpenAPISpecToFile(filename)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -117,7 +117,7 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) (*gin.Engine
 	// UI middleware unnecessarily.
 	// This is a limitation because we serve the UI from / instead of a specific
 	// path prefix.
-	if err := s.registerUIRoutes(router); err != nil {
+	if err := registerUIRoutes(router, s.options.UI); err != nil {
 		return nil, err
 	}
 	return router, nil

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -25,7 +25,7 @@ import (
 // The order of routes in this function is important! Gin saves a route along
 // with all the middleware that will apply to the route when the
 // Router.{GET,POST,etc} method is called.
-func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) (*gin.Engine, error) {
+func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) *gin.Engine {
 	a := &API{t: s.tel, server: s}
 	router := gin.New()
 	router.NoRoute(a.notFoundHandler)
@@ -117,10 +117,8 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) (*gin.Engine
 	// UI middleware unnecessarily.
 	// This is a limitation because we serve the UI from / instead of a specific
 	// path prefix.
-	if err := registerUIRoutes(router, s.options.UI); err != nil {
-		return nil, err
-	}
-	return router, nil
+	registerUIRoutes(router, s.options.UI)
+	return router
 }
 
 type ReqHandlerFunc[Req any] func(c *gin.Context, req *Req) error

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,8 +46,6 @@ type Options struct {
 	AccessKey            string        `mapstructure:"accessKey"`
 	EnableTelemetry      bool          `mapstructure:"enableTelemetry"`
 	EnableCrashReporting bool          `mapstructure:"enableCrashReporting"`
-	EnableUI             bool          `mapstructure:"enableUI"`
-	UIProxyURL           string        `mapstructure:"uiProxyURL"`
 	EnableSetup          bool          `mapstructure:"enableSetup"`
 	SessionDuration      time.Duration `mapstructure:"sessionDuration"`
 
@@ -73,12 +71,18 @@ type Options struct {
 	FullKeyRotationInDays       int    `mapstructure:"fullKeyRotationInDays"` // 365 default
 
 	Addr ListenerOptions
+	UI   UIOptions
 }
 
 type ListenerOptions struct {
 	HTTP    string
 	HTTPS   string
 	Metrics string
+}
+
+type UIOptions struct {
+	Enabled  bool
+	ProxyURL string
 }
 
 type Server struct {
@@ -308,14 +312,14 @@ func (s *Server) loadCertificates() (err error) {
 //go:embed all:ui/*
 var assetFS embed.FS
 
-func (s *Server) registerUIRoutes(router *gin.Engine) error {
-	if !s.options.EnableUI {
+func registerUIRoutes(router *gin.Engine, opts UIOptions) error {
+	if !opts.Enabled {
 		return nil
 	}
 
 	// Proxy requests to an upstream ui server
-	if s.options.UIProxyURL != "" {
-		remote, err := urlx.Parse(s.options.UIProxyURL)
+	if opts.ProxyURL != "" {
+		remote, err := urlx.Parse(opts.ProxyURL)
 		if err != nil {
 			return fmt.Errorf("failed to parse UI proxy URL: %w", err)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,7 +82,7 @@ type ListenerOptions struct {
 
 type UIOptions struct {
 	Enabled  bool
-	ProxyURL types.URL
+	ProxyURL types.URL `mapstructure:"proxyURL"`
 }
 
 type Server struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -917,9 +917,11 @@ func TestServer_Run_UIProxy(t *testing.T) {
 		DBEncryptionKey:         filepath.Join(dir, "sqlite3.db.key"),
 		TLSCache:                filepath.Join(dir, "tlscache"),
 		DBFile:                  filepath.Join(dir, "sqlite3.db"),
-		UI:                      UIOptions{Enabled: true, ProxyURL: uiSrv.URL},
+		UI:                      UIOptions{Enabled: true},
 		EnableSetup:             true,
 	}
+	assert.NilError(t, opts.UI.ProxyURL.Set(uiSrv.URL))
+
 	srv, err := New(opts)
 	assert.NilError(t, err)
 
@@ -962,8 +964,7 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 	}
 
 	s := &Server{options: Options{UI: UIOptions{Enabled: true}}}
-	router, err := s.GenerateRoutes(prometheus.NewRegistry())
-	assert.NilError(t, err)
+	router := s.GenerateRoutes(prometheus.NewRegistry())
 
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
@@ -1013,8 +1014,7 @@ func TestServer_GenerateRoutes_UI(t *testing.T) {
 	}
 
 	s := &Server{options: Options{UI: UIOptions{Enabled: true}}}
-	router, err := s.GenerateRoutes(prometheus.NewRegistry())
-	assert.NilError(t, err)
+	router := s.GenerateRoutes(prometheus.NewRegistry())
 
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.path, nil)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -917,8 +917,7 @@ func TestServer_Run_UIProxy(t *testing.T) {
 		DBEncryptionKey:         filepath.Join(dir, "sqlite3.db.key"),
 		TLSCache:                filepath.Join(dir, "tlscache"),
 		DBFile:                  filepath.Join(dir, "sqlite3.db"),
-		EnableUI:                true,
-		UIProxyURL:              uiSrv.URL,
+		UI:                      UIOptions{Enabled: true, ProxyURL: uiSrv.URL},
 		EnableSetup:             true,
 	}
 	srv, err := New(opts)
@@ -962,7 +961,7 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 		expected func(t *testing.T, resp *httptest.ResponseRecorder)
 	}
 
-	s := &Server{options: Options{EnableUI: true}}
+	s := &Server{options: Options{UI: UIOptions{Enabled: true}}}
 	router, err := s.GenerateRoutes(prometheus.NewRegistry())
 	assert.NilError(t, err)
 
@@ -1013,7 +1012,7 @@ func TestServer_GenerateRoutes_UI(t *testing.T) {
 		expected     func(t *testing.T, resp *httptest.ResponseRecorder)
 	}
 
-	s := &Server{options: Options{EnableUI: true}}
+	s := &Server{options: Options{UI: UIOptions{Enabled: true}}}
 	router, err := s.GenerateRoutes(prometheus.NewRegistry())
 	assert.NilError(t, err)
 


### PR DESCRIPTION
Branched from #1611, so that will need to merge first

This PR does a bit of cleanup from previous changes. I had to introduce an error return value to a few methods that shouldn't need error returns.

To remove the error return I introduced a type for `url.Url` that can be decoded from command line flag or config file. This allows us to handle the parse error earlier. Handling it earlier should also be better for users, as it keeps our errors consistent, and would allow us to implement a validate config command later.