### PR TITLE
data: add a test to demonstrate gorm.DB clone behaviour

### DIFF
--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -55,12 +55,12 @@ func NewRawDB(connection gorm.Dialector) (*gorm.DB, error) {
 	if connection.Name() == "sqlite" {
 		// avoid issues with concurrent writes by telling gorm
 		// not to open multiple connections in the connection pool
-		db2, err := db.DB()
+		sqlDB, err := db.DB()
 		if err != nil {
 			return nil, fmt.Errorf("getting db driver: %w", err)
 		}
 
-		db2.SetMaxOpenConns(1)
+		sqlDB.SetMaxOpenConns(1)
 	}
 
 	return db, nil

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -28,19 +28,11 @@ func NewDB(connection gorm.Dialector) (*gorm.DB, error) {
 		return nil, fmt.Errorf("db conn: %w", err)
 	}
 
-	if err = migrate(db); err != nil {
+	if err = Migrate(db); err != nil {
 		return nil, fmt.Errorf("migration failed: %w", err)
 	}
 
 	return db, nil
-}
-
-func PreMigrate(db *gorm.DB) error {
-	return premigrate(db)
-}
-
-func Migrate(db *gorm.DB) error {
-	return migrate(db)
 }
 
 // NewRawDB creates a new database connection without running migrations

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -73,13 +73,12 @@ func NewPostgresDriver(connection string) (gorm.Dialector, error) {
 }
 
 func get[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) (*T, error) {
-	db2 := db
 	for _, selector := range selectors {
-		db2 = selector(db2)
+		db = selector(db)
 	}
 
-	model := new(T)
-	if err := db2.Model((*T)(nil)).First(model).Error; err != nil {
+	result := new(T)
+	if err := db.Model((*T)(nil)).First(result).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, internal.ErrNotFound
 		}
@@ -87,21 +86,20 @@ func get[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) (*T, error)
 		return nil, err
 	}
 
-	return model, nil
+	return result, nil
 }
 
 func list[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) ([]T, error) {
-	db2 := db
 	for _, selector := range selectors {
-		db2 = selector(db2)
+		db = selector(db)
 	}
 
-	models := make([]T, 0)
-	if err := db2.Model((*T)(nil)).Find(&models).Error; err != nil {
+	result := make([]T, 0)
+	if err := db.Model((*T)(nil)).Find(&result).Error; err != nil {
 		return nil, err
 	}
 
-	return models, nil
+	return result, nil
 }
 
 func save[T models.Modelable](db *gorm.DB, model *T) error {
@@ -163,22 +161,20 @@ func delete[T models.Modelable](db *gorm.DB, id uid.ID) error {
 }
 
 func deleteAll[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) error {
-	db2 := db
 	for _, selector := range selectors {
-		db2 = selector(db2)
+		db = selector(db)
 	}
 
-	return db2.Delete(new(T)).Error
+	return db.Delete(new(T)).Error
 }
 
 func Count[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) (int64, error) {
-	db2 := db
 	for _, selector := range selectors {
-		db2 = selector(db2)
+		db = selector(db)
 	}
 
 	var count int64
-	if err := db2.Model((*T)(nil)).Count(&count).Error; err != nil {
+	if err := db.Model((*T)(nil)).Count(&count).Error; err != nil {
 		return -1, err
 	}
 

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -68,4 +69,58 @@ func TestSnowflakeIDSerialization(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Equal(t, int64(id), intID)
+}
+
+func TestDatabaseSelectors(t *testing.T) {
+	driver, err := NewSQLiteDriver("file::memory:")
+	assert.NilError(t, err)
+
+	db, err := NewRawDB(driver)
+	assert.NilError(t, err)
+	t.Logf("DB pointer: %p", db)
+
+	assert.NilError(t, initializeSchema(db))
+
+	// mimic server.DatabaseMiddleware
+	withCtx := db.WithContext(context.Background())
+	assert.Assert(t, db != withCtx, "db=%p withCtx=%p", db, withCtx)
+	t.Logf("DB pointer: %p", withCtx)
+
+	err = withCtx.Transaction(func(tx *gorm.DB) error {
+		assert.Assert(t, withCtx != tx, "db=%p tx=%p", withCtx, tx)
+		t.Logf("DB pointer: %p", tx)
+
+		// query using one of our helpers and selectors
+		_, err := ListGrants(tx, ByID(534))
+		assert.NilError(t, err)
+
+		// query with Model and Where
+		var groups []models.Group
+		qDB := tx.Model(&models.Group{}).Where("id = ?", 42).Find(&groups)
+		assert.NilError(t, qDB.Error)
+		assert.Assert(t, tx != qDB, "tx=%p queryDB=%p", tx, qDB)
+		t.Logf("DB pointer: %p", qDB)
+
+		// Show that queries have not modified the original gorm.DB references
+		assert.Equal(t, len(db.Statement.Clauses), 0)
+		assert.Equal(t, len(withCtx.Statement.Clauses), 0)
+		assert.Equal(t, len(tx.Statement.Clauses), 0)
+		return nil
+	})
+	assert.NilError(t, err)
+
+	// query using one of our helpers and selectors
+	_, err = ListGrants(db, ByID(534))
+	assert.NilError(t, err)
+
+	// query with Model and Where
+	var groups []models.Group
+	qDB := db.Model(&models.Group{}).Where("id = ?", 42).Find(&groups)
+	assert.NilError(t, qDB.Error)
+	assert.Assert(t, db != qDB, "db=%p queryDB=%p", db, qDB)
+	t.Logf("DB pointer: %p", qDB)
+
+	// Show that queries have not modified the original gorm.DB references
+	assert.Equal(t, len(db.Statement.Clauses), 0)
+	assert.Equal(t, len(withCtx.Statement.Clauses), 0)
 }

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -15,7 +15,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func migrate(db *gorm.DB) error {
+func Migrate(db *gorm.DB) error {
 	m := gormigrate.New(db, gormigrate.DefaultOptions, []*gormigrate.Migration{
 		// rename grants.identity -> grants.subject
 		{
@@ -466,26 +466,26 @@ func migrate(db *gorm.DB) error {
 		// next one here
 	})
 
-	m.InitSchema(premigrate)
+	m.InitSchema(PreMigrate)
 
 	if err := m.Migrate(); err != nil {
 		return err
 	}
 
-	// automigrate again, so that for simple things like adding db fields we don't necessarily need to do a migration
-	return automigrate(db)
+	// initializeSchema again, so that for simple things like adding db fields we don't necessarily need to do a migration
+	return initializeSchema(db)
 }
 
-func premigrate(db *gorm.DB) error {
+func PreMigrate(db *gorm.DB) error {
 	if db.Migrator().HasTable("providers") {
-		// don't pre-auto-mgirate if tables already exist.
+		// don't pre-auto-migrate if tables already exist.
 		return nil
 	}
 
-	return automigrate(db)
+	return initializeSchema(db)
 }
 
-func automigrate(db *gorm.DB) error {
+func initializeSchema(db *gorm.DB) error {
 	tables := []interface{}{
 		&models.Identity{},
 		&models.Group{},

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -18,7 +18,7 @@ func Test202204111503(t *testing.T) {
 		loadSQL(t, db, "202204111503")
 	})
 
-	err := migrate(db)
+	err := Migrate(db)
 	assert.NilError(t, err)
 
 	ids, err := ListIdentities(db, ByName("steven@example.com"))
@@ -37,7 +37,7 @@ func Test202204211705(t *testing.T) {
 
 	models.SymmetricKey = key
 
-	err = migrate(db)
+	err = Migrate(db)
 	assert.NilError(t, err)
 
 	// check it still works


### PR DESCRIPTION
## Summary

This PR adds a test that shows that `gorm.DB` methods always (at least for the cases I've tested), return a pointer to a copy of the `gorm.DB`. The logic for that is in [db.getInstance](https://github.com/go-gorm/gorm/blob/9b80fe9e96e6d9132f935a944a150777a3ffdf03/gorm.go#L362-L385), which seems to be called from most `gorm.DB` methods.

This PR also removes the `db2` variables. Those variables aren't necessary because the gorm methods return copies, and since the type is a pointer, the extra variable would not help if they did not return copies. Both variables would point at the same value.  Creating a copy using assignment only works for non-pointer values. You'd have to deference the pointer to make a copy (but that's not how gorm.DB is expected to be used).

https://github.com/infrahq/infra/pull/1757#pullrequestreview-955629719 is an example of how these extra `db2` variables can pretty easily introduce bugs. It's easy to use the wrong variable when they are similarly named. Removing the variable removes the possibility of a bug from using the wrong one.

Also makes a few other minor cosmetic changes to the migration functions, to remove wrappers and improve naming. I noticed we now only use `NewDB` for tests, which means our tests are not constructing a DB the same way as other code.  We should align those two, but not in this PR.