### PR TITLE
improve: make canonicalPath more strict

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -252,25 +252,18 @@ $ infra use development.kube-system`,
 	}
 }
 
-func canonicalPath(in string) (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
+func canonicalPath(path string) (string, error) {
+	path = os.ExpandEnv(path)
+
+	if strings.HasPrefix(path, "~/") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = strings.Replace(path, "~", homeDir, 1)
 	}
 
-	out := in
-	if strings.HasPrefix(in, "$HOME") {
-		out = strings.Replace(in, "$HOME", homeDir, 1)
-	} else if strings.HasPrefix(in, "~") {
-		out = strings.Replace(in, "~", homeDir, 1)
-	}
-
-	abs, err := filepath.Abs(out)
-	if err != nil {
-		return "", err
-	}
-
-	return abs, nil
+	return filepath.Abs(path)
 }
 
 func newConnectorCmd() *cobra.Command {


### PR DESCRIPTION
## Summary

Previously the following could happen (assuming a value of `/home/user` for `$HOME`):

```
$HOMERUN/config -> /home/userRUN/config
${HOME}/config  -> /working/dir/${HOME}/config
~daniel/config  -> /home/userdaniel/config
```

With these changes both `$HOME` and `${HOME}` are supported substitutions.  As a side-effort other environment variables can also be interpolated into the string, but that shouldn't be a problem. We don't have to document that any env var can be used.
Only `~/` will be replaced with the home dir. Trying to use `~username` will be ignored and `~username` will be treated as a relative path.