### PR TITLE
ci: run data package tests against all supported databases

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14-alpine
+        env:
+          POSTGRES_PASSWORD: password123
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports: ["5432:5432"]
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -13,7 +25,12 @@ jobs:
           go-version: '1.18'
       - run: go install gotest.tools/gotestsum@v1.8.0
       - run: go mod tidy
-      - run: ~/go/bin/gotestsum -ftestname -- -race ./...
+
+      - name: go test
+        run: ~/go/bin/gotestsum -ftestname -- -race ./...
+        env:
+          POSTGRESQL_CONNECTION: "host=localhost port=5432 user=postgres dbname=postgres password=password123"
+
       - name: Check that tests leave a clean git checkout
         run: |
           # show and check changes to committed files

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -15,12 +15,21 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+// TODO: replace all calls to setup with runDBTests, or setupDB
 func setup(t *testing.T) *gorm.DB {
+	t.Helper()
 	driver, err := NewSQLiteDriver("file::memory:")
 	assert.NilError(t, err)
+	return setupDB(t, driver)
+}
 
-	db, err := NewDB(driver)
+func setupDB(t *testing.T, driver gorm.Dialector) *gorm.DB {
+	t.Helper()
+	db, err := NewRawDB(driver)
 	assert.NilError(t, err)
+
+	// TODO: change this to use the same calls as production.
+	assert.NilError(t, Migrate(db))
 
 	fp := secrets.NewFileSecretProviderFromConfig(secrets.FileConfig{
 		Path: os.TempDir(),
@@ -52,24 +61,69 @@ func setupLogging(t *testing.T) {
 	})
 }
 
+// dbDrivers returns the list of database drivers to test.
+// Set POSTGRESQL_CONNECTION to a postgresql connection string to run tests
+// against postgresql.
+func dbDrivers(t *testing.T) []gorm.Dialector {
+	t.Helper()
+	var drivers []gorm.Dialector
+
+	sqlite, err := NewSQLiteDriver("file::memory:")
+	assert.NilError(t, err, "sqlite driver")
+	drivers = append(drivers, sqlite)
+
+	pgConn, ok := os.LookupEnv("POSTGRESQL_CONNECTION")
+	switch {
+	case ok:
+		pgsql, err := NewPostgresDriver(pgConn)
+		assert.NilError(t, err, "postgresql driver")
+
+		db, err := gorm.Open(pgsql)
+		assert.NilError(t, err, "connect to postgresql")
+		t.Cleanup(func() {
+			assert.NilError(t, db.Exec("DROP SCHEMA testing CASCADE").Error)
+		})
+		assert.NilError(t, db.Exec("CREATE SCHEMA testing").Error)
+
+		pgsql, err = NewPostgresDriver(pgConn + " search_path=testing")
+		assert.NilError(t, err, "postgresql driver")
+
+		drivers = append(drivers, pgsql)
+	case os.Getenv("CI") != "":
+		t.Fatalf("CI must test all drivers, set POSTGRESQL_CONNECTION")
+	}
+
+	return drivers
+}
+
+// runDBTests against all supported databases. Defaults to only sqlite locally,
+// and all supported DBs in CI. See dbDrivers to test other databases locally.
+func runDBTests(t *testing.T, run func(t *testing.T, db *gorm.DB)) {
+	for _, driver := range dbDrivers(t) {
+		t.Run(driver.Name(), func(t *testing.T) {
+			run(t, setupDB(t, driver))
+		})
+	}
+}
+
 func TestSnowflakeIDSerialization(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		id := uid.New()
+		g := &models.Group{Model: models.Model{ID: id}, Name: "Foo"}
+		err := db.Create(g).Error
+		assert.NilError(t, err)
 
-	id := uid.New()
-	g := &models.Group{Model: models.Model{ID: id}, Name: "Foo"}
-	err := db.Create(g).Error
-	assert.NilError(t, err)
+		var group models.Group
+		err = db.First(&group, &models.Group{Name: "Foo"}).Error
+		assert.NilError(t, err)
+		assert.Assert(t, 0 != group.ID)
 
-	var group models.Group
-	err = db.First(&group, &models.Group{Name: "Foo"}).Error
-	assert.NilError(t, err)
-	assert.Assert(t, 0 != group.ID)
+		var intID int64
+		err = db.Select("id").Table("groups").Scan(&intID).Error
+		assert.NilError(t, err)
 
-	var intID int64
-	err = db.Select("id").Table("groups").Scan(&intID).Error
-	assert.NilError(t, err)
-
-	assert.Equal(t, int64(id), intID)
+		assert.Equal(t, int64(id), intID)
+	})
 }
 
 func TestDatabaseSelectors(t *testing.T) {

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"testing"
 
+	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
@@ -10,21 +11,22 @@ import (
 )
 
 func TestDuplicateGrant(t *testing.T) {
-	db := setup(t)
-	g := models.Grant{
-		Subject:   "i:1234567",
-		Privilege: "view",
-		Resource:  "infra",
-	}
-	g2 := g
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		g := models.Grant{
+			Subject:   "i:1234567",
+			Privilege: "view",
+			Resource:  "infra",
+		}
+		g2 := g
 
-	err := CreateGrant(db, &g)
-	assert.NilError(t, err)
+		err := CreateGrant(db, &g)
+		assert.NilError(t, err)
 
-	err = CreateGrant(db, &g2)
-	assert.NilError(t, err)
+		err = CreateGrant(db, &g2)
+		assert.NilError(t, err)
 
-	grants, err := ListGrants(db, BySubject("i:1234567"), ByResource("infra"))
-	assert.NilError(t, err)
-	assert.Assert(t, is.Len(grants, 1))
+		grants, err := ListGrants(db, BySubject("i:1234567"), ByResource("infra"))
+		assert.NilError(t, err)
+		assert.Assert(t, is.Len(grants, 1))
+	})
 }

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -59,39 +59,39 @@ func TestCreateGroupDuplicate(t *testing.T) {
 }
 
 func TestGetGroup(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			everyone  = models.Group{Name: "Everyone"}
+			engineers = models.Group{Name: "Engineering"}
+			product   = models.Group{Name: "Product"}
+		)
 
