### PR TITLE
Add safeguard for CLI tests

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -15,6 +16,15 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/uid"
 )
+
+func TestMain(m *testing.M) {
+	// Many tests in this package will modify the home directory. Every test
+	// should call t.Setenv, but as a safeguard setup some env vars.
+	_ = os.Setenv("HOME", "/this test forgot to t.SetEnv(HOME, ...)")
+	_ = os.Setenv("USERPROFILE", "/this test forgot to t.SetEnv(USERPROFILE, ...)")
+	_ = os.Setenv("KUBECONFIG", "/this test forgot to t.SetEnv(KUBECONFIG, ...)")
+	os.Exit(m.Run())
+}
 
 func TestUse(t *testing.T) {
 	home := t.TempDir()

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestKeysAddCmd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // for windows
+
 	setup := func(t *testing.T) chan api.CreateAccessKeyRequest {
 		requestCh := make(chan api.CreateAccessKeyRequest, 1)
 


### PR DESCRIPTION
## Summary

I was wondering why my `~/.infra/config` always had unexpected servers in it. It turns out it was because I forgot to call `t.SetEnv()` in one test case.

This PR fixes the test where I missed it, and adds a safeguard to `TestMain`. With this safeguard, any test that tries to write to a file in `HOME`, or `KUBECONFIG` will fail with a helpful error message.

I tested this on linux, and darwin, hopefully it works the same way on windows.