### PR TITLE
api: more tests for CreateIdentity and DeleteProvider

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -197,6 +197,9 @@ func TestSignupEnabled(t *testing.T) {
 }
 
 func TestServer_Run(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for short run")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 


### PR DESCRIPTION
Extracted out of #1740, since that PR needs more work