### PR TITLE
improve: add a test helper for creating a ClientConfig

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -103,24 +103,10 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 			}
 		}
 
-		svc := httptest.NewTLSServer(http.HandlerFunc(handler))
-		t.Cleanup(svc.Close)
+		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(srv.Close)
 
-		cfg := ClientConfig{
-			Version: "0.3",
-			Hosts: []ClientHostConfig{
-				{
-					PolymorphicID: uid.NewIdentityPolymorphicID(userID),
-					Name:          "test",
-					Host:          svc.Listener.Addr().String(),
-					SkipTLSVerify: true,
-					AccessKey:     "access-key",
-					Expires:       api.Time(time.Now().Add(time.Hour)),
-					Current:       true,
-				},
-			},
-		}
-
+		cfg := newTestClientConfig(srv, api.Identity{ID: userID})
 		err := writeConfig(&cfg)
 		assert.NilError(t, err)
 
@@ -196,4 +182,34 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 		err := Run(context.Background(), "use", "unknown")
 		assert.ErrorContains(t, err, "context not found")
 	})
+}
+
+// newTestClientConfig returns a ClientConfig that can be used to test CLI
+// commands. Most CLI commands require a login first, which saves a ClientConfig
+// to a file.
+// newTestClientConfig provides a reasonable default for most cases, removing
+// the need to perform a full login. The returned value may be modified, and then
+// should be saved to a file with writeConfig.
+// If any fields in identity are not set, they will be set to default values.
+func newTestClientConfig(srv *httptest.Server, identity api.Identity) ClientConfig {
+	if identity.Name == "" {
+		identity.Name = "testuser@example.com"
+	}
+	if identity.ID == 0 {
+		identity.ID = uid.New()
+	}
+	return ClientConfig{
+		Version: "0.3",
+		Hosts: []ClientHostConfig{
+			{
+				PolymorphicID: uid.NewIdentityPolymorphicID(identity.ID),
+				Name:          identity.Name,
+				Host:          srv.Listener.Addr().String(),
+				SkipTLSVerify: true,
+				AccessKey:     "the-access-key",
+				Expires:       api.Time(time.Now().Add(time.Hour)),
+				Current:       true,
+			},
+		},
+	}
 }

--- a/internal/cmd/identities_test.go
+++ b/internal/cmd/identities_test.go
@@ -199,21 +199,7 @@ func TestIdentitiesCmd(t *testing.T) {
 		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
 		t.Cleanup(srv.Close)
 
-		cfg := ClientConfig{
-			Version: "0.3",
-			Hosts: []ClientHostConfig{
-				{
-					PolymorphicID: "i:1234",
-					Name:          "self@example.com",
-					ProviderID:    providerID,
-					Host:          srv.Listener.Addr().String(),
-					Current:       true,
-					AccessKey:     "the-access-key",
-					SkipTLSVerify: true,
-					Expires:       api.Time(time.Now().Add(time.Minute)),
-				},
-			},
-		}
+		cfg := newTestClientConfig(srv, api.Identity{})
 		err := writeConfig(&cfg)
 		assert.NilError(t, err)
 

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -50,20 +50,7 @@ func TestKeysAddCmd(t *testing.T) {
 		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
 		t.Cleanup(srv.Close)
 
-		cfg := ClientConfig{
-			Version: "0.3",
-			Hosts: []ClientHostConfig{
-				{
-					AccessKey:     "the-access-key",
-					Name:          "user1",
-					PolymorphicID: "pid1",
-					Host:          srv.Listener.Addr().String(),
-					Current:       true,
-					SkipTLSVerify: true,
-					Expires:       api.Time(time.Now().Add(time.Minute)),
-				},
-			},
-		}
+		cfg := newTestClientConfig(srv, api.Identity{})
 		err := writeConfig(&cfg)
 		assert.NilError(t, err)
 

--- a/internal/cmd/providers_test.go
+++ b/internal/cmd/providers_test.go
@@ -19,27 +19,11 @@ func TestProviders(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 
-	id := uid.New()
-
 	setup := func(t *testing.T, handler func(http.ResponseWriter, *http.Request)) {
-		svc := httptest.NewTLSServer(http.HandlerFunc(handler))
-		t.Cleanup(svc.Close)
+		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(srv.Close)
 
-		cfg := ClientConfig{
-			Version: "0.3",
-			Hosts: []ClientHostConfig{
-				{
-					PolymorphicID: uid.NewIdentityPolymorphicID(id),
-					Name:          "test",
-					Host:          svc.Listener.Addr().String(),
-					SkipTLSVerify: true,
-					AccessKey:     "access-key",
-					Expires:       api.Time(time.Now().Add(time.Hour)),
-					Current:       true,
-				},
-			},
-		}
-
+		cfg := newTestClientConfig(srv, api.Identity{})
 		err := writeConfig(&cfg)
 		assert.NilError(t, err)
 	}


### PR DESCRIPTION
## Summary

Most CLI commands require a login first. In tests we simulate a login by writing out a `ClientConfig`. This PR extracts a test helper for building that `ClientConfig`, so that if we change the format of the config it'll be less work to migrate the tests.