### PR TITLE
fix: do not look up k8s name when provided

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -306,13 +306,18 @@ func Run(ctx context.Context, options Options) error {
 		return err
 	}
 
-	autoname, chksm, err := k8s.Name()
+	chksm, err := k8s.Checksum()
 	if err != nil {
-		logging.S.Errorf("k8s name error: %s", err)
+		logging.S.Errorf("k8s checksum error: %s", err)
 		return err
 	}
 
 	if options.Name == "" {
+		autoname, err := k8s.Name(chksm)
+		if err != nil {
+			logging.S.Errorf("k8s name error: %s", err)
+			return err
+		}
 		options.Name = autoname
 	}
 


### PR DESCRIPTION
- separate checksum lookup and autoname functions

## Summary
If the name is provided for the kubernetes connector we don't need to do the name look-up. Separate the function so that we can skip this and still get the checksum.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1308
