### PR TITLE
feat: use email name for authinfo inside of kube

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/env"
 	"gotest.tools/v3/fs"
 
@@ -151,6 +152,17 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 
 				_, err = resp.Write(bytes)
 				assert.NilError(t, err)
+			case req.URL.Path == fmt.Sprintf("/v1/identities/%s", userID):
+				identity := api.Identity{
+					ID:   userID,
+					Name: "testuser@example.com",
+				}
+
+				bytes, err := json.Marshal(identity)
+				assert.NilError(t, err)
+
+				_, err = resp.Write(bytes)
+				assert.NilError(t, err)
 			default:
 				resp.WriteHeader(http.StatusBadRequest)
 			}
@@ -180,8 +192,9 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 
 		assert.Equal(t, len(kubeconfig.Clusters), 2)
 		assert.Equal(t, len(kubeconfig.Contexts), 2)
-		assert.Equal(t, len(kubeconfig.AuthInfos), 2)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 1)
 		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster")
+		assert.Assert(t, is.Contains(kubeconfig.AuthInfos, "testuser@example.com"))
 	})
 
 	t.Run("UseClusterWithPrefix", func(t *testing.T) {
@@ -195,8 +208,9 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 
 		assert.Equal(t, len(kubeconfig.Clusters), 2)
 		assert.Equal(t, len(kubeconfig.Contexts), 2)
-		assert.Equal(t, len(kubeconfig.AuthInfos), 2)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 1)
 		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster")
+		assert.Assert(t, is.Contains(kubeconfig.AuthInfos, "testuser@example.com"))
 	})
 
 	t.Run("UseNamespaceWithoutPrefix", func(t *testing.T) {
@@ -210,8 +224,9 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 
 		assert.Equal(t, len(kubeconfig.Clusters), 2)
 		assert.Equal(t, len(kubeconfig.Contexts), 2)
-		assert.Equal(t, len(kubeconfig.AuthInfos), 2)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 1)
 		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster:namespace")
+		assert.Assert(t, is.Contains(kubeconfig.AuthInfos, "testuser@example.com"))
 	})
 
 	t.Run("UseNamespaceWithPrefix", func(t *testing.T) {
@@ -225,8 +240,9 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 
 		assert.Equal(t, len(kubeconfig.Clusters), 2)
 		assert.Equal(t, len(kubeconfig.Contexts), 2)
-		assert.Equal(t, len(kubeconfig.AuthInfos), 2)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 1)
 		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster:namespace")
+		assert.Assert(t, is.Contains(kubeconfig.AuthInfos, "testuser@example.com"))
 	})
 
 	t.Run("UseUnknown", func(t *testing.T) {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -50,6 +50,11 @@ func list(cli *CLI) error {
 		return err
 	}
 
+	identity, err := client.GetIdentity(identityID)
+	if err != nil {
+		return err
+	}
+
 	grants, err := client.ListIdentityGrants(identityID)
 	if err != nil {
 		return err
@@ -138,5 +143,5 @@ func list(cli *CLI) error {
 		cli.Output("You have not been granted access to any active destinations")
 	}
 
-	return writeKubeconfig(destinations, grants)
+	return writeKubeconfig(identity, destinations, grants)
 }


### PR DESCRIPTION
## Summary

Changes AuthInfo inside of kube to use the infra email name for a user

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1851 
