### PR TITLE
fix(ci): actions not running correctly

### DIFF
--- a/.github/workflows/human_pull_request.yml
+++ b/.github/workflows/human_pull_request.yml
@@ -2,11 +2,10 @@ name: pull request
 
 on:
   pull_request:
-    branches-ignore:
-      - 'dependabot/*'
 
 jobs:
   commit-lint:
+    if: startsWith(github.head_ref, 'dependabot/') != true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release_pull_request.yml
+++ b/.github/workflows/release_pull_request.yml
@@ -2,11 +2,10 @@ name: pull request
 
 on:
   pull_request:
-    branches:
-      - 'release-please-*'
 
 jobs:
   codeql-analysis:
+    if: startsWith(github.head_ref, 'release-please-') == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,6 +19,7 @@ jobs:
       - uses: github/codeql-action/analyze@v2
 
   docker:
+    if: startsWith(github.head_ref, 'release-please-') == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`on.pull_request.branches` refers to the base ref of the pull request, e.g. `main`, so the filter cannot be used to filter jobs based on the head ref, e.g. `release-please--branches--main`.