### PR TITLE
improve: remove CreatedBy field and always replace records if provided via server options

### DIFF
--- a/api/grant.go
+++ b/api/grant.go
@@ -7,9 +7,8 @@ import (
 type Grant struct {
 	ID uid.ID `json:"id"`
 
-	Created   Time   `json:"created"`
-	CreatedBy uid.ID `json:"created_by" note:"id of the identity that created the grant"`
-	Updated   Time   `json:"updated"`
+	Created Time `json:"created"`
+	Updated Time `json:"updated"`
 
 	Identity  uid.ID `json:"identity,omitempty"`
 	Group     uid.ID `json:"group,omitempty"`

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -162,22 +162,12 @@
             "format": "date-time",
             "type": "string"
           },
-<<<<<<< HEAD
-          "created_by": {
-            "description": "id of the identity that created the grant",
-            "example": "4yJ3n3D8E2",
-            "format": "uid",
-            "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
-            "type": "string"
-          },
           "group": {
             "example": "4yJ3n3D8E2",
             "format": "uid",
             "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
             "type": "string"
           },
-=======
->>>>>>> 2315de4d (improve: remove CreatedBy field and only replace configuration if provided in code)
           "id": {
             "example": "4yJ3n3D8E2",
             "format": "uid",
@@ -393,13 +383,6 @@
                   "description": "formatted as an RFC3339 date-time",
                   "example": "2022-03-14T09:48:00Z",
                   "format": "date-time",
-                  "type": "string"
-                },
-                "created_by": {
-                  "description": "id of the identity that created the grant",
-                  "example": "4yJ3n3D8E2",
-                  "format": "uid",
-                  "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
                   "type": "string"
                 },
                 "group": {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -162,6 +162,7 @@
             "format": "date-time",
             "type": "string"
           },
+<<<<<<< HEAD
           "created_by": {
             "description": "id of the identity that created the grant",
             "example": "4yJ3n3D8E2",
@@ -175,6 +176,8 @@
             "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
             "type": "string"
           },
+=======
+>>>>>>> 2315de4d (improve: remove CreatedBy field and only replace configuration if provided in code)
           "id": {
             "example": "4yJ3n3D8E2",
             "format": "uid",

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -176,7 +176,6 @@ func grant(t *testing.T, db *gorm.DB, currentUser *models.Identity, subject uid.
 		Subject:   subject,
 		Privilege: privilege,
 		Resource:  resource,
-		CreatedBy: currentUser.ID,
 	})
 	assert.NilError(t, err)
 }

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -53,10 +53,6 @@ func CreateGrant(c *gin.Context, grant *models.Grant) error {
 		return err
 	}
 
-	creator := AuthenticatedIdentity(c)
-
-	grant.CreatedBy = creator.ID
-
 	return data.CreateGrant(db, grant)
 }
 

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -78,7 +78,6 @@ func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
 		Subject:   uid.NewIdentityPolymorphicID(identity.ID),
 		Privilege: models.InfraAdminRole,
 		Resource:  "infra",
-		CreatedBy: identity.ID,
 	}
 
 	if err := data.CreateGrant(db, grant); err != nil {

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -463,6 +463,22 @@ func Migrate(db *gorm.DB) error {
 				return nil
 			},
 		},
+		// drop CreatedBy column
+		{
+			ID: "202205011454",
+			Migrate: func(tx *gorm.DB) error {
+				if err := tx.Migrator().DropColumn(&models.Provider{}, "created_by"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn(&models.Identity{}, "created_by"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn(&models.Group{}, "created_by"); err != nil {
+					return err
+				}
+				return tx.Migrator().DropColumn(&models.Grant{}, "created_by")
+			},
+		},
 		// next one here
 	})
 

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -118,20 +118,6 @@ func ByUserID(userID uid.ID) SelectorFunc {
 	}
 }
 
