### PR TITLE
fix: golint 1.6.0 errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/ssoroka/slice v0.0.0-20220402005549-78f0cea3df8b
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/text v0.3.7
 	gotest.tools/v3 v3.2.0
 )
 
@@ -144,7 +145,6 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/internal/cmd/about.go
+++ b/internal/cmd/about.go
@@ -40,15 +40,12 @@ func newTriangle(a, b, c *point3D, ch rune) *triangle {
 }
 
 func (t *triangle) Draw(surf *sprite.Surface) {
-	err := surf.Triangle(
+	// nolint
+	surf.Triangle(
 		t.A.ScreenX(), t.A.ScreenY(),
 		t.B.ScreenX(), t.B.ScreenY(),
 		t.C.ScreenX(), t.C.ScreenY(),
 		t.Color, true)
-	//nolint
-	if err != nil {
-		// don't do anything
-	}
 }
 
 type point3D struct {

--- a/internal/cmd/about.go
+++ b/internal/cmd/about.go
@@ -45,6 +45,7 @@ func (t *triangle) Draw(surf *sprite.Surface) {
 		t.B.ScreenX(), t.B.ScreenY(),
 		t.C.ScreenX(), t.C.ScreenY(),
 		t.Color, true)
+	//nolint
 	if err != nil {
 		// don't do anything
 	}
@@ -137,8 +138,10 @@ type scrollText struct {
 }
 
 func newScrollText(width, height int) *scrollText {
-	s := &scrollText{BaseSprite: sprite.BaseSprite{
-		Visible: true},
+	s := &scrollText{
+		BaseSprite: sprite.BaseSprite{
+			Visible: true,
+		},
 		TimeOut: 2,
 	}
 	f := sprite.NewJRSMFont()
@@ -207,8 +210,10 @@ type logo3D struct {
 }
 
 func newLogo3D(width, height int) *logo3D {
-	s := &logo3D{BaseSprite: sprite.BaseSprite{
-		Visible: true},
+	s := &logo3D{
+		BaseSprite: sprite.BaseSprite{
+			Visible: true,
+		},
 		angleX: 0.05,
 		angleY: 0.1,
 		angleZ: 0.02,

--- a/internal/cmd/about.go
+++ b/internal/cmd/about.go
@@ -41,7 +41,7 @@ func newTriangle(a, b, c *point3D, ch rune) *triangle {
 
 func (t *triangle) Draw(surf *sprite.Surface) {
 	// nolint
-	surf.Triangle(
+	_ = surf.Triangle(
 		t.A.ScreenX(), t.A.ScreenY(),
 		t.B.ScreenX(), t.B.ScreenY(),
 		t.C.ScreenX(), t.C.ScreenY(),

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -157,7 +157,7 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
-			keys := &api.ListResponse[api.AccessKey]{}
+			keys := &api.ListResponse[api.AccessKey]{} // nolint
 			if options.IdentityName != "" {
 				identity, err := GetIdentityByName(client, options.IdentityName)
 				if err != nil {

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -157,7 +157,7 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
-			keys := &api.ListResponse[api.AccessKey]{} // nolint
+			var keys *api.ListResponse[api.AccessKey]
 			if options.IdentityName != "" {
 				identity, err := GetIdentityByName(client, options.IdentityName)
 				if err != nil {

--- a/internal/cmd/local_server.go
+++ b/internal/cmd/local_server.go
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type ErrResultTimedOut struct{}
@@ -106,7 +109,7 @@ func formatURLMsg(msg string, fallback string) string {
 	}
 
 	formatted := strings.ReplaceAll(msg, "_", " ")
-	formatted = strings.Title(strings.ToLower(formatted))
+	formatted = cases.Title(language.English).String(formatted)
 
 	return formatted
 }

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -117,8 +117,7 @@ func generateJWT(priv *jose.JSONWebKey, email string, expiry time.Time) (string,
 		IssuedAt: jwt.NewNumericDate(time.Now()),
 	}
 
-	var custom claims.Custom
-	custom = claims.Custom{
+	custom := claims.Custom{
 		Name:   email,
 		Groups: []string{"developers"},
 		Nonce:  "randomstring",

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -54,9 +54,7 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 		IssuedAt:  jwt.NewNumericDate(time.Now().UTC()),
 	}
 
-	var custom claims.Custom
-
-	custom = claims.Custom{
+	custom := claims.Custom{
 		Name:   identity.Name,
 		Groups: groups,
 		Nonce:  nonce,


### PR DESCRIPTION
## Summary
The lint runner is running the new golint version (1.6.0) and it is detecting some new warnings. This PR cleans up these problems.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->
