### PR TITLE
api: remove unused method receiver and unused method

### DIFF
--- a/internal/server/debug.go
+++ b/internal/server/debug.go
@@ -12,7 +12,7 @@ import (
 
 func (a *API) pprofHandler(c *gin.Context) {
 	if _, err := access.RequireInfraRole(c, models.InfraAdminRole); err != nil {
-		a.sendAPIError(c, err)
+		sendAPIError(c, err)
 		return
 	}
 

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -20,7 +20,7 @@ import (
 // sendAPIError translates err into the appropriate HTTP status code, builds a
 // response body using api.Error, then sends both as a response to the active
 // request.
-func (a *API) sendAPIError(c *gin.Context, err error) {
+func sendAPIError(c *gin.Context, err error) {
 	resp := &api.Error{
 		Code:    http.StatusInternalServerError,
 		Message: "internal server error", // don't leak any info by default

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -87,7 +87,7 @@ func TestSendAPIError(t *testing.T) {
 			resp := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(resp)
 
-			(&API{}).sendAPIError(c, test.err)
+			sendAPIError(c, test.err)
 
 			assert.Equal(t, test.result.Code, int32(resp.Result().StatusCode))
 			actual := &api.Error{}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -58,7 +58,7 @@ func DatabaseMiddleware(db *gorm.DB) gin.HandlerFunc {
 func AuthenticationMiddleware(a *API) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if err := RequireAccessKey(c); err != nil {
-			a.sendAPIError(c, fmt.Errorf("%w: %s", internal.ErrUnauthorized, err))
+			sendAPIError(c, fmt.Errorf("%w: %s", internal.ErrUnauthorized, err))
 			return
 		}
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -126,19 +126,19 @@ type ReqHandlerFunc[Req any] func(c *gin.Context, req *Req) error
 type ResHandlerFunc[Res any] func(c *gin.Context) (Res, error)
 type ReqResHandlerFunc[Req, Res any] func(c *gin.Context, req *Req) (Res, error)
 
-func get[Req, Res any](a *API, r *gin.RouterGroup, route string, handler ReqResHandlerFunc[Req, Res]) {
+func get[Req, Res any](_ *API, r *gin.RouterGroup, route string, handler ReqResHandlerFunc[Req, Res]) {
 	fullPath := path.Join(r.BasePath(), route)
 	register("GET", fullPath, handler)
 	r.GET(route, func(c *gin.Context) {
 		req := new(Req)
 		if err := bind(c, req); err != nil {
-			a.sendAPIError(c, err)
+			sendAPIError(c, err)
 			return
 		}
 
 		resp, err := handler(c, req)
 		if err != nil {
-			a.sendAPIError(c, err)
+			sendAPIError(c, err)
 			return
 		}
 
@@ -153,13 +153,13 @@ func post[Req, Res any](a *API, r *gin.RouterGroup, route string, handler ReqRes
 	r.POST(route, func(c *gin.Context) {
 		req := new(Req)
 		if err := bind(c, req); err != nil {
-			a.sendAPIError(c, err)
+			sendAPIError(c, err)
 			return
 		}
 
 		resp, err := handler(c, req)
 		if err != nil {
-			a.sendAPIError(c, err)
+			sendAPIError(c, err)
 			return
 		}
 
@@ -176,13 +176,13 @@ func put[Req, Res any](a *API, r *gin.RouterGroup, route string, handler ReqResH
 	r.PUT(route, func(c *gin.Context) {
 		req := new(Req)
 		if err := bind(c, req); err != nil {
-			a.sendAPIError(c, err)
+			sendAPIError(c, err)
 			return
 		}
 
 		resp, err := handler(c, req)
 		if err != nil {
-			a.sendAPIError(c, err)
+			sendAPIError(c, err)
 			return
 		}
 
@@ -199,13 +199,13 @@ func delete[Req any](a *API, r *gin.RouterGroup, route string, handler ReqHandle
 	r.DELETE(route, func(c *gin.Context) {
 		req := new(Req)
 		if err := bind(c, req); err != nil {
-			a.sendAPIError(c, err)
+			sendAPIError(c, err)
 			return
 		}
 
 		err := handler(c, req)
 		if err != nil {
-			a.sendAPIError(c, err)
+			sendAPIError(c, err)
 			return
 		}
 
@@ -249,7 +249,7 @@ type WellKnownJWKResponse struct {
 func (a *API) wellKnownJWKsHandler(c *gin.Context) {
 	keys, err := access.GetPublicJWK(c)
 	if err != nil {
-		a.sendAPIError(c, err)
+		sendAPIError(c, err)
 		return
 	}
 
@@ -266,7 +266,7 @@ func healthHandler(c *gin.Context) {
 // format of the response body. https://github.com/infrahq/infra/issues/1610
 func (a *API) notFoundHandler(c *gin.Context) {
 	if strings.HasPrefix(c.Request.URL.Path, "/v1") {
-		a.sendAPIError(c, internal.ErrNotFound)
+		sendAPIError(c, internal.ErrNotFound)
 		return
 	}
 

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -13,7 +13,6 @@ import (
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/uid"
 )
 
 type Properties = analytics.Properties
@@ -150,21 +149,6 @@ func (t *Telemetry) User(id string, name string) {
 		UserId:    id,
 		Traits:    analytics.NewTraits().SetEmail(name),
 		Timestamp: time.Now().UTC(),
-	})
-	if err != nil {
-		logging.S.Debug(err)
-	}
-}
-
-func (t *Telemetry) Group(identityID, groupID uid.ID, traits map[string]interface{}) {
-	if t == nil {
-		return
-	}
-	err := t.Enqueue(analytics.Group{
-		UserId:    identityID.String(),
-		GroupId:   groupID.String(),
-		Timestamp: time.Now().UTC(),
-		Traits:    traits,
 	})
 	if err != nil {
 		logging.S.Debug(err)


### PR DESCRIPTION
Following up on #1874

I noticed that now `sendAPIError` doesn't need to be a method anymore (it doesn't use `API`).

Also noticed the `Telemetry.Group` method was not being used. Should it be, or is it safe to remove for now?