### PR TITLE
fix(connector): index out of bounds for namespace ClusterRole

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -274,7 +274,7 @@ func updateRoles(c *api.Client, k *kubernetes.Kubernetes, grants []api.Grant) er
 		// <cluster>.<namespace>
 		case 2:
 			crn.ClusterRole = g.Privilege
-			crn.Namespace = parts[2]
+			crn.Namespace = parts[1]
 			crnSubjects[crn] = append(crnSubjects[crn], subj)
 
 		default:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Fixes an index out of bounds in connector when creating cluster roles

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1923