### PR TITLE
api: remove extra grant endpoints

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -224,6 +224,7 @@ func (c Client) DeleteIdentity(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/v1/identities/%s", id))
 }
 
+// Deprecated: use ListGrants
 func (c Client) ListIdentityGrants(id uid.ID) (*ListResponse[Grant], error) {
 	return list[ListResponse[Grant]](c, fmt.Sprintf("/v1/identities/%s/grants", id), nil)
 }
@@ -244,6 +245,7 @@ func (c Client) CreateGroup(req *CreateGroupRequest) (*Group, error) {
 	return post[CreateGroupRequest, Group](c, "/v1/groups", req)
 }
 
+// Deprecated: use ListGrants
 func (c Client) ListGroupGrants(id uid.ID) (*ListResponse[Grant], error) {
 	return list[ListResponse[Grant]](c, fmt.Sprintf("/v1/groups/%s/grants", id), nil)
 }

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -35,7 +35,8 @@ func ListIdentityGrants(c *gin.Context, identityID uid.ID) ([]models.Grant, erro
 		return nil, err
 	}
 
-	return data.ListIdentityGrants(db, identityID)
+	polymorphicID := uid.NewIdentityPolymorphicID(identityID)
+	return data.ListGrants(db, data.BySubject(polymorphicID))
 }
 
 func ListGroupGrants(c *gin.Context, groupID uid.ID) ([]models.Grant, error) {
@@ -44,7 +45,8 @@ func ListGroupGrants(c *gin.Context, groupID uid.ID) ([]models.Grant, error) {
 		return nil, err
 	}
 
-	return data.ListGroupGrants(db, groupID)
+	polymorphicID := uid.NewGroupPolymorphicID(groupID)
+	return data.ListGrants(db, data.BySubject(polymorphicID))
 }
 
 func CreateGrant(c *gin.Context, grant *models.Grant) error {

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -1,8 +1,12 @@
 package access
 
 import (
-	"github.com/gin-gonic/gin"
+	"errors"
 
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -18,35 +22,48 @@ func GetGrant(c *gin.Context, id uid.ID) (*models.Grant, error) {
 }
 
 func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, privilege string) ([]models.Grant, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole)
-	if err != nil {
-		return nil, err
-	}
-
-	return data.ListGrants(db,
-		data.ByOptionalSubject(subject),
+	selectors := []data.SelectorFunc{
 		data.ByOptionalResource(resource),
-		data.ByOptionalPrivilege(privilege))
-}
-
-func ListIdentityGrants(c *gin.Context, identityID uid.ID) ([]models.Grant, error) {
-	db, err := hasAuthorization(c, identityID, isIdentitySelf, models.InfraAdminRole, models.InfraViewRole)
-	if err != nil {
-		return nil, err
+		data.ByOptionalPrivilege(privilege),
 	}
 
-	polymorphicID := uid.NewIdentityPolymorphicID(identityID)
-	return data.ListGrants(db, data.BySubject(polymorphicID))
-}
-
-func ListGroupGrants(c *gin.Context, groupID uid.ID) ([]models.Grant, error) {
-	db, err := hasAuthorization(c, groupID, isUserInGroup, models.InfraAdminRole, models.InfraViewRole)
-	if err != nil {
-		return nil, err
+	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole)
+	if err == nil {
+		selectors = append(selectors, data.ByOptionalSubject(subject))
+		return data.ListGrants(db, selectors...)
 	}
 
-	polymorphicID := uid.NewGroupPolymorphicID(groupID)
-	return data.ListGrants(db, data.BySubject(polymorphicID))
+	if errors.Is(err, internal.ErrForbidden) {
+		// Allow an authenticated identity to view their own grants
+		subjectID, _ := subject.ID()
+		identity := AuthenticatedIdentity(c)
+		switch {
+		case identity == nil:
+			return nil, err
+		case subject.IsIdentity() && identity.ID == subjectID:
+			selectors = append(selectors, data.BySubject(subject))
+			return data.ListGrants(db, selectors...)
+		case subject.IsGroup() && userInGroup(db, identity.ID, subjectID):
+			selectors = append(selectors, data.BySubject(subject))
+			return data.ListGrants(db, selectors...)
+		}
+	}
+
+	return nil, err
+}
+
+func userInGroup(db *gorm.DB, authnUserID uid.ID, groupID uid.ID) bool {
+	groups, err := data.ListIdentityGroups(db, authnUserID)
+	if err != nil {
+		return false
+	}
+
+	for _, g := range groups {
+		if g.ID == groupID {
+			return true
+		}
+	}
+	return false
 }
 
 func CreateGrant(c *gin.Context, grant *models.Grant) error {

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -35,6 +35,7 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 
 	if errors.Is(err, internal.ErrForbidden) {
 		// Allow an authenticated identity to view their own grants
+		db := getDB(c)
 		subjectID, _ := subject.ID()
 		identity := AuthenticatedIdentity(c)
 		switch {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -125,7 +125,7 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 
 				_, err = resp.Write(bytes)
 				assert.NilError(t, err)
-			case req.URL.Path == fmt.Sprintf("/v1/identities/%s/grants", userID):
+			case req.URL.Path == "/v1/grants":
 				grants := api.ListResponse[api.Grant]{
 					Items: []api.Grant{
 						{

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -67,7 +67,7 @@ func updateKubeconfig(client *api.Client, id uid.ID) error {
 		return err
 	}
 
-	grants, err := client.ListIdentityGrants(id)
+	grants, err := client.ListGrants(api.ListGrantsRequest{Identity: id})
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func updateKubeconfig(client *api.Client, id uid.ID) error {
 	}
 
 	for _, g := range groups.Items {
-		groupGrants, err := client.ListGroupGrants(g.ID)
+		groupGrants, err := client.ListGrants(api.ListGrantsRequest{Group: g.ID})
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -55,7 +55,7 @@ func list(cli *CLI) error {
 		return err
 	}
 
-	grants, err := client.ListIdentityGrants(identityID)
+	grants, err := client.ListGrants(api.ListGrantsRequest{Identity: identityID})
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func list(cli *CLI) error {
 	}
 
 	for _, g := range groups.Items {
-		groupGrants, err := client.ListGroupGrants(g.ID)
+		groupGrants, err := client.ListGrants(api.ListGrantsRequest{Group: g.ID})
 		if err != nil {
 			return err
 		}

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -28,16 +28,6 @@ func GetGrant(db *gorm.DB, selectors ...SelectorFunc) (*models.Grant, error) {
 	return get[models.Grant](db, selectors...)
 }
 
-func ListIdentityGrants(db *gorm.DB, userID uid.ID) (result []models.Grant, err error) {
-	polymorphicID := uid.NewIdentityPolymorphicID(userID)
-	return ListGrants(db, ByOptionalSubject(polymorphicID))
-}
-
-func ListGroupGrants(db *gorm.DB, groupID uid.ID) (result []models.Grant, err error) {
-	polymorphicID := uid.NewGroupPolymorphicID(groupID)
-	return ListGrants(db, ByOptionalSubject(polymorphicID))
-}
-
 func ListGrants(db *gorm.DB, selectors ...SelectorFunc) ([]models.Grant, error) {
 	return list[models.Grant](db, selectors...)
 }

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -1,0 +1,314 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+func TestAPI_ListGrants(t *testing.T) {
+	srv := setupServer(t, withAdminIdentity)
+	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+
+	createID := func(t *testing.T, name string) uid.ID {
+		t.Helper()
+		var buf bytes.Buffer
+		body := api.CreateIdentityRequest{Name: name}
+		err := json.NewEncoder(&buf).Encode(body)
+		assert.NilError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "/v1/identities", &buf)
+		assert.NilError(t, err)
+		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+		assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
+		respObj := &api.CreateIdentityResponse{}
+		err = json.Unmarshal(resp.Body.Bytes(), respObj)
+		assert.NilError(t, err)
+		return respObj.ID
+	}
+
+	createGrant := func(t *testing.T, subject uid.PolymorphicID, privilege string) {
+		t.Helper()
+		var buf bytes.Buffer
+		body := api.CreateGrantRequest{
+			Subject:   subject,
+			Privilege: privilege,
+			Resource:  "res1",
+		}
+		err := json.NewEncoder(&buf).Encode(body)
+		assert.NilError(t, err)
+
+		req, err := http.NewRequest(http.MethodPost, "/v1/grants", &buf)
+		assert.NilError(t, err)
+		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+		assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
+	}
+
+	createGroup := func(t *testing.T, name string, users ...uid.ID) uid.ID {
+		t.Helper()
+		group := &models.Group{Name: name}
+		for _, user := range users {
+			iden := models.Identity{Model: models.Model{ID: user}}
+			group.Identities = append(group.Identities, iden)
+		}
+
+		err := data.CreateGroup(srv.db, group)
+		assert.NilError(t, err)
+		return group.ID
+	}
+
+	idInGroup := createID(t, "inagroup@example.com")
+	idOther := createID(t, "other@example.com")
+
+	createGrant(t, uid.NewIdentityPolymorphicID(idInGroup), "custom1")
+	createGrant(t, uid.NewIdentityPolymorphicID(idOther), "custom2")
+
+	groupID := createGroup(t, "humans", idInGroup)
+
+	token := &models.AccessKey{
+		IssuedFor:  idInGroup,
+		ProviderID: data.InfraProvider(srv.db).ID,
+		ExpiresAt:  time.Now().Add(10 * time.Second),
+	}
+
+	accessKey, err := data.CreateAccessKey(srv.db, token)
+	assert.NilError(t, err)
+
+	admin, err := data.GetIdentity(srv.db, data.ByName("admin"))
+	assert.NilError(t, err)
+
+	type testCase struct {
+		urlPath  string
+		setup    func(t *testing.T, req *http.Request)
+		expected func(t *testing.T, resp *httptest.ResponseRecorder)
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		req, err := http.NewRequest(http.MethodGet, tc.urlPath, nil)
+		assert.NilError(t, err)
+		req.Header.Set("Authorization", "Bearer "+accessKey)
+
+		if tc.setup != nil {
+			tc.setup(t, req)
+		}
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+
+		tc.expected(t, resp)
+	}
+
+	testCases := map[string]testCase{
+		"not authenticated": {
+			urlPath: "/v1/grants?subject=i:" + idOther.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Del("Authorization")
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusUnauthorized)
+			},
+		},
+		"not authorized, wrong identity": {
+			urlPath: "/v1/grants?subject=i:" + idOther.String(),
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusForbidden, resp.Body.String())
+			},
+		},
+		"not authorized, wrong group": {
+			urlPath: "/v1/grants?subject=g:abcde",
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusForbidden, resp.Body.String())
+			},
+		},
+		"not authorized, no subject in query": {
+			urlPath: "/v1/grants?resource=res1",
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusForbidden, resp.Body.String())
+			},
+		},
+		"authorized by grant": {
+			urlPath: "/v1/grants?resource=none",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+				var grants []api.Grant
+				err := json.NewDecoder(resp.Body).Decode(&grants)
+				assert.NilError(t, err)
+				assert.Equal(t, len(grants), 0) // no grants for this resource
+
+			},
+		},
+		"authorized by identity matching subject": {
+			urlPath: "/v1/grants?subject=i:" + idInGroup.String(),
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+				var grants []api.Grant
+				err := json.NewDecoder(resp.Body).Decode(&grants)
+				assert.NilError(t, err)
+				expected := []api.Grant{
+					{
+						Subject:   uid.NewIdentityPolymorphicID(idInGroup),
+						Privilege: "custom1",
+						Resource:  "res1",
+					},
+				}
+				assert.DeepEqual(t, grants, expected, cmpAPIGrantShallow)
+			},
+		},
+		"authorized by group matching subject": {
+			urlPath: "/v1/grants?subject=g:" + groupID.String(),
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+				var grants []api.Grant
+				err := json.NewDecoder(resp.Body).Decode(&grants)
+				assert.NilError(t, err)
+				// no grants for this group
+				assert.Equal(t, len(grants), 0)
+			},
+		},
+		"no filters": {
+			urlPath: "/v1/grants",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				connector, err := data.GetIdentity(srv.db, data.ByName("connector"))
+				assert.NilError(t, err)
+
+				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+				var grants []api.Grant
+				err = json.NewDecoder(resp.Body).Decode(&grants)
+				assert.NilError(t, err)
+
+				expected := []api.Grant{
+					{
+						Subject:   uid.NewIdentityPolymorphicID(admin.ID),
+						Privilege: "admin",
+						Resource:  "infra",
+					},
+					{
+						Subject:   uid.NewIdentityPolymorphicID(connector.ID),
+						Privilege: "connector",
+						Resource:  "infra",
+					},
+					{
+						Subject:   uid.NewIdentityPolymorphicID(idInGroup),
+						Privilege: "custom1",
+						Resource:  "res1",
+					},
+					{
+						Subject:   uid.NewIdentityPolymorphicID(idOther),
+						Privilege: "custom2",
+						Resource:  "res1",
+					},
+				}
+				assert.DeepEqual(t, grants, expected, cmpAPIGrantShallow)
+			},
+		},
+		"filter by resource": {
+			urlPath: "/v1/grants?resource=res1",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+				var grants []api.Grant
+				err = json.NewDecoder(resp.Body).Decode(&grants)
+				assert.NilError(t, err)
+
+				expected := []api.Grant{
+					{
+						Subject:   uid.NewIdentityPolymorphicID(idInGroup),
+						Privilege: "custom1",
+						Resource:  "res1",
+					},
+					{
+						Subject:   uid.NewIdentityPolymorphicID(idOther),
+						Privilege: "custom2",
+						Resource:  "res1",
+					},
+				}
+				assert.DeepEqual(t, grants, expected, cmpAPIGrantShallow)
+			},
+		},
+		"filter by resource and privilege": {
+			urlPath: "/v1/grants?resource=res1&privilege=custom1",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+				var grants []api.Grant
+				err = json.NewDecoder(resp.Body).Decode(&grants)
+				assert.NilError(t, err)
+
+				expected := []api.Grant{
+					{
+						Subject:   uid.NewIdentityPolymorphicID(idInGroup),
+						Privilege: "custom1",
+						Resource:  "res1",
+					},
+				}
+				assert.DeepEqual(t, grants, expected, cmpAPIGrantShallow)
+			},
+		},
+		"full JSON response": {
+			urlPath: "/v1/grants?subject=i:" + idInGroup.String(),
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+
+				expected := jsonUnmarshal(t, fmt.Sprintf(`
+					[{
+				      "id": "<any-valid-uid>",
+				      "created_by": "%[1]v",
+				      "privilege": "custom1",
+				      "resource": "res1",
+				      "subject": "i:%[2]v",
+				      "created": "%[3]v",
+				      "updated": "%[3]v"
+					}]`,
+					admin.ID,
+					idInGroup.String(),
+					time.Now().UTC().Format(time.RFC3339),
+				))
+				actual := jsonUnmarshal(t, resp.Body.String())
+				assert.DeepEqual(t, actual, expected, cmpAPIGrantJSON)
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+var cmpAPIGrantShallow = gocmp.Comparer(func(x, y api.Grant) bool {
+	return x.Subject == y.Subject && x.Privilege == y.Privilege && x.Resource == y.Resource
+})
+
+var cmpAPIGrantJSON = gocmp.Options{
+	gocmp.FilterPath(pathMapKey(`created`, `updated`), cmpApproximateTime),
+	gocmp.FilterPath(pathMapKey(`id`), cmpAnyValidUID),
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -123,19 +123,6 @@ func (a *API) DeleteIdentity(c *gin.Context, r *api.Resource) error {
 	return access.DeleteIdentity(c, r.ID)
 }
 
-func (a *API) ListIdentityGrants(c *gin.Context, r *api.Resource) (*api.ListResponse[api.Grant], error) {
-	grants, err := access.ListIdentityGrants(c, r.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	result := api.NewListResponse(grants, func(grant models.Grant) api.Grant {
-		return *grant.ToAPI()
-	})
-
-	return result, nil
-}
-
 func (a *API) ListIdentityGroups(c *gin.Context, r *api.Resource) (*api.ListResponse[api.Group], error) {
 	groups, err := access.ListIdentityGroups(c, r.ID)
 	if err != nil {
@@ -182,19 +169,6 @@ func (a *API) CreateGroup(c *gin.Context, r *api.CreateGroupRequest) (*api.Group
 	}
 
 	return group.ToAPI(), nil
-}
-
-func (a *API) ListGroupGrants(c *gin.Context, r *api.Resource) (*api.ListResponse[api.Grant], error) {
-	grants, err := access.ListGroupGrants(c, r.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	result := api.NewListResponse(grants, func(grant models.Grant) api.Grant {
-		return *grant.ToAPI()
-	})
-
-	return result, nil
 }
 
 // caution: this endpoint is unauthenticated, do not return sensitive info
@@ -430,6 +404,16 @@ func (a *API) ListGrants(c *gin.Context, r *api.ListGrantsRequest) (*api.ListRes
 	})
 
 	return result, nil
+}
+
+// TODO: remove after deprecation period
+func (a *API) ListIdentityGrants(c *gin.Context, r *api.Resource) (*api.ListResponse[api.Grant], error) {
+	return a.ListGrants(c, &api.ListGrantsRequest{Identity: r.ID})
+}
+
+// TODO: remove after deprecation period
+func (a *API) ListGroupGrants(c *gin.Context, r *api.Resource) (*api.ListResponse[api.Grant], error) {
+	return a.ListGrants(c, &api.ListGrantsRequest{Group: r.ID})
 }
 
 func (a *API) GetGrant(c *gin.Context, r *api.Resource) (*api.Grant, error) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -542,7 +542,7 @@ func TestAPI_CreateGrant_Success(t *testing.T) {
 	accessKey, err := data.ValidateAccessKey(srv.db, adminAccessKey(srv))
 	assert.NilError(t, err)
 
-	runStep(t, "response is ok", func(t *testing.T) {
+	runStep(t, "full JSON response", func(t *testing.T) {
 		routes.ServeHTTP(resp, req)
 		assert.Equal(t, resp.Code, http.StatusCreated)
 
@@ -581,11 +581,6 @@ func TestAPI_CreateGrant_Success(t *testing.T) {
 		assert.NilError(t, err)
 		assert.DeepEqual(t, getGrant, newGrant)
 	})
-}
-
-var cmpAPIGrantJSON = gocmp.Options{
-	gocmp.FilterPath(pathMapKey(`created`, `updated`), cmpApproximateTime),
-	gocmp.FilterPath(pathMapKey(`id`), cmpAnyValidUID),
 }
 
 // cmpApproximateTime is a gocmp.Option that compares a time formatted as an
@@ -781,7 +776,7 @@ func TestAPI_GetIdentity(t *testing.T) {
 				assert.Equal(t, idResponse.ID, idMe)
 			},
 		},
-		"full json response": {
+		"full JSON response": {
 			urlPath: "/v1/identities/" + idMe.String(),
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+accessKeyMe)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -54,7 +54,6 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) *gin.Engine 
 	put(a, authn, "/v1/identities/:id", a.UpdateIdentity)
 	delete(a, authn, "/v1/identities/:id", a.DeleteIdentity)
 	get(a, authn, "/v1/identities/:id/groups", a.ListIdentityGroups)
-	get(a, authn, "/v1/identities/:id/grants", a.ListIdentityGrants)
 
 	get(a, authn, "/v1/access-keys", a.ListAccessKeys)
 	post(a, authn, "/v1/access-keys", a.CreateAccessKey)
@@ -63,7 +62,6 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) *gin.Engine 
 	get(a, authn, "/v1/groups", a.ListGroups)
 	post(a, authn, "/v1/groups", a.CreateGroup)
 	get(a, authn, "/v1/groups/:id", a.GetGroup)
-	get(a, authn, "/v1/groups/:id/grants", a.ListGroupGrants)
 
 	get(a, authn, "/v1/grants", a.ListGrants)
 	get(a, authn, "/v1/grants/:id", a.GetGrant)
@@ -97,7 +95,12 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) *gin.Engine 
 
 	get(a, noAuthn, "/v1/version", a.Version)
 
-	// TODO: remove after a couple version.
+	// Deprecated in 0.12
+	// TODO: remove after a couple versions
+	get(a, authn, "/v1/identities/:id/grants", a.ListIdentityGrants)
+	get(a, authn, "/v1/groups/:id/grants", a.ListGroupGrants)
+
+	// TODO: remove after a couple versions
 	noAuthn.GET("/v1/users", removed("v0.9.0"))
 	noAuthn.POST("/v1/users", removed("v0.9.0"))
 	noAuthn.GET("/v1/users/:id", removed("v0.9.0"))


### PR DESCRIPTION
## Summary

Removes `ListIdentityGrants` and `ListGroupGrants` and moves those special authorization rules to `ListGrants`.

This PR keeps the old deprecated routes for now (as aliases of `ListGrants`), but maybe we should remove them.

Most of the change is the addition of API tests, best viewed by individual commit.


## Related Issues

Related to #1680, but maybe the group endpoint should be changed in the same way before we close that issue.


TODO:

* [x] update CLI to use `ListGrant` (will wait until #1865 merges to avoid conflicts)
* [x] deprecate or remove the `Client` methods
* [x] remove or ticket for removing the deprecated API routes - #1868