### PR TITLE
maintain: refactor printTable to use CLI

### DIFF
--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/lensesio/tableprinter"
 )
 
 // CLI exposes common dependencies to commands.
@@ -12,6 +14,8 @@ type CLI struct {
 	Stdin  io.Reader
 	Stdout io.Writer
 	Stderr io.Writer
+
+	table *tableprinter.Printer
 }
 
 // Output a string to CLI.Stdout. Output is like fmt.Printf except that it always
@@ -19,6 +23,10 @@ type CLI struct {
 // To write output without a trailing newline use CLI.Stdout directly.
 func (c *CLI) Output(format string, args ...interface{}) {
 	fmt.Fprintf(c.Stdout, format+"\n", args...)
+}
+
+func (c *CLI) Table(args interface{}) {
+	c.table.Print(args)
 }
 
 // key is a type to ensure no other package can access the CLI value in context.
@@ -38,9 +46,24 @@ func newCLI(ctx context.Context) *CLI {
 	if ok {
 		return cli
 	}
+
+	table := tableprinter.New(os.Stdout)
+	table.HeaderAlignment = tableprinter.AlignLeft
+	table.AutoWrapText = false
+	table.DefaultAlignment = tableprinter.AlignLeft
+	table.CenterSeparator = ""
+	table.ColumnSeparator = ""
+	table.RowSeparator = ""
+	table.HeaderLine = false
+	table.BorderBottom = false
+	table.BorderLeft = false
+	table.BorderRight = false
+	table.BorderTop = false
+
 	return &CLI{
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
+		table:  table,
 	}
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/goware/urlx"
-	"github.com/lensesio/tableprinter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/term"
@@ -68,23 +66,6 @@ func infraHomeDir() (string, error) {
 	}
 
 	return infraDir, nil
-}
-
-func printTable(data interface{}, out io.Writer) {
-	table := tableprinter.New(out)
-
-	table.HeaderAlignment = tableprinter.AlignLeft
-	table.AutoWrapText = false
-	table.DefaultAlignment = tableprinter.AlignLeft
-	table.CenterSeparator = ""
-	table.ColumnSeparator = ""
-	table.RowSeparator = ""
-	table.HeaderLine = false
-	table.BorderBottom = false
-	table.BorderLeft = false
-	table.BorderRight = false
-	table.BorderTop = false
-	table.Print(data)
 }
 
 // Creates a new API Client from the current config

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -59,7 +59,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows, cli.Stdout)
+				cli.Table(rows)
 			} else {
 				cli.Output("No destinations found")
 			}

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -79,7 +79,7 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows, cli.Stdout)
+				cli.Table(rows)
 			} else {
 				cli.Output("No grants found")
 			}

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -131,7 +131,7 @@ func newIdentitiesListCmd(cli *CLI) *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows, cli.Stdout)
+				cli.Table(rows)
 			} else {
 				cli.Output("No identities found")
 			}

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -199,7 +199,7 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows, cli.Stdout)
+				cli.Table(rows)
 			} else {
 				cli.Output("No access keys found")
 			}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -138,7 +138,7 @@ func list(cli *CLI) error {
 	}
 
 	if len(rows) > 0 {
-		printTable(rows, cli.Stdout)
+		cli.Table(rows)
 	} else {
 		cli.Output("You have not been granted access to any active destinations")
 	}

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -60,7 +60,7 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 			}
 
 			if len(rows) > 0 {
-				printTable(rows, cli.Stdout)
+				cli.Table(rows)
 			} else {
 				cli.Output("No providers found")
 			}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

CLI provides an interface for CLI outputs and is an appropriate place to put table printing