### PR TITLE
fix: migrate grants subject

### DIFF
--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -156,7 +156,6 @@ func migrateUserGrantToIdentity(grant api.Grant) identityGrant {
 		CreatedBy: grant.CreatedBy,
 		Updated:   grant.Updated,
 		Subject:   sub,
-		Group:     grant.Group,
 		Privilege: grant.Privilege,
 		Resource:  grant.Resource,
 	}

--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -136,19 +136,26 @@ type identityGrant struct {
 	CreatedBy uid.ID   `json:"created_by"`
 	Updated   api.Time `json:"updated"`
 
-	Identity  uid.ID `json:"identity,omitempty"`
-	Group     uid.ID `json:"group,omitempty"`
-	Privilege string `json:"privilege"`
-	Resource  string `json:"resource"`
+	Subject   uid.PolymorphicID `json:"subject,omitempty"`
+	Privilege string            `json:"privilege"`
+	Resource  string            `json:"resource"`
 }
 
 func migrateUserGrantToIdentity(grant api.Grant) identityGrant {
+	var sub uid.PolymorphicID
+
+	if grant.User != 0 {
+		sub = uid.NewIdentityPolymorphicID(grant.User)
+	} else {
+		sub = uid.NewGroupPolymorphicID(grant.Group)
+	}
+
 	return identityGrant{
 		ID:        grant.ID,
 		Created:   grant.Created,
 		CreatedBy: grant.CreatedBy,
 		Updated:   grant.Updated,
-		Identity:  grant.User,
+		Subject:   sub,
 		Group:     grant.Group,
 		Privilege: grant.Privilege,
 		Resource:  grant.Resource,


### PR DESCRIPTION
## Summary
When adding response migrations for grants the grants response was modified to match the response that was currently in main. It should have been migrated for the response in v0.12.2 instead. This fixes that v0.12.2 grants migrations and ensures v0.12.2 connectors work with the new version.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1934
