### PR TITLE
improve: enable Sqlite WAL

### DIFF
--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -3,6 +3,7 @@ package data
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -64,6 +65,14 @@ func NewSQLiteDriver(connection string) (gorm.Dialector, error) {
 			return nil, err
 		}
 	}
+	uri, err := url.Parse(connection)
+	if err != nil {
+		return nil, err
+	}
+	query := uri.Query()
+	query.Add("_journal_mode", "WAL")
+	uri.RawQuery = query.Encode()
+	connection = uri.String()
 
 	return sqlite.Open(connection), nil
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -58,7 +58,7 @@ func DatabaseMiddleware(db *gorm.DB) gin.HandlerFunc {
 func AuthenticationMiddleware(a *API) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if err := RequireAccessKey(c); err != nil {
-			sendAPIError(c, fmt.Errorf("%w: %s", internal.ErrUnauthorized, err))
+			sendAPIError(c, err)
 			return
 		}
 
@@ -109,7 +109,7 @@ func RequireAccessKey(c *gin.Context) error {
 
 	identity.LastSeenAt = time.Now().UTC()
 	if err = data.SaveIdentity(db, identity); err != nil {
-		return fmt.Errorf("%w: identity update fail: %s", internal.ErrUnauthorized, err)
+		return fmt.Errorf("identity update fail: %w", err)
 	}
 
 	c.Set("identity", identity)


### PR DESCRIPTION
## Summary

I noticed about a 3-4x performance improvement from enabling sqlite's WAL, which oddly isn't enabled by default. This enables it.

In the course of testing the old database locked messages, I also noticed we were hiding some db errors which didn't seem correct, so I've fixed that too.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

