### PR TITLE
fix: handle panics properly

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -42,7 +42,7 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) *gin.Engine 
 
 	// This group of middleware only applies to non-ui routes
 	api := router.Group("/",
-		sentrygin.New(sentrygin.Options{}),
+		sentrygin.New(sentrygin.Options{Repanic: true}),
 		metrics.Middleware(promRegistry),
 		DatabaseMiddleware(a.server.db), // must be after TimeoutMiddleware to time out db queries.
 	)


### PR DESCRIPTION
## Summary

While working on some tests I ran into a situation where I was receiving a 200 response code unexpectedly. It turns out the handler had panic'ed, but there were no logs indicating that is what happened.

Without this change a panic in an HTTP handler will result in a 200 response code with no logs. For some reason the sentrygin middleware doesn't set the response code.

By having it re-panic, the `gin.Recovery` middleware does the right thing. It logs the panic to stder and returns a 500 status code.

I'm not sure if we are going to keep the sentry-gin middleware, but this fixes it for now.