### PR TITLE
fix: add additional signup check

### DIFF
--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -35,7 +35,12 @@ func SignupEnabled(c *gin.Context) (bool, error) {
 		return false, err
 	}
 
-	return identities+providers+grants == int64(0), nil
+	accessKeys, err := data.Count[models.AccessKey](db.Unscoped())
+	if err != nil {
+		return false, err
+	}
+
+	return identities+providers+grants+accessKeys == 0, nil
 }
 
 // Signup creates a user identity using the supplied name and password and


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

When connector is enabled in the same helm install as server, it will
create an identity and access key to allow the connector to communicate
with the server. This identity is created with "connector" which is
filtered out in the signup check leading to signup to be enabled.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
