### PR TITLE
Rename CurrentIdentity to AuthenticatedIdentity

### DIFF
--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -40,7 +40,7 @@ const ResourceInfraAPI = "infra"
 func RequireInfraRole(c *gin.Context, oneOfRoles ...string) (*gorm.DB, error) {
 	db := getDB(c)
 
-	identity := CurrentIdentity(c)
+	identity := AuthenticatedIdentity(c)
 	if identity == nil {
 		return nil, fmt.Errorf("no active identity")
 	}

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -74,7 +74,7 @@ func DeleteRequestAccessKey(c *gin.Context) error {
 
 func DeleteAllIdentityAccessKeys(c *gin.Context) error {
 	// does not need authorization check, this action is limited to the calling user
-	identity := CurrentIdentity(c)
+	identity := AuthenticatedIdentity(c)
 	if identity == nil {
 		return fmt.Errorf("no active identity")
 	}

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -63,7 +63,7 @@ func UpdateCredential(c *gin.Context, user *models.Identity, newPassword string)
 	userCredential.OneTimePassword = false
 	userCredential.OneTimePasswordUsed = false
 
-	if user.ID != CurrentIdentity(c).ID {
+	if user.ID != AuthenticatedIdentity(c).ID {
 		// an admin can only set a one time password for a user
 		userCredential.OneTimePassword = true
 		userCredential.OneTimePasswordUsed = false

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -50,7 +50,7 @@ func CreateGrant(c *gin.Context, grant *models.Grant) error {
 		return err
 	}
 
-	creator := CurrentIdentity(c)
+	creator := AuthenticatedIdentity(c)
 
 	grant.CreatedBy = creator.ID
 

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -10,7 +10,7 @@ import (
 
 // isUserInGroup is used by authorization checks to see if the calling user is requesting their own attributes
 func isUserInGroup(c *gin.Context, requestedResourceID uid.ID) (bool, error) {
-	user := CurrentIdentity(c)
+	user := AuthenticatedIdentity(c)
 
 	if user != nil {
 		lookupDB := getDB(c)

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -15,17 +15,21 @@ import (
 
 // isIdentitySelf is used by authorization checks to see if the calling identity is requesting their own attributes
 func isIdentitySelf(c *gin.Context, requestedResourceID uid.ID) (bool, error) {
-	identity := CurrentIdentity(c)
+	identity := AuthenticatedIdentity(c)
 	return identity != nil && identity.ID == requestedResourceID, nil
 }
 
-func CurrentIdentity(c *gin.Context) *models.Identity {
-	identity, ok := c.MustGet("identity").(*models.Identity)
-	if !ok {
-		return nil
+// AuthenticatedIdentity returns the identity that is associated with the access key
+// that was used to authenticate the request.
+// Returns nil if there is no identity in the context, which likely means the
+// request was not authenticated.
+func AuthenticatedIdentity(c *gin.Context) *models.Identity {
+	if raw, ok := c.Get("identity"); ok {
+		if identity, ok := raw.(*models.Identity); ok {
+			return identity
+		}
 	}
-
-	return identity
+	return nil
 }
 
 func GetIdentity(c *gin.Context, id uid.ID) (*models.Identity, error) {

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -65,7 +65,7 @@ func DeleteProvider(c *gin.Context, id uid.ID) error {
 // RetrieveUserProviderTokens gets the providerUser for the current session token was created for
 func RetrieveUserProviderTokens(c *gin.Context) (*models.ProviderUser, error) {
 	// added by the authentication middleware
-	identity := CurrentIdentity(c)
+	identity := AuthenticatedIdentity(c)
 	if identity == nil {
 		return nil, errors.New("no provider token context user")
 	}

--- a/internal/access/token.go
+++ b/internal/access/token.go
@@ -10,7 +10,7 @@ import (
 )
 
 func CreateToken(c *gin.Context) (token *models.Token, err error) {
-	identity := CurrentIdentity(c)
+	identity := AuthenticatedIdentity(c)
 	if identity == nil {
 		return nil, fmt.Errorf("no active identity")
 	}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -166,6 +166,7 @@ func Middleware() gin.HandlerFunc {
 		)
 
 		logger := L
+		// TODO: use access.GetAuthenticatedIdentity, requires refactor
 		if raw, ok := c.Get("identity"); ok {
 			if identity, ok := raw.(*models.Identity); ok {
 				logger = logger.With(zap.Stringer("identity", identity.ID))

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -319,7 +319,7 @@ func (a *API) ListDestinations(c *gin.Context, r *api.ListDestinationsRequest) (
 
 // Introspect is used by clients to get info about the token they are using
 func (a *API) Introspect(c *gin.Context, r *api.EmptyRequest) (*api.Introspect, error) {
-	identity := access.CurrentIdentity(c)
+	identity := access.AuthenticatedIdentity(c)
 	if identity != nil {
 		return &api.Introspect{ID: identity.ID, Name: identity.Name, IdentityType: identity.Kind.String()}, nil
 	}
@@ -375,7 +375,7 @@ func (a *API) DeleteDestination(c *gin.Context, r *api.Resource) error {
 }
 
 func (a *API) CreateToken(c *gin.Context, r *api.EmptyRequest) (*api.CreateTokenResponse, error) {
-	if access.CurrentIdentity(c) != nil {
+	if access.AuthenticatedIdentity(c) != nil {
 		err := a.UpdateIdentityInfoFromProvider(c)
 		if err != nil {
 			return nil, fmt.Errorf("update ident info from provider: %w", err)
@@ -584,7 +584,7 @@ func (a *API) Version(c *gin.Context, r *api.EmptyRequest) (*api.Version, error)
 
 // UpdateIdentityInfoFromProvider calls the identity provider used to authenticate this user session to update their current information
 func (a *API) UpdateIdentityInfoFromProvider(c *gin.Context) error {
-	user := access.CurrentIdentity(c)
+	user := access.AuthenticatedIdentity(c)
 	if user == nil {
 		return nil
 	}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -18,22 +18,12 @@ import (
 )
 
 func TestListProviders(t *testing.T) {
-	s := setupServer(t)
-
-	adminAccessKey := "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb"
-	s.options = Options{AdminAccessKey: adminAccessKey}
-
-	err := s.importAccessKeys()
-	assert.NilError(t, err)
-
+	s := setupServer(t, withDefaultAdminAccessKey)
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
-	assert.NilError(t, err)
 
-	testProvider := &models.Provider{
-		Name: "mokta",
-	}
+	testProvider := &models.Provider{Name: "mokta"}
 
-	err = data.CreateProvider(s.db, testProvider)
+	err := data.CreateProvider(s.db, testProvider)
 	assert.NilError(t, err)
 
 	dbProviders, err := data.ListProviders(s.db)
@@ -43,7 +33,7 @@ func TestListProviders(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "/v1/providers", nil)
 	assert.NilError(t, err)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", adminAccessKey))
+	req.Header.Add("Authorization", "Bearer "+s.options.AdminAccessKey)
 
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
@@ -59,29 +49,22 @@ func TestListProviders(t *testing.T) {
 }
 
 func TestDeleteProvider(t *testing.T) {
-	s := setupServer(t)
-
-	adminAccessKey := "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb"
-	s.options = Options{AdminAccessKey: adminAccessKey}
-
-	err := s.importAccessKeys()
-	assert.NilError(t, err)
+	s := setupServer(t, withDefaultAdminAccessKey)
 
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
-	assert.NilError(t, err)
 
 	testProvider := &models.Provider{
 		Name: "mokta",
 	}
 
-	err = data.CreateProvider(s.db, testProvider)
+	err := data.CreateProvider(s.db, testProvider)
 	assert.NilError(t, err)
 
 	route := fmt.Sprintf("/v1/providers/%s", testProvider.ID)
 	req, err := http.NewRequest(http.MethodDelete, route, nil)
 	assert.NilError(t, err)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", adminAccessKey))
+	req.Header.Add("Authorization", "Bearer "+s.options.AdminAccessKey)
 
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
@@ -89,23 +72,23 @@ func TestDeleteProvider(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.Code, resp.Body.String())
 }
 
+// withDefaultAdminAccessKey may be used with setupServer to setup the server
+// with a default AdminAccessKey. The value for the key can be retrieved from
+// server.options.AdminAccessKey.
+func withDefaultAdminAccessKey(_ *testing.T, opts *Options) {
+	opts.AdminAccessKey = "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb"
+}
+
 func TestDeleteProvider_NoDeleteInternalProvider(t *testing.T) {
-	s := setupServer(t)
-
-	adminAccessKey := "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb"
-	s.options = Options{AdminAccessKey: adminAccessKey}
-
-	err := s.importAccessKeys()
-	assert.NilError(t, err)
+	s := setupServer(t, withDefaultAdminAccessKey)
 
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
-	assert.NilError(t, err)
 
 	route := fmt.Sprintf("/v1/providers/%s", s.InternalProvider.ID)
 	req, err := http.NewRequest(http.MethodDelete, route, nil)
 	assert.NilError(t, err)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", adminAccessKey))
+	req.Header.Add("Authorization", "Bearer "+s.options.AdminAccessKey)
 
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
@@ -189,30 +172,23 @@ func TestCreateIdentity(t *testing.T) {
 }
 
 func TestDeleteIdentity(t *testing.T) {
-	s := setupServer(t)
-
-	adminAccessKey := "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb"
-	s.options = Options{AdminAccessKey: adminAccessKey}
-
-	err := s.importAccessKeys()
-	assert.NilError(t, err)
+	s := setupServer(t, withDefaultAdminAccessKey)
 
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
-	assert.NilError(t, err)
 
 	testUser := &models.Identity{
 		Name: "test",
 		Kind: models.UserKind,
 	}
 
-	err = data.CreateIdentity(s.db, testUser)
+	err := data.CreateIdentity(s.db, testUser)
 	assert.NilError(t, err)
 
 	route := fmt.Sprintf("/v1/identities/%s", testUser.ID)
 	req, err := http.NewRequest(http.MethodDelete, route, nil)
 	assert.NilError(t, err)
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", adminAccessKey))
+	req.Header.Add("Authorization", "Bearer "+s.options.AdminAccessKey)
 
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
@@ -221,16 +197,9 @@ func TestDeleteIdentity(t *testing.T) {
 }
 
 func TestDeleteIdentity_NoDeleteInternalIdentities(t *testing.T) {
-	s := setupServer(t)
-
-	adminAccessKey := "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb"
-	s.options = Options{AdminAccessKey: adminAccessKey}
-
-	err := s.importAccessKeys()
-	assert.NilError(t, err)
+	s := setupServer(t, withDefaultAdminAccessKey)
 
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
-	assert.NilError(t, err)
 
 	for name := range s.InternalIdentities {
 		t.Run(name, func(t *testing.T) {
@@ -238,7 +207,7 @@ func TestDeleteIdentity_NoDeleteInternalIdentities(t *testing.T) {
 			req, err := http.NewRequest(http.MethodDelete, route, nil)
 			assert.NilError(t, err)
 
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", adminAccessKey))
+			req.Header.Add("Authorization", "Bearer "+s.options.AdminAccessKey)
 
 			resp := httptest.NewRecorder()
 			routes.ServeHTTP(resp, req)
@@ -261,7 +230,12 @@ func TestDeleteIdentity_NoDeleteSelf(t *testing.T) {
 	err := data.CreateIdentity(s.db, testUser)
 	assert.NilError(t, err)
 
-	testAccessKey, err := data.CreateAccessKey(s.db, &models.AccessKey{Name: "test", IssuedFor: testUser.ID, ExpiresAt: time.Now().Add(time.Hour), ProviderID: s.InternalProvider.ID})
+	testAccessKey, err := data.CreateAccessKey(s.db, &models.AccessKey{
+		Name:       "test",
+		IssuedFor:  testUser.ID,
+		ExpiresAt:  time.Now().Add(time.Hour),
+		ProviderID: s.InternalProvider.ID,
+	})
 	assert.NilError(t, err)
 
 	route := fmt.Sprintf("/v1/identities/%s", testUser.ID)

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -118,11 +119,9 @@ func (t *Telemetry) Event(c *gin.Context, event string, properties ...map[string
 		Properties:  analytics.Properties{},
 	}
 	if c != nil {
-		if user, ok := c.Get("identity"); ok {
-			if u, ok := user.(*models.Identity); ok {
-				track.UserId = u.ID.String()
-				track.Properties["type"] = u.Kind.String()
-			}
+		if u := access.AuthenticatedIdentity(c); u != nil {
+			track.UserId = u.ID.String()
+			track.Properties["type"] = u.Kind.String()
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR contains 2 refactor commits. I was making these changes while writing a test for the `CreateGrant` API endpoint, and I thought I would PR them first to keep them separate from the test.

1. I was about to write a third copy of `CurrentIdentity` when I realized I had missed the existing one. I renamed `CurrentIdentity` to `AuthenticatedIdentity` with the hope that "authenticated identity" clarifies that this is getting the identity from the request. `AuthenticatedRequestIdentity` could also work, but is maybe a bit long. Also added some godoc to it.

2. refactor `setupServer` (our test helper for setting up a server for API tests) to accept functions to customize the options. I think we'll want to work on consolidating `setupServer` with `server.New` as much as possible. For now this should give us the ability to customize the setup for each test.