### PR TITLE
cli: use DefaultsFromEnv - part 2

### DIFF
--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -14,10 +14,10 @@ import (
 )
 
 type grantsCmdOptions struct {
-	Identity    string `mapstructure:"identity"`
-	Destination string `mapstructure:"destination"`
-	IsGroup     bool   `mapstructure:"group"`
-	Role        string `mapstructure:"role"`
+	Identity    string
+	Destination string
+	IsGroup     bool
+	Role        string
 }
 
 func newGrantsCmd() *cobra.Command {
@@ -42,16 +42,13 @@ func newGrantsCmd() *cobra.Command {
 }
 
 func newGrantsListCmd() *cobra.Command {
+	var options grantsCmdOptions
+
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List grants",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var options grantsCmdOptions
-			if err := parseOptions(cmd, &options, "INFRA_GRANTS"); err != nil {
-				return err
-			}
-
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err
@@ -92,11 +89,13 @@ func newGrantsListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("destination", "", "Filter by destination")
+	cmd.Flags().StringVar(&options.Destination, "destination", "", "Filter by destination")
 	return cmd
 }
 
 func newGrantRemoveCmd() *cobra.Command {
+	var options grantsCmdOptions
+
 	cmd := &cobra.Command{
 		Use:     "remove IDENTITY DESTINATION",
 		Aliases: []string{"rm"},
@@ -114,21 +113,14 @@ $ infra grants remove devGroup -g ...
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var options grantsCmdOptions
-			if err := parseOptions(cmd, &options, "INFRA_GRANTS"); err != nil {
-				return err
-			}
-
 			options.Identity = args[0]
 			options.Destination = args[1]
-
 			return removeGrant(options)
 		},
 	}
 
-	cmd.Flags().BoolP("group", "g", false, "Group to revoke access from")
-	cmd.Flags().String("role", "", "Role to revoke")
-
+	cmd.Flags().BoolVarP(&options.IsGroup, "group", "g", false, "Group to revoke access from")
+	cmd.Flags().StringVar(&options.Role, "role", "", "Role to revoke")
 	return cmd
 }
 
@@ -170,6 +162,8 @@ func removeGrant(cmdOptions grantsCmdOptions) error {
 }
 
 func newGrantAddCmd() *cobra.Command {
+	var options grantsCmdOptions
+
 	cmd := &cobra.Command{
 		Use:   "add IDENTITY DESTINATION",
 		Short: "Grant access to a destination",
@@ -190,20 +184,14 @@ For full documentation on grants with more examples, see:
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var options grantsCmdOptions
-			if err := parseOptions(cmd, &options, "INFRA_GRANTS"); err != nil {
-				return err
-			}
-
 			options.Identity = args[0]
 			options.Destination = args[1]
-
 			return addGrant(options)
 		},
 	}
 
-	cmd.Flags().BoolP("group", "g", false, "Required if identity is of type 'group'")
-	cmd.Flags().String("role", models.BasePermissionConnect, "Type of access that identity will be given")
+	cmd.Flags().BoolVarP(&options.IsGroup, "group", "g", false, "Required if identity is of type 'group'")
+	cmd.Flags().StringVar(&options.Role, "role", models.BasePermissionConnect, "Type of access that identity will be given")
 	return cmd
 }
 

