### PR TITLE
Use CLI.Stdout more consistently

### DIFF
--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -21,11 +21,6 @@ func (c *CLI) Output(format string, args ...interface{}) {
 	fmt.Fprintf(c.Stdout, format+"\n", args...)
 }
 
-// TODO indicates a place where os.Stdout is being used instead of CLI.Stdout.
-// It is temporary, and can be removed once everything is ported to use CLI
-// for output.
-var TODO = os.Stdout
-
 // key is a type to ensure no other package can access the CLI value in context.
 type key struct{}
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -196,7 +196,7 @@ func apiClient(host string, accessKey string, skipTLSVerify bool) (*api.Client, 
 	}, nil
 }
 
-func newUseCmd() *cobra.Command {
+func newUseCmd(_ *CLI) *cobra.Command {
 	return &cobra.Command{
 		Use:   "use DESTINATION",
 		Short: "Access a destination",
@@ -326,13 +326,13 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if rootOpts.Version {
-				return version()
+				return version(cli)
 			}
 			if rootOpts.Info {
 				if err := mustBeLoggedIn(); err != nil {
 					return fmt.Errorf("login check: %w", err)
 				}
-				if err := info(); err != nil {
+				if err := info(cli); err != nil {
 					return fmt.Errorf("info: %w", err)
 				}
 				return nil
@@ -342,10 +342,10 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 	}
 
 	// Core commands:
-	rootCmd.AddCommand(newLoginCmd())
-	rootCmd.AddCommand(newLogoutCmd())
+	rootCmd.AddCommand(newLoginCmd(cli))
+	rootCmd.AddCommand(newLogoutCmd(cli))
 	rootCmd.AddCommand(newListCmd(cli))
-	rootCmd.AddCommand(newUseCmd())
+	rootCmd.AddCommand(newUseCmd(cli))
 
 	// Management commands:
 	rootCmd.AddCommand(newDestinationsCmd(cli))
@@ -355,11 +355,11 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 	rootCmd.AddCommand(newProvidersCmd(cli))
 
 	// Hidden
-	rootCmd.AddCommand(newTokensCmd())
-	rootCmd.AddCommand(newInfoCmd())
+	rootCmd.AddCommand(newTokensCmd(cli))
+	rootCmd.AddCommand(newInfoCmd(cli))
 	rootCmd.AddCommand(newServerCmd())
 	rootCmd.AddCommand(newConnectorCmd())
-	rootCmd.AddCommand(newVersionCmd())
+	rootCmd.AddCommand(newVersionCmd(cli))
 
 	rootCmd.Flags().BoolVar(&rootOpts.Version, "version", false, "Display Infra version")
 	rootCmd.Flags().BoolVar(&rootOpts.Info, "info", false, "Display info about the current logged in session")

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -344,15 +344,15 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 	// Core commands:
 	rootCmd.AddCommand(newLoginCmd())
 	rootCmd.AddCommand(newLogoutCmd())
-	rootCmd.AddCommand(newListCmd())
+	rootCmd.AddCommand(newListCmd(cli))
 	rootCmd.AddCommand(newUseCmd())
 
 	// Management commands:
-	rootCmd.AddCommand(newDestinationsCmd())
-	rootCmd.AddCommand(newGrantsCmd())
-	rootCmd.AddCommand(newIdentitiesCmd())
+	rootCmd.AddCommand(newDestinationsCmd(cli))
+	rootCmd.AddCommand(newGrantsCmd(cli))
+	rootCmd.AddCommand(newIdentitiesCmd(cli))
 	rootCmd.AddCommand(newKeysCmd(cli))
-	rootCmd.AddCommand(newProvidersCmd())
+	rootCmd.AddCommand(newProvidersCmd(cli))
 
 	// Hidden
 	rootCmd.AddCommand(newTokensCmd())

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -8,7 +8,7 @@ import (
 	"github.com/infrahq/infra/api"
 )
 
-func newDestinationsCmd() *cobra.Command {
+func newDestinationsCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "destinations",
 		Aliases: []string{"dst", "dest", "destination"},
@@ -22,13 +22,13 @@ func newDestinationsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newDestinationsListCmd())
+	cmd.AddCommand(newDestinationsListCmd(cli))
 	cmd.AddCommand(newDestinationsRemoveCmd())
 
 	return cmd
 }
 
-func newDestinationsListCmd() *cobra.Command {
+func newDestinationsListCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -59,9 +59,9 @@ func newDestinationsListCmd() *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows, TODO)
+				printTable(rows, cli.Stdout)
 			} else {
-				fmt.Println("No destinations found")
+				cli.Output("No destinations found")
 			}
 
 			return nil

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -35,8 +35,8 @@ func newGrantsCmd(cli *CLI) *cobra.Command {
 	}
 
 	cmd.AddCommand(newGrantsListCmd(cli))
-	cmd.AddCommand(newGrantAddCmd())
-	cmd.AddCommand(newGrantRemoveCmd())
+	cmd.AddCommand(newGrantAddCmd(cli))
+	cmd.AddCommand(newGrantRemoveCmd(cli))
 
 	return cmd
 }
@@ -94,7 +94,7 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 	return cmd
 }
 
