### PR TITLE
fix: cluster add page ui bugs

### DIFF
--- a/ui/components/input.js
+++ b/ui/components/input.js
@@ -3,13 +3,14 @@ export default function ({
   type,
   value,
   placeholder,
+  handleInputChange,
+  handleKeyDown,
+  disabled = false,
   error,
   hasDropdownSelection = true,
   optionType,
   options,
-  handleInputChange,
   handleSelectOption,
-  handleKeyDown, 
   selectedItem
 }) {
   return (
@@ -20,12 +21,14 @@ export default function ({
         </label>}
       <div className='relative rounded shadow-sm'>
         <input
+          autoFocus
           type={type}
           value={value}
-          className={`block w-full px-4 py-3 sm:text-sm border-2 bg-transparent rounded-full focus:outline-none focus:ring focus:ring-cyan-600 ${error ? 'border-pink-500' : 'border-gray-800'}`}
+          className={`block w-full px-4 py-3 sm:text-sm border bg-transparent rounded-full focus:outline-none focus:ring focus:ring-cyan-600 disabled:opacity-30 ${error ? 'border-pink-500' : 'border-gray-800'}`}
           placeholder={placeholder}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
+          disabled={disabled}
         />
         {hasDropdownSelection &&
           <div className='absolute inset-y-0 right-6 flex items-center'>

--- a/ui/components/modals/fullscreen.js
+++ b/ui/components/modals/fullscreen.js
@@ -7,14 +7,14 @@ export default function ({ children, closeHref, backHref, verticalCenteredConten
       <div className={`flex flex-none text-right ${backHref ? 'justify-between' : 'justify-end'}`}>
         {backHref && (
           <Link href={backHref || '/'}>
-            <a className='flex items-center text-gray-400 px-4'>
-              <ArrowLeftIcon className='w-3 h-3 mr-1' /><div className='text-sm text-gray-400 mr-2'>Back</div>
+            <a className='flex items-center text-gray-light px-4'>
+              <ArrowLeftIcon className='w-3 h-3 mr-1' /><div className='text-sm text-gray-light mr-2'>Back</div>
             </a>
           </Link>
         )}
         <Link href={closeHref || '/'}>
           <a className='flex items-center p-4'>
-            <div className='text-sm text-gray-400 mr-2'>Close</div><XIcon className='w-6 h-6 text-white' />
+            <div className='text-sm text-gray-light mr-2'>Close</div><XIcon className='w-6 h-6 text-gray-light' />
           </a>
         </Link>
       </div>

--- a/ui/pages/destinations/add.js
+++ b/ui/pages/destinations/add.js
@@ -23,7 +23,7 @@ function CommandInput ({ enabledCommandInput, accessKey, currentDestinationName 
   const value = enabledCommandInput ? commandValue : ''
 
   return (
-    <div className='border-2 border-gray-800 rounded-lg shadow-sm overflow-hidden my-5'>
+    <div className='border border-gray-800 rounded-lg shadow-sm overflow-hidden my-5'>
       <textarea
         rows={5}
         name='commandInput'
@@ -45,6 +45,7 @@ export default function () {
   const [currentDestinationName, setCurrentDestinationName] = useState('')
   const [connected, setConnected] = useState(false)
   const [enabledCommandInput, setEnabledCommandInput] = useState(false)
+  const [disabledInput, setDisabledInput] = useState(false)
   const [numDestinations, setNumDestinations] = useState(0)
 
   useEffect(() => {
@@ -84,6 +85,7 @@ export default function () {
     const type = 'kubernetes'
     const destinationName = type + '.' + name
 
+    setDisabledInput(true)
     setCurrentDestinationName(name)
     setEnabledCommandInput(name.length > 0)
     setConnectorFullName(destinationName)
@@ -133,11 +135,12 @@ export default function () {
               hasDropdownSelection={false}
               handleInputChange={e => setName(e.target.value)}
               handleKeyDown={(e) => handleKeyDownEvent(e.key)}
+              disabled={disabledInput}
             />
           </div>
           <button
             onClick={() => handleNext()}
-            disabled={name.length === 0}
+            disabled={name.length === 0 || disabledInput}
             type='button'
             className='bg-gradient-to-tr from-indigo-300 to-pink-100 hover:from-indigo-200 hover:to-pink-50 p-0.5 mx-auto rounded-full disabled:opacity-30'
           >
@@ -159,10 +162,10 @@ export default function () {
             <h2 className='text-gray-500 text-center px-2 mb-2 mt-4'>
               Your cluster will be detected automatically. This may take a few minutes.
             </h2>
-            <div className='border-2 border-dashed border-pink-300 opacity-60 rounded-lg shadow-sm overflow-hidden my-5 px-5 py-3'>
+            <div className='border border-dashed border-pink-light/20 rounded-lg shadow-sm overflow-hidden my-5 px-5 py-3'>
               <div className='flex items-center justify-center p-0.5 w-full'>
                 <img className={`w-8 h-8' ${connected ? '' : 'animate-pulse'}`} src='/connected-icon.svg' />
-                <p className='text-pink-500 text-sm px-2 py-3'>{connected ? 'Connected!' : 'Waiting for connection...'}</p>
+                <p className='text-pink-dark text-sm px-2 py-3'>{connected ? 'Connected!' : 'Waiting for connection...'}</p>
               </div>
             </div>
             {connected &&

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,3 +1,12 @@
+function withOpacityValue(variable) {
+  return ({ opacityValue }) => {
+    if (opacityValue === undefined) {
+      return `rgb(${variable})`
+    }
+    return `rgb(${variable} / ${opacityValue})`
+  }
+}
+
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
@@ -6,7 +15,14 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        black: '#0A0E12'
+        black: '#0A0E12',
+        pink: {
+          'light': withOpacityValue('228 64 255'),
+          dark: '#CB2EEC'
+        },
+        gray: {
+          light: '#B2B2B2'
+        }
       },
       transitionProperty: {
         size: 'height, padding, background'


### PR DESCRIPTION
## Summary
- modified tailwind config file to add some custom colour 
- fixed varies cluster add page ui bugs

- [x] Input should not be in focus after next is clicked
- [x] Next should be disabled once user clicks it
- [x]  disabled the entire input once user click next
- [ ] needs copy/paste icon - #1717 
- [x] replace circle icon to pulsing circle icon
- [x] Waiting for connection wrapper/circle/text are all different colors
- [x] close and x can be the same shade of gray #B2B2B2
- [x] 1px borders for every input/field


## Related Issues
Resolves #1733