--- a/internal/cmd/grants_test.go
+++ b/internal/cmd/grants_test.go
@@ -1,0 +1,277 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+)
+
+func TestGrantsAddCmd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // for windows
+
+	setup := func(t *testing.T) chan api.CreateGrantRequest {
+		requestCh := make(chan api.CreateGrantRequest, 1)
+
+		handler := func(resp http.ResponseWriter, req *http.Request) {
+			query := req.URL.Query()
+
+			if requestMatches(req, http.MethodGet, "/v1/identities") {
+				resp.WriteHeader(http.StatusOK)
+				switch query.Get("name") {
+				case "existing@example.com":
+					writeResponse(t, resp, []api.Identity{{ID: 3000}})
+				case "existingMachine":
+					writeResponse(t, resp, []api.Identity{{ID: 3001}})
+				default:
+					writeResponse(t, resp, map[string]interface{}{})
+				}
+				return
+			}
+
+			if requestMatches(req, http.MethodGet, "/v1/groups") {
+				resp.WriteHeader(http.StatusOK)
+				if query.Get("name") == "existingGroup" {
+					writeResponse(t, resp, []api.Group{{ID: 4000}})
+					return
+				}
+				writeResponse(t, resp, map[string]interface{}{})
+				return
+			}
+
+			if !requestMatches(req, http.MethodPost, "/v1/grants") {
+				resp.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			defer close(requestCh)
+			var createReq api.CreateGrantRequest
+			err := json.NewDecoder(req.Body).Decode(&createReq)
+			assert.Check(t, err)
+
+			requestCh <- createReq
+			writeResponse(t, resp, api.Grant{ID: 7000})
+		}
+		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(srv.Close)
+
+		cfg := newTestClientConfig(srv, api.Identity{})
+		err := writeConfig(&cfg)
+		assert.NilError(t, err)
+		return requestCh
+	}
+
+	t.Run("add default role to existing identity", func(t *testing.T) {
+		ch := setup(t)
+		ctx := context.Background()
+		err := Run(ctx, "grants", "add", "existing@example.com", "the-destination")
+		assert.NilError(t, err)
+
+		createReq := <-ch
+		expected := api.CreateGrantRequest{
+			Subject:   "i:TJ",
+			Privilege: "connect",
+			Resource:  "the-destination",
+		}
+		assert.DeepEqual(t, createReq, expected)
+	})
+	t.Run("add role to existing identity", func(t *testing.T) {
+		ch := setup(t)
+		ctx := context.Background()
+		err := Run(ctx, "grants", "add", "existing@example.com", "the-destination", "--role", "role")
+		assert.NilError(t, err)
+
+		createReq := <-ch
+		expected := api.CreateGrantRequest{
+			Subject:   "i:TJ",
+			Privilege: "role",
+			Resource:  "the-destination",
+		}
+		assert.DeepEqual(t, createReq, expected)
+	})
+	t.Run("add role to existing machine identity", func(t *testing.T) {
+		ch := setup(t)
+		ctx := context.Background()
+		err := Run(ctx, "grants", "add", "existingMachine", "the-destination", "--role", "role")
+		assert.NilError(t, err)
+
+		createReq := <-ch
+		expected := api.CreateGrantRequest{
+			Subject:   "i:TK",
+			Privilege: "role",
+			Resource:  "the-destination",
+		}
+		assert.DeepEqual(t, createReq, expected)
+	})
+	t.Run("add role to existing group", func(t *testing.T) {
+		ch := setup(t)
+		ctx := context.Background()
+		err := Run(ctx,
+			"grants", "add", "existingGroup", "the-destination",
+			"--group", "--role", "role")
+		assert.NilError(t, err)
+
+		createReq := <-ch
+		expected := api.CreateGrantRequest{
+			Subject:   "g:2bY",
+			Privilege: "role",
+			Resource:  "the-destination",
+		}
+		assert.DeepEqual(t, createReq, expected)
+	})
+}
+
+func writeResponse(t *testing.T, resp io.Writer, body interface{}) {
+	t.Helper()
+	err := json.NewEncoder(resp).Encode(body)
+	assert.Check(t, err, "failed to write API response")
+}
+
+func TestGrantRemoveCmd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // for windows
+
+	setup := func(t *testing.T) chan string {
+		requestCh := make(chan string, 5)
+
+		handler := func(resp http.ResponseWriter, req *http.Request) {
+			query := req.URL.Query()
+
+			if requestMatches(req, http.MethodGet, "/v1/identities") {
+				resp.WriteHeader(http.StatusOK)
+				switch query.Get("name") {
+				case "existing@example.com":
+					writeResponse(t, resp, []api.Identity{{ID: 3000}})
+				case "existingMachine":
+					writeResponse(t, resp, []api.Identity{{ID: 3001}})
+				default:
+					writeResponse(t, resp, []api.Identity{})
+				}
+				return
+			}
+
+			if requestMatches(req, http.MethodGet, "/v1/groups") {
+				resp.WriteHeader(http.StatusOK)
+				if query.Get("name") == "existingGroup" {
+					writeResponse(t, resp, []api.Group{{ID: 4000}})
+					return
+				}
+				writeResponse(t, resp, map[string]interface{}{})
+				return
+			}
+
+			if requestMatches(req, http.MethodGet, "/v1/grants") {
+				resp.WriteHeader(http.StatusOK)
+				if query.Get("resource") != "the-destination" {
+					writeResponse(t, resp, []api.Grant{})
+					return
+				}
+
+				if query.Get("privilege") == "custom" {
+					switch query.Get("subject") {
+					case "i:TK": // ID=3001
+						writeResponse(t, resp, []api.Grant{{ID: 6001}, {ID: 6002}})
+					case "g:2bY": // ID=4000
+						writeResponse(t, resp, []api.Grant{{ID: 9001}, {ID: 9002}})
+					default:
+						writeResponse(t, resp, []api.Grant{})
+					}
+					return
+				}
+
+				if query.Get("privilege") != "" {
+					writeResponse(t, resp, []api.Grant{})
+					return
+				}
+
+				switch query.Get("subject") {
+				case "i:TJ": // ID=3000
+					writeResponse(t, resp, []api.Grant{{ID: 5001}, {ID: 5002}, {ID: 5003}})
+				case "g:2bY": // ID=4000
+					writeResponse(t, resp, []api.Grant{{ID: 7001}, {ID: 7002}})
+				default:
+					writeResponse(t, resp, []api.Grant{})
+				}
+				return
+			}
+
+			if requestMatchesPrefix(req, http.MethodDelete, "/v1/grants") {
+				resp.WriteHeader(http.StatusOK)
+
+				requestCh <- path.Base(req.URL.Path)
+				writeResponse(t, resp, map[string]interface{}{})
+				return
+			}
+
+			resp.WriteHeader(http.StatusInternalServerError)
+		}
+		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(srv.Close)
+
+		cfg := newTestClientConfig(srv, api.Identity{})
+		err := writeConfig(&cfg)
+		assert.NilError(t, err)
+		return requestCh
+	}
+
+	t.Run("remove default grants from identity", func(t *testing.T) {
+		ch := setup(t)
+		ctx := context.Background()
+		err := Run(ctx, "grants", "remove", "existing@example.com", "the-destination")
+		assert.NilError(t, err)
+
+		reqIDs := readChan(ch)
+		expected := []string{"2ue", "2uf", "2ug"}
+		assert.DeepEqual(t, reqIDs, expected)
+	})
+	t.Run("remove grant from identity", func(t *testing.T) {
+		ch := setup(t)
+		ctx := context.Background()
+		err := Run(ctx, "grants", "remove", "existingMachine", "the-destination", "--role", "custom")
+		assert.NilError(t, err)
+
+		reqIDs := readChan(ch)
+		expected := []string{"2Mt", "2Mu"}
+		assert.DeepEqual(t, reqIDs, expected)
+	})
+	t.Run("remove grant from group", func(t *testing.T) {
+		ch := setup(t)
+		ctx := context.Background()
+		err := Run(ctx,
+			"grants", "remove", "existingGroup", "the-destination",
+			"--group", "--role", "custom")
+		assert.NilError(t, err)
+
+		reqIDs := readChan(ch)
+		expected := []string{"3Fc", "3Fd"}
+		assert.DeepEqual(t, reqIDs, expected)
+	})
+}
+
+// readChan reads ch until there are no more buffered items
+func readChan(ch chan string) []string {
+	var items []string
+	for {
+		select {
+		case item := <-ch:
+			items = append(items, item)
+		default:
+			return items
+		}
+	}
+}
+
+func requestMatchesPrefix(req *http.Request, method string, path string) bool {
+	return req.Method == method && strings.HasPrefix(req.URL.Path, path)
+}

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -36,10 +36,6 @@ func newIdentitiesCmd() *cobra.Command {
 	return cmd
 }
 
