### PR TITLE
fix: make dev using wrong version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-tag := $(patsubst v%,%,$(shell git describe --tags))
+tag := $(patsubst v%,%,$(shell git describe --tags --abbrev=0))
 version := $(tag:v%=%)
 
 generate:
@@ -39,12 +39,8 @@ goreleaser:
 build: goreleaser
 	goreleaser build --snapshot --rm-dist
 
-export IMAGE_TAG=0.0.0-development
-
-build/docker:
-	docker build --build-arg TELEMETRY_WRITE_KEY=${TELEMETRY_WRITE_KEY} . -t infrahq/infra:$(IMAGE_TAG)
-
-export OKTA_SECRET=infra-okta
+dev/docker:
+	docker build --build-arg BUILDVERSION=$(version) --build-arg TELEMETRY_WRITE_KEY=${TELEMETRY_WRITE_KEY} . -t infrahq/infra:dev
 
 %.yaml: %.yaml.in
 	envsubst <$< >$@
@@ -54,7 +50,7 @@ docker-desktop.yaml: docker-desktop.yaml.in
 NS = $(patsubst %,-n %,$(NAMESPACE))
 VALUES ?= docker-desktop.yaml
 
-dev: $(VALUES) build/docker
+dev: $(VALUES) dev/docker
 	# docker desktop setup for the dev environment
 	# create a token and get the token secret from:
 	# https://dev-02708987-admin.okta.com/admin/access/api/tokens

--- a/docker-desktop.yaml.in
+++ b/docker-desktop.yaml.in
@@ -1,4 +1,4 @@
 global:
   image:
-    tag: $IMAGE_TAG
+    tag: dev
     pullPolicy: Never

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,7 +33,6 @@ The local setup can be customized with environment varibles. Some are required f
 | Name             | Description                                                   | Default               |
 |------------------|---------------------------------------------------------------|-----------------------|
 | `NAMESPACE`      | Kubernetes namespace to install `infra`                       | `""`                  |
-| `IMAGE_TAG`      | Docker tag                                                    | `0.0.0-development`   |
 | `VALUES`         | Values file to pass to Helm                                   | `docker-desktop.yaml` |
 
 ```bash

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -605,7 +605,7 @@ func Run(ctx context.Context, options Options) error {
 		ErrorLog:  logging.StandardErrorLog(),
 	}
 
-	logging.S.Infof("starting infra (%s) - https:%s metrics:%s", internal.Version, tlsServer.Addr, metricsServer.Addr)
+	logging.S.Infof("starting infra (%s) - https:%s metrics:%s", internal.FullVersion(), tlsServer.Addr, metricsServer.Addr)
 
 	return tlsServer.ListenAndServeTLS("", "")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -186,7 +186,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	logging.S.Infof("starting infra (%s) - http:%s https:%s metrics:%s",
-		internal.Version, s.Addrs.HTTP, s.Addrs.HTTPS, s.Addrs.Metrics)
+		internal.FullVersion(), s.Addrs.HTTP, s.Addrs.HTTPS, s.Addrs.Metrics)
 
 	return group.Wait()
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`make dev` makes some assumptions about the code base, one of which is to set infra version. This has side effects since the introduction of API migrations which causes the connector to report its API version incorrectly.

1. Docker image will always tag `dev` docker images when build locally with `make dev`
2. `IMAGE_TAG` is no longer supported to change the docker image tag
3. The version is injected into the Docker image at build time with contents of `git describe --tag --abbrev=0`
4. Server and connector on start up with report their full version
