### PR TITLE
improve: feedback on grant roles

### DIFF
--- a/docs/guides/granting-access.md
+++ b/docs/guides/granting-access.md
@@ -2,7 +2,7 @@
 
 ## Roles
 
-Infra allows granting different levels of access via **roles**, such as `view`, `edit` or `admin`. Each connector has different roles that can be used:
+Infra allows granting different levels of access via **roles**, such as `view`, `connector` or `admin`. Each connector has different roles that can be used:
 
 - [Kubernetes Roles](../connectors/kubernetes.md#roles)
 

--- a/docs/guides/granting-access.md
+++ b/docs/guides/granting-access.md
@@ -2,7 +2,7 @@
 
 ## Roles
 
-Infra allows granting different levels of access via **roles**, such as `view`, `connector` or `admin`. Each connector has different roles that can be used:
+Infra allows granting different levels of access via the **roles** `view` or `admin`. Each connector has different roles that can be used:
 
 - [Kubernetes Roles](../connectors/kubernetes.md#roles)
 

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -222,6 +222,15 @@ func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 
 	cli.Output("Access granted!")
 
+	// Warn user if destination is kubernetes that role is not validated
+	if cmdOptions.Destination != models.InternalInfraProviderName {
+		switch cmdOptions.Role {
+		case "cluster-admin", "admin", "edit", "view":
+			cli.Output("\nFor more information on default roles, see\nhttps://github.com/infrahq/infra/blob/main/docs/connectors/kubernetes.md#roles")
+		default:
+			cli.Output("\n[%s] is not a default kubernetes user facing role. For more information, see\nhttps://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings", cmdOptions.Role)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Gives user feedback if the grant is an invalid one for infra, or the proper links if it is kubernetes. 

- API returns bad request with invalid roles for infra
- CLI links user to infra documentation if role is a default expected one (admin, view, etc.)
- CLI warns user if it is not one of the defaults, and links to the kubernetes [article](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
Related to #1394