### PR TITLE
fix: make setting secrets in env clear

### DIFF
--- a/docs/install/configure/secrets.md
+++ b/docs/install/configure/secrets.md
@@ -115,10 +115,11 @@ secrets:
       base64Raw: false
 ```
 
-which you would then use like this. First create the environment variable:
+which you would then use like this. First define an environment variable in the context where it will be accessed. [There are many ways to do this in Kubernetes](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/). Typically the environment variable in Kubernetes will be defined in the [deployment](/helm/charts/infra/templates/server/deployment.yaml). To temporarily define an environment variable you can use `kubectl`:
 
 ```bash
-$ export OKTA_CLIENT_SECRET="c3VwZXIgc2VjcmV0IQ=="
+$ kubectl set env deployment/infra OKTA_CLIENT_SECRET=c3VwZXIgc2VjcmV0IQ==
+# you will need to restart any running pods for this to be applied
 ```
 
 Then use the name of the secret back-end and the name of the environment variable in the `infra.yaml` file:


### PR DESCRIPTION
## Summary
This documentation made it look like the environment variable should be set in the local context. Update the docs to give more context which make it clear this environment variable should be defined in the context that the infra server is running in.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Updated associated docs where necessary

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1618
