### PR TITLE
fix(cli): fix the extension-deadline flag

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -395,8 +395,8 @@ infra keys add first-key bot --ttl=12h --extension-deadline=1h
 ### Options
 
 ```
-      --extension-deadline string   A specified deadline that an access key must be used within to remain valid, defaults to 30 days
-      --ttl string                  The total time that an access key will be valid for, defaults to 30 days
+      --extension-deadline duration   A specified deadline that an access key must be used within to remain valid (default 720h0m0s)
+      --ttl duration                  The total time that an access key will be valid for (default 720h0m0s)
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -32,11 +32,13 @@ func newKeysCmd() *cobra.Command {
 }
 
 type keyCreateOptions struct {
-	TTL               string `mapstructure:"ttl"`
-	ExtensionDeadline string `mapstructure:"extension-deadline"`
+	TTL               time.Duration
+	ExtensionDeadline time.Duration
 }
 
 func newKeysAddCmd() *cobra.Command {
+	var options keyCreateOptions
+
 	cmd := &cobra.Command{
 		Use:   "add ACCESS_KEY_NAME MACHINE_NAME",
 		Short: "Create an access key for authentication",
@@ -46,11 +48,6 @@ infra keys add first-key bot --ttl=12h --extension-deadline=1h
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var options keyCreateOptions
-			if err := parseOptions(cmd, &options, "INFRA_KEYS"); err != nil {
-				return err
-			}
-
 			keyName := args[0]
 			machineName := args[1]
 
@@ -68,35 +65,23 @@ infra keys add first-key bot --ttl=12h --extension-deadline=1h
 				return err
 			}
 
-			deadline := ThirtyDays
-			if options.ExtensionDeadline != "" {
-				deadline, err = time.ParseDuration(options.ExtensionDeadline)
-				if err != nil {
-					return err
-				}
-			}
-
-			ttl := ThirtyDays
-			if options.TTL != "" {
-				ttl, err = time.ParseDuration(options.TTL)
-				if err != nil {
-					return fmt.Errorf("parsing ttl: %w", err)
-				}
-			}
-
-			resp, err := client.CreateAccessKey(&api.CreateAccessKeyRequest{IdentityID: machine.ID, Name: keyName, TTL: api.Duration(ttl), ExtensionDeadline: api.Duration(deadline)})
+			resp, err := client.CreateAccessKey(&api.CreateAccessKeyRequest{
+				IdentityID:        machine.ID,
+				Name:              keyName,
+				TTL:               api.Duration(options.TTL),
+				ExtensionDeadline: api.Duration(options.ExtensionDeadline),
+			})
 			if err != nil {
 				return err
 			}
 
 			fmt.Printf("key: %s \n", resp.AccessKey)
-
 			return nil
 		},
 	}
 
-	cmd.Flags().String("ttl", "", "The total time that an access key will be valid for, defaults to 30 days")
-	cmd.Flags().String("extension-deadline", "", "A specified deadline that an access key must be used within to remain valid, defaults to 30 days")
+	cmd.Flags().DurationVar(&options.TTL, "ttl", ThirtyDays, "The total time that an access key will be valid for")
+	cmd.Flags().DurationVar(&options.ExtensionDeadline, "extension-deadline", ThirtyDays, "A specified deadline that an access key must be used within to remain valid")
 
 	return cmd
 }

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/uid"
+)
+
+func TestKeysAddCmd(t *testing.T) {
+	setup := func(t *testing.T) chan api.CreateAccessKeyRequest {
+		requestCh := make(chan api.CreateAccessKeyRequest, 1)
+
+		handler := func(resp http.ResponseWriter, req *http.Request) {
+			// the command does a lookup for machine ID
+			if requestMatches(req, http.MethodGet, "/v1/identities") {
+				resp.WriteHeader(http.StatusOK)
+				err := json.NewEncoder(resp).Encode([]*api.Identity{
+					{ID: uid.ID(12345678)},
+				})
+				assert.Check(t, err)
+				return
+			}
+
+			if !requestMatches(req, http.MethodPost, "/v1/access-keys") {
+				resp.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			var createRequest api.CreateAccessKeyRequest
+			err := json.NewDecoder(req.Body).Decode(&createRequest)
+			assert.Check(t, err)
+
+			resp.WriteHeader(http.StatusOK)
+			err = json.NewEncoder(resp).Encode(&api.CreateAccessKeyResponse{
+				AccessKey: "the-access-key",
+			})
+			assert.Check(t, err)
+			requestCh <- createRequest
+			close(requestCh)
+		}
+
+		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(srv.Close)
+
+		cfg := ClientConfig{
+			Version: "0.3",
+			Hosts: []ClientHostConfig{
+				{
+					AccessKey:     "the-access-key",
+					Host:          srv.Listener.Addr().String(),
+					Current:       true,
+					SkipTLSVerify: true,
+					Expires:       api.Time(time.Now().Add(time.Minute)),
+				},
+			},
+		}
+		err := writeConfig(&cfg)
+		assert.NilError(t, err)
+
+		return requestCh
+	}
+
+	t.Run("all flags", func(t *testing.T) {
+		ch := setup(t)
+
+		ctx := context.Background()
+		err := Run(ctx, "keys", "add", "--ttl=400h", "--extension-deadline=5h", "the-name", "my-machine")
+		assert.NilError(t, err)
+
+		req := <-ch
+		expected := api.CreateAccessKeyRequest{
+			IdentityID:        uid.ID(12345678),
+			Name:              "the-name",
+			TTL:               api.Duration(400 * time.Hour),
+			ExtensionDeadline: api.Duration(5 * time.Hour),
+		}
+		assert.DeepEqual(t, expected, req)
+	})
+}
+
+func requestMatches(req *http.Request, method string, path string) bool {
+	return req.Method == method && req.URL.Path == path
+}


### PR DESCRIPTION
## Summary

I started by changing the fields from string to `time.Duration` to avoid the need to `ParseDuration`. Then I wrote a test for the command. The test was failing because `--extension-deadline` was not being passed to the API. I'm not sure why, the struct field tags look right. I don't think it was the change to the field types, because the `ttl` field was working and it had the same type.

I changed the command to use `DurationVar`, which got the test to pass.

This change removes support for setting these fields from environment variables, but that should be an easy thing to restore. I am working on a proposal for how we can do that with a single function, without the need for viper.

Since this is a CLI command that we expect humans to run, I guess no one is trying to use it with environment variables right now. The command line flags will be a lot more convenient for humans in most cases.