### PR TITLE
api: improve errors returned by api.Client

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,12 +1,61 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"gotest.tools/v3/assert"
 )
+
+func TestErrorStatusCode(t *testing.T) {
+	codes := []int{
+		http.StatusContinue,
+		http.StatusOK,
+		http.StatusCreated,
+		http.StatusMovedPermanently,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusInternalServerError,
+		http.StatusNotImplemented,
+		http.StatusBadGateway,
+	}
+
+	t.Run("equal to self, not equal to other codes", func(t *testing.T) {
+		for c := 0; c < len(codes); c++ {
+			err := Error{Code: int32(codes[c])}
+			for o := 0; o < len(codes); o++ {
+				if o == c {
+					assert.Equal(t, ErrorStatusCode(err), int32(codes[o]))
+					continue
+				}
+
+				assert.Assert(t, ErrorStatusCode(err) != int32(codes[o]),
+					"code=%v, other=%v", err.Code, codes[o])
+			}
+		}
+	})
+
+	t.Run("nil error returns 0", func(t *testing.T) {
+		assert.Equal(t, ErrorStatusCode(nil), int32(0))
+	})
+
+	t.Run("other errors return 0", func(t *testing.T) {
+		assert.Equal(t, ErrorStatusCode(fmt.Errorf("other error")), int32(0))
+	})
+
+	t.Run("from wrapped error", func(t *testing.T) {
+		err := fmt.Errorf("with some wrapping: %w",
+			Error{Code: int32(http.StatusInternalServerError)})
+
+		actual := ErrorStatusCode(err)
+		assert.Equal(t, actual, int32(http.StatusInternalServerError))
+	})
+}
 
 func TestGet(t *testing.T) {
 	requestCh := make(chan *http.Request, 5)
@@ -18,6 +67,10 @@ func TestGet(t *testing.T) {
 			_, _ = resp.Write([]byte(`{}`))
 		case "/bad":
 			resp.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(resp).Encode(Error{
+				Code:    http.StatusBadRequest,
+				Message: "bad request: it failed because",
+			})
 		default:
 			resp.WriteHeader(http.StatusInternalServerError)
 		}
@@ -50,12 +103,21 @@ func TestGet(t *testing.T) {
 		assert.DeepEqual(t, req.Header, expectedHeaders)
 	})
 
-	t.Run("failed request", func(t *testing.T) {
+	t.Run("bad request", func(t *testing.T) {
 		_, err := get[stubResponse](c, "/bad")
-		assert.ErrorContains(t, err, `responded 400`)
+		assert.Error(t, err, `GET /bad failed: bad request: it failed because`)
 		req := <-requestCh
 		assert.Equal(t, req.Method, http.MethodGet)
 		assert.Equal(t, req.URL.Path, "/bad")
+		assert.DeepEqual(t, req.Header, expectedHeaders)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		_, err := get[stubResponse](c, "/invalid")
+		assert.Error(t, err, `GET /invalid failed: 500 internal server error`)
+		req := <-requestCh
+		assert.Equal(t, req.Method, http.MethodGet)
+		assert.Equal(t, req.URL.Path, "/invalid")
 		assert.DeepEqual(t, req.Header, expectedHeaders)
 	})
 }

--- a/api/errors.go
+++ b/api/errors.go
@@ -2,26 +2,28 @@ package api
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
 )
 
