### PR TITLE
draft: include identity names in API response

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -9,6 +9,7 @@ type AccessKey struct {
 	Created           Time   `json:"created"`
 	Name              string `json:"name"`
 	IssuedFor         uid.ID `json:"issuedFor"`
+	IssuedForName     string `json:"issuedForName"`
 	ProviderID        uid.ID `json:"providerID"`
 	Expires           Time   `json:"expires,omitempty" note:"key is no longer valid after this time"`
 	ExtensionDeadline Time   `json:"extensionDeadline" note:"key must be renewed after this time"`

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -34,6 +34,9 @@
             "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
             "type": "string"
           },
+          "issuedForName": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -171,7 +171,7 @@ func newKeysListCmd() *cobra.Command {
 			for _, k := range keys {
 				rows = append(rows, row{
 					Name:              k.Name,
-					IssuedFor:         k.IssuedFor.String(),
+					IssuedFor:         k.IssuedForName,
 					Created:           k.Created.Relative("never"),
 					Expires:           k.Expires.Relative("never"),
 					ExtensionDeadline: k.ExtensionDeadline.Relative("never"),

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -401,11 +401,18 @@ func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) ([]ap
 	results := make([]api.AccessKey, len(accessKeys))
 
 	for i, a := range accessKeys {
+		// TODO: this would be better as a JOIN query
+		identity, err := access.GetIdentity(c, a.IssuedFor)
+		if err != nil {
+			return nil, err
+		}
+
 		results[i] = api.AccessKey{
 			ID:                a.ID,
 			Name:              a.Name,
 			Created:           api.Time(a.CreatedAt),
 			IssuedFor:         a.IssuedFor,
+			IssuedForName:     identity.Name,
 			ProviderID:        a.ProviderID,
 			Expires:           api.Time(a.ExpiresAt),
 			ExtensionDeadline: api.Time(a.ExtensionDeadline),


### PR DESCRIPTION
Related to #1548

The CLI should not have to perform more queries to provide a reasonable response. If our CLI needs this, there's a good chance that other API consumers will need it as well.

This PR augments the list keys API response to include the identity name. That way the CLI can use it without have to query for the identity.