### PR TITLE
fix: logout should always succeed

### DIFF
--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -70,6 +70,7 @@ func logoutOfServer(hostConfig *ClientHostConfig) (success bool) {
 
 	client, err := apiClient(hostConfig.Host, hostConfig.AccessKey, hostConfig.SkipTLSVerify)
 	if err != nil {
+		logging.S.Debugf("err: %s", err)
 		return false
 	}
 
@@ -80,8 +81,10 @@ func logoutOfServer(hostConfig *ClientHostConfig) (success bool) {
 	err = client.Logout()
 	switch {
 	case api.ErrorStatusCode(err) == http.StatusUnauthorized:
+		logging.S.Debugf("err: %s", err)
 		return false
 	case err != nil:
+		logging.S.Debugf("err: %s", err)
 		return false
 	}
 

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -253,15 +253,15 @@ func TestLogout(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		testFields := setupError(t)
 		err := Run(context.Background(), "logout", testFields.serverURLs[0])
-		assert.ErrorContains(t, err, "Failed to logout of server "+testFields.serverURLs[0])
+		assert.NilError(t, err)
 
 		assert.Equal(t, int32(1), atomic.LoadInt32(testFields.count), "calls to API")
 
 		updatedCfg, err := readConfig()
 		assert.NilError(t, err)
 
-		expected := testFields.config
-		assert.DeepEqual(t, &expected, updatedCfg)
+		assert.Assert(t, updatedCfg.Hosts[0].Name == "")
+		assert.Assert(t, updatedCfg.Hosts[0].AccessKey == "")
 	})
 
 	t.Run("with too many arguments", func(t *testing.T) {


### PR DESCRIPTION
## Summary

If the /logout api call fails for some reason, we should just delete the access key and continue; we don't really care why it failed, and the key will time out anyway.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1863