-	var (
-		everyone  = models.Group{Name: "Everyone"}
-		engineers = models.Group{Name: "Engineering"}
-		product   = models.Group{Name: "Product"}
-	)
+		createGroups(t, db, everyone, engineers, product)
 
-	createGroups(t, db, everyone, engineers, product)
-
-	group, err := GetGroup(db, ByName(everyone.Name))
-	assert.NilError(t, err)
-	assert.Assert(t, 0 != group.ID)
+		group, err := GetGroup(db, ByName(everyone.Name))
+		assert.NilError(t, err)
+		assert.Assert(t, 0 != group.ID)
+	})
 }
 
 func TestListGroups(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			everyone  = models.Group{Name: "Everyone"}
+			engineers = models.Group{Name: "Engineering"}
+			product   = models.Group{Name: "Product"}
+		)
 
-	var (
-		everyone  = models.Group{Name: "Everyone"}
-		engineers = models.Group{Name: "Engineering"}
-		product   = models.Group{Name: "Product"}
-	)
+		createGroups(t, db, everyone, engineers, product)
 
-	createGroups(t, db, everyone, engineers, product)
+		groups, err := ListGroups(db)
+		assert.NilError(t, err)
+		assert.Equal(t, 3, len(groups))
 
-	groups, err := ListGroups(db)
-	assert.NilError(t, err)
-	assert.Equal(t, 3, len(groups))
-
-	groups, err = ListGroups(db, ByName(engineers.Name))
-	assert.NilError(t, err)
-	assert.Equal(t, 1, len(groups))
+		groups, err = ListGroups(db, ByName(engineers.Name))
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(groups))
+	})
 }
 
 func TestDeleteGroup(t *testing.T) {


### PR DESCRIPTION
## Summary

The `data` package is our abstraction for interacting with the database. We should run the tests in this package against all supported database (sqlite and postgres) to make sure that queries work in both scenarios.

This PR setups up CI config and adds supports for running the tests against postgres locally as well. Postgres is required in CI, but optional for local runs.

Tests in the `data` package should receive a db from `runDBTests`, to run against all databases.  I've only added this to a couple tests to demonstrate the pattern. I'll apply it to all the tests once we're happy with the approach.

Since there are plenty of whitespace changes, the diff is best viewed with [hide whitespace](https://github.com/infrahq/infra/pull/1922/files?diff=split&w=1).


TODO:
* [x] use `runDBTests` in all the other `data` tests