-type addIdentityCmdOptions struct {
-	Password bool `mapstructure:"password"`
-}
-
 func newIdentitiesAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add IDENTITY",
@@ -54,11 +50,6 @@ EMAIL must contain a valid email address in the form of "local@domain".
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-
-			var options addIdentityCmdOptions
-			if err := parseOptions(cmd, &options, ""); err != nil {
-				return err
-			}
 
 			createResp, err := CreateIdentity(&api.CreateIdentityRequest{Name: name, SetOneTimePassword: true})
 			if err != nil {

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -125,20 +125,17 @@ func newKeysRemoveCmd() *cobra.Command {
 }
 
 type keyListOptions struct {
-	MachineName string `mapstructure:"machine"`
+	MachineName string
 }
 
 func newKeysListCmd() *cobra.Command {
+	var options keyListOptions
+
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List access keys",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var options keyListOptions
-			if err := parseOptions(cmd, &options, "INFRA_KEYS"); err != nil {
-				return err
-			}
-
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err
@@ -195,7 +192,7 @@ func newKeysListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("machine", "m", "", "The name of a machine to list access keys for")
+	cmd.Flags().StringVarP(&options.MachineName, "machine", "m", "", "The name of a machine to list access keys for")
 
 	return cmd
 }

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -34,6 +34,7 @@ func TestKeysAddCmd(t *testing.T) {
 				return
 			}
 
+			defer close(requestCh)
 			var createRequest api.CreateAccessKeyRequest
 			err := json.NewDecoder(req.Body).Decode(&createRequest)
 			assert.Check(t, err)
@@ -44,7 +45,6 @@ func TestKeysAddCmd(t *testing.T) {
 			})
 			assert.Check(t, err)
 			requestCh <- createRequest
-			close(requestCh)
 		}
 
 		srv := httptest.NewTLSServer(http.HandlerFunc(handler))

--- a/internal/cmd/providers_test.go
+++ b/internal/cmd/providers_test.go
@@ -6,59 +6,89 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/uid"
 )
 
