### PR TITLE
fix: do not set a otp on machine identities

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -58,8 +58,10 @@ func (a *API) CreateIdentity(c *gin.Context, r *api.CreateIdentityRequest) (*api
 		Kind: kind,
 	}
 
+	setOTP := r.SetOneTimePassword && (identity.Kind == models.UserKind)
+
 	// infra identity creation should be attempted even if an identity is already known
-	if r.SetOneTimePassword {
+	if setOTP {
 		identities, err := access.ListIdentities(c, identity.Name, nil)
 		if err != nil {
 			return nil, fmt.Errorf("list identities: %w", err)
@@ -86,7 +88,7 @@ func (a *API) CreateIdentity(c *gin.Context, r *api.CreateIdentityRequest) (*api
 		Name: identity.Name,
 	}
 
-	if r.SetOneTimePassword {
+	if setOTP {
 		_, err = access.CreateProviderUser(c, access.InfraProvider(c), identity)
 		if err != nil {
 			return nil, fmt.Errorf("create provider user")

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -343,6 +343,21 @@ func TestCreateIdentity(t *testing.T) {
 		assert.Equal(t, "test-link-identity@example.com", resp.Name)
 		assert.Check(t, resp.OneTimePassword != "")
 	})
+
+	t.Run("new machine identities do not get one time password", func(t *testing.T) {
+		req := &api.CreateIdentityRequest{
+			Name:               "test-infra-machine-otp",
+			Kind:               "machine",
+			SetOneTimePassword: true,
+		}
+
+		resp, err := handler.CreateIdentity(c, req)
+		assert.NilError(t, err)
+
+		assert.NilError(t, err)
+		assert.Equal(t, "test-infra-machine-otp", resp.Name)
+		assert.Check(t, resp.OneTimePassword == "")
+	})
 }
 
 func TestDeleteIdentity(t *testing.T) {


### PR DESCRIPTION
## Summary
There was a bug in identity creation through the CLI that would set a one time password on machine identities by default. Fixing this behavior to not set a one time password on machine identity creation.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1622 
