### PR TITLE
maintain: fix a potentially flaky test

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -122,7 +122,13 @@ func TestServer_Run(t *testing.T) {
 	}()
 
 	t.Run("metrics server started", func(t *testing.T) {
-		resp, err := http.Get("http://" + srv.Addrs.Metrics.String() + "/metrics")
+		// perform one API call to populate metrics
+		resp, err := http.Get("http://" + srv.Addrs.HTTP.String() + "/v1/version")
+		assert.NilError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		resp, err = http.Get("http://" + srv.Addrs.Metrics.String() + "/metrics")
 		assert.NilError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)


### PR DESCRIPTION


## Summary

The metrics server subtest was looking for the `http_request_duration_seconds` metric which only exists after an API request is performed. This was relying on other tests having run first.

This commit fixes the problem adding a call to `/v1/version` to make sure at least one API request was handled.
