### PR TITLE
fix: hide `revoke` button for self in settings > admins

### DIFF
--- a/ui/lib/admin.js
+++ b/ui/lib/admin.js
@@ -6,7 +6,6 @@ export function useAdmin () {
 
   return {
     loading: !grants && !grantsError,
-    admin: !!grants?.find(g => g.privilege === 'admin'),
-    auth: auth
+    admin: !!grants?.find(g => g.privilege === 'admin')
   }
 }

--- a/ui/lib/admin.js
+++ b/ui/lib/admin.js
@@ -6,6 +6,7 @@ export function useAdmin () {
 
   return {
     loading: !grants && !grantsError,
-    admin: !!grants?.find(g => g.privilege === 'admin')
+    admin: !!grants?.find(g => g.privilege === 'admin'),
+    auth: auth
   }
 }

--- a/ui/pages/settings/admin.js
+++ b/ui/pages/settings/admin.js
@@ -3,6 +3,7 @@ import useSWR, { useSWRConfig } from 'swr'
 import { useTable } from 'react-table'
 
 import { validateEmail } from '../../lib/email'
+import { useAdmin } from '../../lib/admin'
 
 import InputDropdown from '../../components/input'
 import Table from '../../components/table'
@@ -21,14 +22,17 @@ const columns = [{
   Cell: ({ value: admin, rows }) => {
     const { data: user } = useSWR(`/v1/identities/${admin.subject.replace('i:', '')}`, { fallbackData: { name: '', kind: '' } })
     const { mutate } = useSWRConfig()
+    const { auth } = useAdmin()
 
     const [open, setOpen] = useState(false)
+    
+    const isSelf = admin.subject.replace('i:', '') === auth.id
 
     return (
       <div className='opacity-0 group-hover:opacity-100 flex justify-end text-right'>
-        <button onClick={() => setOpen(true)} className='p-2 -mr-2 cursor-pointer text-gray-500 hover:text-white'>
+        {!isSelf && <button onClick={() => setOpen(true)} className='p-2 -mr-2 cursor-pointer text-gray-500 hover:text-white'>
           Revoke
-        </button>
+        </button>}
         <DeleteModal
           open={open}
           setOpen={setOpen}
@@ -139,7 +143,7 @@ export default function () {
           onSubmit={() => handleAddAdmin()}
           disabled={adminEmail.length === 0}
           type='submit'
-          className='bg-gradient-to-tr from-indigo-300 to-pink-100 hover:from-indigo-200 hover:to-pink-50 p-0.5 mx-auto rounded-full'
+          className='bg-gradient-to-tr from-indigo-300 to-pink-100 hover:from-indigo-200 hover:to-pink-50 p-0.5 mx-auto rounded-full disabled:opacity-30'
         >
           <div className='bg-black flex items-center text-sm px-14 py-3 rounded-full'>
             Add

--- a/ui/pages/settings/admin.js
+++ b/ui/pages/settings/admin.js
@@ -3,7 +3,6 @@ import useSWR, { useSWRConfig } from 'swr'
 import { useTable } from 'react-table'
 
 import { validateEmail } from '../../lib/email'
-import { useAdmin } from '../../lib/admin'
 
 import InputDropdown from '../../components/input'
 import Table from '../../components/table'
@@ -21,8 +20,9 @@ const columns = [{
   accessor: a => a,
   Cell: ({ value: admin, rows }) => {
     const { data: user } = useSWR(`/v1/identities/${admin.subject.replace('i:', '')}`, { fallbackData: { name: '', kind: '' } })
+    const { data: auth } = useSWR('/v1/introspect')
     const { mutate } = useSWRConfig()
-    const { auth } = useAdmin()
+
 
     const [open, setOpen] = useState(false)
     


### PR DESCRIPTION
## Summary
1. hide revoke button for self in the admins page
2. disable add button when there is no input

## Related Issues
Resolves #1685 
