### PR TITLE
feat: create admin user on first login

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -318,12 +318,12 @@ func (c Client) Logout() error {
 	return err
 }
 
-func (c Client) SetupRequired() (*SetupRequiredResponse, error) {
-	return get[SetupRequiredResponse](c, "/v1/setup")
+func (c Client) SignupEnabled() (*SignupEnabledResponse, error) {
+	return get[SignupEnabledResponse](c, "/v1/signup")
 }
 
-func (c Client) Setup() (*CreateAccessKeyResponse, error) {
-	return post[EmptyRequest, CreateAccessKeyResponse](c, "/v1/setup", &EmptyRequest{})
+func (c Client) Signup() (*CreateAccessKeyResponse, error) {
+	return post[EmptyRequest, CreateAccessKeyResponse](c, "/v1/signup", &EmptyRequest{})
 }
 
 func (c Client) GetVersion() (*Version, error) {

--- a/api/client.go
+++ b/api/client.go
@@ -322,8 +322,8 @@ func (c Client) SignupEnabled() (*SignupEnabledResponse, error) {
 	return get[SignupEnabledResponse](c, "/v1/signup")
 }
 
-func (c Client) Signup() (*CreateAccessKeyResponse, error) {
-	return post[EmptyRequest, CreateAccessKeyResponse](c, "/v1/signup", &EmptyRequest{})
+func (c Client) Signup(req *SignupRequest) (*CreateAccessKeyResponse, error) {
+	return post[SignupRequest, CreateAccessKeyResponse](c, "/v1/signup", req)
 }
 
 func (c Client) GetVersion() (*Version, error) {

--- a/api/setup.go
+++ b/api/setup.go
@@ -1,5 +1,0 @@
-package api
-
-type SetupRequiredResponse struct {
-	Required bool `json:"required"`
-}

--- a/api/signup.go
+++ b/api/signup.go
@@ -3,3 +3,8 @@ package api
 type SignupEnabledResponse struct {
 	Enabled bool `json:"enabled"`
 }
+
+type SignupRequest struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+}

--- a/api/signup.go
+++ b/api/signup.go
@@ -1,0 +1,5 @@
+package api
+
+type SignupEnabledResponse struct {
+	Enabled bool `json:"enabled"`
+}

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -3366,6 +3366,23 @@
       "post": {
         "description": "Signup",
         "operationId": "Signup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
           "400": {
             "content": {
@@ -3421,7 +3438,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateAccessKeyResponse"
+                  "$ref": "#/components/schemas/Identity"
                 }
               }
             },

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -387,9 +387,9 @@
           "clientID"
         ]
       },
-      "SetupRequiredResponse": {
+      "SignupEnabledResponse": {
         "properties": {
-          "required": {
+          "enabled": {
             "type": "boolean"
           }
         }
@@ -3292,10 +3292,10 @@
         ]
       }
     },
-    "/v1/setup": {
+    "/v1/signup": {
       "get": {
-        "description": "SetupRequired",
-        "operationId": "SetupRequired",
+        "description": "SignupEnabled",
+        "operationId": "SignupEnabled",
         "responses": {
           "400": {
             "content": {
@@ -3351,21 +3351,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SetupRequiredResponse"
+                  "$ref": "#/components/schemas/SignupEnabledResponse"
                 }
               }
             },
             "description": "Success"
           }
         },
-        "summary": "SetupRequired",
+        "summary": "SignupEnabled",
         "tags": [
           "Misc"
         ]
       },
       "post": {
-        "description": "Setup",
-        "operationId": "Setup",
+        "description": "Signup",
+        "operationId": "Signup",
         "responses": {
           "400": {
             "content": {
@@ -3428,7 +3428,7 @@
             "description": "Success"
           }
         },
-        "summary": "Setup",
+        "summary": "Signup",
         "tags": [
           "Misc"
         ]

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -85,44 +85,10 @@ Use the following command to find the Infra login URL. If you are not using a `L
 kubectl get service infra-server -o jsonpath="{.status.loadBalancer.ingress[*]['ip', 'hostname']}"
 ```
 
-This will output the admin access key which you can use to login in cases of emergency recovery. Please store this in a safe place as you will not see this again.
+Follow the instructions to create an admin account using email and password login.
 
 
-### 3. Setup a local user
-
-Now that the Infra server is setup you can create a user.  The `infra id add` command creates a one-time password for the user.
-
-```
-infra id add name@example.com
-```
-
-Grant the user Infra administrator privileges.
-
-```
-infra grants add name@example.com infra --role admin
-```
-
-Grant the user Kubernetes cluster administrator privileges.
-
-```
-infra grants add name@example.com kubernetes.example-name --role cluster-admin 
-```
-
-> To view different roles allowed for Kubernetes clusters, see [Kubernetes Roles](../connectors/kubernetes.md#roles)
-
-
-### 4. Login to Infra with the newly created user
-
-Login again to switch from admin to your newly created user.
-
-```
-infra login
-```
-
-Select the Infra instance, and login with username `name@example.com`, and the password
-from the previous step.
-
-### 5. Connect your first Kubernetes cluster
+### 3. Connect your first Kubernetes cluster
 
 In order to add connectors to Infra, you will need to set three pieces of information:
 
@@ -147,7 +113,15 @@ helm upgrade --install infra-connector infrahq/infra \
 ```
 
 
-### 6. Use your Kubernetes clusters
+### 4. Use your Kubernetes clusters
+
+Grant the user Kubernetes cluster administrator privileges.
+
+```
+infra grants add name@example.com kubernetes.example-name --role cluster-admin
+```
+
+> To view different roles allowed for Kubernetes clusters, see [Kubernetes Roles](../connectors/kubernetes.md#roles)
 
 You can now access the connected Kubernetes clusters via your favorite tools directly. Infra in the background automatically synchronizes your Kubernetes configuration file (kubeconfig).
 
@@ -179,6 +153,6 @@ infra grants add name@example.com infra --role admin
 ```
 </details>
 
-### 7. Share the cluster(s) with other developers
+### 5. Share the cluster(s) with other developers
 
 To share access with Infra, developers will need to install Infra CLI, and be provided the login URL. If using local users, please share the one-time password.

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -24,7 +24,7 @@ func CreateCredential(c *gin.Context, user models.Identity) (string, error) {
 		return "", fmt.Errorf("generate: %w", err)
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(oneTimePassword), bcrypt.MinCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(oneTimePassword), bcrypt.DefaultCost)
 	if err != nil {
 		return "", fmt.Errorf("hash: %w", err)
 	}

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -62,7 +62,7 @@ func TestLoginWithUserCredential(t *testing.T) {
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
 
-				hash, err := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.MinCost)
+				hash, err := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 				assert.NilError(t, err)
 
 				userCredential := &models.Credential{
@@ -89,7 +89,7 @@ func TestLoginWithUserCredential(t *testing.T) {
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
 
-				hash, err := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.MinCost)
+				hash, err := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 				assert.NilError(t, err)
 
 				userCredential := &models.Credential{
@@ -119,7 +119,7 @@ func TestLoginWithUserCredential(t *testing.T) {
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
 
-				hash, err := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.MinCost)
+				hash, err := bcrypt.GenerateFromPassword([]byte("password"), bcrypt.DefaultCost)
 				assert.NilError(t, err)
 
 				userCredential := &models.Credential{

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -1,16 +1,14 @@
 package access
 
 import (
-	"fmt"
-	"math"
-	"time"
-
 	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func SignupEnabled(c *gin.Context) (bool, error) {
@@ -25,46 +23,57 @@ func SignupEnabled(c *gin.Context) (bool, error) {
 	return settings.SignupEnabled, nil
 }
 
-func Signup(c *gin.Context) (string, *models.AccessKey, error) {
+func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
 	// no authorization is setup yet
 	db := getDB(c)
 
 	settings, err := data.GetSettings(db)
 	if err != nil {
 		logging.S.Errorf("settings: %s", err)
-		return "", nil, internal.ErrForbidden
+		return nil, internal.ErrForbidden
 	}
 
 	if !settings.SignupEnabled {
-		return "", nil, internal.ErrForbidden
+		return nil, internal.ErrForbidden
 	}
 
-	infraProvider, err := data.GetProvider(db, data.ByName(models.InternalInfraProviderName))
+	identity := &models.Identity{
+		Name: name,
+		Kind: models.UserKind,
+	}
+
+	if err := data.CreateIdentity(db, identity); err != nil {
+		return nil, err
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
-	admin, err := data.GetIdentity(db, data.ByName(models.InternalInfraAdminIdentityName))
-	if err != nil {
-		return "", nil, err
+	credential := &models.Credential{
+		IdentityID:   identity.ID,
+		PasswordHash: hash,
 	}
 
-	key := &models.AccessKey{
-		Name:       fmt.Sprintf("%s-access-key", models.InternalInfraAdminIdentityName),
-		IssuedFor:  admin.ID,
-		ExpiresAt:  time.Now().Add(math.MaxInt64).UTC(),
-		ProviderID: infraProvider.ID,
+	if err := data.CreateCredential(db, credential); err != nil {
+		return nil, err
 	}
 
-	raw, err := data.CreateAccessKey(db, key)
-	if err != nil {
-		return "", nil, err
+	grant := &models.Grant{
+		Subject:   uid.NewIdentityPolymorphicID(identity.ID),
+		Privilege: models.InfraAdminRole,
+		Resource:  "infra",
+	}
+
+	if err := data.CreateGrant(db, grant); err != nil {
+		return nil, err
 	}
 
 	settings.SignupEnabled = false
 	if err := data.SaveSettings(db, settings); err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
-	return raw, key, nil
+	return identity, nil
 }

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -13,7 +13,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func SetupRequired(c *gin.Context) (bool, error) {
+func SignupEnabled(c *gin.Context) (bool, error) {
 	// no authorization is setup yet
 	db := getDB(c)
 
@@ -22,10 +22,10 @@ func SetupRequired(c *gin.Context) (bool, error) {
 		return false, err
 	}
 
-	return settings.SetupRequired, nil
+	return settings.SignupEnabled, nil
 }
 
-func Setup(c *gin.Context) (string, *models.AccessKey, error) {
+func Signup(c *gin.Context) (string, *models.AccessKey, error) {
 	// no authorization is setup yet
 	db := getDB(c)
 
@@ -35,7 +35,7 @@ func Setup(c *gin.Context) (string, *models.AccessKey, error) {
 		return "", nil, internal.ErrForbidden
 	}
 
-	if !settings.SetupRequired {
+	if !settings.SignupEnabled {
 		return "", nil, internal.ErrForbidden
 	}
 
@@ -61,7 +61,7 @@ func Setup(c *gin.Context) (string, *models.AccessKey, error) {
 		return "", nil, err
 	}
 
-	settings.SetupRequired = false
+	settings.SignupEnabled = false
 	if err := data.SaveSettings(db, settings); err != nil {
 		return "", nil, err
 	}

--- a/internal/access/signup_test.go
+++ b/internal/access/signup_test.go
@@ -1,0 +1,63 @@
+package access
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/server/data"
+)
+
+func TestSignup(t *testing.T) {
+	setup := func(t *testing.T, signupEnabled bool) *gin.Context {
+		db := setupDB(t)
+
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Set("db", db)
+
+		_, err := data.InitializeSettings(db, signupEnabled)
+		assert.NilError(t, err)
+
+		return c
+	}
+
+	user := "admin@infrahq.com"
+	pass := "password"
+
+	t.Run("Enabled", func(t *testing.T) {
+		c := setup(t, true)
+
+		required, err := SignupEnabled(c)
+		assert.NilError(t, err)
+		assert.Equal(t, required, true)
+
+		identity, err := Signup(c, user, pass)
+		assert.NilError(t, err)
+		assert.Equal(t, identity.Name, user)
+
+		// check "signupEnabled" flag gets flipped
+		_, err = Signup(c, user, pass)
+		assert.ErrorContains(t, err, "forbidden")
+
+		// check "admin" user can login
+		_, identity2, requireUpdate, err := LoginWithUserCredential(c, user, pass, time.Now().Add(time.Hour))
+		assert.NilError(t, err)
+		assert.DeepEqual(t, identity, identity2)
+		assert.Equal(t, requireUpdate, false)
+
+	})
+
+	t.Run("NotEnabled", func(t *testing.T) {
+		c := setup(t, false)
+
+		required, err := SignupEnabled(c)
+		assert.NilError(t, err)
+		assert.Equal(t, required, false)
+
+		_, err = Signup(c, user, pass)
+		assert.ErrorContains(t, err, "forbidden")
+	})
+}

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -225,9 +225,8 @@ func checkUserOrMachine(s string) (models.IdentityKind, error) {
 		return models.MachineKind, nil
 	}
 
-	_, err := mail.ParseAddress(s)
-	if err != nil {
-		return models.UserKind, fmt.Errorf("invalid email: %q", s)
+	if err := checkEmailRequirements(s); err != nil {
+		return models.MachineKind, err
 	}
 
 	return models.UserKind, nil
@@ -328,38 +327,85 @@ func GetIdentityFromName(client *api.Client, name string) (*api.Identity, error)
 func promptUpdatePassword(oldPassword string) (string, error) {
 	fmt.Fprintf(os.Stderr, "  Enter a new password (min length 8):\n")
 
-PROMPT:
-	newPassword := ""
-	if err := survey.AskOne(&survey.Password{Message: "    New password:"}, &newPassword, survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)); err != nil {
+	newPassword, err := promptPasswordConfirm(oldPassword)
+	if err != nil {
 		return "", err
-	}
-
-	if err := checkPasswordRequirements(newPassword, oldPassword); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
-		goto PROMPT
-	}
-
-	confirmNewPassword := ""
-	if err := survey.AskOne(&survey.Password{Message: "Confirm password:"}, &confirmNewPassword, survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)); err != nil {
-		return "", err
-	}
-
-	if confirmNewPassword != newPassword {
-		fmt.Println("  Passwords do not match.")
-		goto PROMPT
 	}
 
 	return newPassword, nil
 }
 
-func checkPasswordRequirements(newPassword string, oldPassword string) error {
-	if len(newPassword) < 8 {
-		return errors.New("  Password cannot be less than 8 characters.")
+func promptPasswordConfirm(oldPassword string) (string, error) {
+	var passwordConfirm struct {
+		Password string
+		Confirm  string
 	}
-	if newPassword == oldPassword {
-		return errors.New("  New password cannot be the same as your old password.")
+
+	prompts := []*survey.Question{
+		{
+			Name:     "Password",
+			Prompt:   &survey.Password{Message: "Password:"},
+			Validate: checkPasswordRequirements(oldPassword),
+		},
+		{
+			Name:     "Confirm",
+			Prompt:   &survey.Password{Message: "Confirm Password:"},
+			Validate: checkConfirmPassword(&passwordConfirm.Password),
+		},
 	}
+
+	if err := survey.Ask(prompts, &passwordConfirm, survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)); err != nil {
+		return "", err
+	}
+
+	return passwordConfirm.Password, nil
+}
+
+func checkEmailRequirements(val interface{}) error {
+	email, ok := val.(string)
+	if !ok {
+		return fmt.Errorf("unexpected type for email: %T", val)
+	}
+
+	if _, err := mail.ParseAddress(email); err != nil {
+		return fmt.Errorf("input must be a valid email")
+	}
+
 	return nil
+}
+
+func checkPasswordRequirements(oldPassword string) survey.Validator {
+	return func(val interface{}) error {
+		newPassword, ok := val.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type for password: %T", val)
+		}
+
+		if len(newPassword) < 8 {
+			return fmt.Errorf("input must be at least 8 characters long")
+		}
+
+		if newPassword == oldPassword {
+			return fmt.Errorf("input must be different than the current password")
+		}
+
+		return nil
+	}
+}
+
+func checkConfirmPassword(password *string) survey.Validator {
+	return func(val interface{}) error {
+		confirm, ok := val.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type for password: %T", val)
+		}
+
+		if *password != confirm {
+			return fmt.Errorf("input must match the new password")
+		}
+
+		return nil
+	}
 }
 
 // isIdentitySelf checks if the caller is updating their current local user

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -408,7 +408,7 @@ func promptLocalLogin() (*api.LoginRequestPasswordCredentials, error) {
 	questionPrompt := []*survey.Question{
 		{
 			Name:     "Email",
-			Prompt:   &survey.Input{Message: "   Email:"},
+			Prompt:   &survey.Input{Message: "Email:"},
 			Validate: survey.Required,
 		},
 		{

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -107,12 +107,12 @@ func login(options loginCmdOptions) error {
 	}
 
 	// If first-time setup needs to be run, accessKey is auto-populated
-	setupRequired, err := client.SetupRequired()
+	signupEnabled, err := client.SignupEnabled()
 	if err != nil {
 		return err
 	}
-	if setupRequired.Required && options.AccessKey == "" {
-		options.AccessKey, err = runSetupForLogin(client)
+	if signupEnabled.Enabled && options.AccessKey == "" {
+		options.AccessKey, err = runSignupForLogin(client)
 		if err != nil {
 			return err
 		}
@@ -315,8 +315,8 @@ func loginToProvider(provider *api.Provider) (*api.LoginRequestOIDC, error) {
 	}, nil
 }
 
-func runSetupForLogin(client *api.Client) (string, error) {
-	setupRes, err := client.Setup()
+func runSignupForLogin(client *api.Client) (string, error) {
+	signupRes, err := client.Signup()
 	if err != nil {
 		return "", err
 	}
@@ -324,10 +324,10 @@ func runSetupForLogin(client *api.Client) (string, error) {
 	fmt.Println()
 	fmt.Printf("  Congratulations, Infra has been successfully installed.\n")
 	fmt.Printf("  Running setup for the first time...\n\n")
-	fmt.Printf("  Access Key: %s\n", setupRes.AccessKey)
+	fmt.Printf("  Access Key: %s\n", signupRes.AccessKey)
 	fmt.Printf(fmt.Sprintf("  %s", termenv.String("IMPORTANT: Store in a safe place. You will not see it again.\n\n").Bold().String()))
 
-	return setupRes.AccessKey, nil
+	return signupRes.AccessKey, nil
 }
 
 // Only used when logging in or switching to a new session, since user has no credentials. Otherwise, use defaultAPIClient().

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -106,19 +106,23 @@ func login(options loginCmdOptions) error {
 		return err
 	}
 
-	// If first-time setup needs to be run, accessKey is auto-populated
+	loginReq := &api.LoginRequest{}
+
+	// if signup is required, use it to create an admin account
+	// and use those credentials for subsequent requests
 	signupEnabled, err := client.SignupEnabled()
 	if err != nil {
 		return err
 	}
-	if signupEnabled.Enabled && options.AccessKey == "" {
-		options.AccessKey, err = runSignupForLogin(client)
+
+	if signupEnabled.Enabled {
+		loginReq.PasswordCredentials, err = runSignupForLogin(client)
 		if err != nil {
 			return err
 		}
-	}
 
-	loginReq := &api.LoginRequest{}
+		return loginToInfra(client, loginReq)
+	}
 
 	switch {
 	case options.AccessKey != "":
@@ -315,19 +319,28 @@ func loginToProvider(provider *api.Provider) (*api.LoginRequestOIDC, error) {
 	}, nil
 }
 
-func runSignupForLogin(client *api.Client) (string, error) {
-	signupRes, err := client.Signup()
-	if err != nil {
-		return "", err
+func runSignupForLogin(client *api.Client) (*api.LoginRequestPasswordCredentials, error) {
+	fmt.Fprintln(os.Stderr, "  Welcome to Infra. Set up your admin user:")
+
+	email := ""
+	if err := survey.AskOne(&survey.Input{Message: "Email:"}, &email, survey.WithStdio(os.Stdin, os.Stderr, os.Stderr), survey.WithValidator(checkEmailRequirements)); err != nil {
+		return nil, err
 	}
 
-	fmt.Println()
-	fmt.Printf("  Congratulations, Infra has been successfully installed.\n")
-	fmt.Printf("  Running setup for the first time...\n\n")
-	fmt.Printf("  Access Key: %s\n", signupRes.AccessKey)
-	fmt.Printf(fmt.Sprintf("  %s", termenv.String("IMPORTANT: Store in a safe place. You will not see it again.\n\n").Bold().String()))
+	password, err := promptPasswordConfirm("")
+	if err != nil {
+		return nil, err
+	}
 
-	return signupRes.AccessKey, nil
+	_, err = client.Signup(&api.SignupRequest{Name: email, Password: password})
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.LoginRequestPasswordCredentials{
+		Email:    email,
+		Password: password,
+	}, nil
 }
 
 // Only used when logging in or switching to a new session, since user has no credentials. Otherwise, use defaultAPIClient().

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -71,7 +71,7 @@ func newServerCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&options.UI.Enabled, "enable-ui", false, "Enable Infra server UI")
 	cmd.Flags().Var(&options.UI.ProxyURL, "ui-proxy-url", "Proxy upstream UI requests to this url")
 	cmd.Flags().Duration("session-duration", time.Hour*12, "User session duration")
-	cmd.Flags().Bool("enable-setup", true, "Enable one-time setup")
+	cmd.Flags().Bool("enable-signup", true, "Enable one-time admin signup")
 
 	return cmd
 }

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -160,7 +160,7 @@ func serverOptionsWithDefaults() server.Options {
 	o.EnableTelemetry = true
 	o.EnableCrashReporting = true
 	o.SessionDuration = 12 * time.Hour
-	o.EnableSetup = true
+	o.EnableSignup = true
 	return o
 }
 

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -428,6 +428,16 @@ func migrate(db *gorm.DB) error {
 			},
 			// context lost, cannot roll back
 		},
+		// #1518: rename models.Settings.SetupRequired to models.Settings.SignupRequired
+		{
+			ID: "202204181613",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Migrator().RenameColumn(&models.Settings{}, "setup_required", "signup_required")
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Migrator().RenameColumn(&models.Settings{}, "signup_required", "setup_required")
+			},
+		},
 		// next one here
 	})
 

--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -12,7 +12,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func InitializeSettings(db *gorm.DB, setupRequired bool) (*models.Settings, error) {
+func InitializeSettings(db *gorm.DB, signupEnabled bool) (*models.Settings, error) {
 	pubkey, seckey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func InitializeSettings(db *gorm.DB, setupRequired bool) (*models.Settings, erro
 	}
 
 	defaults := models.Settings{
-		SetupRequired: setupRequired,
+		SignupEnabled: signupEnabled,
 	}
 
 	settings := models.Settings{

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -498,21 +498,13 @@ func (a *API) SignupEnabled(c *gin.Context, _ *api.EmptyRequest) (*api.SignupEna
 	}, nil
 }
 
-func (a *API) Signup(c *gin.Context, _ *api.EmptyRequest) (*api.CreateAccessKeyResponse, error) {
-	raw, accessKey, err := access.Signup(c)
+func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.Identity, error) {
+	identity, err := access.Signup(c, r.Name, r.Password)
 	if err != nil {
 		return nil, err
 	}
 
-	return &api.CreateAccessKeyResponse{
-		ID:                accessKey.ID,
-		Created:           api.Time(accessKey.CreatedAt),
-		Name:              accessKey.Name,
-		IssuedFor:         accessKey.IssuedFor,
-		Expires:           api.Time(accessKey.ExpiresAt),
-		ExtensionDeadline: api.Time(accessKey.ExtensionDeadline),
-		AccessKey:         raw,
-	}, nil
+	return identity.ToAPI(), nil
 }
 
 func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, error) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -487,19 +487,19 @@ func (a *API) DeleteGrant(c *gin.Context, r *api.Resource) error {
 	return access.DeleteGrant(c, r.ID)
 }
 
-func (a *API) SetupRequired(c *gin.Context, _ *api.EmptyRequest) (*api.SetupRequiredResponse, error) {
-	setupRequired, err := access.SetupRequired(c)
+func (a *API) SignupEnabled(c *gin.Context, _ *api.EmptyRequest) (*api.SignupEnabledResponse, error) {
+	signupEnabled, err := access.SignupEnabled(c)
 	if err != nil {
 		return nil, err
 	}
 
-	return &api.SetupRequiredResponse{
-		Required: setupRequired,
+	return &api.SignupEnabledResponse{
+		Enabled: signupEnabled,
 	}, nil
 }
 
-func (a *API) Setup(c *gin.Context, _ *api.EmptyRequest) (*api.CreateAccessKeyResponse, error) {
-	raw, accessKey, err := access.Setup(c)
+func (a *API) Signup(c *gin.Context, _ *api.EmptyRequest) (*api.CreateAccessKeyResponse, error) {
+	raw, accessKey, err := access.Signup(c)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/models/settings.go
+++ b/internal/server/models/settings.go
@@ -6,5 +6,5 @@ type Settings struct {
 	PrivateJWK []byte
 	PublicJWK  []byte
 
-	SetupRequired bool
+	SignupEnabled bool
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -88,8 +88,8 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) *gin.Engine 
 
 	// these endpoints do not require authentication
 	noAuthn := api.Group("/")
-	get(a, noAuthn, "/v1/setup", a.SetupRequired)
-	post(a, noAuthn, "/v1/setup", a.Setup)
+	get(a, noAuthn, "/v1/signup", a.SignupEnabled)
+	post(a, noAuthn, "/v1/signup", a.Signup)
 
 	post(a, noAuthn, "/v1/login", a.Login)
 
@@ -111,6 +111,7 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) *gin.Engine 
 	noAuthn.GET("/v1/machines/:id", removed("v0.9.0"))
 	noAuthn.DELETE("/v1/machines/:id", removed("v0.9.0"))
 	noAuthn.GET("/v1/machines/:id/grants", removed("v0.9.0"))
+	noAuthn.GET("/v1/setup", removed("v0.11.0"))
 
 	// registerUIRoutes must happen last because it uses catch-all middleware
 	// with no handlers. Any route added after the UI will end up using the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,7 +46,7 @@ type Options struct {
 	AccessKey            string        `mapstructure:"accessKey"`
 	EnableTelemetry      bool          `mapstructure:"enableTelemetry"`
 	EnableCrashReporting bool          `mapstructure:"enableCrashReporting"`
-	EnableSetup          bool          `mapstructure:"enableSetup"`
+	EnableSignup         bool          `mapstructure:"enableSignup"`
 	SessionDuration      time.Duration `mapstructure:"sessionDuration"`
 
 	DBFile                  string `mapstructure:"dbFile"`
@@ -162,7 +162,7 @@ func New(options Options) (*Server, error) {
 		return nil, fmt.Errorf("importing access keys: %w", err)
 	}
 
-	settings, err := data.InitializeSettings(server.db, server.setupRequired())
+	settings, err := data.InitializeSettings(server.db, server.signupEnabled())
 	if err != nil {
 		return nil, fmt.Errorf("settings: %w", err)
 	}
@@ -590,8 +590,8 @@ func (s *Server) createDBKey(provider secrets.SymmetricKeyProvider, rootKeyId st
 	return nil
 }
 
-func (s *Server) setupRequired() bool {
-	if !s.options.EnableSetup {
+func (s *Server) signupEnabled() bool {
+	if !s.options.EnableSignup {
 		return false
 	}
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Rework the `setup` workflow to instead run a `sign-up` workflow. Sign-up will allow the first user to immediate create an admin user without running subsequent infra commands.

### Minor refactoring

* Consolidate prompt validation with `survey.Validator`s
* Revert prompt formatting since it does not look very good

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1518
