### PR TITLE
cli: support testing the stdout produced by CLI commands

### DIFF
--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+)
+
+// CLI exposes common dependencies to commands.
+type CLI struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Output a string to CLI.Stdout. Output is like fmt.Printf except that it always
+// adds a trailing newline.
+// To write output without a trailing newline use CLI.Stdout directly.
+func (c *CLI) Output(format string, args ...interface{}) {
+	fmt.Fprintf(c.Stdout, format+"\n", args...)
+}
+
+// TODO indicates a place where os.Stdout is being used instead of CLI.Stdout.
+// It is temporary, and can be removed once everything is ported to use CLI
+// for output.
+var TODO = os.Stdout
+
+// key is a type to ensure no other package can access the CLI value in context.
+type key struct{}
+
+// ctxKey used to store CLI in the context.
+var ctxKey = key{}
+
+// newCli looks for a CLI stores in context. If one exists, the CLI from
+// context is returned, otherwise a new CLI is created with streams set to the
+// standard input and output streams.
+//
+// newCLI is a shim for testing, allowing tests to use a buffer instead of the
+// standard streams.
+func newCLI(ctx context.Context) *CLI {
+	cli, ok := ctx.Value(ctxKey).(*CLI)
+	if ok {
+		return cli
+	}
+	return &CLI{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}

--- a/internal/cmd/cli_test.go
+++ b/internal/cmd/cli_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+)
+
+// PatchCLI returns a context which contains a CLI value with the output streams
+// set to buffers. PatchCLI is used by tests to record the output produced by
+// CLI commands.
+func PatchCLI(ctx context.Context) (context.Context, BufferedStreams) {
+	bufs := BufferedStreams{
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+	}
+	cli := &CLI{
+		Stdout: io.MultiWriter(bufs.Stdout, os.Stdout),
+		Stderr: io.MultiWriter(bufs.Stderr, os.Stderr),
+		Stdin:  os.Stdin,
+	}
+	return context.WithValue(ctx, ctxKey, cli), bufs
+}
+
+type BufferedStreams struct {
+	Stdout *bytes.Buffer
+	Stderr *bytes.Buffer
+}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -31,7 +32,8 @@ import (
 // Run the main CLI command with the given args. The args should not contain
 // the name of the binary (ex: os.Args[1:]).
 func Run(ctx context.Context, args ...string) error {
-	cmd := NewRootCmd()
+	cli := newCLI(ctx)
+	cmd := NewRootCmd(cli)
 	cmd.SetArgs(args)
 	return cmd.ExecuteContext(ctx)
 }
@@ -140,8 +142,8 @@ func infraHomeDir() (string, error) {
 	return infraDir, nil
 }
 
-func printTable(data interface{}) {
-	table := tableprinter.New(os.Stdout)
+func printTable(data interface{}, out io.Writer) {
+	table := tableprinter.New(out)
 
 	table.HeaderAlignment = tableprinter.AlignLeft
 	table.AutoWrapText = false
@@ -318,7 +320,7 @@ type rootOptions struct {
 	Version bool
 }
 
-func NewRootCmd() *cobra.Command {
+func NewRootCmd(cli *CLI) *cobra.Command {
 	cobra.EnableCommandSorting = false
 	var rootOpts rootOptions
 
@@ -357,7 +359,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newDestinationsCmd())
 	rootCmd.AddCommand(newGrantsCmd())
 	rootCmd.AddCommand(newIdentitiesCmd())
-	rootCmd.AddCommand(newKeysCmd())
+	rootCmd.AddCommand(newKeysCmd(cli))
 	rootCmd.AddCommand(newProvidersCmd())
 
 	// Hidden

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -59,7 +59,7 @@ func newDestinationsListCmd() *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows)
+				printTable(rows, TODO)
 			} else {
 				fmt.Println("No destinations found")
 			}

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -81,7 +81,7 @@ func newGrantsListCmd() *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows)
+				printTable(rows, TODO)
 			} else {
 				fmt.Println("No grants found")
 			}

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -159,7 +159,7 @@ func newIdentitiesListCmd() *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows)
+				printTable(rows, TODO)
 			} else {
 				fmt.Println("No identities found")
 			}

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -12,7 +12,7 @@ import (
 
 const ThirtyDays = 30 * (24 * time.Hour)
 
-func newKeysCmd() *cobra.Command {
+func newKeysCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "keys",
 		Short:   "Manage access keys",
@@ -26,7 +26,7 @@ func newKeysCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newKeysListCmd())
+	cmd.AddCommand(newKeysListCmd(cli))
 	cmd.AddCommand(newKeysAddCmd())
 	cmd.AddCommand(newKeysRemoveCmd())
 
@@ -128,7 +128,7 @@ type keyListOptions struct {
 	MachineName string
 }
 
-func newKeysListCmd() *cobra.Command {
+func newKeysListCmd(cli *CLI) *cobra.Command {
 	var options keyListOptions
 
 	cmd := &cobra.Command{
@@ -184,9 +184,9 @@ func newKeysListCmd() *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows)
+				printTable(rows, cli.Stdout)
 			} else {
-				fmt.Println("No access keys found")
+				cli.Output("No access keys found")
 			}
 
 			return nil

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/uid"
@@ -25,6 +26,10 @@ func TestKeysAddCmd(t *testing.T) {
 		handler := func(resp http.ResponseWriter, req *http.Request) {
 			// the command does a lookup for machine ID
 			if requestMatches(req, http.MethodGet, "/v1/identities") {
+				if req.URL.Query().Get("name") != "my-machine" {
+					resp.WriteHeader(http.StatusBadRequest)
+					return
+				}
 				resp.WriteHeader(http.StatusOK)
 				err := json.NewEncoder(resp).Encode([]*api.Identity{
 					{ID: uid.ID(12345678)},
@@ -87,4 +92,103 @@ func TestKeysAddCmd(t *testing.T) {
 
 func requestMatches(req *http.Request, method string, path string) bool {
 	return req.Method == method && req.URL.Path == path
+}
+
+func TestKeysListCmd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // for windows
+
+	base := time.Now().Add(-24 * time.Hour)
+
+	setup := func(t *testing.T) {
+		handler := func(resp http.ResponseWriter, req *http.Request) {
+			query := req.URL.Query()
+
+			// the command does a lookup for machine ID
+			if requestMatches(req, http.MethodGet, "/v1/identities") {
+				if query.Get("name") != "my-machine" {
+					resp.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				resp.WriteHeader(http.StatusOK)
+				err := json.NewEncoder(resp).Encode([]*api.Identity{
+					{ID: uid.ID(12345678)},
+				})
+				assert.Check(t, err)
+				return
+			}
+
+			if !requestMatches(req, http.MethodGet, "/v1/access-keys") {
+				resp.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			resp.WriteHeader(http.StatusOK)
+			if query.Get("identity_id") == uid.ID(12345678).String() {
+				err := json.NewEncoder(resp).Encode([]api.AccessKey{
+					{
+						Name:          "machine-key",
+						IssuedFor:     uid.ID(12345678),
+						IssuedForName: "my-machine",
+						Created:       api.Time(base.Add(5 * time.Minute)),
+						Expires:       api.Time(base.Add(30 * time.Hour)),
+					},
+				})
+				assert.Check(t, err)
+				return
+			}
+			err := json.NewEncoder(resp).Encode([]api.AccessKey{
+				{
+					Name:          "front-door",
+					IssuedFor:     uid.ID(12345),
+					IssuedForName: "admin",
+					Created:       api.Time(base.Add(time.Minute)),
+				},
+				{
+					Name:              "side-door",
+					IssuedFor:         uid.ID(12345),
+					IssuedForName:     "admin",
+					Created:           api.Time(base.Add(time.Minute)),
+					Expires:           api.Time(base.Add(30 * time.Hour)),
+					ExtensionDeadline: api.Time(base.Add(50 * time.Hour)),
+				},
+				{
+					Name:          "storage",
+					IssuedFor:     uid.ID(12349),
+					IssuedForName: "clerk",
+					Created:       api.Time(base.Add(4 * time.Hour)),
+					Expires:       api.Time(base.Add(30 * time.Hour)),
+				},
+			})
+			assert.Check(t, err)
+		}
+
+		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(srv.Close)
+
+		cfg := newTestClientConfig(srv, api.Identity{})
+		err := writeConfig(&cfg)
+		assert.NilError(t, err)
+	}
+
+	t.Run("list all", func(t *testing.T) {
+		setup(t)
+		ctx, bufs := PatchCLI(context.Background())
+
+		err := Run(ctx, "keys", "list")
+		assert.NilError(t, err)
+
+		golden.Assert(t, bufs.Stdout.String(), t.Name())
+	})
+
+	t.Run("filter by machine name", func(t *testing.T) {
+		setup(t)
+		ctx, bufs := PatchCLI(context.Background())
+
+		err := Run(ctx, "keys", "list", "--machine", "my-machine")
+		assert.NilError(t, err)
+
+		golden.Assert(t, bufs.Stdout.String(), t.Name())
+	})
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -133,7 +133,7 @@ func list() error {
 	}
 
 	if len(rows) > 0 {
-		printTable(rows)
+		printTable(rows, TODO)
 	} else {
 		fmt.Println("You have not been granted access to any active destinations")
 	}

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -60,7 +60,7 @@ func newProvidersListCmd() *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows)
+				printTable(rows, TODO)
 			} else {
 				fmt.Println("No providers found")
 			}

--- a/internal/cmd/testdata/TestKeysListCmd/filter_by_machine_name
+++ b/internal/cmd/testdata/TestKeysListCmd/filter_by_machine_name
@@ -1,0 +1,2 @@
+  NAME         ISSUED FOR  CREATED       EXPIRES           EXTENSION DEADLINE  
+  machine-key  my-machine  24 hours ago  6 hours from now  never               

--- a/internal/cmd/testdata/TestKeysListCmd/list_all
+++ b/internal/cmd/testdata/TestKeysListCmd/list_all
@@ -1,0 +1,4 @@
+  NAME        ISSUED FOR  CREATED       EXPIRES           EXTENSION DEADLINE  
+  front-door  admin       24 hours ago  never             never               
+  side-door   admin       24 hours ago  6 hours from now  tomorrow            
+  storage     clerk       20 hours ago  6 hours from now  never               

--- a/internal/docgen/main.go
+++ b/internal/docgen/main.go
@@ -15,7 +15,7 @@ func main() {
 	}
 	defer f.Close()
 
-	rootCmd := cmd.NewRootCmd()
+	rootCmd := cmd.NewRootCmd(nil)
 	err = GenMarkdownFile(rootCmd, f)
 	if err != nil {
 		log.Println(err.Error())


### PR DESCRIPTION
## Summary

One of the primary responsibilities of the CLI is to output things in a format that is easy for humans to consume. We should have some test coverage of that output, to prevent regressions. When we intentionally make change to the output it also gives us an easy way to preview the changes by looking at the tests.

This PR implements an approach that I've used previously to test CLI output.
1. the first commit adds a `CLI` type for passing around input and output streams. I think it's likely we'll add more fields to this type in the future. The `api.Client` could be one of the fields, common CLI flags that may be used in multiple commands is another one.
2. the second commit adds a test for `infra keys list` that uses the support added in 1

This PR uses [golden files](https://softwareengineering.stackexchange.com/a/358792) (called [Output comparison testing in wikipedia](https://en.wikipedia.org/wiki/Software_testing#Output_comparison_testing)) to store the expected values. Golden files are nice because:
* they are strict about the expected output
* they allow both the contributor and reviewers to easily see what the output will look like
* they are easy to update when they change

To update a golden file, run `go test ./internal/cmd -test.update-golden`, then look at the `git diff` to make sure the change is what you expect.