-func CreatedBy(id uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("created_by = ?", id)
-	}
-}
-
-// NotCreatedBy filters out entities not created by the passed in ID
-func NotCreatedBy(id uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		// the created_by field is default 0 when not set by default
-		return db.Where("created_by != ?", id)
-	}
-}
-
 func NotName(name string) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Not("name = ?", name)

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -70,7 +70,6 @@ func TestAPI_PProfHandler(t *testing.T) {
 					Subject:   user.PolyID(),
 					Privilege: models.InfraAdminRole,
 					Resource:  access.ResourceInfraAPI,
-					CreatedBy: user.ID,
 				})
 				assert.NilError(t, err)
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func adminAccessKey(s *Server) string {
-	for _, id := range s.options.Identities {
+	for _, id := range s.options.Config.Identities {
 		if id.Name == "admin" {
 			return id.AccessKey
 		}
@@ -318,11 +318,12 @@ func TestAPI_DeleteProvider(t *testing.T) {
 // withAdminIdentity may be used with setupServer to setup the server
 // with an admin identity and access key
 func withAdminIdentity(_ *testing.T, opts *Options) {
-	opts.Identities = append(opts.Identities, Identity{
+	opts.Config.Identities = append(opts.Config.Identities, Identity{
 		Name:      "admin",
 		AccessKey: "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb",
 	})
-	opts.Grants = append(opts.Grants, Grant{
+
+	opts.Config.Grants = append(opts.Config.Grants, Grant{
 		User:     "admin",
 		Role:     "admin",
 		Resource: "infra",
@@ -549,7 +550,6 @@ func TestAPI_CreateGrant_Success(t *testing.T) {
 		expected := jsonUnmarshal(t, fmt.Sprintf(`
 		{
 		  "id": "<any-valid-uid>",
-		  "created_by": "%[1]v",
 		  "privilege": "admin-role",
 		  "resource": "some-cluster",
 		  "identity": "TJ",

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -540,9 +540,6 @@ func TestAPI_CreateGrant_Success(t *testing.T) {
 	assert.NilError(t, err)
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 
-	accessKey, err := data.ValidateAccessKey(srv.db, adminAccessKey(srv))
-	assert.NilError(t, err)
-
 	runStep(t, "response is ok", func(t *testing.T) {
 		routes.ServeHTTP(resp, req)
 		assert.Equal(t, resp.Code, http.StatusCreated)
@@ -551,12 +548,11 @@ func TestAPI_CreateGrant_Success(t *testing.T) {
 		{
 		  "id": "<any-valid-uid>",
 		  "privilege": "admin-role",
-		  "resource": "some-cluster",
+          "resource": "some-cluster",
 		  "identity": "TJ",
-		  "created": "%[2]v",
-		  "updated": "%[2]v"
+		  "created": "%[1]v",
+		  "updated": "%[1]v"
 		}`,
-			accessKey.IssuedFor,
 			time.Now().UTC().Format(time.RFC3339),
 		))
 		actual := jsonUnmarshal(t, resp.Body.String())

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -40,8 +40,7 @@ func setupDB(t *testing.T) *gorm.DB {
 	models.SymmetricKey = key
 
 	err = data.CreateProvider(db, &models.Provider{
-		Name:      models.InternalInfraProviderName,
-		CreatedBy: models.CreatedBySystem,
+		Name: models.InternalInfraProviderName,
 	})
 	assert.NilError(t, err)
 

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -37,7 +37,6 @@ type Grant struct {
 	Subject   uid.PolymorphicID `validate:"required"` // usually an identity, but could be a role definition
 	Privilege string            `validate:"required"` // role or permission
 	Resource  string            `validate:"required"` // Universal Resource Notation
-	CreatedBy uid.ID
 }
 
 func (r *Grant) ToAPI() *api.Grant {
@@ -45,7 +44,6 @@ func (r *Grant) ToAPI() *api.Grant {
 		ID:        r.ID,
 		Created:   api.Time(r.CreatedAt),
 		Updated:   api.Time(r.UpdatedAt),
-		CreatedBy: r.CreatedBy,
 		Privilege: r.Privilege,
 		Resource:  r.Resource,
 	}

--- a/internal/server/models/group.go
+++ b/internal/server/models/group.go
@@ -8,8 +8,7 @@ import (
 type Group struct {
 	Model
 
-	Name      string `gorm:"uniqueIndex:idx_groups_name_provider_id,where:deleted_at is NULL"`
-	CreatedBy uid.ID
+	Name string `gorm:"uniqueIndex:idx_groups_name_provider_id,where:deleted_at is NULL"`
 
 	Identities []Identity `gorm:"many2many:identities_groups"`
 }

--- a/internal/server/models/identity.go
+++ b/internal/server/models/identity.go
@@ -17,7 +17,6 @@ type Identity struct {
 
 	Name       string    `gorm:"uniqueIndex:idx_identities_name,where:deleted_at is NULL"`
 	LastSeenAt time.Time // updated on when an identity uses a session token
-	CreatedBy  uid.ID
 
 	Groups []Group `gorm:"many2many:identities_groups"`
 }

--- a/internal/server/models/model.go
+++ b/internal/server/models/model.go
@@ -13,8 +13,6 @@ type Modelable interface {
 	IsAModel() // there's nothing specific about this function except that all Model structs will have it.
 }
 
-const CreatedBySystem = 1
-
 type Model struct {
 	ID uid.ID
 	// CreatedAt is set by GORM to time.Now when a record is first created.

--- a/internal/server/models/provider.go
+++ b/internal/server/models/provider.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/uid"
 )
 
 const InternalInfraProviderName = "infra"
@@ -14,7 +13,6 @@ type Provider struct {
 	URL          string
 	ClientID     string
 	ClientSecret EncryptedAtRest
-	CreatedBy    uid.ID
 }
 
 func (p *Provider) ToAPI() *api.Provider {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,7 +160,7 @@ func New(options Options) (*Server, error) {
 		}
 	}
 
-	if err := server.loadConfig(); err != nil {
+	if err := server.loadConfig(server.db, options.Config); err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -160,8 +160,8 @@ func New(options Options) (*Server, error) {
 		}
 	}
 
-	if err := server.loadConfig(server.options.Config); err != nil {
-		return nil, fmt.Errorf("configs: %w", err)
+	if err := server.loadConfig(); err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
 	}
 
 	if err := server.listen(); err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -37,7 +37,7 @@ func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
 	err := loadDefaultSecretConfig(s.secrets)
 	assert.NilError(t, err)
 
-	err = s.loadConfig()
+	err = s.loadConfig(s.db, s.options.Config)
 	assert.NilError(t, err)
 
 	data.InvalidateCache()
@@ -410,7 +410,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 	checkAuthenticated()
 
 	// reload server config
-	err = s.loadConfig()
+	err = s.loadConfig(s.db, Config{})
 	assert.NilError(t, err)
 
 	// retry the authenticated endpoint

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -37,7 +37,7 @@ func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
 	err := loadDefaultSecretConfig(s.secrets)
 	assert.NilError(t, err)
 
-	err = s.loadConfig(s.options.Config)
+	err = s.loadConfig()
 	assert.NilError(t, err)
 
 	data.InvalidateCache()
@@ -410,7 +410,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 	checkAuthenticated()
 
 	// reload server config
-	err = s.loadConfig(s.options.Config)
+	err = s.loadConfig()
 	assert.NilError(t, err)
 
 	// retry the authenticated endpoint


### PR DESCRIPTION
This removes the `CreatedBy` field which was previously used to track configuration loading. While helpful to know who created what, this is better handled by later storing event data. The hope is this would help remove tricky edge cases (e.g. a resource created by "the system") which could avoid issues similar to #1788 in the future.

Instead, the Infra server now disregards how records are created. If non-empty slices are provided for `providers:`, `grants:` or `identities:` in the server configuration, existing records (except default must-have records) are simply deleted (no matter where they originate from).

Note: as an important change, if any of the above slices are provided in the server's configuration, any existing records **of that kind** are deleted.

The user can then decide to:
1. "Lock" records (e.g. `grants`) to what is provided in the `server.yaml` file
2. Use the API or UI to manage these records ad-hoc

As a future change we can consider moving the server configuration on top of the API, allowing:
1. Custom semantics around how "declared" records are managed
2. Additional ways to configure Infra via code: terraform, etc
3. New CLI commands such as `infra import -f <infra.yaml>` or similar