-func newGrantRemoveCmd() *cobra.Command {
+func newGrantRemoveCmd(cli *CLI) *cobra.Command {
 	var options grantsCmdOptions
 
 	cmd := &cobra.Command{
@@ -118,7 +118,7 @@ $ infra grants remove janedoe@example.com infra --role admin
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.Identity = args[0]
 			options.Destination = args[1]
-			return removeGrant(options)
+			return removeGrant(cli, options)
 		},
 	}
 
@@ -127,7 +127,7 @@ $ infra grants remove janedoe@example.com infra --role admin
 	return cmd
 }
 
-func removeGrant(cmdOptions grantsCmdOptions) error {
+func removeGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 	client, err := defaultAPIClient()
 	if err != nil {
 		return err
@@ -159,12 +159,12 @@ func removeGrant(cmdOptions grantsCmdOptions) error {
 		}
 	}
 
-	fmt.Println("Access revoked!")
+	cli.Output("Access revoked!")
 
 	return nil
 }
 
-func newGrantAddCmd() *cobra.Command {
+func newGrantAddCmd(cli *CLI) *cobra.Command {
 	var options grantsCmdOptions
 
 	cmd := &cobra.Command{
@@ -187,7 +187,7 @@ $ infra grants add johndoe@example.com infra --role admin
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.Identity = args[0]
 			options.Destination = args[1]
-			return addGrant(options)
+			return addGrant(cli, options)
 		},
 	}
 
@@ -196,7 +196,7 @@ $ infra grants add johndoe@example.com infra --role admin
 	return cmd
 }
 
-func addGrant(cmdOptions grantsCmdOptions) error {
+func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 	client, err := defaultAPIClient()
 	if err != nil {
 		return err
@@ -227,7 +227,7 @@ func addGrant(cmdOptions grantsCmdOptions) error {
 		return err
 	}
 
-	fmt.Println("Access granted!")
+	cli.Output("Access granted!")
 
 	return nil
 }

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -20,7 +20,7 @@ type grantsCmdOptions struct {
 	Role        string
 }
 
-func newGrantsCmd() *cobra.Command {
+func newGrantsCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "grants",
 		Short:   "Manage access to destinations",
@@ -34,14 +34,14 @@ func newGrantsCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newGrantsListCmd())
+	cmd.AddCommand(newGrantsListCmd(cli))
 	cmd.AddCommand(newGrantAddCmd())
 	cmd.AddCommand(newGrantRemoveCmd())
 
 	return cmd
 }
 
-func newGrantsListCmd() *cobra.Command {
+func newGrantsListCmd(cli *CLI) *cobra.Command {
 	var options grantsCmdOptions
 
 	cmd := &cobra.Command{
@@ -81,9 +81,9 @@ func newGrantsListCmd() *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows, TODO)
+				printTable(rows, cli.Stdout)
 			} else {
-				fmt.Println("No grants found")
+				cli.Output("No grants found")
 			}
 
 			return nil

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -28,7 +28,7 @@ func newIdentitiesCmd(cli *CLI) *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newIdentitiesAddCmd())
+	cmd.AddCommand(newIdentitiesAddCmd(cli))
 	cmd.AddCommand(newIdentitiesEditCmd())
 	cmd.AddCommand(newIdentitiesListCmd(cli))
 	cmd.AddCommand(newIdentitiesRemoveCmd())
@@ -36,7 +36,7 @@ func newIdentitiesCmd(cli *CLI) *cobra.Command {
 	return cmd
 }
 
