### PR TITLE
improve: confirm password mismatch returns to first password prompt

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -291,13 +291,13 @@ $ infra grants remove janedoe@example.com infra --role admin
 
 ## `infra identities add`
 
-Create an identity.
+Create an identity
 
 ### Synopsis
 
-Create an identity.
+Create an identity
 
-A new user identity must change their one time password before further usage.
+Note: A new user identity must change their one time password before further usage.
 
 ```
 infra identities add IDENTITY [flags]

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -52,7 +52,7 @@ func (e *FailedLoginError) Error() string {
 		panic("LoggedInIdentity cannot be set unless user is logged in")
 	}
 	if isLoggedInCurrent() {
-		msg += fmt.Sprintf(" Your existing session as %s is still active.", e.LoggedInIdentity)
+		msg += fmt.Sprintf(" You are still logged in as [%s].", e.LoggedInIdentity)
 	}
 
 	return msg

--- a/internal/cmd/identities.go
+++ b/internal/cmd/identities.go
@@ -280,7 +280,7 @@ PROMPT:
 		{
 			Name:     "Confirm",
 			Prompt:   &survey.Password{Message: "Confirm Password:"},
-			Validate: checkConfirmPassword(),
+			Validate: survey.Required,
 		},
 	}
 
@@ -311,16 +311,6 @@ func checkPasswordRequirements(oldPassword string) survey.Validator {
 			return fmt.Errorf("input must be different than the current password")
 		}
 
-		return nil
-	}
-}
-
-func checkConfirmPassword() survey.Validator {
-	return func(val interface{}) error {
-		_, ok := val.(string)
-		if !ok {
-			return fmt.Errorf("unexpected type for password: %T", val)
-		}
 		return nil
 	}
 }

--- a/internal/cmd/identities_test.go
+++ b/internal/cmd/identities_test.go
@@ -30,15 +30,11 @@ func TestCheckPasswordRequirements(t *testing.T) {
 }
 
 func TestCheckConfirmPassword(t *testing.T) {
-	password := "password"
 
-	err := checkConfirmPassword(&password)("password")
+	err := checkConfirmPassword()("password")
 	assert.NilError(t, err)
 
-	err = checkConfirmPassword(&password)("drowssap")
-	assert.ErrorContains(t, err, "input must match the new password")
-
-	err = checkConfirmPassword(&password)(nil)
+	err = checkConfirmPassword()(nil)
 	assert.ErrorContains(t, err, "unexpected type for password")
 }
 

--- a/internal/cmd/identities_test.go
+++ b/internal/cmd/identities_test.go
@@ -29,15 +29,6 @@ func TestCheckPasswordRequirements(t *testing.T) {
 	assert.ErrorContains(t, err, "unexpected type for password")
 }
 
-func TestCheckConfirmPassword(t *testing.T) {
-
-	err := checkConfirmPassword()("password")
-	assert.NilError(t, err)
-
-	err = checkConfirmPassword()(nil)
-	assert.ErrorContains(t, err, "unexpected type for password")
-}
-
 func TestIdentitiesCmd(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -290,9 +290,9 @@ func oidcflow(host string, clientId string) (string, error) {
 // Prompt user to change their preset password when loggin in for the first time
 func updateUserPassword(client *api.Client, pid uid.PolymorphicID, oldPassword string) error {
 	// Todo otp: update term to temporary password (https://github.com/infrahq/infra/issues/1441)
-	fmt.Println("\n  One time password was used.")
+	fmt.Println("\n  One time password was used. Enter a new password (min length 8):")
 
-	newPassword, err := promptUpdatePassword(oldPassword)
+	newPassword, err := promptSetPassword(oldPassword)
 	if err != nil {
 		return err
 	}
@@ -344,7 +344,7 @@ func runSignupForLogin(client *api.Client) (*api.LoginRequestPasswordCredentials
 		return nil, err
 	}
 
-	password, err := promptPasswordConfirm("")
+	password, err := promptSetPassword("")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

If password confirm does not match the first one, right now it prompts only the second one. 
This change remprompts both: 

**Old:**
```
  Password: abc
  Confirm password: abcd
Passwords do not match. 
  Confirm password: abcd
```

**Now:**
```
  Password: abc
  Confirm password: abcd
Passwords do not match. Please try again.
  Password: ...
  Confirm password: ...
```

**Reason**
During admin signup, if user mistypes first password, they have no clear way to fix it. 


**Additional small changes**
- merges `promptUpdatePassword` and `promptConfirmPassword` because it only included a message `fmt.println`. Moved that msg out to the respective functions that call it, since the message is different each time. 