### PR TITLE
Add a test for CreateGrant API endpoint

### DIFF
--- a/internal/server/models/model.go
+++ b/internal/server/models/model.go
@@ -14,17 +14,21 @@ type Modelable interface {
 }
 
 type Model struct {
-	ID        uid.ID
+	ID uid.ID
+	// CreatedAt is set by GORM to time.Now when a record is first created.
+	// See https://gorm.io/docs/conventions.html#Timestamp-Tracking
 	CreatedAt time.Time
+	// CreatedAt is set by GORM to time.Now when a record is updated.
+	// See https://gorm.io/docs/conventions.html#Timestamp-Tracking
 	UpdatedAt time.Time
 	DeletedAt gorm.DeletedAt
 }
 
 func (Model) IsAModel() {}
 
-// Set an ID if one does not already exist. Unfortunately, we can use `gorm:"default"`
-// tags since the ID must be dynamically generated and not all databases support UUID generation
-func (m *Model) BeforeCreate(tx *gorm.DB) error {
+// BeforeCreate sets an ID if one does not already exist. Unfortunately, we can use `gorm:"default"`
+// tags since the ID must be dynamically generated and not all databases support UUID generation.
+func (m *Model) BeforeCreate(_ *gorm.DB) error {
 	if m.ID == 0 {
 		m.ID = uid.New()
 	}


### PR DESCRIPTION
## Summary

This PR adds a test for `CreateGrant` (`POST /v1/grants`). I believe this is the first API test that is strict about the API response body, so it includes some new helper functions. We don't necessarily need to write every API test in this way, but I think we should have at least one test for each API endpoint that makes assertions about the body of the response. 

There are other ways of testing APIs. We could decode the response into the `api` type. The problem with that approach is that we will mask regressions in the API. If we change the `api` type, the test doesn't fail! It is easy to unintentionally change API responses, and tests like this help prevent API regressions.  It does mean that when we add fields we will have to update these tests. That's probably a good reason to have a small number of tests that are strict about the API response, so we only have to update one or two tests when we add fields to the response.

As we write more of these we may want to extract them into an `apitest` package.

There are a few fields here that are not predictable (uid and times), which makes writing a strict test more difficult. The approach taken here is to do an approximate comparison. An alternative would be to patch the uid generator and the database `time.Now` to set specific values. I think the approximate comparison might be easier to maintain than a lot of patching.