### PR TITLE
fix: resolves issue with stacked response migrations

### DIFF
--- a/internal/server/apimigrator.go
+++ b/internal/server/apimigrator.go
@@ -240,16 +240,13 @@ func (w *responseWriter) Flush() {
 	bytesToFlush := len(w.body)
 	w.size = bytesToFlush
 	for bytesToFlush > 0 {
-		bytesFlushed, err := w.ResponseWriter.Write(w.body)
+		bytesFlushed, err := w.ResponseWriter.Write(w.body[w.size-bytesToFlush:])
 		if err != nil {
 			w.flushErr = err
 			return
 		}
 		bytesToFlush -= bytesFlushed
-		w.body = w.body[bytesFlushed:]
 	}
-	//nolint:forcetypeassert
-	w.ResponseWriter.(http.Flusher).Flush()
 	w.flushErr = nil
 }
 

--- a/internal/server/apimigrator_test.go
+++ b/internal/server/apimigrator_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,7 +24,7 @@ type upgradedTestRequest struct {
 func TestAddRequestRewrite(t *testing.T) {
 	srv := setupServer(t, withAdminIdentity)
 
-	a := &API{server: srv}
+	a := &API{server: srv, disableOpenAPIGeneration: true}
 	router := gin.New()
 
 	addRequestRewrite(a, "get", "/test", "0.1.0", func(old legacyTestRequest) upgradedTestRequest {
@@ -33,7 +34,7 @@ func TestAddRequestRewrite(t *testing.T) {
 	})
 
 	get(a, router.Group("/"), "/test", func(c *gin.Context, req *upgradedTestRequest) (*api.EmptyResponse, error) {
-		assert.Assert(t, req.VegetableCount == 12)
+		assert.Equal(t, req.VegetableCount, 12)
 		return nil, nil
 	})
 
@@ -41,13 +42,43 @@ func TestAddRequestRewrite(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test?cucumberCount=5&carrotCount=7", nil)
 	router.ServeHTTP(resp, req)
 
-	assert.Assert(t, resp.Result().StatusCode == 200)
+	assert.Equal(t, resp.Result().StatusCode, 200)
+}
+
+func TestStackedAddRequestRewrite(t *testing.T) {
+	srv := setupServer(t, withAdminIdentity)
+
+	a := &API{server: srv, disableOpenAPIGeneration: true}
+	router := gin.New()
+
+	addRequestRewrite(a, "get", "/test", "0.1.0", func(old legacyTestRequest) upgradedTestRequest {
+		return upgradedTestRequest{
+			VegetableCount: old.CarrotCount + old.CucumberCount,
+		}
+	})
+
+	addRequestRewrite(a, "get", "/test", "0.1.1", func(old upgradedTestRequest) upgradedTestRequest {
+		return upgradedTestRequest{
+			VegetableCount: old.VegetableCount * 2,
+		}
+	})
+
+	get(a, router.Group("/"), "/test", func(c *gin.Context, req *upgradedTestRequest) (*api.EmptyResponse, error) {
+		assert.Equal(t, req.VegetableCount, 24)
+		return nil, nil
+	})
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test?cucumberCount=5&carrotCount=7", nil)
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, resp.Result().StatusCode, 200)
 }
 
 func TestRedirect(t *testing.T) {
 	srv := setupServer(t, withAdminIdentity)
 
-	a := &API{server: srv}
+	a := &API{server: srv, disableOpenAPIGeneration: true}
 	router := gin.New()
 
 	addRedirect(a, http.MethodGet, "/test", "/supertest", "0.1.0")
@@ -62,4 +93,102 @@ func TestRedirect(t *testing.T) {
 	router.ServeHTTP(resp, req)
 
 	assert.Assert(t, resp.Result().StatusCode == 200)
+}
+
+type legacyResponse struct {
+	Shoes int
+}
+
+type upgradedResponse struct {
+	Loafers  int
+	Sneakers int
+}
+
+func TestAddResponseRewrite(t *testing.T) {
+	srv := setupServer(t, withAdminIdentity)
+
+	a := &API{server: srv, disableOpenAPIGeneration: true}
+	router := gin.New()
+
+	addResponseRewrite(a, "get", "/test", "0.1.0", func(n upgradedResponse) legacyResponse {
+		return legacyResponse{
+			Shoes: n.Loafers + n.Sneakers,
+		}
+	})
+
+	get(a, router.Group("/"), "/test", func(c *gin.Context, _ *api.EmptyRequest) (*upgradedResponse, error) {
+		return &upgradedResponse{
+			Loafers:  3,
+			Sneakers: 5,
+		}, nil
+	})
+
+	t.Run("old version downgrades", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Add("Infra-Version", "0.1.0")
+		router.ServeHTTP(resp, req)
+
+		assert.Equal(t, resp.Result().StatusCode, 200)
+
+		r := &legacyResponse{}
+		err := json.Unmarshal(resp.Body.Bytes(), r)
+		assert.NilError(t, err)
+		assert.Equal(t, r.Shoes, 8)
+	})
+
+	t.Run("new version unchanged", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Add("Infra-Version", "0.1.1")
+		router.ServeHTTP(resp, req)
+
+		assert.Equal(t, resp.Result().StatusCode, 200)
+
+		r := &upgradedResponse{}
+		err := json.Unmarshal(resp.Body.Bytes(), r)
+		assert.NilError(t, err)
+		assert.Equal(t, r.Loafers, 3)
+		assert.Equal(t, r.Sneakers, 5)
+	})
+}
+
+func TestStackedResponseRewrites(t *testing.T) {
+	srv := setupServer(t, withAdminIdentity)
+
+	a := &API{server: srv, disableOpenAPIGeneration: true}
+	router := gin.New()
+
+	addResponseRewrite(a, "get", "/test", "0.1.0", func(n upgradedResponse) legacyResponse {
+		return legacyResponse{
+			Shoes: n.Loafers + n.Sneakers,
+		}
+	})
+
+	addResponseRewrite(a, "get", "/test", "0.1.1", func(n upgradedResponse) upgradedResponse {
+		return upgradedResponse{
+			Loafers:  n.Loafers * 2,
+			Sneakers: n.Sneakers * 2,
+		}
+	})
+
+	get(a, router.Group("/"), "/test", func(c *gin.Context, _ *api.EmptyRequest) (*upgradedResponse, error) {
+		return &upgradedResponse{
+			Loafers:  3,
+			Sneakers: 5,
+		}, nil
+	})
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Add("Infra-Version", "0.1.0")
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, resp.Result().StatusCode, 200)
+
+	r := &legacyResponse{}
+	err := json.Unmarshal(resp.Body.Bytes(), r)
+	assert.NilError(t, err)
+	assert.Equal(t, r.Shoes, 16)
+
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -21,9 +21,10 @@ import (
 )
 
 type API struct {
-	t          *Telemetry
-	server     *Server
-	migrations []apiMigration
+	t                        *Telemetry
+	server                   *Server
+	migrations               []apiMigration
+	disableOpenAPIGeneration bool
 }
 
 func (a *API) ListIdentities(c *gin.Context, r *api.ListIdentitiesRequest) (*api.ListResponse[api.Identity], error) {

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -36,7 +36,10 @@ var (
 	}
 )
 
-func register[Req, Res any](method, path string, handler ReqResHandlerFunc[Req, Res]) {
+func register[Req, Res any](a *API, method, path string, handler ReqResHandlerFunc[Req, Res]) {
+	if a.disableOpenAPIGeneration {
+		return
+	}
 	funcName := getFuncName(handler)
 
 	//nolint:gocritic
@@ -47,7 +50,10 @@ func register[Req, Res any](method, path string, handler ReqResHandlerFunc[Req, 
 	reg(method, path, funcName, rqt, rst)
 }
 
-func registerReq[Req any](method, path string, handler ReqHandlerFunc[Req]) {
+func registerReq[Req any](a *API, method, path string, handler ReqHandlerFunc[Req]) {
+	if a.disableOpenAPIGeneration {
+		return
+	}
 	funcName := getFuncName(handler)
 
 	//nolint:gocritic

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -133,7 +133,7 @@ type ReqResHandlerFunc[Req, Res any] func(c *gin.Context, req *Req) (Res, error)
 
 func get[Req, Res any](a *API, r *gin.RouterGroup, route string, handler ReqResHandlerFunc[Req, Res]) {
 	fullPath := path.Join(r.BasePath(), route)
-	register(http.MethodGet, fullPath, handler)
+	register(a, http.MethodGet, fullPath, handler)
 	handlers := includeRewritesFor(a, http.MethodGet, fullPath, func(c *gin.Context) {
 		req := new(Req)
 		if err := bind(c, req); err != nil {
@@ -158,7 +158,7 @@ func get[Req, Res any](a *API, r *gin.RouterGroup, route string, handler ReqResH
 
 func post[Req, Res any](a *API, r *gin.RouterGroup, route string, handler ReqResHandlerFunc[Req, Res]) {
 	fullPath := path.Join(r.BasePath(), route)
-	register(http.MethodPost, fullPath, handler)
+	register(a, http.MethodPost, fullPath, handler)
 
 	handlers := includeRewritesFor(a, http.MethodPost, fullPath, func(c *gin.Context) {
 		req := new(Req)
@@ -187,7 +187,7 @@ func post[Req, Res any](a *API, r *gin.RouterGroup, route string, handler ReqRes
 
 func put[Req, Res any](a *API, r *gin.RouterGroup, route string, handler ReqResHandlerFunc[Req, Res]) {
 	fullPath := path.Join(r.BasePath(), route)
-	register(http.MethodPut, fullPath, handler)
+	register(a, http.MethodPut, fullPath, handler)
 
 	handlers := includeRewritesFor(a, http.MethodPut, fullPath, func(c *gin.Context) {
 		req := new(Req)
@@ -216,7 +216,7 @@ func put[Req, Res any](a *API, r *gin.RouterGroup, route string, handler ReqResH
 
 func delete[Req any](a *API, r *gin.RouterGroup, route string, handler ReqHandlerFunc[Req]) {
 	fullPath := path.Join(r.BasePath(), route)
-	registerReq(http.MethodDelete, fullPath, handler)
+	registerReq(a, http.MethodDelete, fullPath, handler)
 
 	handlers := includeRewritesFor(a, http.MethodDelete, fullPath, func(c *gin.Context) {
 		req := new(Req)


### PR DESCRIPTION
## Summary

stacked migrations were interacting oddly with the flush behavior, where flush would flush layers it didn't own. This was code adopted from gin that didn't make sense in this context. added tests and resolved.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->
