### PR TITLE
feat: move info and version from flags to other commands

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -21,6 +21,8 @@
 * [infra providers list](#infra-providers-list)
 * [infra providers add](#infra-providers-add)
 * [infra providers remove](#infra-providers-remove)
+* [infra info](#infra-info)
+* [infra version](#infra-version)
 * [infra about](#infra-about)
 
 
@@ -517,6 +519,36 @@ infra providers remove PROVIDER [flags]
 
 ```
 $ infra providers remove okta
+```
+
+### Options inherited from parent commands
+
+```
+      --help               Display help
+      --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
+```
+
+## `infra info`
+
+Display the info about the current session
+
+```
+infra info [flags]
+```
+
+### Options inherited from parent commands
+
+```
+      --help               Display help
+      --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
+```
+
+## `infra version`
+
+Display the Infra version
+
+```
+infra version [flags]
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -288,15 +288,14 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 	rootCmd.AddCommand(newKeysCmd(cli))
 	rootCmd.AddCommand(newProvidersCmd(cli))
 
-	// Hidden
-	rootCmd.AddCommand(newTokensCmd(cli))
+	// Other commands:
 	rootCmd.AddCommand(newInfoCmd(cli))
-	rootCmd.AddCommand(newServerCmd())
-	rootCmd.AddCommand(newConnectorCmd())
 	rootCmd.AddCommand(newVersionCmd(cli))
 
-	rootCmd.Flags().BoolVar(&rootOpts.Version, "version", false, "Display Infra version")
-	rootCmd.Flags().BoolVar(&rootOpts.Info, "info", false, "Display info about the current logged in session")
+	// Hidden
+	rootCmd.AddCommand(newTokensCmd(cli))
+	rootCmd.AddCommand(newServerCmd())
+	rootCmd.AddCommand(newConnectorCmd())
 
 	rootCmd.PersistentFlags().String("log-level", "info", "Show logs when running the command [error, warn, info, debug]")
 	rootCmd.PersistentFlags().Bool("help", false, "Display help")

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -239,16 +239,8 @@ func defaultConnectorOptions() connector.Options {
 	return connector.Options{}
 }
 
-// rootOptions are options specified by users on the command line that are
-// used by the root command.
-type rootOptions struct {
-	Info    bool
-	Version bool
-}
-
 func NewRootCmd(cli *CLI) *cobra.Command {
 	cobra.EnableCommandSorting = false
-	var rootOpts rootOptions
 
 	rootCmd := &cobra.Command{
 		Use:               "infra",
@@ -259,18 +251,6 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 			return rootPreRun(cmd.Flags())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootOpts.Version {
-				return version(cli)
-			}
-			if rootOpts.Info {
-				if err := mustBeLoggedIn(); err != nil {
-					return fmt.Errorf("login check: %w", err)
-				}
-				if err := info(cli); err != nil {
-					return fmt.Errorf("info: %w", err)
-				}
-				return nil
-			}
 			return cmd.Help()
 		},
 	}

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -10,10 +10,10 @@ import (
 
 func newInfoCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
-		Use:    "info",
-		Short:  "Display the info about the current session",
-		Args:   NoArgs,
-		Hidden: true,
+		Use:   "info",
+		Short: "Display the info about the current session",
+		Args:  NoArgs,
+		Group: "Other commands:",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := mustBeLoggedIn(); err != nil {
 				return err

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -13,10 +13,10 @@ import (
 
 func newVersionCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
-		Use:    "version",
-		Short:  "Display the Infra version",
-		Hidden: true,
-		Args:   NoArgs,
+		Use:   "version",
+		Short: "Display the Infra version",
+		Group: "Other commands:",
+		Args:  NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return version(cli)
 		},


### PR DESCRIPTION
## Summary

Add info and version into `other commands`. 
Remove flag versions of info and version. 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] ~Wrote appropriate unit tests~
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1861
