### PR TITLE
feat: introduce cli errors

### DIFF
--- a/internal/cmd/error.go
+++ b/internal/cmd/error.go
@@ -25,7 +25,7 @@ func (e Error) Error() string {
 		if string(e.Message[len(e.Message)-1]) == "." {
 			e.Message = e.Message[:len(e.Message)-1]
 		}
-		return fmt.Sprintf("%v:\n       %v", e.Message, e.OriginalError)
+		return fmt.Sprintf("%v:\n%v", e.Message, e.OriginalError)
 	}
 
 	return e.Message

--- a/internal/cmd/error.go
+++ b/internal/cmd/error.go
@@ -5,13 +5,13 @@ import "fmt"
 // CLI Errors are user facing errors that are formatted.
 // Should be used for communication, rather than a stacktrace.
 type Error struct {
-	// Error that is caused by the system, used for debugging
-	// Only set this if you need it to be printed as part of the message
+	// OriginalError is an error that is caused by the system, used for logging/debugging
+	// Only set this if you need it to be printed as part of the user facing 'Message'.
 	OriginalError error
 
-	// Human readable error message that user will read on the CLI.
+	// Message is a human readable error message that user will read on the CLI.
 	// These should be full sentences, rather than a stack trace.
-	// May include suggestions.
+	// Consider including suggestions to resolve the error.
 	Message string
 }
 

--- a/internal/cmd/error.go
+++ b/internal/cmd/error.go
@@ -2,7 +2,7 @@ package cmd
 
 import "fmt"
 
-// CLI Errors are user facing errors that is formatted.
+// CLI Errors are user facing errors that are formatted.
 // Should be used for communication, rather than a stacktrace.
 type Error struct {
 	// Error that is caused by the system, used for debugging

--- a/internal/cmd/error.go
+++ b/internal/cmd/error.go
@@ -6,7 +6,7 @@ import "fmt"
 // Should be used for communication, rather than a stacktrace.
 type Error struct {
 	// Error that is caused by the system, used for debugging
-	// Only set this if you need it to be printed as part of the messsage
+	// Only set this if you need it to be printed as part of the message
 	OriginalError error
 
 	// Human readable error message that user will read on the CLI.

--- a/internal/cmd/error.go
+++ b/internal/cmd/error.go
@@ -1,0 +1,36 @@
+package cmd
+
+import "fmt"
+
+// CLI Errors are user facing errors that is formatted.
+// Should be used for communication, rather than a stacktrace.
+type Error struct {
+	// Error that is caused by the system, used for debugging
+	// Only set this if you need it to be printed as part of the messsage
+	OriginalError error
+
+	// Human readable error message that user will read on the CLI.
+	// These should be full sentences, rather than a stack trace.
+	// May include suggestions.
+	Message string
+}
+
+func (e Error) Error() string {
+	if e.OriginalError != nil {
+		if len(e.Message) == 0 {
+			return fmt.Sprintf("Internal error:\n%v", e.OriginalError)
+		}
+
+		// Strip '.' at the end when message includes the original error
+		if string(e.Message[len(e.Message)-1]) == "." {
+			e.Message = e.Message[:len(e.Message)-1]
+		}
+		return fmt.Sprintf("%v:\n       %v", e.Message, e.OriginalError)
+	}
+
+	return e.Message
+}
+
+func (e Error) Unwrap() error {
+	return e.OriginalError
+}

--- a/internal/cmd/error_test.go
+++ b/internal/cmd/error_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestUserFacingError(t *testing.T) {
+	var err error = Error{
+		OriginalError: fmt.Errorf("underlying"),
+		Message:       "failed to logout",
+	}
+
+	var e Error
+	ok := errors.As(err, &e)
+	assert.Assert(t, ok)
+	assert.Equal(t, e.Message, "failed to logout")
+
+	// // err != UserFacingError{} -> false
+	// ok = errors.Is(err, UserFacingError{})
+	// assert.Assert(t, ok)
+}

--- a/internal/cmd/error_test.go
+++ b/internal/cmd/error_test.go
@@ -8,18 +8,61 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestUserFacingError(t *testing.T) {
-	var err error = Error{
-		OriginalError: fmt.Errorf("underlying"),
-		Message:       "failed to logout",
-	}
+func TestCLIError(t *testing.T) {
 
-	var e Error
-	ok := errors.As(err, &e)
-	assert.Assert(t, ok)
-	assert.Equal(t, e.Message, "failed to logout")
+	t.Run("only OriginalError", func(t *testing.T) {
+		var err error = Error{
+			OriginalError: fmt.Errorf("failed, original error"),
+		}
 
-	// // err != UserFacingError{} -> false
-	// ok = errors.Is(err, UserFacingError{})
-	// assert.Assert(t, ok)
+		assert.Error(t, err, "Internal error:\nfailed, original error")
+	})
+
+	t.Run("only message", func(t *testing.T) {
+		var err error = Error{
+			Message: "failed, message",
+		}
+
+		assert.Error(t, err, "failed, message")
+	})
+
+	t.Run("message and error", func(t *testing.T) {
+		var err error = Error{
+			OriginalError: fmt.Errorf("failed, original error"),
+			Message:       "failed, message",
+		}
+
+		assert.Error(t, err, "failed, message:\nfailed, original error")
+	})
+
+	t.Run("message and error, message needs formatting", func(t *testing.T) {
+		var err error = Error{
+			OriginalError: fmt.Errorf("failed, original error"),
+			Message:       "failed, message.",
+		}
+
+		assert.Error(t, err, "failed, message:\nfailed, original error")
+	})
+
+	t.Run("message and error, message needs formatting", func(t *testing.T) {
+
+		var err error = Error{
+			OriginalError: fmt.Errorf("failed, original error"),
+			Message:       "failed, message.",
+		}
+
+		assert.Error(t, err, "failed, message:\nfailed, original error")
+	})
+
+	t.Run("unwrap", func(t *testing.T) {
+		var originalError = fmt.Errorf("failed, original error")
+
+		var err error = Error{
+			OriginalError: originalError,
+			Message:       "failed, message",
+		}
+
+		ok := errors.Is(err, originalError)
+		assert.Assert(t, ok)
+	})
 }


### PR DESCRIPTION
## Summary

Introduce cli errors. These will be used for outputting user facing messages in a consistent format, where as the original errors (`OriginalError`) should be used for debugging. 

See a draft of how this is to be used: #1760

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Related #1394 