### PR TITLE
Replace viper with cliopts.Load (take 2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,10 +46,10 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/infrahq/secrets v0.0.0-20220419190655-ce9f012a8941
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/pdevine/go-asciisprite v0.1.6
 	github.com/spf13/afero v1.8.2
 	github.com/spf13/pflag v1.0.5
-	github.com/spf13/viper v1.11.0
 	github.com/ssoroka/slice v0.0.0-20220402005549-78f0cea3df8b
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gotest.tools/v3 v3.2.0
@@ -69,7 +69,6 @@ require (
 	github.com/denisenkom/go-mssqldb v0.9.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell v1.1.4 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
@@ -121,7 +120,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
@@ -132,21 +130,16 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
-	github.com/pelletier/go-toml/v2 v2.0.0-beta.8 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
-	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/stretchr/testify v1.7.1 // indirect
 	github.com/ugorji/go/codec v1.2.6 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	go.uber.org/atomic v1.9.0 // indirect
@@ -161,7 +154,6 @@ require (
 	google.golang.org/grpc v1.45.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,7 +162,6 @@ github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell v1.1.4 h1:6Bubmk3vZvnL9umQ9qTV2kwNQnjaZ4HLAbxR+xR3ATg=
@@ -515,8 +514,6 @@ github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
-github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -601,10 +598,6 @@ github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0Mw
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pdevine/go-asciisprite v0.1.6 h1:XoCz3hp/Uu11jqW+mz6hip/60fVyAc0TCQe0rt9a2Es=
 github.com/pdevine/go-asciisprite v0.1.6/go.mod h1:l0QHNFjlxaGuffAHCFMH+YrveBx6BBjetM2E8rFvgd4=
-github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
-github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml/v2 v2.0.0-beta.8 h1:dy81yyLYJDwMTifq24Oi/IslOslRrDSb3jwDggjz3Z0=
-github.com/pelletier/go-toml/v2 v2.0.0-beta.8/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -673,15 +666,9 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
-github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
-github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
-github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/viper v1.11.0 h1:7OX/1FS6n7jHD1zGrZTM7WtY13ZELRyosK4k93oPr44=
-github.com/spf13/viper v1.11.0/go.mod h1:djo0X/bA5+tYVoCn+C7cAYJGcVn/qYLFTG8gdUsX7Zk=
 github.com/ssoroka/slice v0.0.0-20220402005549-78f0cea3df8b h1:nDFJ1KYD1CSRP3nHtkvCH+ztuoz+QW++OvCLgpS6kQE=
 github.com/ssoroka/slice v0.0.0-20220402005549-78f0cea3df8b/go.mod h1:l4Ov7Zo7X3/MCC+pefg/lN7x8X8FKb1Ub7oxosKKJa0=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
@@ -697,8 +684,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
-github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.2.6/go.mod h1:anCg0y61KIhDlPZmnH+so+RQbysYVyDko0IMgJv0Nn0=
 github.com/ugorji/go/codec v1.2.6 h1:7kbGefxLoDBuYXOms4yD7223OpNMMPNPZxXk5TvFcyQ=
@@ -1157,8 +1142,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/ini.v1 v1.66.4 h1:SsAcf+mM7mRZo2nJNGt8mZCjG8ZRaNGMURJw7BsIST4=
-gopkg.in/ini.v1 v1.66.4/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/segmentio/analytics-go.v3 v3.1.0 h1:UzxH1uaGZRpMKDhJyBz0pexz6yUoBU3x8bJsRk/HV6U=
 gopkg.in/segmentio/analytics-go.v3 v3.1.0/go.mod h1:4QqqlTlSSpVlWA9/9nDcPw+FkM2yv1NQoYjUbL9/JAw=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/internal/cmd/cliopts/config.go
+++ b/internal/cmd/cliopts/config.go
@@ -1,0 +1,91 @@
+package cliopts
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"gopkg.in/yaml.v2"
+)
+
+type Options struct {
+	FieldTagName string
+	Filename     string
+	EnvPrefix    string
+	Flags        FlagSet
+}
+
+// Load configuration into target. Configuration may come from multiple sources.
+//
+// To set default values, apply them to target before calling Load.
+// Configuration is loaded in the following order:
+//    1. from a yaml file identified by opts.Filename
+//    2. from environment variables that start with opts.EnvPrefix
+//    3. from command line flags in opts.Flags
+//
+// Values are matched to the fields in target by convention. To override the
+// convention use the 'config' struct field tag to specify a different name.
+//
+// For example, the field target.Addr.HTTPS would be set from:
+//
+//    // YAML
+//   {"addr": {"https": "value"}}
+//   // environment variable
+//   PREFIX_ADDR_HTTPS=value
+//   // command line flag
+//   flags.String(&target.Addr.HTTPS, ...)
+//
+func Load(target interface{}, opts Options) error {
+	if opts.FieldTagName == "" {
+		opts.FieldTagName = "config"
+	}
+	if opts.Filename != "" {
+		if err := loadFromFile(target, opts); err != nil {
+			return err
+		}
+	}
+	if opts.EnvPrefix != "" {
+		if err := loadFromEnv(target, opts); err != nil {
+			return err
+		}
+	}
+	if opts.Flags != nil {
+		if err := loadFromFlags(target, opts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadFromFile(target interface{}, opts Options) error {
+	fh, err := os.Open(opts.Filename)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	var raw map[string]interface{}
+	if err := yaml.NewDecoder(fh).Decode(&raw); err != nil {
+		return fmt.Errorf("failed to decode yaml from %s: %w", opts.Filename, err)
+	}
+
+	if err := decode(target, raw, opts); err != nil {
+		return fmt.Errorf("failed to decode from %s: %w", opts.Filename, err)
+	}
+	return nil
+}
+
+func decode(target interface{}, raw map[string]interface{}, opts Options) error {
+	cfg := mapstructure.DecoderConfig{
+		Squash:  true,
+		Result:  target,
+		TagName: opts.FieldTagName,
+		MatchName: func(key string, fieldName string) bool {
+			return strings.EqualFold(key, fieldName)
+		},
+	}
+	decoder, err := mapstructure.NewDecoder(&cfg)
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(raw)
+}

--- a/internal/cmd/cliopts/config.go
+++ b/internal/cmd/cliopts/config.go
@@ -76,12 +76,10 @@ func loadFromFile(target interface{}, opts Options) error {
 
 func decode(target interface{}, raw map[string]interface{}, opts Options) error {
 	cfg := mapstructure.DecoderConfig{
-		Squash:  true,
-		Result:  target,
-		TagName: opts.FieldTagName,
-		MatchName: func(key string, fieldName string) bool {
-			return strings.EqualFold(key, fieldName)
-		},
+		Squash:    true,
+		Result:    target,
+		TagName:   opts.FieldTagName,
+		MatchName: strings.EqualFold,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),

--- a/internal/cmd/cliopts/config.go
+++ b/internal/cmd/cliopts/config.go
@@ -34,7 +34,7 @@ type Options struct {
 //   // environment variable
 //   PREFIX_ADDR_HTTPS=value
 //   // command line flag
-//   flags.String(&target.Addr.HTTPS, ...)
+//   flags.String("addr-https", ...)
 //
 func Load(target interface{}, opts Options) error {
 	if opts.FieldTagName == "" {
@@ -82,6 +82,12 @@ func decode(target interface{}, raw map[string]interface{}, opts Options) error 
 		MatchName: func(key string, fieldName string) bool {
 			return strings.EqualFold(key, fieldName)
 		},
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.StringToSliceHookFunc(","),
+			HookPrepareForDecode,
+			HookSetFromString,
+		),
 	}
 	decoder, err := mapstructure.NewDecoder(&cfg)
 	if err != nil {

--- a/internal/cmd/cliopts/config.go
+++ b/internal/cmd/cliopts/config.go
@@ -76,7 +76,8 @@ func loadFromFile(target interface{}, opts Options) error {
 
 const fieldTagName = "config"
 
-// DecodeConfig returns the default configured used by Load.
+// DecodeConfig returns the default DecoderConfig used by Load. This config
+// can be used by tests in other packages to simulate a call to Load.
 func DecodeConfig(target interface{}) mapstructure.DecoderConfig {
 	return mapstructure.DecoderConfig{
 		Squash:  true,
@@ -86,8 +87,8 @@ func DecodeConfig(target interface{}) mapstructure.DecoderConfig {
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
 			hookFlagValueSlice,
-			HookPrepareForDecode,
-			HookSetFromString,
+			hookPrepareForDecode,
+			hookSetFromString,
 		),
 	}
 }

--- a/internal/cmd/cliopts/config_test.go
+++ b/internal/cmd/cliopts/config_test.go
@@ -21,6 +21,7 @@ type Example struct {
 	BoolFromEnv   bool
 	UintFromEnv   uint
 	NetIPFromEnv  string
+	SkipTLSVerify bool
 
 	Nest    Nested
 	NestPtr *Nested
@@ -186,6 +187,7 @@ two: "from-file-3"
 	flags.Bool("nest-ptr-flag", false, "")
 	flags.StringSlice("many-things", nil, "")
 	flags.IntSlice("many-numbers", nil, "")
+	flags.Bool("skip-tls-verify", false, "")
 
 	err := flags.Parse([]string{
 		"--string-field=from-flag-1",
@@ -199,6 +201,7 @@ two: "from-file-3"
 		"--many-numbers=9",
 		"--many-numbers=10",
 		"--many-numbers=11",
+		"--skip-tls-verify",
 	})
 	assert.NilError(t, err)
 
@@ -220,6 +223,7 @@ two: "from-file-3"
 		BoolFromEnv:   true,
 		UintFromEnv:   412,
 		NetIPFromEnv:  "0.0.0.0",
+		SkipTLSVerify: true,
 		More:          "not-this-either",
 		Nest: Nested{
 			Two:     "left-as-default-2",

--- a/internal/cmd/cliopts/config_test.go
+++ b/internal/cmd/cliopts/config_test.go
@@ -1,0 +1,229 @@
+package cliopts
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
+type Example struct {
+	One         string
+	StringField string
+	BoolField   bool
+	Int32Field  int32
+	Singleword  int
+	HostTHING   string
+	More        string
+
+	StringFromEnv string
+	BoolFromEnv   bool
+	UintFromEnv   uint
+	NetIPFromEnv  string
+
+	Nest    Nested
+	NestPtr *Nested
+
+	Nested
+
+	// TODO: slice, and map
+	// TODO: type that defines Unmarshal/Decode method
+}
+
+type Nested struct {
+	Two     string
+	Twine   string
+	Numb    int
+	Flag    bool
+	Ratio   float64
+	Another string
+}
+
+func TestLoad(t *testing.T) {
+	content := `
+stringField: from-file
+boolField: true
+int32Field: 2
+singleword: 3
+hostThing: ok
+more: not-this
+
+stringFromEnv: from-file-2
+boolFromEnv: false
+uintFromEnv: 5
+
+nest:
+    numb: -2
+    another: not-this
+
+nestPtr:
+    two: "the-value"
+    ratio: 3.15
+
+two: "from-file-3"
+`
+	f := fs.NewFile(t, t.Name(), fs.WithContent(content))
+
+	t.Setenv("APPNAME_STRING_FROM_ENV", "from-env-1")
+	t.Setenv("APPNAME_BOOL_FROM_ENV", "true")
+	t.Setenv("APPNAME_UINT_FROM_ENV", "412")
+	t.Setenv("APPNAME_NET_IP_FROM_ENV", "0.0.0.0")
+	t.Setenv("APPNAME_NEST_TWINE", "from-env-2")
+	t.Setenv("APPNAME_NEST_RATIO", "3.14")
+	t.Setenv("APPNAME_NEST_PTR_TWINE", "from-env-3")
+	t.Setenv("APPNAME_NEST_PTR_FLAG", "true")
+	t.Setenv("APPNAME_TWINE", "from-env-4")
+	t.Setenv("APPNAME_MORE", "not-this-either")
+
+	target := Example{
+		One:         "left-as-default",
+		StringField: "default-1",
+		Int32Field:  1,
+		More:        "default-2",
+		Nest: Nested{
+			Two: "left-as-default-2",
+		},
+	}
+
+	opts := Options{
+		Filename:  f.Path(),
+		EnvPrefix: "APPNAME",
+	}
+	err := Load(&target, opts)
+	assert.NilError(t, err)
+	expected := Example{
+		One:           "left-as-default",
+		StringField:   "from-file",
+		BoolField:     true,
+		Int32Field:    2,
+		Singleword:    3,
+		HostTHING:     "ok",
+		StringFromEnv: "from-env-1",
+		BoolFromEnv:   true,
+		UintFromEnv:   412,
+		NetIPFromEnv:  "0.0.0.0",
+		More:          "not-this-either",
+		Nest: Nested{
+			Two:     "left-as-default-2",
+			Twine:   "from-env-2",
+			Numb:    -2,
+			Ratio:   3.14,
+			Another: "not-this",
+		},
+		NestPtr: &Nested{
+			Two:   "the-value",
+			Twine: "from-env-3",
+			Flag:  true,
+			Ratio: 3.15,
+		},
+		Nested: Nested{
+			Two:   "from-file-3",
+			Twine: "from-env-4",
+		},
+	}
+	assert.DeepEqual(t, target, expected)
+}
+
+func TestLoad_WithFlags(t *testing.T) {
+	content := `
+stringField: from-file
+boolField: true
+int32Field: 2
+singleword: 3
+hostThing: ok
+more: not-this
+
+stringFromEnv: from-file-2
+boolFromEnv: false
+uintFromEnv: 5
+
+nest:
+    numb: -2
+    another: not-this
+
+nestPtr:
+    two: "the-value"
+    ratio: 3.15
+
+two: "from-file-3"
+`
+	f := fs.NewFile(t, t.Name(), fs.WithContent(content))
+
+	t.Setenv("APPNAME_STRING_FROM_ENV", "from-env-1")
+	t.Setenv("APPNAME_BOOL_FROM_ENV", "true")
+	t.Setenv("APPNAME_UINT_FROM_ENV", "412")
+	t.Setenv("APPNAME_NET_IP_FROM_ENV", "0.0.0.0")
+	t.Setenv("APPNAME_NEST_TWINE", "from-env-2")
+	t.Setenv("APPNAME_NEST_RATIO", "3.14")
+	t.Setenv("APPNAME_NEST_PTR_TWINE", "from-env-3")
+	t.Setenv("APPNAME_TWINE", "from-env-4")
+	t.Setenv("APPNAME_MORE", "not-this-either")
+
+	target := Example{
+		One:         "left-as-default",
+		StringField: "default-1",
+		Int32Field:  1,
+		More:        "default-2",
+		Nest: Nested{
+			Two: "left-as-default-2",
+		},
+	}
+
+	flags := pflag.NewFlagSet("any", pflag.ContinueOnError)
+	flags.String("string-field", "", "")
+	flags.Int32("int-32-field", 0, "")
+	flags.Bool("bool-field", false, "")
+	flags.String("nest-twine", "", "")
+	flags.String("two", "", "")
+	flags.Bool("nest-ptr-flag", false, "")
+
+	err := flags.Parse([]string{
+		"--string-field=from-flag-1",
+		"--int-32-field=45",
+		"--bool-field=false",
+		"--nest-twine=from-flag-2",
+		"--two=from-flag-3",
+		"--nest-ptr-flag",
+	})
+	assert.NilError(t, err)
+
+	opts := Options{
+		Filename:  f.Path(),
+		EnvPrefix: "APPNAME",
+		Flags:     flags,
+	}
+	err = Load(&target, opts)
+	assert.NilError(t, err)
+	expected := Example{
+		One:           "left-as-default",
+		StringField:   "from-flag-1",
+		BoolField:     false,
+		Int32Field:    45,
+		Singleword:    3,
+		HostTHING:     "ok",
+		StringFromEnv: "from-env-1",
+		BoolFromEnv:   true,
+		UintFromEnv:   412,
+		NetIPFromEnv:  "0.0.0.0",
+		More:          "not-this-either",
+		Nest: Nested{
+			Two:     "left-as-default-2",
+			Twine:   "from-flag-2",
+			Numb:    -2,
+			Ratio:   3.14,
+			Another: "not-this",
+		},
+		NestPtr: &Nested{
+			Two:   "the-value",
+			Twine: "from-env-3",
+			Flag:  true,
+			Ratio: 3.15,
+		},
+		Nested: Nested{
+			Two:   "from-flag-3",
+			Twine: "from-env-4",
+		},
+	}
+	assert.DeepEqual(t, target, expected)
+}

--- a/internal/cmd/cliopts/config_test.go
+++ b/internal/cmd/cliopts/config_test.go
@@ -179,6 +179,7 @@ two: "from-file-3"
 	}
 
 	flags := pflag.NewFlagSet("any", pflag.ContinueOnError)
+	flags.String("one", "not-the-real-default", "")
 	flags.String("string-field", "", "")
 	flags.Int32("int-32-field", 0, "")
 	flags.Bool("bool-field", false, "")

--- a/internal/cmd/cliopts/config_test.go
+++ b/internal/cmd/cliopts/config_test.go
@@ -27,7 +27,10 @@ type Example struct {
 
 	Nested
 
-	// TODO: slice, and map
+	ManyThings  []string
+	ManyNumbers []int
+
+	// TODO: and map
 	// TODO: type that defines Unmarshal/Decode method
 }
 
@@ -62,6 +65,8 @@ nestPtr:
     ratio: 3.15
 
 two: "from-file-3"
+manyThings: [one, two]
+manyNumbers: [1,2,3]
 `
 	f := fs.NewFile(t, t.Name(), fs.WithContent(content))
 
@@ -121,6 +126,8 @@ two: "from-file-3"
 			Two:   "from-file-3",
 			Twine: "from-env-4",
 		},
+		ManyThings:  []string{"one", "two"},
+		ManyNumbers: []int{1, 2, 3},
 	}
 	assert.DeepEqual(t, target, expected)
 }
@@ -177,6 +184,8 @@ two: "from-file-3"
 	flags.String("nest-twine", "", "")
 	flags.String("two", "", "")
 	flags.Bool("nest-ptr-flag", false, "")
+	flags.StringSlice("many-things", nil, "")
+	flags.IntSlice("many-numbers", nil, "")
 
 	err := flags.Parse([]string{
 		"--string-field=from-flag-1",
@@ -185,6 +194,11 @@ two: "from-file-3"
 		"--nest-twine=from-flag-2",
 		"--two=from-flag-3",
 		"--nest-ptr-flag",
+		"--many-things=first",
+		"--many-things=second",
+		"--many-numbers=9",
+		"--many-numbers=10",
+		"--many-numbers=11",
 	})
 	assert.NilError(t, err)
 
@@ -224,6 +238,8 @@ two: "from-file-3"
 			Two:   "from-flag-3",
 			Twine: "from-env-4",
 		},
+		ManyThings:  []string{"first", "second"},
+		ManyNumbers: []int{9, 10, 11},
 	}
 	assert.DeepEqual(t, target, expected)
 }

--- a/internal/cmd/cliopts/flat.go
+++ b/internal/cmd/cliopts/flat.go
@@ -71,17 +71,10 @@ func (w *flatSourceWalker) Struct(value reflect.Value) error {
 		// TODO: what is this case?
 		return nil
 	}
-	cfg := mapstructure.DecoderConfig{
-		Result:           value.Addr().Interface(),
-		TagName:          w.opts.FieldTagName,
-		WeaklyTypedInput: true,
-		MatchName:        w.matchName,
-		DecodeHook: mapstructure.ComposeDecodeHookFunc(
-			mapstructure.StringToTimeDurationHookFunc(),
-			mapstructure.StringToSliceHookFunc(","),
-			hookFlagValueSlice,
-		),
-	}
+	cfg := DecodeConfig(value.Addr().Interface())
+	cfg.WeaklyTypedInput = true
+	cfg.MatchName = w.matchName
+
 	decoder, err := mapstructure.NewDecoder(&cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create decoder for struct: %w", err)

--- a/internal/cmd/cliopts/flat.go
+++ b/internal/cmd/cliopts/flat.go
@@ -32,7 +32,9 @@ func loadFromEnv(target interface{}, opts Options) error {
 func loadFromFlags(target interface{}, opts Options) error {
 	source := map[string]interface{}{}
 	opts.Flags.VisitAll(func(flag *pflag.Flag) {
-		source[flag.Name] = flag.Value
+		if flag.Changed {
+			source[flag.Name] = flag.Value
+		}
 	})
 
 	walker := &flatSourceWalker{

--- a/internal/cmd/cliopts/flat.go
+++ b/internal/cmd/cliopts/flat.go
@@ -1,0 +1,143 @@
+package cliopts
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/iancoleman/strcase"
+	"github.com/mitchellh/mapstructure"
+	"github.com/mitchellh/reflectwalk"
+	"github.com/spf13/pflag"
+)
+
+func loadFromEnv(target interface{}, opts Options) error {
+	opts.EnvPrefix = strings.ToUpper(opts.EnvPrefix)
+	walker := &flatSourceWalker{
+		source:   toMap(opts.EnvPrefix, os.Environ()),
+		location: []string{opts.EnvPrefix},
+		fieldNameFormat: func(name string) string {
+			return strings.ToUpper(strcase.ToSnake(name))
+		},
+		fieldSeparator: "_",
+	}
+
+	if err := reflectwalk.Walk(target, walker); err != nil {
+		return fmt.Errorf("failed to load from environment variables: %w", err)
+	}
+	return nil
+}
+
+func loadFromFlags(target interface{}, opts Options) error {
+	source := map[string]string{}
+	opts.Flags.VisitAll(func(flag *pflag.Flag) {
+		// TODO: a better way to get values out of flags...
+		// TODO: will not work for some flag types.
+		source[flag.Name] = flag.Value.String()
+	})
+
+	walker := &flatSourceWalker{
+		source:          source,
+		fieldNameFormat: strcase.ToKebab,
+		fieldSeparator:  "-",
+	}
+
+	if err := reflectwalk.Walk(target, walker); err != nil {
+		return fmt.Errorf("failed to load from command line flag: %w", err)
+	}
+	return nil
+}
+
+type flatSourceWalker struct {
+	opts            Options
+	location        []string
+	source          map[string]string
+	fieldNameFormat func(string) string
+	fieldSeparator  string
+}
+
+func (w *flatSourceWalker) Enter(reflectwalk.Location) error {
+	return nil
+}
+
+func (w *flatSourceWalker) Exit(loc reflectwalk.Location) error {
+	if loc == reflectwalk.Struct && len(w.location) > 0 {
+		w.location = w.location[:len(w.location)-1]
+	}
+	return nil
+}
+
+func (w *flatSourceWalker) Struct(value reflect.Value) error {
+	cfg := mapstructure.DecoderConfig{
+		Result:           value.Addr().Interface(),
+		TagName:          w.opts.FieldTagName,
+		WeaklyTypedInput: true,
+		MatchName:        w.matchName,
+	}
+	decoder, err := mapstructure.NewDecoder(&cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create decoder for struct: %w", err)
+	}
+	if err := decoder.Decode(w.source); err != nil {
+		return fmt.Errorf("failed to decode into struct: %w", err)
+	}
+	return nil
+}
+
+func (w *flatSourceWalker) StructField(field reflect.StructField, value reflect.Value) error {
+	if value.Kind() == reflect.Struct || isPtrToStruct(value) {
+		if field.Anonymous { // embedded struct
+			w.location = append(w.location, "")
+			return nil
+		}
+		w.location = append(w.location, w.fieldNameFormat(field.Name))
+	}
+	return nil
+}
+
+func (w *flatSourceWalker) matchName(key string, fieldName string) bool {
+	var sb strings.Builder
+	for _, part := range w.location {
+		if part == "" { // skip empty part for embedded struct
+			continue
+		}
+		sb.WriteString(part)
+		sb.WriteString(w.fieldSeparator)
+	}
+	sb.WriteString(w.fieldNameFormat(fieldName))
+	return key == sb.String()
+}
+
+func isPtrToStruct(value reflect.Value) bool {
+	return value.Kind() == reflect.Ptr && value.Elem().Kind() == reflect.Struct
+}
+
+// toMap converts an environment variable slice to a map of key/value pairs.
+// The environment slice is filtered to only include keys that match the prefix
+// because mapstructure iterates over this map, and any keys that do not match
+// the prefix will never be used.
+func toMap(prefix string, env []string) map[string]string {
+	result := map[string]string{}
+	for _, raw := range env {
+		key, value := getParts(raw)
+		if strings.HasPrefix(key, prefix) {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func getParts(raw string) (string, string) {
+	if raw == "" {
+		return "", ""
+	}
+	// Environment variables on windows can begin with =
+	// http://blogs.msdn.com/b/oldnewthing/archive/2010/05/06/10008132.aspx
+	parts := strings.SplitN(raw[1:], "=", 2)
+	key := raw[:1] + parts[0]
+	if len(parts) == 1 {
+		return key, ""
+	}
+	return key, parts[1]
+}

--- a/internal/cmd/cliopts/flat.go
+++ b/internal/cmd/cliopts/flat.go
@@ -48,7 +48,6 @@ func loadFromFlags(target interface{}, opts Options) error {
 }
 
 type flatSourceWalker struct {
-	opts            Options
 	location        []string
 	source          map[string]interface{}
 	fieldNameFormat func(string) string

--- a/internal/cmd/cliopts/flat.go
+++ b/internal/cmd/cliopts/flat.go
@@ -67,6 +67,10 @@ func (w *flatSourceWalker) Exit(loc reflectwalk.Location) error {
 }
 
 func (w *flatSourceWalker) Struct(value reflect.Value) error {
+	if !value.CanAddr() {
+		// TODO: what is this case?
+		return nil
+	}
 	cfg := mapstructure.DecoderConfig{
 		Result:           value.Addr().Interface(),
 		TagName:          w.opts.FieldTagName,

--- a/internal/cmd/cliopts/hooks.go
+++ b/internal/cmd/cliopts/hooks.go
@@ -1,8 +1,23 @@
-package decode
+package cliopts
 
 import (
 	"reflect"
 )
+
+type flagValueSlice interface {
+	GetSlice() []string
+}
+
+// hookFlagValueSlice allows for decoding from pflag.SliceValue types into a
+// slice in the target.
+func hookFlagValueSlice(from reflect.Value, to reflect.Value) (interface{}, error) {
+	source := from.Interface()
+	v, ok := source.(flagValueSlice)
+	if !ok {
+		return source, nil
+	}
+	return v.GetSlice(), nil
+}
 
 type Decoder func(target interface{}, source interface{}) error
 

--- a/internal/cmd/cliopts/hooks.go
+++ b/internal/cmd/cliopts/hooks.go
@@ -19,19 +19,17 @@ func hookFlagValueSlice(from reflect.Value, to reflect.Value) (interface{}, erro
 	return v.GetSlice(), nil
 }
 
-type Decoder func(target interface{}, source interface{}) error
-
 type PrepareForDecoder interface {
 	PrepareForDecode(data interface{}) error
 }
 
-// HookPrepareForDecode is a mapstructure.DecodeHookFuncValue that enables decoding
+// hookPrepareForDecode is a mapstructure.DecodeHookFuncValue that enables decoding
 // of any type that implements the PrepareForDecoder interface.
 //
 // Types that implement PrepareForDecoder can use the passed in data to set
 // concrete types on any polymorphic fields, which will allow mapstructure.Decode
 // to properly decode the config into the expected type.
-func HookPrepareForDecode(from reflect.Value, to reflect.Value) (interface{}, error) {
+func hookPrepareForDecode(from reflect.Value, to reflect.Value) (interface{}, error) {
 	source := from.Interface()
 	unmapper, ok := to.Interface().(PrepareForDecoder)
 	if !ok {
@@ -51,12 +49,12 @@ type FromString interface {
 	Set(string) error
 }
 
-// HookSetFromString allows any complex type that implements FromString to
+// hookSetFromString allows any complex type that implements FromString to
 // set its value from a string.
 //
 // This same interface is accepted by spf13/pflag, which allows us to use the
 // same type for command line flags, env vars, and config files.
-func HookSetFromString(from reflect.Value, to reflect.Value) (interface{}, error) {
+func hookSetFromString(from reflect.Value, to reflect.Value) (interface{}, error) {
 	source := from.Interface()
 	v, ok := source.(string)
 	if !ok {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -13,12 +13,9 @@ import (
 	"strings"
 
 	"github.com/goware/urlx"
-	"github.com/iancoleman/strcase"
 	"github.com/lensesio/tableprinter"
-	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 	"golang.org/x/term"
 
 	"github.com/infrahq/infra/api"
@@ -55,74 +52,6 @@ func mustBeLoggedIn() error {
 	}
 
 	return nil
-}
-
-func parseOptions(cmd *cobra.Command, options interface{}, envPrefix string) error {
-	v := viper.New()
-
-	if configFileFlag := cmd.Flags().Lookup("config-file"); configFileFlag != nil {
-		if configFile := configFileFlag.Value.String(); configFile != "" {
-			v.SetConfigFile(configFile)
-		}
-	}
-
-	if envPrefix != "" {
-		v.SetEnvPrefix(envPrefix)
-		v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-		v.AutomaticEnv()
-
-		// workaround for viper not correctly binding env vars
-		// https://github.com/spf13/viper/issues/761
-		envKeys := make(map[string]interface{})
-		if err := mapstructure.Decode(options, &envKeys); err != nil {
-			return err
-		}
-
-		// bind file options (lower camel case) to environment options (envPrefix + upper snake case)
-		// e.g. accessKey -> INFRA_CONNECTOR_ACCESS_KEY
-		for envKey := range envKeys {
-			fullEnvKey := fmt.Sprintf("%s_%s", envPrefix, envKey)
-			if err := v.BindEnv(envKey, strcase.ToScreamingSnake(fullEnvKey)); err != nil {
-				return err
-			}
-		}
-	}
-
-	errs := make([]error, 0)
-	// bind command line options (lower snake case) to file options (lower camel case)
-	// e.g. access-key -> accessKey
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		if err := v.BindPFlag(strcase.ToLowerCamel(f.Name), f); err != nil {
-			errs = append(errs, err)
-		}
-	})
-
-	if len(errs) > 0 {
-		var sb strings.Builder
-
-		sb.WriteString("multiple errors seen while binding flags:\n\n")
-
-		for _, err := range errs {
-			fmt.Fprintf(&sb, "* %s\n", err)
-		}
-
-		return errors.New(sb.String())
-	}
-
-	if err := v.ReadInConfig(); err != nil {
-		var errNotFound *viper.ConfigFileNotFoundError
-		if errors.As(err, &errNotFound) {
-			return err
-		}
-	}
-
-	hooks := mapstructure.ComposeDecodeHookFunc(
-		mapstructure.StringToTimeDurationHookFunc(),
-		mapstructure.StringToSliceHookFunc(","),
-		cliopts.HookPrepareForDecode,
-		cliopts.HookSetFromString,
-	)
-	return v.Unmarshal(options, viper.DecodeHook(hooks))
 }
 
 func infraHomeDir() (string, error) {
@@ -266,6 +195,8 @@ func canonicalPath(path string) (string, error) {
 }
 
 func newConnectorCmd() *cobra.Command {
+	var configFilename string
+
 	cmd := &cobra.Command{
 		Use:    "connector",
 		Short:  "Start the Infra connector",
@@ -274,11 +205,13 @@ func newConnectorCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			logging.SetServerLogger()
 
-			// override default strcase.ToLowerCamel behaviour
-			strcase.ConfigureAcronym("skip-tls-verify", "skipTLSVerify")
-
 			var options connector.Options
-			if err := parseOptions(cmd, &options, "INFRA_CONNECTOR"); err != nil {
+			err := cliopts.Load(&options, cliopts.Options{
+				Filename:  configFilename,
+				EnvPrefix: "INFRA_CONNECTOR",
+				Flags:     cmd.Flags(),
+			})
+			if err != nil {
 				return err
 			}
 
@@ -286,7 +219,7 @@ func newConnectorCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("config-file", "f", "", "Connector config file")
+	cmd.Flags().StringVarP(&configFilename, "config-file", "f", "", "Connector config file")
 	cmd.Flags().StringP("server", "s", "", "Infra server hostname")
 	cmd.Flags().StringP("access-key", "a", "", "Infra access key (use file:// to load from a file)")
 	cmd.Flags().StringP("name", "n", "", "Destination name")

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -205,7 +205,7 @@ func newConnectorCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			logging.SetServerLogger()
 
-			var options connector.Options
+			options := defaultConnectorOptions()
 			err := cliopts.Load(&options, cliopts.Options{
 				Filename:  configFilename,
 				EnvPrefix: "INFRA_CONNECTOR",
@@ -232,6 +232,12 @@ func newConnectorCmd() *cobra.Command {
 
 // runConnector is a shim for testing
 var runConnector = connector.Run
+
+// defaultConnectorOptions is empty for now. It exists so that it can be
+// referenced by a test.
+func defaultConnectorOptions() connector.Options {
+	return connector.Options{}
+}
 
 // rootOptions are options specified by users on the command line that are
 // used by the root command.

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -25,7 +25,6 @@ import (
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/cmd/cliopts"
 	"github.com/infrahq/infra/internal/connector"
-	"github.com/infrahq/infra/internal/decode"
 	"github.com/infrahq/infra/internal/logging"
 )
 
@@ -120,8 +119,8 @@ func parseOptions(cmd *cobra.Command, options interface{}, envPrefix string) err
 	hooks := mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
-		decode.HookPrepareForDecode,
-		decode.HookSetFromString,
+		cliopts.HookPrepareForDecode,
+		cliopts.HookSetFromString,
 	)
 	return v.Unmarshal(options, viper.DecodeHook(hooks))
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -215,7 +215,7 @@ func newConnectorCmd() *cobra.Command {
 				return err
 			}
 
-			return connector.Run(cmd.Context(), options)
+			return runConnector(cmd.Context(), options)
 		},
 	}
 
@@ -229,6 +229,9 @@ func newConnectorCmd() *cobra.Command {
 
 	return cmd
 }
+
+// runConnector is a shim for testing
+var runConnector = connector.Run
 
 // rootOptions are options specified by users on the command line that are
 // used by the root command.

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -68,28 +68,37 @@ func newServerCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&configFilename, "config-file", "f", "", "Server configuration file")
-	cmd.Flags().String("tls-cache", "$HOME/.infra/cache", "Directory to cache TLS certificates")
-	cmd.Flags().String("db-file", "$HOME/.infra/sqlite3.db", "Path to SQLite 3 database")
+	cmd.Flags().String("tls-cache", "", "Directory to cache TLS certificates")
+	cmd.Flags().String("db-file", "", "Path to SQLite 3 database")
 	cmd.Flags().String("db-name", "", "Database name")
 	cmd.Flags().String("db-host", "", "Database host")
 	cmd.Flags().Int("db-port", 0, "Database port")
 	cmd.Flags().String("db-username", "", "Database username")
 	cmd.Flags().String("db-password", "", "Database password (secret)")
 	cmd.Flags().String("db-parameters", "", "Database additional connection parameters")
-	cmd.Flags().String("db-encryption-key", "$HOME/.infra/sqlite3.db.key", "Database encryption key")
-	cmd.Flags().String("db-encryption-key-provider", "native", "Database encryption key provider")
-	cmd.Flags().Bool("enable-telemetry", true, "Enable telemetry")
-	cmd.Flags().Bool("enable-crash-reporting", true, "Enable crash reporting")
+	cmd.Flags().String("db-encryption-key", "", "Database encryption key")
+	cmd.Flags().String("db-encryption-key-provider", "", "Database encryption key provider")
+	cmd.Flags().Bool("enable-telemetry", false, "Enable telemetry")
+	cmd.Flags().Bool("enable-crash-reporting", false, "Enable crash reporting")
 	cmd.Flags().BoolVar(&options.UI.Enabled, "enable-ui", false, "Enable Infra server UI")
 	cmd.Flags().Var(&options.UI.ProxyURL, "ui-proxy-url", "Proxy upstream UI requests to this url")
-	cmd.Flags().Duration("session-duration", 12*time.Hour, "User session duration")
-	cmd.Flags().Bool("enable-signup", true, "Enable one-time admin signup")
+	cmd.Flags().Duration("session-duration", 0, "User session duration")
+	cmd.Flags().Bool("enable-signup", false, "Enable one-time admin signup")
 
 	return cmd
 }
 
 func defaultServerOptions() server.Options {
 	return server.Options{
+		TLSCache:                "$HOME/.infra/cache",
+		DBFile:                  "$HOME/.infra/sqlite3.db",
+		DBEncryptionKey:         "$HOME/.infra/sqlite3.db.key",
+		DBEncryptionKeyProvider: "native",
+		EnableTelemetry:         true,
+		EnableCrashReporting:    true,
+		SessionDuration:         12 * time.Hour,
+		EnableSignup:            true,
+
 		Addr: server.ListenerOptions{
 			HTTP:    ":80",
 			HTTPS:   ":443",

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -82,7 +82,7 @@ func newServerCmd() *cobra.Command {
 	cmd.Flags().Bool("enable-crash-reporting", true, "Enable crash reporting")
 	cmd.Flags().BoolVar(&options.UI.Enabled, "enable-ui", false, "Enable Infra server UI")
 	cmd.Flags().Var(&options.UI.ProxyURL, "ui-proxy-url", "Proxy upstream UI requests to this url")
-	cmd.Flags().Duration("session-duration", time.Hour*12, "User session duration")
+	cmd.Flags().Duration("session-duration", 12*time.Hour, "User session duration")
 	cmd.Flags().Bool("enable-signup", true, "Enable one-time admin signup")
 
 	return cmd

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -74,7 +74,6 @@ func TestServerCmd_ParseOptions(t *testing.T) {
 		{
 			name: "config filename specified as env var",
 			setup: func(t *testing.T, cmd *cobra.Command) {
-				t.Skip("does not work yet")
 				content := `
                     addr:
                       http: "127.0.0.1:1455"`
@@ -93,7 +92,6 @@ func TestServerCmd_ParseOptions(t *testing.T) {
 		{
 			name: "env var can set a value outside of the top level",
 			setup: func(t *testing.T, cmd *cobra.Command) {
-				t.Skip("does not work yet")
 				t.Setenv("INFRA_SERVER_ADDR_HTTP", "127.0.0.1:1455")
 			},
 			expected: func(t *testing.T) server.Options {

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -136,6 +136,31 @@ func TestServerCmd_LoadOptions(t *testing.T) {
 				return expected
 			},
 		},
+		{
+			name: "options from all flags",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				cmd.SetArgs([]string{
+					"--db-name", "database-name",
+					"--db-file", "$HOME/database-filename",
+					"--db-port", "12345",
+					"--db-host", "thehostname",
+					"--enable-telemetry=false",
+					"--session-duration", "3m",
+					"--enable-signup=false",
+				})
+			},
+			expected: func(t *testing.T) server.Options {
+				expected := serverOptionsWithDefaults()
+				expected.DBName = "database-name"
+				expected.DBFile = "/home/user/database-filename"
+				expected.DBHost = "thehostname"
+				expected.DBPort = 12345
+				expected.EnableTelemetry = false
+				expected.SessionDuration = 3 * time.Minute
+				expected.EnableSignup = false
+				return expected
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/infrahq/infra/internal/server"
 )
 
-func TestServerCmd_ParseOptions(t *testing.T) {
+func TestServerCmd_LoadOptions(t *testing.T) {
 	type testCase struct {
 		name        string
 		setup       func(t *testing.T, cmd *cobra.Command)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -196,6 +196,10 @@ func importKeyProviders(
 }
 
 func (kp *KeyProvider) PrepareForDecode(data interface{}) error {
+	if kp.Kind != "" {
+		// this instance was already prepared from a previous call
+		return nil
+	}
 	kind := getKindFromUnstructured(data)
 	switch kind {
 	case "vault":
@@ -212,8 +216,8 @@ func (kp *KeyProvider) PrepareForDecode(data interface{}) error {
 }
 
 type SecretProvider struct {
-	Kind   string      `mapstructure:"kind"`
-	Name   string      `mapstructure:"name"`
+	Kind   string      `config:"kind"`
+	Name   string      `config:"name"`
 	Config interface{} // contains secret-provider-specific config
 }
 
@@ -475,6 +479,10 @@ func loadDefaultSecretConfig(storage map[string]secrets.SecretStorage) error {
 // setting a concrete type for the config based on the kind. Failures to decode
 // will be handled by mapstructure, or by importSecrets.
 func (sp *SecretProvider) PrepareForDecode(data interface{}) error {
+	if sp.Kind != "" {
+		// this instance was already prepared from a previous call
+		return nil
+	}
 	kind := getKindFromUnstructured(data)
 	switch kind {
 	case "vault":

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -211,19 +211,8 @@ secrets:
 }
 
 func decodeConfig(target interface{}, source interface{}) error {
-	// Copied from viper defaultDecoderConfig
-	config := &mapstructure.DecoderConfig{
-		Result:           target,
-		WeaklyTypedInput: true,
-		DecodeHook: mapstructure.ComposeDecodeHookFunc(
-			mapstructure.StringToTimeDurationHookFunc(),
-			mapstructure.StringToSliceHookFunc(","),
-			cliopts.HookPrepareForDecode,
-			cliopts.HookSetFromString,
-		),
-	}
-
-	decoder, err := mapstructure.NewDecoder(config)
+	cfg := cliopts.DecodeConfig(target)
+	decoder, err := mapstructure.NewDecoder(&cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -8,7 +8,7 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
-	"github.com/infrahq/infra/internal/decode"
+	"github.com/infrahq/infra/internal/cmd/cliopts"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -218,8 +218,8 @@ func decodeConfig(target interface{}, source interface{}) error {
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
-			decode.HookPrepareForDecode,
-			decode.HookSetFromString,
+			cliopts.HookPrepareForDecode,
+			cliopts.HookSetFromString,
 		),
 	}
 


### PR DESCRIPTION
## Summary

Original PR #1682

The last 2 commits here address the problem with flag default values overwriting settings from config.  Full details about the two options and trade-offs in the last commit message, copied here:

For long-running commands (infra server, and infra connector) all
options can be set from the config file, and most can be set from env vars,
but only a few will be set from command line flags.

Command line flags accept default values, but anything that uses
cliopts.Load can set defaults on the struct before calling Load.

Because of these two constraints, we end up with two options:

1. have cliopts honor the default values set in flags, allowing defaults
   to be specified in two different ways.
2. only allow defaults to be set on the struct before calling
   cliopts.Load.

This commit goes with the second option, ignore defaults set on flags so
that we only have one way of specifying default values.

To prevent surprises, this commit also adds two tests for the flags on
these commands. The tests check that the flags all use the zero value as
the default. This should point the contributor to the right place if
they accidentally add a non-zero value on a flag.