### PR TITLE
maintain: run all tests in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-      - run: go install gotest.tools/gotestsum@v1.7.0
+      - run: go install gotest.tools/gotestsum@v1.8.0
       - run: go mod tidy
-      - run: ~/go/bin/gotestsum --no-color=false -ftestname -- -short -race ./...
+      - run: ~/go/bin/gotestsum -ftestname -- -race ./...
 
   go-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION

## Summary

Removes the -short flag from CI, so that all tests are run. Previously we were using it to skip tests that required docker containers and kubernetes.

Also update the version of gotestsum, which should use color by default.
