### PR TITLE
improve: generalize oidc client config

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -204,8 +204,8 @@ func (o *mockOIDCImplementation) RefreshAccessToken(providerUser *models.Provide
 	return string(providerUser.AccessToken), &providerUser.ExpiresAt, nil
 }
 
-func (m *mockOIDCImplementation) GetUserInfo(providerUser *models.ProviderUser) (*authn.UserInfo, error) {
-	return &authn.UserInfo{Email: m.UserEmailResp, Groups: m.UserGroupsResp}, nil
+func (m *mockOIDCImplementation) GetUserInfo(providerUser *models.ProviderUser) (*authn.InfoClaims, error) {
+	return &authn.InfoClaims{Email: m.UserEmailResp, Groups: m.UserGroupsResp}, nil
 }
 
 func TestExchangeAuthCodeForProviderTokens(t *testing.T) {

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -101,7 +101,7 @@ func ListIdentities(c *gin.Context, name string, ids []uid.ID) ([]models.Identit
 }
 
 // UpdateUserInfoFromProvider calls the user info endpoint of an external identity provider to see a user's current attributes
-func UpdateUserInfoFromProvider(c *gin.Context, info *authn.UserInfo, user *models.Identity, provider *models.Provider) error {
+func UpdateUserInfoFromProvider(c *gin.Context, info *authn.InfoClaims, user *models.Identity, provider *models.Provider) error {
 	// no auth, this is not publically exposed
 	db := getDB(c)
 

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -85,7 +85,7 @@ func InfraProvider(c *gin.Context) *models.Provider {
 }
 
 func ExchangeAuthCodeForAccessKey(c *gin.Context, code string, provider *models.Provider, oidc authn.OIDC, expires time.Time, redirectURL string) (*models.Identity, string, error) {
-	// does not need authorization check, this function should only be called internally
+	// does not need authorization check, this function should only be called internally during login (login is a public endpoint)
 	db := getDB(c)
 
 	// exchange code for tokens from identity provider (these tokens are for the IDP, not Infra)


### PR DESCRIPTION
- set auth URL from provider well known endpoint
- make user info endpoint dynamic

## Summary
OIDC Provider clients make some assumptions about the endpoints they should be connecting based on the Okta endpoints. We can prepare for general OIDC by automatically finding these endpoints at the `.well-known/openid-configuration` endpoint that OIDC providers publicly expose.

This change does not have any impact on the current user experience or backwards compatibility.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1703
