### PR TITLE
fix: fix 404 and proxy ui routes

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -329,6 +329,7 @@ func registerUIRoutes(router *gin.Engine, opts UIOptions) {
 
 		router.Use(func(c *gin.Context) {
 			proxy.ServeHTTP(c.Writer, c.Request)
+			c.Abort()
 		})
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1065,7 +1065,7 @@ func TestServer_GenerateRoutes_UI(t *testing.T) {
 		},
 		{
 			name:         "page without .html suffix",
-			path:         "/providers",
+			path:         "/providers/add/admins",
 			expectedCode: http.StatusOK,
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				actual := resp.Header().Get("Content-Type")

--- a/internal/server/static_fs.go
+++ b/internal/server/static_fs.go
@@ -35,8 +35,13 @@ const uiFilePathPrefix = "ui"
 
 func (sfs StaticFileSystem) Exists(prefix string, filepath string) bool {
 	if p := strings.TrimPrefix(filepath, prefix); len(p) < len(filepath) {
-		_, err := sfs.base.Open(path.Join(uiFilePathPrefix, p))
-		return err == nil
+		if _, err := sfs.base.Open(path.Join(uiFilePathPrefix, p)); err == nil {
+			return true
+		}
+
+		if _, err := sfs.base.Open(path.Join(uiFilePathPrefix+".html", p)); err == nil {
+			return true
+		}
 	}
 
 	return false

--- a/internal/server/static_fs.go
+++ b/internal/server/static_fs.go
@@ -39,7 +39,7 @@ func (sfs StaticFileSystem) Exists(prefix string, filepath string) bool {
 			return true
 		}
 
-		if _, err := sfs.base.Open(path.Join(uiFilePathPrefix+".html", p)); err == nil {
+		if _, err := sfs.base.Open(path.Join(uiFilePathPrefix, p+".html")); err == nil {
 			return true
 		}
 	}

--- a/internal/server/static_fs_test.go
+++ b/internal/server/static_fs_test.go
@@ -40,3 +40,29 @@ func TestStaticFileSystemAppendDotHtml(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, stat.Name(), "dashboard.html")
 }
+
+func TestStaticFileSystemExists(t *testing.T) {
+	fs := afero.NewHttpFs(afero.NewMemMapFs())
+	_, err := fs.Create("ui/dashboard/foo")
+	assert.NilError(t, err)
+
+	sfs := &StaticFileSystem{
+		base: fs,
+	}
+
+	exists := sfs.Exists("/", "/dashboard")
+	assert.Equal(t, exists, true)
+}
+
+func TestStaticFileSystemExistsAppendDotHtml(t *testing.T) {
+	fs := afero.NewHttpFs(afero.NewMemMapFs())
+	_, err := fs.Create("ui/dashboard/foo.html")
+	assert.NilError(t, err)
+
+	sfs := &StaticFileSystem{
+		base: fs,
+	}
+
+	exists := sfs.Exists("/", "/dashboard/foo")
+	assert.Equal(t, exists, true)
+}


### PR DESCRIPTION
Fixes:
* ui routes falling through to the NotFound handler in development
* Embedded FS not detecting `.html` files exist – (e.g. when the user loads `/a/path` it should check if `/a/path.html` exists as well as `/a/path`
