### PR TITLE
feat: change signup request endpoint to use email

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -5,6 +5,6 @@ type SignupEnabledResponse struct {
 }
 
 type SignupRequest struct {
-	Name     string `json:"name"`
-	Password string `json:"password"`
+	Email    string `json:"email" validate:"required,email"`
+	Password string `json:"password" validate:"required"`
 }

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -3371,13 +3371,18 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "name": {
+                  "email": {
+                    "example": "email@example.com",
                     "type": "string"
                   },
                   "password": {
                     "type": "string"
                   }
                 },
+                "required": [
+                  "email",
+                  "password"
+                ],
                 "type": "object"
               }
             }

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -332,7 +332,7 @@ func runSignupForLogin(client *api.Client) (*api.LoginRequestPasswordCredentials
 		return nil, err
 	}
 
-	_, err = client.Signup(&api.SignupRequest{Name: email, Password: password})
+	_, err = client.Signup(&api.SignupRequest{Email: email, Password: password})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -499,7 +499,7 @@ func (a *API) SignupEnabled(c *gin.Context, _ *api.EmptyRequest) (*api.SignupEna
 }
 
 func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.Identity, error) {
-	identity, err := access.Signup(c, r.Name, r.Password)
+	identity, err := access.Signup(c, r.Email, r.Password)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Changes `POST /v1/signup` to use `email` as a field)

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