-func newIdentitiesAddCmd() *cobra.Command {
+func newIdentitiesAddCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add IDENTITY",
 		Short: "Create an identity.",
@@ -61,12 +61,12 @@ $ infra identities add machine-a`,
 			}
 
 			if createResp.OneTimePassword != "" {
-				fmt.Fprintf(os.Stderr, "Created user identity.\n")
-				fmt.Printf("Email: %s\n", createResp.Name)
-				fmt.Printf("Password: %s\n", createResp.OneTimePassword)
+				fmt.Fprintf(cli.Stderr, "Created user identity.\n")
+				cli.Output("Email: %s", createResp.Name)
+				cli.Output("Password: %s", createResp.OneTimePassword)
 			} else {
-				fmt.Fprintf(os.Stderr, "Created machine identity.\n")
-				fmt.Printf("Name: %s\n", createResp.Name)
+				fmt.Fprintf(cli.Stderr, "Created machine identity.\n")
+				cli.Output("Name: %s", createResp.Name)
 			}
 
 			return nil

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -14,7 +14,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func newIdentitiesCmd() *cobra.Command {
+func newIdentitiesCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "identities",
 		Aliases: []string{"id", "identity"},
@@ -30,7 +30,7 @@ func newIdentitiesCmd() *cobra.Command {
 
 	cmd.AddCommand(newIdentitiesAddCmd())
 	cmd.AddCommand(newIdentitiesEditCmd())
-	cmd.AddCommand(newIdentitiesListCmd())
+	cmd.AddCommand(newIdentitiesListCmd(cli))
 	cmd.AddCommand(newIdentitiesRemoveCmd())
 
 	return cmd
@@ -125,7 +125,7 @@ $ infra identities edit janedoe@example.com --password`,
 	return cmd
 }
 
-func newIdentitiesListCmd() *cobra.Command {
+func newIdentitiesListCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -159,9 +159,9 @@ func newIdentitiesListCmd() *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows, TODO)
+				printTable(rows, cli.Stdout)
 			} else {
-				fmt.Println("No identities found")
+				cli.Output("No identities found")
 			}
 
 			return nil

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"text/tabwriter"
 
@@ -11,7 +10,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func newInfoCmd() *cobra.Command {
+func newInfoCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
 		Use:    "info",
 		Short:  "Display the info about the current session",
@@ -21,12 +20,12 @@ func newInfoCmd() *cobra.Command {
 			if err := mustBeLoggedIn(); err != nil {
 				return err
 			}
-			return info()
+			return info(cli)
 		},
 	}
 }
 
