### PR TITLE
maintain: cosmetic changes to CLI outputs

### DIFF
--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -31,7 +31,7 @@ func newIdentitiesCmd(cli *CLI) *cobra.Command {
 	cmd.AddCommand(newIdentitiesAddCmd(cli))
 	cmd.AddCommand(newIdentitiesEditCmd())
 	cmd.AddCommand(newIdentitiesListCmd(cli))
-	cmd.AddCommand(newIdentitiesRemoveCmd())
+	cmd.AddCommand(newIdentitiesRemoveCmd(cli))
 
 	return cmd
 }
@@ -169,7 +169,7 @@ func newIdentitiesListCmd(cli *CLI) *cobra.Command {
 	}
 }
 
-func newIdentitiesRemoveCmd() *cobra.Command {
+func newIdentitiesRemoveCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "remove IDENTITY",
 		Aliases: []string{"rm"},
@@ -199,6 +199,8 @@ $ infra identities remove machine-a`,
 					return err
 				}
 			}
+
+			fmt.Fprintf(cli.Stderr, "Deleted identity %q\n", name)
 
 			return nil
 		},

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -165,14 +165,14 @@ func logoutOne(clear bool, server string) error {
 		return fmt.Errorf("Failed to logout of server %s due to an internal error: %w.", host.Host, err)
 	}
 	if success {
-		fmt.Fprintf(os.Stderr, "Logged out of server %s", host.Host)
+		fmt.Fprintf(os.Stderr, "Logged out of server %s\n", host.Host)
 	}
 
 	if clear {
 		serverURL := host.Host
 		config.Hosts[idx] = config.Hosts[len(config.Hosts)-1]
 		config.Hosts = config.Hosts[:len(config.Hosts)-1]
-		logging.S.Debugf("cleared server [%s]\n", serverURL)
+		logging.S.Debugf("cleared server [%s]", serverURL)
 	}
 
 	if err := clearKubeconfig(); err != nil {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Update CLI outputs:

- Add a new line to logout confirmation
- Remove extra newline from `Debugf`
- Add a confirmation message when removing identities