### PR TITLE
fix: loading connector.Options

### DIFF
--- a/internal/cmd/cliopts/config_test.go
+++ b/internal/cmd/cliopts/config_test.go
@@ -179,6 +179,7 @@ two: "from-file-3"
 	}
 
 	flags := pflag.NewFlagSet("any", pflag.ContinueOnError)
+	flags.String("one", "not-the-real-default", "")
 	flags.String("string-field", "", "")
 	flags.Int32("int-32-field", 0, "")
 	flags.Bool("bool-field", false, "")

--- a/internal/cmd/cliopts/flat.go
+++ b/internal/cmd/cliopts/flat.go
@@ -32,7 +32,9 @@ func loadFromEnv(target interface{}, opts Options) error {
 func loadFromFlags(target interface{}, opts Options) error {
 	source := map[string]interface{}{}
 	opts.Flags.VisitAll(func(flag *pflag.Flag) {
-		source[flag.Name] = flag.Value
+		if flag.Changed {
+			source[flag.Name] = flag.Value
+		}
 	})
 
 	walker := &flatSourceWalker{

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -222,7 +222,7 @@ func newConnectorCmd() *cobra.Command {
 				return err
 			}
 
-			return connector.Run(cmd.Context(), options)
+			return runConnector(cmd.Context(), options)
 		},
 	}
 
@@ -236,6 +236,9 @@ func newConnectorCmd() *cobra.Command {
 
 	return cmd
 }
+
+// runConnector is a shim for testing
+var runConnector = connector.Run
 
 // rootOptions are options specified by users on the command line that are
 // used by the root command.


### PR DESCRIPTION
## Summary

Flag default values were overwriting the values from the config. Existing tests did not capture that case apparently.

A consequence of this change is that default values for flags won't do anything for the server or connector. We can probably address that in a follow up to make it an error to set a non-zero default value for flags, or handle it in some other way.