### PR TITLE
api: sort list identities by name

### DIFF
--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -93,6 +93,7 @@ func GetIdentity(db *gorm.DB, selectors ...SelectorFunc) (*models.Identity, erro
 }
 
 func ListIdentities(db *gorm.DB, selectors ...SelectorFunc) ([]models.Identity, error) {
+	db = db.Order("name ASC")
 	return list[models.Identity](db, selectors...)
 }
 


### PR DESCRIPTION
## Summary

While working on something else I thought I had found a bug in list identities. I wrote a test for the API endpoint, and then realized the problem was I had typed the identity name wrong.

This commit:
* orders identities by name ascending
* adds a test for `ListIdentities` API endpoint
* improves the tests for `data.ListIdentities` by asserting an order

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

Related to #1606, but only for list identities.
