### PR TITLE
improve: validate provider fields

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -41,9 +41,9 @@ func checkError(status int, body []byte) error {
 	case http.StatusNotFound:
 		return ErrNotFound
 	case http.StatusBadRequest:
-		return fmt.Errorf("%w: %s", ErrBadRequest, apiError.Message)
+		return fmt.Errorf(apiError.Message)
 	case http.StatusBadGateway:
-		// this errror should be displayed to the user so they can see its an external problem
+		// this error should be displayed to the user so they can see its an external problem
 		return fmt.Errorf(apiError.Message)
 	case http.StatusInternalServerError:
 		return ErrInternal

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -52,7 +52,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("failed request", func(t *testing.T) {
 		_, err := get[stubResponse](c, "/bad")
-		assert.ErrorContains(t, err, `responded 400: bad request`)
+		assert.ErrorContains(t, err, `responded 400`)
 		req := <-requestCh
 		assert.Equal(t, req.Method, http.MethodGet)
 		assert.Equal(t, req.URL.Path, "/bad")

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -199,6 +199,10 @@ type mockOIDCImplementation struct {
 	UserGroupsResp []string
 }
 
+func (m *mockOIDCImplementation) Validate() error {
+	return nil
+}
+
 func (m *mockOIDCImplementation) ExchangeAuthCodeForProviderTokens(code string) (acc, ref string, exp time.Time, email string, err error) {
 	return "acc", "ref", exp, m.UserEmailResp, nil
 }

--- a/internal/server/authn/errors.go
+++ b/internal/server/authn/errors.go
@@ -1,0 +1,9 @@
+package authn
+
+import "fmt"
+
+var (
+	ErrInvalidProviderURL          = fmt.Errorf("invalid provider url")
+	ErrInvalidProviderClientID     = fmt.Errorf("invalid client id")
+	ErrInvalidProviderClientSecret = fmt.Errorf("invalid client secret")
+)

--- a/internal/server/authn/errors.go
+++ b/internal/server/authn/errors.go
@@ -2,12 +2,11 @@ package authn
 
 import (
 	"fmt"
-
-	"github.com/infrahq/infra/internal"
 )
 
 var (
-	ErrInvalidProviderURL          = fmt.Errorf("%w: %s", internal.ErrBadRequest, "invalid provider url")
-	ErrInvalidProviderClientID     = fmt.Errorf("%w: %s", internal.ErrBadRequest, "invalid provider client id")
-	ErrInvalidProviderClientSecret = fmt.Errorf("%w: %s", internal.ErrBadRequest, "invalid provider client secret")
+	ErrValidation                  = fmt.Errorf("validation failed")
+	ErrInvalidProviderURL          = fmt.Errorf("%w: invalid provider url", ErrValidation)
+	ErrInvalidProviderClientID     = fmt.Errorf("%w: invalid provider client id", ErrValidation)
+	ErrInvalidProviderClientSecret = fmt.Errorf("%w: invalid provider client secret", ErrValidation)
 )

--- a/internal/server/authn/errors.go
+++ b/internal/server/authn/errors.go
@@ -1,9 +1,13 @@
 package authn
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/infrahq/infra/internal"
+)
 
 var (
-	ErrInvalidProviderURL          = fmt.Errorf("invalid provider url")
-	ErrInvalidProviderClientID     = fmt.Errorf("invalid client id")
-	ErrInvalidProviderClientSecret = fmt.Errorf("invalid client secret")
+	ErrInvalidProviderURL          = fmt.Errorf("%w: %s", internal.ErrBadRequest, "invalid provider url")
+	ErrInvalidProviderClientID     = fmt.Errorf("%w: %s", internal.ErrBadRequest, "invalid provider client id")
+	ErrInvalidProviderClientSecret = fmt.Errorf("%w: %s", internal.ErrBadRequest, "invalid provider client secret")
 )

--- a/internal/server/authn/oidc.go
+++ b/internal/server/authn/oidc.go
@@ -50,17 +50,20 @@ func (o *oidcImplementation) Validate() error {
 	ctx := context.Background()
 	conf, _, err := o.clientConfig(ctx)
 	if err != nil {
-		return fmt.Errorf("%w: %s", ErrInvalidProviderURL, err)
+		logging.S.Debugf("error validating oidc provider: %s", err)
+		return ErrInvalidProviderURL
 	}
 
 	_, err = conf.Exchange(ctx, "test-code") // 'test-code' is a placeholder for a valid authorization code, it will always fail
 	if err != nil {
 		if strings.Contains(err.Error(), "client_id") || strings.Contains(err.Error(), "client id") {
-			return fmt.Errorf("%w: %s", ErrInvalidProviderClientID, err)
+			logging.S.Debugf("error validating oidc provider client: %s", err)
+			return ErrInvalidProviderClientID
 		}
 
 		if strings.Contains(err.Error(), "secret") {
-			return fmt.Errorf("%w: %s", ErrInvalidProviderClientSecret, err)
+			logging.S.Debugf("error validating oidc provider client: %s", err)
+			return ErrInvalidProviderClientSecret
 		}
 	}
 

--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -1,0 +1,14 @@
+package authn
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestValidateInvalidURL(t *testing.T) {
+	oidc := NewOIDC("invalid.example.com", "some_client_id", "some_client_secret", "http://localhost:8301")
+
+	err := oidc.Validate()
+	assert.ErrorIs(t, err, ErrInvalidProviderURL)
+}

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -14,6 +14,7 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/authn"
 )
 
 func (a *API) sendAPIError(c *gin.Context, err error) {
@@ -41,10 +42,10 @@ func (a *API) sendAPIError(c *gin.Context, err error) {
 		resp.Message = err.Error()
 	case errors.As(err, validationErrors):
 		resp.Code = http.StatusBadRequest
-		resp.Message = fmt.Sprintf("%s: %s", internal.ErrBadRequest, err)
+		resp.Message = err.Error()
 
 		parseFieldErrors(resp, validationErrors)
-	case errors.Is(err, internal.ErrBadRequest):
+	case errors.Is(err, internal.ErrBadRequest), errors.Is(err, authn.ErrValidation):
 		resp.Code = http.StatusBadRequest
 		resp.Message = err.Error()
 	case errors.Is(err, internal.ErrNotImplemented):

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -41,10 +41,9 @@ func (a *API) sendAPIError(c *gin.Context, err error) {
 		resp.Message = err.Error()
 	case errors.As(err, validationErrors):
 		resp.Code = http.StatusBadRequest
-		resp.Message = err.Error()
+		resp.Message = fmt.Sprintf("%s: %s", internal.ErrBadRequest, err)
 
 		parseFieldErrors(resp, validationErrors)
-
 	case errors.Is(err, internal.ErrBadRequest):
 		resp.Code = http.StatusBadRequest
 		resp.Message = err.Error()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -628,7 +628,7 @@ func (a *API) UpdateIdentityInfoFromProvider(c *gin.Context) error {
 
 // validateProvider checks that a provider being modified is valid
 func (a *API) validateProvider(c *gin.Context, provider *models.Provider) error {
-	oidc, err := a.providerClient(c, provider, "http://localhost:8301")
+	oidc, err := a.providerClient(c, provider, "") // redirect URL is not used during validation
 	if err != nil {
 		return fmt.Errorf("%w: %s", internal.ErrBadRequest, err)
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -633,30 +633,7 @@ func (a *API) validateProvider(c *gin.Context, provider *models.Provider) error 
 		return fmt.Errorf("%w: %s", internal.ErrBadRequest, err)
 	}
 
-	if err := oidc.Validate(); err != nil {
-		logging.S.Debugf("could not validate provider: %s", err)
-
-		var msg strings.Builder
-		msg.WriteString("invalid identity provider")
-
-		// remove the error message trace for display
-		if errors.Is(err, authn.ErrInvalidProviderURL) {
-			msg.WriteString(": ")
-			msg.WriteString(authn.ErrInvalidProviderURL.Error())
-		}
-		if errors.Is(err, authn.ErrInvalidProviderClientID) {
-			msg.WriteString(": ")
-			msg.WriteString(authn.ErrInvalidProviderClientID.Error())
-		}
-		if errors.Is(err, authn.ErrInvalidProviderClientSecret) {
-			msg.WriteString(": ")
-			msg.WriteString(authn.ErrInvalidProviderClientSecret.Error())
-		}
-
-		return fmt.Errorf("%w: %s", internal.ErrBadRequest, &msg)
-	}
-
-	return nil
+	return oidc.Validate()
 }
 
 func (a *API) providerClient(c *gin.Context, provider *models.Provider, redirectURL string) (authn.OIDC, error) {


### PR DESCRIPTION
- check provider url and client are valid
- return better error message for a secret that does not exist

## Summary
When an identity provider is added to Infra through the API or CLI check that the URL, client ID and client secret are valid. This relies on some information being present in the response from the identity provider. We will probably iterate on this as more identity providers are supported.

Example outputs:
```
$ infra providers add okta --url invalid-example.okta.com --client-id ${CLIENT_ID} --client-secret ${CLIENT_SECRET}
ERROR  POST "/v1/providers" responded 400: bad request: invalid provider url

$ infra providers add okta --url example.okta.com --client-id ${INVALID_CLIENT_ID} --client-secret ${CLIENT_SECRET}
ERROR  POST "/v1/providers" responded 400: bad request: invalid client id

$ infra providers add okta --url example.okta.com --client-id ${CLIENT_ID} --client-secret ${INVALID_CLIENT_SECRET}
ERROR  POST "/v1/providers" responded 400: bad request: invalid client secret

$ infra providers add okta --url example.okta.com --client-id ${CLIENT_ID} --client-secret kubernetes:${CLIENT_SECRET}
ERROR  POST "/v1/providers" responded 400: bad request: client secret not found
```
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1715 
Resolves #1736 
