### PR TITLE
maintain: remove unused BindGroupIdentities

### DIFF
--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -7,14 +7,6 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func BindGroupIdentities(db *gorm.DB, group *models.Group, identities ...models.Identity) error {
-	if err := db.Model(group).Association("Identities").Replace(identities); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func CreateGroup(db *gorm.DB, group *models.Group) error {
 	return add(db, group)
 }


### PR DESCRIPTION
## Summary

While working on `ListGroups` I came across `data.BindGroupIdentities` which was only used in tests. I suspect this function was replaced by `data.AssignIdentityToGroups` at some point.

This PR removes `data.BindGroupIdentities` and the tests for it. The one test of other functionality that used this function was changed to use `data.AssignIdentityToGroups` to better mirror production code paths.