### PR TITLE
cli: add 'no args' validator to commands

### DIFF
--- a/internal/cmd/about.go
+++ b/internal/cmd/about.go
@@ -20,9 +20,10 @@ func newAboutCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:    "about",
 		Short:  "Display information about Infra",
+		Args:   NoArgs,
 		Group:  "Other commands:",
 		Hidden: false,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return about()
 		},
 	}

--- a/internal/cmd/args.go
+++ b/internal/cmd/args.go
@@ -47,3 +47,16 @@ func MaxArgs(max int) cobra.PositionalArgs {
 			cmd.UseLine())
 	}
 }
+
+// NoArgs validates that a cobra command is executed with no arguments, otherwise
+// it returns an error that includes the usage string.
+func NoArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%q accepts no arguments.\nSee \"%s --help\".\n\nUsage:  %s\n",
+		cmd.CommandPath(),
+		cmd.CommandPath(),
+		cmd.UseLine())
+}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -275,8 +275,9 @@ func newConnectorCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "connector",
 		Short:  "Start the Infra connector",
+		Args:   NoArgs,
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			logging.SetServerLogger()
 
 			// override default strcase.ToLowerCamel behaviour

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -33,7 +33,8 @@ func newDestinationsListCmd() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List connected destinations",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:    NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -48,7 +48,8 @@ func newGrantsListCmd() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List grants",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:    NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -124,7 +124,8 @@ func newIdentitiesListCmd() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List all identities",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:    NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -15,8 +15,9 @@ func newInfoCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:    "info",
 		Short:  "Display the info about the current session",
+		Args:   NoArgs,
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := mustBeLoggedIn(); err != nil {
 				return err
 			}

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -135,7 +135,8 @@ func newKeysListCmd() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List access keys",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:    NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -15,6 +15,7 @@ func newListCmd() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List accessible destinations",
+		Args:    NoArgs,
 		Group:   "Core commands:",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -37,7 +37,8 @@ func newProvidersListCmd() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List connected identity providers",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:    NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -16,8 +16,9 @@ func newServerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "server",
 		Short:  "Start Infra server",
+		Args:   NoArgs,
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			logging.SetServerLogger()
 
 			if err := parseOptions(cmd, &options, "INFRA_SERVER"); err != nil {

--- a/internal/cmd/tokens.go
+++ b/internal/cmd/tokens.go
@@ -32,7 +32,8 @@ func newTokensAddCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "add",
 		Short: "Create a token",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:  NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := tokensCreate(); err != nil {
 				return err
 			}

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -17,7 +17,8 @@ func newVersionCmd() *cobra.Command {
 		Use:    "version",
 		Short:  "Display the Infra version",
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:   NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return version()
 		},
 	}


### PR DESCRIPTION
## Summary

So that if a user accidentally runs a command with positional
arguments, they get feedback about it. Without this, commands can be
misleading because they would print unexpected output when the user
forgets to add a flag.

Builds on #1674