### PR TITLE
improve: do not allow invalid roles for grants

### DIFF
--- a/docs/guides/granting-access.md
+++ b/docs/guides/granting-access.md
@@ -2,7 +2,7 @@
 
 ## Roles
 
-Infra allows granting different levels of access via **roles**, such as `view`, `edit` or `admin`. Each connector has different roles that can be used:
+Infra allows granting different levels of access via **roles**, such as `view`, `connector` or `admin`. Each connector has different roles that can be used:
 
 - [Kubernetes Roles](../connectors/kubernetes.md#roles)
 

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -202,6 +202,10 @@ func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 		return err
 	}
 
+	if err := checkRole(cmdOptions.Role, cmdOptions.Destination); err != nil {
+		return err
+	}
+
 	identityType, err := getIdentityType(cmdOptions.Identity, cmdOptions.IsGroup)
 	if err != nil {
 		return err
@@ -358,4 +362,32 @@ func addGrantIdentity(client *api.Client, name string, identityType identityType
 	}
 
 	return id, nil
+}
+
+func checkRole(role string, destination string) error {
+	if destination == "infra" {
+		switch role {
+		case "admin":
+			fallthrough
+		case "view":
+			fallthrough
+		case "connector":
+			return nil
+		default:
+			return fmt.Errorf("[%s] is not a valid role for infra", role)
+		}
+	}
+
+	switch role {
+	case "cluster-admin":
+		fallthrough
+	case "admin":
+		fallthrough
+	case "edit":
+		fallthrough
+	case "view":
+		return nil
+	default:
+		return fmt.Errorf("[%s] is not a valid role for a kubernetes destination", role)
+	}
 }


### PR DESCRIPTION
## Summary

Introduce errors when user attempts to grant an invalid role for that type of destination, as our doc states. 
In the future, we should read from API responses (bad request - fields) and output the same error there, rather than 'failing early'. 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
