### PR TITLE
fix: stop user from removing the last admin

### DIFF
--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -66,5 +66,5 @@ func DeleteGrant(c *gin.Context, id uid.ID) error {
 		return err
 	}
 
-	return data.DeleteGrants(db, data.ByID(id), data.NotCreatedBy(models.CreatedBySystem))
+	return data.DeleteGrants(db, data.ByID(id))
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -471,6 +471,22 @@ func (a *API) CreateGrant(c *gin.Context, r *api.CreateGrantRequest) (*api.Grant
 }
 
 func (a *API) DeleteGrant(c *gin.Context, r *api.Resource) error {
+	grant, err := access.GetGrant(c, r.ID)
+	if err != nil {
+		return err
+	}
+
+	if grant.Resource == access.ResourceInfraAPI && grant.Privilege == models.InfraAdminRole {
+		infraAdminGrants, err := access.ListGrants(c, "", grant.Resource, grant.Privilege)
+		if err != nil {
+			return err
+		}
+
+		if len(infraAdminGrants) == 1 {
+			return fmt.Errorf("%w: cannot remove the last infra admin", internal.ErrForbidden)
+		}
+	}
+
 	return access.DeleteGrant(c, r.ID)
 }
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Block users from removing the last infra admin from the system. Admins have the permissions to remove other admins but this can lead to a situation where no admins remain making it more the service more difficult to manage.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1744
