### PR TITLE
improve: remove NotCreatedBy system filter for grants list

### DIFF
--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -14,7 +14,7 @@ func GetGrant(c *gin.Context, id uid.ID) (*models.Grant, error) {
 		return nil, err
 	}
 
-	return data.GetGrant(db, data.ByID(id), data.NotCreatedBy(models.CreatedBySystem))
+	return data.GetGrant(db, data.ByID(id))
 }
 
 func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, privilege string) ([]models.Grant, error) {
@@ -23,7 +23,10 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 		return nil, err
 	}
 
-	return data.ListGrants(db, data.ByOptionalSubject(subject), data.ByOptionalResource(resource), data.ByOptionalPrivilege(privilege), data.NotCreatedBy(models.CreatedBySystem))
+	return data.ListGrants(db,
+		data.ByOptionalSubject(subject),
+		data.ByOptionalResource(resource),
+		data.ByOptionalPrivilege(privilege))
 }
 
 func ListIdentityGrants(c *gin.Context, identityID uid.ID) ([]models.Grant, error) {

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -64,6 +64,7 @@ func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
 		Subject:   uid.NewIdentityPolymorphicID(identity.ID),
 		Privilege: models.InfraAdminRole,
 		Resource:  "infra",
+		CreatedBy: models.CreatedBySystem,
 	}
 
 	if err := data.CreateGrant(db, grant); err != nil {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -559,6 +559,7 @@ func (s *Server) setupInternalInfraIdentity(name, role string) (*models.Identity
 			Subject:   id.PolyID(),
 			Privilege: role,
 			Resource:  models.InternalInfraProviderName,
+			CreatedBy: models.CreatedBySystem,
 		}
 
 		err = data.CreateGrant(s.db, grant)

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -30,12 +30,12 @@ func GetGrant(db *gorm.DB, selectors ...SelectorFunc) (*models.Grant, error) {
 
 func ListIdentityGrants(db *gorm.DB, userID uid.ID) (result []models.Grant, err error) {
 	polymorphicID := uid.NewIdentityPolymorphicID(userID)
-	return ListGrants(db, ByOptionalSubject(polymorphicID), NotCreatedBy(models.CreatedBySystem))
+	return ListGrants(db, ByOptionalSubject(polymorphicID))
 }
 
 func ListGroupGrants(db *gorm.DB, groupID uid.ID) (result []models.Grant, err error) {
 	polymorphicID := uid.NewGroupPolymorphicID(groupID)
-	return ListGrants(db, ByOptionalSubject(polymorphicID), NotCreatedBy(models.CreatedBySystem))
+	return ListGrants(db, ByOptionalSubject(polymorphicID))
 }
 
 func ListGrants(db *gorm.DB, selectors ...SelectorFunc) ([]models.Grant, error) {


### PR DESCRIPTION
## Summary

Show all grants when listing grants. This was fixed on the CLI side in #1533.

I kept the filter for `DeleteGrants` for now. I wanted to handle it explicitly with a more specific error, but that would break `infra grant delete` because it iterates over all grants. I think we should revisit that separately, it works well for now.

I tested it manually and saw this:

```
$ infra grant list
  IDENTITY   ACCESS     DESTINATION  
  admin      admin      infra        
  connector  connector  infra        
```

To automate a test for this we need more of an integration test (with both CLI and a real API) and some way to capture the stdout of the CLI. We don't have a pattern for that yet, but it's something I'm going to look at adding soon.

## Checklist

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

Resolves #1669