-func info() error {
+func info(cli *CLI) error {
 	config, err := currentHostConfig()
 	if err != nil {
 		return err
@@ -37,7 +36,7 @@ func info() error {
 		return err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.AlignRight)
+	w := tabwriter.NewWriter(cli.Stdout, 0, 0, 1, ' ', tabwriter.AlignRight)
 	defer w.Flush()
 
 	fmt.Fprintln(w)

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -27,7 +27,7 @@ func newKeysCmd(cli *CLI) *cobra.Command {
 	}
 
 	cmd.AddCommand(newKeysListCmd(cli))
-	cmd.AddCommand(newKeysAddCmd())
+	cmd.AddCommand(newKeysAddCmd(cli))
 	cmd.AddCommand(newKeysRemoveCmd())
 
 	return cmd
@@ -38,7 +38,7 @@ type keyCreateOptions struct {
 	ExtensionDeadline time.Duration
 }
 
-func newKeysAddCmd() *cobra.Command {
+func newKeysAddCmd(cli *CLI) *cobra.Command {
 	var options keyCreateOptions
 
 	cmd := &cobra.Command{
@@ -78,7 +78,7 @@ $ infra keys add example-key machine-a --ttl=12h
 				return err
 			}
 
-			fmt.Printf("key: %s \n", resp.AccessKey)
+			cli.Output("key: %s", resp.AccessKey)
 			return nil
 		},
 	}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -10,7 +10,7 @@ import (
 	"github.com/infrahq/infra/api"
 )
 
-func newListCmd() *cobra.Command {
+func newListCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -24,12 +24,12 @@ func newListCmd() *cobra.Command {
 			return mustBeLoggedIn()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return list()
+			return list(cli)
 		},
 	}
 }
 
-func list() error {
+func list(cli *CLI) error {
 	client, err := defaultAPIClient()
 	if err != nil {
 		return err
@@ -133,9 +133,9 @@ func list() error {
 	}
 
 	if len(rows) > 0 {
-		printTable(rows, TODO)
+		printTable(rows, cli.Stdout)
 	} else {
-		fmt.Println("You have not been granted access to any active destinations")
+		cli.Output("You have not been granted access to any active destinations")
 	}
 
 	return writeKubeconfig(destinations, grants)

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -42,7 +42,7 @@ const (
 
 const cliLoginRedirectURL = "http://localhost:8301"
 
-func newLoginCmd() *cobra.Command {
+func newLoginCmd(_ *CLI) *cobra.Command {
 	var options loginCmdOptions
 
 	cmd := &cobra.Command{

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -17,7 +17,7 @@ type logoutCmdOptions struct {
 	all    bool
 }
 
-func newLogoutCmd() *cobra.Command {
+func newLogoutCmd(_ *CLI) *cobra.Command {
 	var options logoutCmdOptions
 
 	cmd := &cobra.Command{

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -26,7 +26,7 @@ func newProvidersCmd(cli *CLI) *cobra.Command {
 	}
 
 	cmd.AddCommand(newProvidersListCmd(cli))
-	cmd.AddCommand(newProvidersAddCmd())
+	cmd.AddCommand(newProvidersAddCmd(cli))
 	cmd.AddCommand(newProvidersRemoveCmd())
 
 	return cmd
@@ -93,7 +93,7 @@ func (o providerAddOptions) Validate() error {
 	return nil
 }
 
-func newProvidersAddCmd() *cobra.Command {
+func newProvidersAddCmd(cli *CLI) *cobra.Command {
 	var opts providerAddOptions
 
 	cmd := &cobra.Command{
@@ -128,7 +128,7 @@ $ infra providers add okta --url example.okta.com --client-id 0oa3sz06o6do0muoW5
 				return err
 			}
 
-			fmt.Printf("Provider %s added\n", args[0])
+			cli.Output("Provider %s added", args[0])
 			return nil
 		},
 	}

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/infrahq/infra/internal/cmd/cliopts"
 )
 
-func newProvidersCmd() *cobra.Command {
+func newProvidersCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "providers",
 		Short:   "Manage identity providers",
@@ -25,14 +25,14 @@ func newProvidersCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newProvidersListCmd())
+	cmd.AddCommand(newProvidersListCmd(cli))
 	cmd.AddCommand(newProvidersAddCmd())
 	cmd.AddCommand(newProvidersRemoveCmd())
 
 	return cmd
 }
 
-func newProvidersListCmd() *cobra.Command {
+func newProvidersListCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -60,9 +60,9 @@ func newProvidersListCmd() *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows, TODO)
+				printTable(rows, cli.Stdout)
 			} else {
-				fmt.Println("No providers found")
+				cli.Output("No providers found")
 			}
 
 			return nil

--- a/internal/cmd/tokens.go
+++ b/internal/cmd/tokens.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -10,7 +9,7 @@ import (
 	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 )
 
-func newTokensCmd() *cobra.Command {
+func newTokensCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "tokens",
 		Short:  "Create & manage tokens",
@@ -23,27 +22,23 @@ func newTokensCmd() *cobra.Command {
 		},
 	}
 
-	cmd.AddCommand(newTokensAddCmd())
+	cmd.AddCommand(newTokensAddCmd(cli))
 
 	return cmd
 }
 
-func newTokensAddCmd() *cobra.Command {
+func newTokensAddCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
 		Use:   "add",
 		Short: "Create a token",
 		Args:  NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := tokensCreate(); err != nil {
-				return err
-			}
-
-			return nil
+			return tokensCreate(cli)
 		},
 	}
 }
 
-func tokensCreate() error {
+func tokensCreate(cli *CLI) error {
 	client, err := defaultAPIClient()
 	if err != nil {
 		return err
@@ -71,7 +66,7 @@ func tokensCreate() error {
 		return err
 	}
 
-	fmt.Println(string(bts))
+	cli.Output(string(bts))
 
 	return nil
 }

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"text/tabwriter"
 
@@ -12,20 +11,20 @@ import (
 	"github.com/infrahq/infra/internal/logging"
 )
 
-func newVersionCmd() *cobra.Command {
+func newVersionCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
 		Use:    "version",
 		Short:  "Display the Infra version",
 		Hidden: true,
 		Args:   NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return version()
+			return version(cli)
 		},
 	}
 }
 
-func version() error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.AlignRight)
+func version(cli *CLI) error {
+	w := tabwriter.NewWriter(cli.Stdout, 0, 0, 1, ' ', tabwriter.AlignRight)
 	defer w.Flush()
 
 	fmt.Fprintln(w)


### PR DESCRIPTION
## Summary

Follow up to #1708

This PR removes the `TODO` type, and uses the new `CLI.Stdout` and `CLI.Stderr` in most places. There are a few more calls to `fmt.Printf` which will require a bit more work to change. We can probably address those when we write tests that require it. I'm hoping this passes the `CLI` struct to enough places to make it easy to use for new commands or new output.






