### PR TITLE
maintain: restore required email error test

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -679,7 +679,7 @@ func (Server) loadGrant(db *gorm.DB, input Grant) (*models.Grant, error) {
 
 		id = uid.NewGroupPolymorphicID(group.ID)
 
-	// TODO: this gotta go
+	// TODO: remove this when deprecated machines in config are removed
 	case input.Machine != "":
 		machine, err := data.GetIdentity(db, data.ByName(input.Machine))
 		if err != nil {

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -60,6 +60,21 @@ func TestSendAPIError(t *testing.T) {
 				Message: "not implemented",
 			},
 		},
+		{
+			err: validate.Struct(struct {
+				Email string `validate:"required,email" json:"email"`
+			}{}),
+			result: api.Error{
+				Code:    http.StatusBadRequest,
+				Message: "Email: is required",
+				FieldErrors: []api.FieldError{
+					{
+						FieldName: "Email",
+						Errors:    []string{"is required"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -320,24 +320,6 @@ func withAdminIdentity(_ *testing.T, opts *Options) {
 	})
 }
 
-func TestDeleteProvider_NoDeleteInternalProvider(t *testing.T) {
-	s := setupServer(t, withAdminIdentity)
-
-	routes := s.GenerateRoutes(prometheus.NewRegistry())
-	internalProvider := data.InfraProvider(s.db)
-
-	route := fmt.Sprintf("/v1/providers/%s", internalProvider.ID)
-	req, err := http.NewRequest(http.MethodDelete, route, nil)
-	assert.NilError(t, err)
-
-	req.Header.Add("Authorization", "Bearer "+adminAccessKey(s))
-
-	resp := httptest.NewRecorder()
-	routes.ServeHTTP(resp, req)
-
-	assert.Equal(t, http.StatusForbidden, resp.Code, resp.Body.String())
-}
-
 func TestCreateIdentity(t *testing.T) {
 	srv := setupServer(t, withAdminIdentity)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())


### PR DESCRIPTION
## Summary
A little more clean-up around the identity kind consolidation. Restoring an error test, removing a redundant test and updating a comment.

Restoring
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1657