-func TestProviders(t *testing.T) {
+func TestProvidersAddCmd(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 
-	setup := func(t *testing.T, handler func(http.ResponseWriter, *http.Request)) {
+	setup := func(t *testing.T) chan api.CreateProviderRequest {
+		requestCh := make(chan api.CreateProviderRequest, 1)
+
+		handler := func(resp http.ResponseWriter, req *http.Request) {
+			defer close(requestCh)
+			if !requestMatches(req, http.MethodPost, "/v1/providers") {
+				resp.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			var createRequest api.CreateProviderRequest
+			err := json.NewDecoder(req.Body).Decode(&createRequest)
+			assert.Check(t, err)
+
+			requestCh <- createRequest
+
+			_, _ = resp.Write([]byte(`{}`))
+		}
 		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
 		t.Cleanup(srv.Close)
 
 		cfg := newTestClientConfig(srv, api.Identity{})
 		err := writeConfig(&cfg)
 		assert.NilError(t, err)
+		return requestCh
 	}
 
-	t.Run("AddOktaProvider", func(t *testing.T) {
-		setup(t, func(resp http.ResponseWriter, req *http.Request) {
-			if req.Method == http.MethodPost && req.URL.Path == "/v1/providers" {
-				var createProviderRequest api.CreateProviderRequest
+	t.Run("okta provider with flags", func(t *testing.T) {
+		ch := setup(t)
 
-				err := json.NewDecoder(req.Body).Decode(&createProviderRequest)
-				assert.NilError(t, err)
-
-				assert.Check(t, "okta" == createProviderRequest.Name)
-				assert.Check(t, "okta-url" == createProviderRequest.URL)
-				assert.Check(t, "okta-client-id" == createProviderRequest.ClientID)
-				assert.Check(t, "okta-client-secret" == createProviderRequest.ClientSecret)
-
-				provider := api.Provider{
-					ID:       uid.New(),
-					Name:     createProviderRequest.Name,
-					Created:  api.Time(time.Now()),
-					Updated:  api.Time(time.Now()),
-					URL:      createProviderRequest.URL,
-					ClientID: createProviderRequest.ClientID,
-				}
-
-				bytes, err := json.Marshal(&provider)
-				assert.NilError(t, err)
-
-				_, err = resp.Write(bytes)
-				assert.NilError(t, err)
-			}
-		})
-
-		err := Run(context.Background(), "providers", "add", "okta", "--url", "okta-url", "--client-id", "okta-client-id", "--client-secret", "okta-client-secret")
+		err := Run(context.Background(),
+			"providers", "add", "okta",
+			"--url", "https://okta.com/path",
+			"--client-id", "okta-client-id",
+			"--client-secret", "okta-client-secret",
+		)
 		assert.NilError(t, err)
+
+		createProviderRequest := <-ch
+
+		expected := api.CreateProviderRequest{
+			Name:         "okta",
+			URL:          "https://okta.com/path",
+			ClientID:     "okta-client-id",
+			ClientSecret: "okta-client-secret",
+		}
+		assert.DeepEqual(t, createProviderRequest, expected)
+	})
+
+	t.Run("okta provider with env vars", func(t *testing.T) {
+		ch := setup(t)
+
+		t.Setenv("INFRA_PROVIDER_URL", "https://okta.com/path")
+		t.Setenv("INFRA_PROVIDER_CLIENT_ID", "okta-client-id")
+		t.Setenv("INFRA_PROVIDER_CLIENT_SECRET", "okta-client-secret")
+
+		err := Run(context.Background(), "providers", "add", "okta")
+		assert.NilError(t, err)
+
+		createProviderRequest := <-ch
+
+		expected := api.CreateProviderRequest{
+			Name:         "okta",
+			URL:          "https://okta.com/path",
+			ClientID:     "okta-client-id",
+			ClientSecret: "okta-client-secret",
+		}
+		assert.DeepEqual(t, createProviderRequest, expected)
+	})
+
+	t.Run("missing require flags", func(t *testing.T) {
+		err := Run(context.Background(), "providers", "add", "okta")
+		assert.ErrorContains(t, err, "missing value for required flags: url, client-id, client-secret")
 	})
 }

--- a/uid/snowflake.go
+++ b/uid/snowflake.go
@@ -68,6 +68,7 @@ func (u *ID) UnmarshalText(b []byte) error {
 	return nil
 }
 
-func (u *ID) MarshalText() ([]byte, error) {
+// TODO: test cases
+func (u ID) MarshalText() ([]byte, error) {
 	return []byte(u.String()), nil
 }


### PR DESCRIPTION
Branched from #1655, and includes a commit with #1667, so those two will probably need to merge first

## Summary

Converts the remaining "interactive" (short lived) CLI commands to remove the calls to `parseOptions`. The only two calls that are left are for the "long running" commands (`server` and `connector`) which will need a different approach.

Also adds some tests for the commands that changes, to show the options are passed to the API correctly. 