### PR TITLE
feat(cmd): optional access key name

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -22,7 +22,7 @@ type ListAccessKeysRequest struct {
 
 type CreateAccessKeyRequest struct {
 	IdentityID        uid.ID   `json:"identityID" validate:"required"`
-	Name              string   `json:"name" validate:"required,excludes= "`
+	Name              string   `json:"name" validate:"excludes= "`
 	TTL               Duration `json:"ttl" validate:"required" note:"maximum time valid"`
 	ExtensionDeadline Duration `json:"extensionDeadline,omitempty" validate:"required" note:"How long the key is active for before it needs to be renewed. The access key must be used within this amount of time to renew validity"`
 }

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -526,7 +526,6 @@
                 },
                 "required": [
                   "identityID",
-                  "name",
                   "ttl",
                   "extensionDeadline"
                 ],

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -424,7 +424,7 @@ Create an access key
 Create an access key. Only machine identities are supported at this time.
 
 ```
-infra keys add KEY IDENTITY [flags]
+infra keys add IDENTITY [flags]
 ```
 
 ### Examples
@@ -439,8 +439,9 @@ $ infra keys add example-key machine-a --ttl=12h
 ### Options
 
 ```
-      --extension-deadline duration   A specified deadline that an access key must be used within to remain valid (default 720h0m0s)
-      --ttl duration                  The total time that an access key will be valid for (default 720h0m0s)
+      --extension-deadline duration   A specified deadline that the access key must be used within to remain valid (default 720h0m0s)
+      --name string                   The name of the access key
+      --ttl duration                  The total time that the access key will be valid for (default 720h0m0s)
 ```
 
 ### Options inherited from parent commands

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -41,6 +41,10 @@ func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey, identityID uid
 		return "", fmt.Errorf("get access key identity: %w", err)
 	}
 
+	if accessKey.Name == "" {
+		accessKey.Name = fmt.Sprintf("%s-%s", identity.Name, time.Now().UTC().Format("2006-01-02T15:04:05.000000"))
+	}
+
 	if identity.Kind != models.MachineKind {
 		// direct access key creation isn't supported for user identities yet
 		return "", internal.ErrNotImplemented

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -70,7 +70,7 @@ func TestKeysAddCmd(t *testing.T) {
 		ch := setup(t)
 
 		ctx := context.Background()
-		err := Run(ctx, "keys", "add", "--ttl=400h", "--extension-deadline=5h", "the-name", "my-machine")
+		err := Run(ctx, "keys", "add", "--ttl=400h", "--extension-deadline=5h", "--name=the-name", "my-machine")
 		assert.NilError(t, err)
 
 		req := <-ch
@@ -83,10 +83,21 @@ func TestKeysAddCmd(t *testing.T) {
 		assert.DeepEqual(t, expected, req)
 	})
 
+	t.Run("automatic name", func(t *testing.T) {
+		ch := setup(t)
+
+		ctx := context.Background()
+		err := Run(ctx, "keys", "add", "--ttl=400h", "--extension-deadline=5h", "my-machine")
+		assert.NilError(t, err)
+
+		req := <-ch
+		assert.Equal(t, req.Name, "") // filled by server
+	})
+
 	t.Run("without required arguments", func(t *testing.T) {
 		err := Run(context.Background(), "keys", "add")
-		assert.ErrorContains(t, err, `"infra keys add" requires exactly 2 arguments`)
-		assert.ErrorContains(t, err, `Usage:  infra keys add KEY IDENTITY`)
+		assert.ErrorContains(t, err, `"infra keys add" requires exactly 1 argument`)
+		assert.ErrorContains(t, err, `Usage:  infra keys add IDENTITY`)
 	})
 }
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -844,7 +844,7 @@ func (s Server) loadAccessKey(db *gorm.DB, identity *models.Identity, provider *
 		}
 
 		accessKey := &models.AccessKey{
-			Name:       fmt.Sprintf("%s-%s", identity.Name, time.Now().Format("20060102150405")),
+			Name:       fmt.Sprintf("%s-%s", identity.Name, time.Now().UTC().Format("2006-01-02T15:04:05.000000")),
 			IssuedFor:  identity.ID,
 			ExpiresAt:  time.Now().AddDate(10, 0, 0),
 			KeyID:      keyID,

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ssoroka/slice"
 	"gorm.io/gorm"
 
-	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -123,20 +122,4 @@ func DeleteIdentities(db *gorm.DB, selectors ...SelectorFunc) error {
 
 func SaveIdentity(db *gorm.DB, identity *models.Identity) error {
 	return save(db, identity)
-}
-
-var infraConnectorCache *models.Identity
-
-func InfraConnectorIdentity(db *gorm.DB) *models.Identity {
-	if infraConnectorCache == nil {
-		connector, err := GetIdentity(db, ByName(models.InternalInfraConnectorIdentityName))
-		if err != nil {
-			logging.S.Panic(err)
-			return nil
-		}
-
-		infraConnectorCache = connector
-	}
-
-	return infraConnectorCache
 }

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -3,7 +3,6 @@ package data
 import (
 	"gorm.io/gorm"
 
-	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -41,21 +40,4 @@ func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
 	}
 
 	return deleteAll[models.Provider](db, ByIDs(ids))
-}
-
-var infraProviderCache *models.Provider
-
-// InfraProvider is a lazy-loaded cached reference to the infra provider, since it's used in a lot of places
-func InfraProvider(db *gorm.DB) *models.Provider {
-	if infraProviderCache == nil {
-		infra, err := get[models.Provider](db, ByName(models.InternalInfraProviderName))
-		if err != nil {
-			logging.S.Panic(err)
-			return nil
-		}
-
-		infraProviderCache = infra
-	}
-
-	return infraProviderCache
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/data"
 )
 
 func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
@@ -36,6 +37,9 @@ func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
 
 	err = s.loadConfig(s.options.Config)
 	assert.NilError(t, err)
+
+	data.InvalidateCache()
+	t.Cleanup(data.InvalidateCache)
 
 	return s
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Move name positional parameter to a keyword parameter for infra keys add. If name is not specified, generate one based on the identity issuing the key and the current timestamp

Move `infraProviderCache` and `infraConnectorIdentityCache` to `data/data.go` and a way to reset the cache value. This is mainly used for tests as the database gets recreated frequently which causes the cache to point to a nonexistent object

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1479