-var (
-	// ErrUnauthorized refers to the http response code unauthorized, which really means not authenticated, despite its name. See https://stackoverflow.com/a/6937030/155585
-	ErrUnauthorized = fmt.Errorf("unauthorized")
-	// ErrForbidden means you don't have permissions to the requested resource
-	ErrForbidden = fmt.Errorf("forbidden")
-	// ErrBadGateway means an invalid response was received from an upstream server (probably an OIDC provider)
-	ErrBadGateway = fmt.Errorf("bad gateway")
-
-	ErrDuplicate  = fmt.Errorf("duplicate record")
-	ErrNotFound   = fmt.Errorf("record not found")
-	ErrBadRequest = fmt.Errorf("bad request")
-	ErrInternal   = fmt.Errorf("internal error")
-)
-
+// Error is used as the response body for failed HTTP requests. It is also
+// the error returned by api.Client methods when the request fails.
 type Error struct {
-	Code        int32        `json:"code"` // should be a repeat of the http response status code
-	Message     string       `json:"message"`
+	// Code is the HTTP status of the response.
+	Code int32 `json:"code"`
+	// Message contains the full text of the failure as a single string. The
+	// details of the failure may also be available in a structured representation
+	// from one of the other fields on the Error struct.
+	Message string `json:"message"`
+	// FieldErrors contains a structured representation of any validation errors.
 	FieldErrors []FieldError `json:"fieldErrors,omitempty"`
+}
+
+func (e Error) Error() string {
+	if e.Message == "" {
+		return fmt.Sprintf("%d %v", e.Code, strings.ToLower(http.StatusText(int(e.Code))))
+	}
+	return e.Message
 }
 
 type FieldError struct {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -153,17 +153,17 @@ func login(options loginCmdOptions) error {
 
 func loginToInfra(client *api.Client, loginReq *api.LoginRequest) error {
 	loginRes, err := client.Login(loginReq)
-	if err != nil {
-		if errors.Is(err, api.ErrUnauthorized) {
-			switch {
-			case loginReq.AccessKey != "":
-				return &FailedLoginError{getLoggedInIdentityName(), accessKeyLogin}
-			case loginReq.PasswordCredentials != nil:
-				return &FailedLoginError{getLoggedInIdentityName(), localLogin}
-			case loginReq.OIDC != nil:
-				return &FailedLoginError{getLoggedInIdentityName(), oidcLogin}
-			}
+	if api.ErrorStatusCode(err) == http.StatusUnauthorized {
+		switch {
+		case loginReq.AccessKey != "":
+			return &FailedLoginError{getLoggedInIdentityName(), accessKeyLogin}
+		case loginReq.PasswordCredentials != nil:
+			return &FailedLoginError{getLoggedInIdentityName(), localLogin}
+		case loginReq.OIDC != nil:
+			return &FailedLoginError{getLoggedInIdentityName(), oidcLogin}
 		}
+	}
+	if err != nil {
 		return err
 	}
 

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -77,12 +78,11 @@ func logoutOfServer(hostConfig *ClientHostConfig) (success bool, err error) {
 	hostConfig.Name = ""
 
 	err = client.Logout()
-	if err != nil {
-		if errors.Is(err, api.ErrUnauthorized) {
-			logging.S.Warn(err.Error())
-			return false, nil
-		}
-
+	switch {
+	case api.ErrorStatusCode(err) == http.StatusUnauthorized:
+		logging.S.Warn(err.Error())
+		return false, nil
+	case err != nil:
 		return false, err
 	}
 

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -17,6 +17,9 @@ import (
 	"github.com/infrahq/infra/internal/server/authn"
 )
 
+// sendAPIError translates err into the appropriate HTTP status code, builds a
+// response body using api.Error, then sends both as a response to the active
+// request.
 func (a *API) sendAPIError(c *gin.Context, err error) {
 	resp := &api.Error{
 		Code:    http.StatusInternalServerError,
@@ -30,9 +33,11 @@ func (a *API) sendAPIError(c *gin.Context, err error) {
 	switch {
 	case errors.Is(err, internal.ErrUnauthorized):
 		resp.Code = http.StatusUnauthorized
+		// hide the error text, it may contain sensitive information
 		resp.Message = "unauthorized"
 	case errors.Is(err, internal.ErrForbidden):
 		resp.Code = http.StatusForbidden
+		// hide the error text, it may contain sensitive information
 		resp.Message = "forbidden"
 	case errors.Is(err, internal.ErrDuplicate):
 		resp.Code = http.StatusConflict

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,46 +20,50 @@ func TestSendAPIError(t *testing.T) {
 		result api.Error
 	}{
 		{
-			err: internal.ErrBadRequest,
+			err:    internal.ErrBadRequest,
+			result: api.Error{Code: http.StatusBadRequest, Message: "bad request"},
+		},
+		{
+			err: fmt.Errorf("not right: %w", internal.ErrBadRequest),
 			result: api.Error{
-				Code:    400,
-				Message: "bad request",
+				Code:    http.StatusBadRequest,
+				Message: "not right: bad request",
 			},
 		},
 		{
-			err: internal.ErrUnauthorized,
-			result: api.Error{
-				Code:    http.StatusUnauthorized,
-				Message: "unauthorized",
-			},
+			err:    internal.ErrUnauthorized,
+			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized"},
 		},
 		{
-			err: internal.ErrForbidden,
-			result: api.Error{
-				Code:    http.StatusForbidden,
-				Message: "forbidden",
-			},
+			err:    fmt.Errorf("hide this: %w", internal.ErrUnauthorized),
+			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized"},
 		},
 		{
-			err: internal.ErrDuplicate,
+			err:    internal.ErrForbidden,
+			result: api.Error{Code: http.StatusForbidden, Message: "forbidden"},
+		},
+		{
+			err:    fmt.Errorf("hide this: %w", internal.ErrForbidden),
+			result: api.Error{Code: http.StatusForbidden, Message: "forbidden"},
+		},
+		{
+			err:    internal.ErrDuplicate,
+			result: api.Error{Code: http.StatusConflict, Message: "duplicate record"},
+		},
+		{
+			err: fmt.Errorf("%w: nope too many", internal.ErrDuplicate),
 			result: api.Error{
 				Code:    http.StatusConflict,
-				Message: "duplicate record",
+				Message: "duplicate record: nope too many",
 			},
 		},
 		{
-			err: internal.ErrNotFound,
-			result: api.Error{
-				Code:    http.StatusNotFound,
-				Message: "record not found",
-			},
+			err:    internal.ErrNotFound,
+			result: api.Error{Code: http.StatusNotFound, Message: "record not found"},
 		},
 		{
-			err: internal.ErrNotImplemented,
-			result: api.Error{
-				Code:    http.StatusNotImplemented,
-				Message: "not implemented",
-			},
+			err:    internal.ErrNotImplemented,
+			result: api.Error{Code: http.StatusNotImplemented, Message: "not implemented"},
 		},
 		{
 			err: validate.Struct(struct {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -576,7 +576,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 		return &api.LoginResponse{PolymorphicID: user.PolyID(), Name: user.Name, AccessKey: key, Expires: api.Time(expires)}, nil
 	}
 
-	return nil, api.ErrBadRequest
+	return nil, fmt.Errorf("%w: missing login credentials", internal.ErrBadRequest)
 }
 
 func (a *API) Logout(c *gin.Context, r *api.EmptyRequest) (*api.EmptyResponse, error) {


### PR DESCRIPTION
## Summary

This PR attempts to address two problems:
1. Right now the `api.Client` doesn't expose enough detail about the request error. The caller of an `api.Client` method should be able to access all of the structured fields in the response body, so it can format a message appropriately. `api.Client` should also expose the underlying error code in some way, so that the caller can make a choice based on the error code.
2. Both the `internal` package and the `api` package had a set of error variables that are very similar. This makes it easy to use the wrong variable. This PR fixes one instance where an `api.ErrBadRequest` was used in place of `internal.ErrBadRequest`, which would result in a 500 status code, instead of a 400 status code. The `api` error variables are removed, and replaced with `api.Error`.