### PR TITLE
fix(api): fix marshaling of api.Time values

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -15,14 +15,11 @@ type Resource struct {
 
 type Time time.Time
 
-func (t *Time) MarshalJSON() ([]byte, error) {
-	if t == nil {
+func (t Time) MarshalJSON() ([]byte, error) {
+	if time.Time(t).IsZero() {
 		return []byte("null"), nil
 	}
-	if time.Time(*t).IsZero() {
-		return []byte("null"), nil
-	}
-	s := time.Time(*t).UTC().Format(time.RFC3339)
+	s := time.Time(t).UTC().Format(time.RFC3339)
 	return []byte(`"` + s + `"`), nil
 }
 


### PR DESCRIPTION
## Summary

Previously it worked for pointers, but not values, because of the method receiver on MarshalJSON being a pointer.

I tried to call `time.Time.MarshalJSON`, but that uses the format `RFC3339Nano` , not `RFC3339`, so it's not exactly what we want.


## Related Issues

Resolves #1614
