### PR TITLE
improve(cli): add user agent to requests

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -15,6 +15,8 @@ type Client struct {
 	URL       string
 	AccessKey string
 	HTTP      http.Client
+	// Headers are HTTP headers that will be added to every request made by the Client.
+	Headers http.Header
 }
 
 func checkError(status int, body []byte) error {
@@ -59,6 +61,7 @@ func get[Res any](client Client, path string) (*Res, error) {
 		return nil, err
 	}
 
+	addHeaders(req, client.Headers)
 	req.Header.Add("Authorization", "Bearer "+client.AccessKey)
 
 	resp, err := client.HTTP.Do(req)
@@ -91,6 +94,7 @@ func list[Res any](client Client, path string, query map[string]string) ([]Res, 
 		return nil, err
 	}
 
+	addHeaders(req, client.Headers)
 	req.Header.Add("Authorization", "Bearer "+client.AccessKey)
 
 	q := req.URL.Query()
@@ -135,6 +139,7 @@ func request[Req, Res any](client Client, method string, path string, req *Req) 
 		return nil, err
 	}
 
+	addHeaders(httpReq, client.Headers)
 	httpReq.Header.Add("Authorization", "Bearer "+client.AccessKey)
 	httpReq.Header.Set("Content-Type", "application/json")
 
@@ -195,6 +200,12 @@ func delete(client Client, path string) error {
 	}
 
 	return nil
+}
+
+func addHeaders(req *http.Request, headers http.Header) {
+	for key, values := range headers {
+		req.Header[key] = values
+	}
 }
 
 func (c Client) ListIdentities(req ListIdentitiesRequest) ([]Identity, error) {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGet(t *testing.T) {
+	requestCh := make(chan *http.Request, 5)
+	handler := func(resp http.ResponseWriter, r *http.Request) {
+		requestCh <- r
+		switch r.URL.Path {
+		case "/good":
+			resp.WriteHeader(http.StatusOK)
+			_, _ = resp.Write([]byte(`{}`))
+		case "/bad":
+			resp.WriteHeader(http.StatusBadRequest)
+		default:
+			resp.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+
+	c := Client{
+		URL:       srv.URL,
+		AccessKey: "the-access-key",
+		Headers:   http.Header{},
+	}
+	c.Headers.Add("User-Agent", "testing")
+	c.Headers.Add("X-Custom", "custom")
+
+	type stubResponse struct{}
+
+	expectedHeaders := http.Header{
+		"User-Agent":      []string{"testing"},
+		"X-Custom":        []string{"custom"},
+		"Accept-Encoding": []string{"gzip"},
+		"Authorization":   []string{"Bearer the-access-key"},
+	}
+
+	t.Run("success request", func(t *testing.T) {
+		_, err := get[stubResponse](c, "/good")
+		assert.NilError(t, err)
+		req := <-requestCh
+		assert.Equal(t, req.Method, http.MethodGet)
+		assert.Equal(t, req.URL.Path, "/good")
+		assert.DeepEqual(t, req.Header, expectedHeaders)
+	})
+
+	t.Run("failed request", func(t *testing.T) {
+		_, err := get[stubResponse](c, "/bad")
+		assert.ErrorContains(t, err, `responded 400: bad request`)
+		req := <-requestCh
+		assert.Equal(t, req.Method, http.MethodGet)
+		assert.Equal(t, req.URL.Path, "/bad")
+		assert.DeepEqual(t, req.Header, expectedHeaders)
+	})
+}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/goware/urlx"
@@ -19,6 +20,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/connector"
 	"github.com/infrahq/infra/internal/decode"
 	"github.com/infrahq/infra/internal/logging"
@@ -168,6 +170,10 @@ func apiClient(host string, accessKey string, skipTLSVerify bool) (*api.Client, 
 
 	u.Scheme = "https"
 
+	headers := http.Header{}
+	ua := fmt.Sprintf("Infra CLI/%v (%v/%v)", internal.Version, runtime.GOOS, runtime.GOARCH)
+	headers.Add("User-Agent", ua)
+
 	return &api.Client{
 		URL:       fmt.Sprintf("%s://%s", u.Scheme, u.Host),
 		AccessKey: accessKey,
@@ -179,6 +185,7 @@ func apiClient(host string, accessKey string, skipTLSVerify bool) (*api.Client, 
 				},
 			},
 		},
+		Headers: headers,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

This commit adds support to `api.Client` for setting headers.

The CLI uses this support to add a more descriptive user agent header, which should look something like this:

    Infra CLI/0.10.3 (darwin/arm64)
    Infra CLI/0.10.3 (linux/amd64)

This will allow us to identify traffic from different sources.