### PR TITLE
cli: use DefaultsFromEnv - part 1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,7 +40,8 @@ jobs:
           go-version: '1.18'
       - name: Check generated docs are updated
         run: |
-          go run ./internal/docgen
+          # fake a terminal to get the right defaults for non-interactive
+          script -e -q -c "go run ./internal/docgen"
           go run ./internal/openapigen docs/api/openapi3.json
           git diff --exit-code
       - name: Check go mod is tidy

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -52,6 +52,7 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy
 
 ```
       --key string        Login with an access key
+      --non-interactive   Disable all prompts for input
       --provider string   Login with an identity provider
       --skip-tls-verify   Skip verifying server TLS certificates
 ```
@@ -61,7 +62,6 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra logout`
@@ -111,7 +111,6 @@ $ infra logout --all --clear
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra list`
@@ -127,7 +126,6 @@ infra list [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra use`
@@ -154,7 +152,6 @@ $ infra use development.kube-system
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra destinations list`
@@ -170,7 +167,6 @@ infra destinations list [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra destinations remove`
@@ -186,7 +182,6 @@ infra destinations remove DESTINATION [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra grants list`
@@ -208,7 +203,6 @@ infra grants list [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra grants add`
@@ -249,7 +243,6 @@ infra grants add IDENTITY DESTINATION [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra grants remove`
@@ -286,7 +279,6 @@ infra grants remove IDENTITY DESTINATION [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra identities add`
@@ -312,7 +304,6 @@ infra identities add IDENTITY [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra identities edit`
@@ -326,7 +317,8 @@ infra identities edit IDENTITY [flags]
 ### Options
 
 ```
-  -p, --password   Update password field
+      --non-interactive   Disable all prompts for input
+  -p, --password          Update password field
 ```
 
 ### Options inherited from parent commands
@@ -334,7 +326,6 @@ infra identities edit IDENTITY [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra identities list`
@@ -350,7 +341,6 @@ infra identities list [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra identities remove`
@@ -366,7 +356,6 @@ infra identities remove NAME [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra keys list`
@@ -388,7 +377,6 @@ infra keys list [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra keys add`
@@ -420,7 +408,6 @@ infra keys add first-key bot --ttl=12h --extension-deadline=1h
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra keys remove`
@@ -436,7 +423,6 @@ infra keys remove ACCESS_KEY_NAME [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra providers list`
@@ -452,7 +438,6 @@ infra providers list [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra providers add`
@@ -484,7 +469,6 @@ infra providers add PROVIDER [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra providers remove`
@@ -500,7 +484,6 @@ infra providers remove PROVIDER [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 
 ## `infra about`
@@ -516,6 +499,5 @@ infra about [flags]
 ```
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
-      --non-interactive    Disable all prompts for input
 ```
 

--- a/internal/cmd/cliopts/flags.go
+++ b/internal/cmd/cliopts/flags.go
@@ -1,0 +1,68 @@
+package cliopts
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+type FlagSet interface {
+	VisitAll(fn func(*pflag.Flag))
+}
+
+// DefaultsFromEnv looks for an environment variable for any unset flags. When
+// an environment variable is found, the flag value is set from the environment
+// variable.
+//
+// The environment variable for a flag has the prefix prepended, dashes replaced
+// with underscores, and lowercase converted to uppercase (ex:
+// --my-flag would be set from PREFIX_MY_FLAG).
+//
+// DefaultsFromEnv should be called after FlagSet.Parse, but before any flags
+// are used.
+func DefaultsFromEnv(prefix string, flags FlagSet) error {
+	replacer := strings.NewReplacer("-", "_")
+	prefix = prefix + "_"
+
+	var errs []error
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if flag.Changed {
+			return
+		}
+
+		key := strings.ToUpper(prefix + replacer.Replace(flag.Name))
+		v, exists := os.LookupEnv(key)
+		if !exists {
+			return
+		}
+		if err := flag.Value.Set(v); err != nil {
+			err = fmt.Errorf("failed to set %v from environment variable: %w", flag.Name, err)
+			errs = append(errs, err)
+		}
+	})
+
+	if len(errs) > 0 {
+		return MultiError(errs)
+	}
+	return nil
+}
+
+type MultiError []error
+
+func (e MultiError) Error() string {
+	errs := ([]error)(e)
+	switch len(errs) {
+	case 1:
+		return errs[0].Error()
+	default:
+		var sb strings.Builder
+		sb.WriteString("multiple errors:")
+		for _, err := range errs {
+			sb.WriteString("\n    " + err.Error())
+		}
+		sb.WriteString("\n")
+		return sb.String()
+	}
+}

--- a/internal/cmd/cliopts/flags.go
+++ b/internal/cmd/cliopts/flags.go
@@ -24,7 +24,7 @@ type FlagSet interface {
 // are used.
 func DefaultsFromEnv(prefix string, flags FlagSet) error {
 	replacer := strings.NewReplacer("-", "_")
-	prefix = prefix + "_"
+	prefix += "_"
 
 	var errs []error
 	flags.VisitAll(func(flag *pflag.Flag) {

--- a/internal/cmd/cliopts/flags_test.go
+++ b/internal/cmd/cliopts/flags_test.go
@@ -1,0 +1,208 @@
+package cliopts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"gotest.tools/v3/assert"
+)
+
+func TestDefaultsFromEnv(t *testing.T) {
+	type target struct {
+		OneMore string
+		Next    int32
+		Many    []string
+	}
+
+	setup := func(tg *target) *pflag.FlagSet {
+		flags := pflag.NewFlagSet("testing", pflag.ContinueOnError)
+		flags.String("word", "default-value", "")
+		flags.Int("count", 12, "")
+		flags.String("two-parts", "", "")
+		flags.StringVar(&tg.OneMore, "one-more-extra-long", "", "")
+		flags.Int32Var(&tg.Next, "next", 0, "")
+		flags.StringSliceVar(&tg.Many, "many", nil, "")
+		flags.StringSlice("many-others", nil, "")
+		return flags
+	}
+
+	t.Run("values from flags", func(t *testing.T) {
+		t.Setenv("MYAPP_WORD", "from-env")
+		t.Setenv("MYAPP_COUNT", "3")
+		t.Setenv("MYAPP_TWO_PARTS", "from-env-2")
+		t.Setenv("MYAPP_ONE_MORE_EXTRA_LONG", "from-env-3")
+		t.Setenv("MYAPP_NEXT", "4")
+		t.Setenv("MYAPP_MANY", "a,b,c")
+		t.Setenv("MYAPP_MANY_OTHERS", "d,e,f")
+
+		tg := target{}
+		flags := setup(&tg)
+		args := []string{
+			"--word", "the-value",
+			"--count", "22",
+			"--two-parts", "one-two",
+			"--one-more-extra-long", "value-one",
+			"--next", "23",
+			"--many", "one,two,three",
+			"--many-others", "four",
+			"--many-others", "five",
+		}
+		err := flags.Parse(args)
+		assert.NilError(t, err)
+
+		err = DefaultsFromEnv("MYAPP", flags)
+		assert.NilError(t, err)
+
+		expected := target{
+			OneMore: "value-one",
+			Next:    23,
+			Many:    []string{"one", "two", "three"},
+		}
+		assert.DeepEqual(t, tg, expected)
+
+		v, err := flags.GetString("word")
+		assert.NilError(t, err)
+		assert.Equal(t, v, "the-value")
+
+		i, err := flags.GetInt("count")
+		assert.NilError(t, err)
+		assert.Equal(t, i, 22)
+
+		v, err = flags.GetString("two-parts")
+		assert.NilError(t, err)
+		assert.Equal(t, v, "one-two")
+
+		s, err := flags.GetStringSlice("many-others")
+		assert.NilError(t, err)
+		assert.DeepEqual(t, s, []string{"four", "five"})
+	})
+
+	t.Run("defaults from flags", func(t *testing.T) {
+		tg := target{}
+		flags := setup(&tg)
+		err := flags.Parse(nil)
+		assert.NilError(t, err)
+
+		err = DefaultsFromEnv("MYAPP", flags)
+		assert.NilError(t, err)
+
+		expected := target{}
+		assert.DeepEqual(t, tg, expected)
+
+		v, err := flags.GetString("word")
+		assert.NilError(t, err)
+		assert.Equal(t, v, "default-value")
+
+		i, err := flags.GetInt("count")
+		assert.NilError(t, err)
+		assert.Equal(t, i, 12)
+
+		v, err = flags.GetString("two-parts")
+		assert.NilError(t, err)
+		assert.Equal(t, v, "")
+
+		s, err := flags.GetStringSlice("many-others")
+		assert.NilError(t, err)
+		assert.DeepEqual(t, s, []string{})
+	})
+
+	t.Run("values from env", func(t *testing.T) {
+		t.Setenv("MYAPP_WORD", "from-env")
+		t.Setenv("MYAPP_COUNT", "3")
+		t.Setenv("MYAPP_TWO_PARTS", "from-env-2")
+		t.Setenv("MYAPP_ONE_MORE_EXTRA_LONG", "from-env-3")
+		t.Setenv("MYAPP_NEXT", "4")
+		t.Setenv("MYAPP_MANY", "a,b,c")
+		t.Setenv("MYAPP_MANY_OTHERS", "d,e,f")
+
+		tg := target{}
+		flags := setup(&tg)
+		err := flags.Parse(nil)
+		assert.NilError(t, err)
+
+		err = DefaultsFromEnv("MYAPP", flags)
+		assert.NilError(t, err)
+
+		expected := target{
+			OneMore: "from-env-3",
+			Next:    4,
+			Many:    []string{"a", "b", "c"},
+		}
+		assert.DeepEqual(t, tg, expected)
+
+		v, err := flags.GetString("word")
+		assert.NilError(t, err)
+		assert.Equal(t, v, "from-env")
+
+		i, err := flags.GetInt("count")
+		assert.NilError(t, err)
+		assert.Equal(t, i, 3)
+
+		v, err = flags.GetString("two-parts")
+		assert.NilError(t, err)
+		assert.Equal(t, v, "from-env-2")
+
+		s, err := flags.GetStringSlice("many-others")
+		assert.NilError(t, err)
+		assert.DeepEqual(t, s, []string{"d", "e", "f"})
+	})
+
+	t.Run("errors setting value from env var", func(t *testing.T) {
+		t.Setenv("MYAPP_WORD", "from-env")
+		t.Setenv("MYAPP_COUNT", "not-a-number")
+		t.Setenv("MYAPP_NEXT", "true")
+		t.Setenv("MYAPP_MANY_OTHERS", "d")
+
+		tg := target{}
+		flags := setup(&tg)
+		err := flags.Parse(nil)
+		assert.NilError(t, err)
+
+		err = DefaultsFromEnv("MYAPP", flags)
+		assert.ErrorContains(t, err, `failed to set count from environment variable: strconv.ParseInt: parsing "not-a-number": invalid syntax`)
+		assert.ErrorContains(t, err, `failed to set next from environment variable: strconv.ParseInt: parsing "true": invalid syntax`)
+	})
+
+}
+
+func TestMultiError_Error(t *testing.T) {
+	type testCase struct {
+		errs     []error
+		expected string
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		m := MultiError(tc.errs)
+		actual := m.Error()
+		assert.Equal(t, actual, tc.expected)
+	}
+
+	testCases := map[string]testCase{
+		"1 error": {
+			errs:     []error{fmt.Errorf("failed once")},
+			expected: "failed once",
+		},
+		"3 errors": {
+			errs: []error{
+				fmt.Errorf("failed once"),
+				fmt.Errorf("failed twice"),
+				fmt.Errorf("failed three times"),
+			},
+			expected: `multiple errors:
+    failed once
+    failed twice
+    failed three times
+`,
+		},
+	}
+	runTestCases(t, run, testCases)
+}
+
+func runTestCases[TC any](t *testing.T, run func(*testing.T, TC), testCases map[string]TC) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/internal/cmd/cliopts/flags_test.go
+++ b/internal/cmd/cliopts/flags_test.go
@@ -21,7 +21,7 @@ func TestDefaultsFromEnv(t *testing.T) {
 		flags.Int("count", 12, "")
 		flags.String("two-parts", "", "")
 		flags.StringVar(&tg.OneMore, "one-more-extra-long", "", "")
-		flags.Int32Var(&tg.Next, "next", 0, "")
+		flags.Int32Var(&tg.Next, "next", 222, "")
 		flags.StringSliceVar(&tg.Many, "many", nil, "")
 		flags.StringSlice("many-others", nil, "")
 		return flags
@@ -87,7 +87,7 @@ func TestDefaultsFromEnv(t *testing.T) {
 		err = DefaultsFromEnv("MYAPP", flags)
 		assert.NilError(t, err)
 
-		expected := target{}
+		expected := target{Next: 222}
 		assert.DeepEqual(t, tg, expected)
 
 		v, err := flags.GetString("word")

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"golang.org/x/term"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
@@ -392,7 +393,8 @@ func rootPreRun(flags *pflag.FlagSet) error {
 }
 
 func addNonInteractiveFlag(flags *pflag.FlagSet, bind *bool) {
-	flags.BoolVar(bind, "non-interactive", false, "Disable all prompts for input")
+	isNonInteractiveMode := os.Stdin == nil || !term.IsTerminal(int(os.Stdin.Fd()))
+	flags.BoolVar(bind, "non-interactive", isNonInteractiveMode, "Disable all prompts for input")
 }
 
 func usageTemplate() string {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -19,10 +19,9 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/infrahq/infra/internal/cmd/cliopts"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/cmd/cliopts"
 	"github.com/infrahq/infra/internal/connector"
 	"github.com/infrahq/infra/internal/decode"
 	"github.com/infrahq/infra/internal/logging"

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -14,7 +14,10 @@ func newDestinationsCmd() *cobra.Command {
 		Aliases: []string{"dst", "dest", "destination"},
 		Short:   "Manage destinations",
 		Group:   "Management commands:",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := rootPreRun(cmd.Flags()); err != nil {
+				return err
+			}
 			return mustBeLoggedIn()
 		},
 	}

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -26,7 +26,10 @@ func newGrantsCmd() *cobra.Command {
 		Short:   "Manage access to destinations",
 		Aliases: []string{"grant"},
 		Group:   "Management commands:",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := rootPreRun(cmd.Flags()); err != nil {
+				return err
+			}
 			return mustBeLoggedIn()
 		},
 	}

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -20,7 +20,10 @@ func newIdentitiesCmd() *cobra.Command {
 		Aliases: []string{"id", "identity"},
 		Short:   "Manage identities (users & machines)",
 		Group:   "Management commands:",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := rootPreRun(cmd.Flags()); err != nil {
+				return err
+			}
 			return mustBeLoggedIn()
 		},
 	}

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -101,7 +101,7 @@ func newIdentitiesEditCmd() *cobra.Command {
 			}
 
 			if kind == models.MachineKind {
-				fmt.Println("machine identities have no editable fields")
+				return fmt.Errorf("machine identities have no editable fields")
 			}
 
 			if kind == models.UserKind {
@@ -110,7 +110,7 @@ func newIdentitiesEditCmd() *cobra.Command {
 				}
 
 				if opts.Password && opts.NonInteractive {
-					return errors.New("Non-interactive mode is not supported to edit sensitive fields")
+					return errors.New("Interactive mode is required to edit sensitive fields")
 				}
 
 				if err = UpdateIdentity(name, opts); err != nil {

--- a/internal/cmd/identities_test.go
+++ b/internal/cmd/identities_test.go
@@ -224,10 +224,24 @@ func TestIdentitiesCmd(t *testing.T) {
 		assert.Equal(t, models.UserKind, (*modifiedIdentities)[0].Kind)
 	})
 
+	t.Run("edit machine identity fails", func(t *testing.T) {
+		setup(t)
+		err := Run(context.Background(), "id", "edit", "HAL")
+		assert.ErrorContains(t, err, "machine identities have no editable fields")
+	})
+
 	t.Run("edit user identity no password flag", func(t *testing.T) {
 		setup(t)
 		err := Run(context.Background(), "id", "edit", "new-user@example.com")
 		assert.ErrorContains(t, err, "Specify a field to update")
+	})
+
+	t.Run("edit user identity interactive with password", func(t *testing.T) {
+		setup(t)
+		t.Setenv("INFRA_PASSWORD", "true")
+		t.Setenv("INFRA_NON_INTERACTIVE", "true")
+		err := Run(context.Background(), "id", "edit", "new-user@example.com")
+		assert.ErrorContains(t, err, "Interactive mode is required to edit sensitive fields")
 	})
 
 	t.Run("removes only the specified identity", func(t *testing.T) {

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -16,10 +16,10 @@ func newInfoCmd() *cobra.Command {
 		Use:    "info",
 		Short:  "Display the info about the current session",
 		Hidden: true,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return mustBeLoggedIn()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := mustBeLoggedIn(); err != nil {
+				return err
+			}
 			return info()
 		},
 	}

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -19,7 +19,10 @@ func newKeysCmd() *cobra.Command {
 		Long:    "Manage access keys for machine identities to authenticate with Infra and call the API",
 		Aliases: []string{"key"},
 		Group:   "Management commands:",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := rootPreRun(cmd.Flags()); err != nil {
+				return err
+			}
 			return mustBeLoggedIn()
 		},
 	}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -16,7 +16,10 @@ func newListCmd() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List accessible destinations",
 		Group:   "Core commands:",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := rootPreRun(cmd.Flags()); err != nil {
+				return err
+			}
 			return mustBeLoggedIn()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -17,7 +17,6 @@ import (
 	"github.com/goware/urlx"
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/generate"
@@ -120,7 +119,7 @@ func login(options loginCmdOptions) error {
 			return err
 		}
 	default:
-		if options.isNonInteractiveMode() {
+		if options.NonInteractive {
 			return fmt.Errorf("Non-interactive login requires key, instead run: 'infra login SERVER --non-interactive --key KEY")
 		}
 		loginMethod, provider, err := promptLoginOptions(client)
@@ -223,10 +222,6 @@ func updateInfraConfig(client *api.Client, loginReq *api.LoginRequest, loginRes 
 	}
 
 	return nil
-}
-
-func (o loginCmdOptions) isNonInteractiveMode() bool {
-	return o.NonInteractive || os.Stdin == nil || !term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func oidcflow(host string, clientId string) (string, error) {
@@ -342,7 +337,7 @@ func newAPIClient(options loginCmdOptions) (*api.Client, error) {
 				return nil, err
 			}
 
-			if options.isNonInteractiveMode() {
+			if options.NonInteractive {
 				fmt.Fprintf(os.Stderr, "%s\n", ErrTLSNotVerified.Error())
 				return nil, fmt.Errorf("Non-interactive login does not allow insecure connection by default,\n       unless overridden with  '--skip-tls-verify'.")
 			}
@@ -497,7 +492,7 @@ func promptSkipTLSVerify() error {
 
 // Returns the host address of the Infra server that user would like to log into
 func promptServer(options loginCmdOptions) (string, error) {
-	if options.isNonInteractiveMode() {
+	if options.NonInteractive {
 		return "", fmt.Errorf("Non-interactive login requires the [SERVER] argument")
 	}
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -15,7 +15,6 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/cli/browser"
 	"github.com/goware/urlx"
-	"github.com/iancoleman/strcase"
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -27,10 +26,11 @@ import (
 )
 
 type loginCmdOptions struct {
-	Server        string `mapstructure:"server"`
-	AccessKey     string `mapstructure:"key"`
-	Provider      string `mapstructure:"provider"`
-	SkipTLSVerify bool   `mapstructure:"skipTLSVerify"`
+	Server         string
+	AccessKey      string
+	Provider       string
+	SkipTLSVerify  bool
+	NonInteractive bool
 }
 
 type loginMethod int8
@@ -44,6 +44,8 @@ const (
 const cliLoginRedirectURL = "http://localhost:8301"
 
 func newLoginCmd() *cobra.Command {
+	var options loginCmdOptions
+
 	cmd := &cobra.Command{
 		Use:   "login [SERVER]",
 		Short: "Login to Infra",
@@ -61,13 +63,6 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy`,
 		Args:  cobra.MaximumNArgs(1),
 		Group: "Core commands:",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var options loginCmdOptions
-			strcase.ConfigureAcronym("skip-tls-verify", "skipTLSVerify")
-
-			if err := parseOptions(cmd, &options, "INFRA"); err != nil {
-				return err
-			}
-
 			if len(args) == 1 {
 				options.Server = args[0]
 			}
@@ -76,9 +71,10 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy`,
 		},
 	}
 
-	cmd.Flags().String("key", "", "Login with an access key")
-	cmd.Flags().String("provider", "", "Login with an identity provider")
-	cmd.Flags().Bool("skip-tls-verify", false, "Skip verifying server TLS certificates")
+	cmd.Flags().StringVar(&options.AccessKey, "key", "", "Login with an access key")
+	cmd.Flags().StringVar(&options.Provider, "provider", "", "Login with an identity provider")
+	cmd.Flags().BoolVar(&options.SkipTLSVerify, "skip-tls-verify", false, "Skip verifying server TLS certificates")
+	addNonInteractiveFlag(cmd.Flags(), &options.NonInteractive)
 	return cmd
 }
 
@@ -86,13 +82,13 @@ func login(options loginCmdOptions) error {
 	var err error
 
 	if options.Server == "" {
-		options.Server, err = promptServer()
+		options.Server, err = promptServer(options)
 		if err != nil {
 			return err
 		}
 	}
 
-	client, err := newAPIClient(options.Server, options.SkipTLSVerify)
+	client, err := newAPIClient(options)
 	if err != nil {
 		return err
 	}
@@ -124,6 +120,9 @@ func login(options loginCmdOptions) error {
 			return err
 		}
 	default:
+		if options.isNonInteractiveMode() {
+			return fmt.Errorf("Non-interactive login requires key, instead run: 'infra login SERVER --non-interactive --key KEY")
+		}
 		loginMethod, provider, err := promptLoginOptions(client)
 		if err != nil {
 			return err
@@ -226,8 +225,8 @@ func updateInfraConfig(client *api.Client, loginReq *api.LoginRequest, loginRes 
 	return nil
 }
 
-func isNonInteractiveMode() bool {
-	return rootOptions.NonInteractive || os.Stdin == nil || !term.IsTerminal(int(os.Stdin.Fd()))
+func (o loginCmdOptions) isNonInteractiveMode() bool {
+	return o.NonInteractive || os.Stdin == nil || !term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func oidcflow(host string, clientId string) (string, error) {
@@ -335,22 +334,27 @@ func runSignupForLogin(client *api.Client) (*api.LoginRequestPasswordCredentials
 }
 
 // Only used when logging in or switching to a new session, since user has no credentials. Otherwise, use defaultAPIClient().
-func newAPIClient(server string, skipTLSVerify bool) (*api.Client, error) {
-	if !skipTLSVerify {
+func newAPIClient(options loginCmdOptions) (*api.Client, error) {
+	if !options.SkipTLSVerify {
 		// Prompt user only if server fails the TLS verification
-		if err := verifyTLS(server); err != nil {
+		if err := verifyTLS(options.Server); err != nil {
 			if !errors.Is(err, ErrTLSNotVerified) {
 				return nil, err
+			}
+
+			if options.isNonInteractiveMode() {
+				fmt.Fprintf(os.Stderr, "%s\n", ErrTLSNotVerified.Error())
+				return nil, fmt.Errorf("Non-interactive login does not allow insecure connection by default,\n       unless overridden with  '--skip-tls-verify'.")
 			}
 
 			if err = promptSkipTLSVerify(); err != nil {
 				return nil, err
 			}
-			skipTLSVerify = true
+			options.SkipTLSVerify = true
 		}
 	}
 
-	client, err := apiClient(server, "", skipTLSVerify)
+	client, err := apiClient(options.Server, "", options.SkipTLSVerify)
 	if err != nil {
 		return nil, err
 	}
@@ -441,10 +445,6 @@ func listProviders(client *api.Client) ([]api.Provider, error) {
 }
 
 func promptLoginOptions(client *api.Client) (loginMethod loginMethod, provider *api.Provider, err error) {
-	if isNonInteractiveMode() {
-		return 0, nil, fmt.Errorf("Non-interactive login requires key, instead run: 'infra login SERVER --non-interactive --key KEY")
-	}
-
 	providers, err := listProviders(client)
 	if err != nil {
 		return 0, nil, err
@@ -480,11 +480,6 @@ func promptLoginOptions(client *api.Client) (loginMethod loginMethod, provider *
 
 // Error out if it fails TLS verification and user does not want to connect.
 func promptSkipTLSVerify() error {
-	if isNonInteractiveMode() {
-		fmt.Fprintf(os.Stderr, "%s\n", ErrTLSNotVerified.Error())
-		return fmt.Errorf("Non-interactive login does not allow insecure connection by default,\n       unless overridden with  '--skip-tls-verify'.")
-	}
-
 	// Although the same error, format is a little different for interactive/non-interactive.
 	fmt.Fprintf(os.Stderr, "  %s\n", ErrTLSNotVerified.Error())
 	confirmPrompt := &survey.Confirm{
@@ -501,8 +496,8 @@ func promptSkipTLSVerify() error {
 }
 
 // Returns the host address of the Infra server that user would like to log into
-func promptServer() (string, error) {
-	if isNonInteractiveMode() {
+func promptServer(options loginCmdOptions) (string, error) {
+	if options.isNonInteractiveMode() {
 		return "", fmt.Errorf("Non-interactive login requires the [SERVER] argument")
 	}
 

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -15,7 +15,10 @@ func newProvidersCmd() *cobra.Command {
 		Short:   "Manage identity providers",
 		Aliases: []string{"provider"},
 		Group:   "Management commands:",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := rootPreRun(cmd.Flags()); err != nil {
+				return err
+			}
 			return mustBeLoggedIn()
 		},
 	}

--- a/internal/cmd/tokens.go
+++ b/internal/cmd/tokens.go
@@ -15,7 +15,10 @@ func newTokensCmd() *cobra.Command {
 		Use:    "tokens",
 		Short:  "Create & manage tokens",
 		Hidden: true,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := rootPreRun(cmd.Flags()); err != nil {
+				return err
+			}
 			return mustBeLoggedIn()
 		},
 	}


### PR DESCRIPTION
(best viewed by individual commit, more details in the commit messages)

## Summary

This PR adds a new `cliopts.DefaultsFromEnv` for loading default values for flags from environment variables. The new function is used in two commands for now: `infra login`, and `infra identities edit`. This should be enough to demonstrate the pattern. I'll add it to other places once everyone is happy with this approach.

Also fixes a bug related to `cobra.Command.PersistentPreRunE` in a parent command clobbering the one from the root command. Fixing that bug was necessary to write tests for this, because `DefaultsFromEnv` is called from `PersistentPreRunE`.

Adds another test case for `infra id edit`, but nothing for `infra login` yet.