### PR TITLE
fix: do not label signup user grant as created by system

### DIFF
--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -76,7 +76,7 @@ func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
 		Subject:   uid.NewIdentityPolymorphicID(identity.ID),
 		Privilege: models.InfraAdminRole,
 		Resource:  "infra",
-		CreatedBy: models.CreatedBySystem,
+		CreatedBy: identity.ID,
 	}
 
 	if err := data.CreateGrant(db, grant); err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/infrahq/secrets"
 	"github.com/prometheus/client_golang/prometheus"
@@ -345,4 +347,62 @@ func TestServer_GenerateRoutes_UI(t *testing.T) {
 			run(t, tc)
 		})
 	}
+}
+
+func TestServer_PersistSignupUser(t *testing.T) {
+	s := setupServer(t, func(_ *testing.T, opts *Options) {
+		opts.EnableSignup = true
+		opts.SessionDuration = time.Minute
+	})
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
+
+	var buf bytes.Buffer
+	email := "admin@email.com"
+	passwd := "supersecretpassword"
+
+	// run signup for "admin@email.com"
+	signupReq := api.SignupRequest{Email: email, Password: passwd}
+	err := json.NewEncoder(&buf).Encode(signupReq)
+	assert.NilError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/signup", &buf)
+	resp := httptest.NewRecorder()
+	routes.ServeHTTP(resp, req)
+	assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
+
+	signupResp := &api.CreateIdentityResponse{}
+	err = json.Unmarshal(resp.Body.Bytes(), signupResp)
+	assert.NilError(t, err)
+
+	// login with "admin@email.com" to get an access key
+	loginReq := api.LoginRequest{PasswordCredentials: &api.LoginRequestPasswordCredentials{Email: email, Password: passwd}}
+	err = json.NewEncoder(&buf).Encode(loginReq)
+	assert.NilError(t, err)
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/login", &buf)
+	resp = httptest.NewRecorder()
+	routes.ServeHTTP(resp, req)
+	assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
+
+	loginResp := &api.LoginResponse{}
+	err = json.Unmarshal(resp.Body.Bytes(), loginResp)
+	assert.NilError(t, err)
+
+	checkAuthenticated := func() {
+		req = httptest.NewRequest(http.MethodGet, "/v1/identities", nil)
+		req.Header.Set("Authorization", "Bearer "+loginResp.AccessKey)
+		resp = httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+		assert.Equal(t, resp.Code, http.StatusOK)
+	}
+
+	// try an authenticated endpoint with the access key
+	checkAuthenticated()
+
+	// reload server config
+	err = s.loadConfig(s.options.Config)
+	assert.NilError(t, err)
+
+	// retry the authenticated endpoint
+	checkAuthenticated()
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

anything labelled "created by system" is pruned on startup by config
loading. since the admin user/grant is not part of the config, it will
be pruned.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1788
