### PR TITLE
api: replace static openapi document with a field on API

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,12 @@ jobs:
       - run: go install gotest.tools/gotestsum@v1.8.0
       - run: go mod tidy
       - run: ~/go/bin/gotestsum -ftestname -- -race ./...
+      - name: Check that tests leave a clean git checkout
+        run: |
+          # show and check changes to committed files
+          git diff --exit-code
+          # show and check for uncommitted files
+          git status --short; [[ "$(git status --short)" == "" ]]
 
   test-ui:
     runs-on: ubuntu-latest

--- a/internal/openapigen/main.go
+++ b/internal/openapigen/main.go
@@ -23,7 +23,7 @@ func run(args []string) error {
 	filename := args[0]
 
 	s := server.Server{}
-	s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
-	return server.WriteOpenAPISpecToFile(filename)
+	return server.WriteOpenAPIDocToFile(routes.OpenAPIDocument, filename)
 }

--- a/internal/server/apimigrator_test.go
+++ b/internal/server/apimigrator_test.go
@@ -28,7 +28,7 @@ type upgradedTestRequest struct {
 func TestAddRequestRewrite(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 
-	a := &API{server: srv, disableOpenAPIGeneration: true}
+	a := &API{server: srv}
 	router := gin.New()
 
 	addRequestRewrite(a, "get", "/test", "0.1.0", func(old legacyTestRequest) upgradedTestRequest {
@@ -52,7 +52,7 @@ func TestAddRequestRewrite(t *testing.T) {
 func TestStackedAddRequestRewrite(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 
-	a := &API{server: srv, disableOpenAPIGeneration: true}
+	a := &API{server: srv}
 	router := gin.New()
 
 	addRequestRewrite(a, "get", "/test", "0.1.0", func(old legacyTestRequest) upgradedTestRequest {
@@ -82,7 +82,7 @@ func TestStackedAddRequestRewrite(t *testing.T) {
 func TestRedirect(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 
-	a := &API{server: srv, disableOpenAPIGeneration: true}
+	a := &API{server: srv}
 	router := gin.New()
 
 	addRedirect(a, http.MethodGet, "/test", "/supertest", "0.1.0")
@@ -102,7 +102,7 @@ func TestRedirect(t *testing.T) {
 func TestRedirectOfRequestAndResponseRewrite(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 
-	a := &API{server: srv, disableOpenAPIGeneration: true}
+	a := &API{server: srv}
 	router := gin.New()
 
 	addRedirect(a, "get", "/oldtest", "/test", "0.1.0")
@@ -143,7 +143,7 @@ func TestRedirectOfRequestAndResponseRewrite(t *testing.T) {
 func TestRedirectOfRequestAndResponseRewriteWithStackedRedirects(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 
-	a := &API{server: srv, disableOpenAPIGeneration: true}
+	a := &API{server: srv}
 	router := gin.New()
 
 	addRequestRewrite(a, "get", "/test", "0.1.1", func(old legacyTestRequest) upgradedTestRequest {
@@ -185,7 +185,7 @@ func TestRedirectOfRequestAndResponseRewriteWithStackedRedirects(t *testing.T) {
 func TestRedirectWithPathVariable(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 
-	a := &API{server: srv, disableOpenAPIGeneration: true}
+	a := &API{server: srv}
 	router := gin.New()
 
 	type getUserRequest struct {
@@ -212,14 +212,14 @@ type legacyResponse struct {
 }
 
 type upgradedResponse struct {
-	Loafers  int
+	Loafers  int `json:"loafers"`
 	Sneakers int `json:"sneakers,omitempty"`
 }
 
 func TestAddResponseRewrite(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 
-	a := &API{server: srv, disableOpenAPIGeneration: true}
+	a := &API{server: srv}
 	router := gin.New()
 
 	addResponseRewrite(a, "get", "/test", "0.1.0", func(n upgradedResponse) legacyResponse {
@@ -268,7 +268,7 @@ func TestAddResponseRewrite(t *testing.T) {
 func TestStackedResponseRewrites(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 
-	a := &API{server: srv, disableOpenAPIGeneration: true}
+	a := &API{server: srv}
 	router := gin.New()
 
 	addResponseRewrite(a, "get", "/test", "0.1.0", func(n upgradedResponse) legacyResponse {

--- a/internal/server/apimigrator_test.go
+++ b/internal/server/apimigrator_test.go
@@ -307,7 +307,7 @@ func TestStackedResponseRewrites(t *testing.T) {
 func TestEmptyVersionHeader(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 
-	a := &API{server: srv, disableOpenAPIGeneration: true}
+	a := &API{server: srv}
 	router := gin.New()
 
 	addResponseRewrite(a, "get", "/test", "0.1.0", func(n upgradedResponse) legacyResponse {

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -192,7 +192,9 @@ func Count[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) (int64, e
 
 var infraProviderCache *models.Provider
 
-// InfraProvider is a lazy-loaded cached reference to the infra provider, since it's used in a lot of places
+// InfraProvider is a lazy-loaded cached reference to the infra provider. The
+// cache lasts for the entire lifetime of the process, so any test or test
+// helper that calls InfraProvider must call InvalidateCache to clean up.
 func InfraProvider(db *gorm.DB) *models.Provider {
 	if infraProviderCache == nil {
 		infra, err := get[models.Provider](db, ByName(models.InternalInfraProviderName))
@@ -209,7 +211,9 @@ func InfraProvider(db *gorm.DB) *models.Provider {
 
 var infraConnectorCache *models.Identity
 
-// InfraConnectorIdentity is a lazy-loaded reference to the connector identity
+// InfraConnectorIdentity is a lazy-loaded reference to the connector identity.
+// The cache lasts for the entire lifetime of the process, so any test or test
+// helper that calls InfraConnectorIdentity must call InvalidateCache to clean up.
 func InfraConnectorIdentity(db *gorm.DB) *models.Identity {
 	if infraConnectorCache == nil {
 		connector, err := GetIdentity(db, ByName(models.InternalInfraConnectorIdentityName))

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -37,6 +37,7 @@ func setup(t *testing.T) *gorm.DB {
 	assert.NilError(t, err)
 
 	setupLogging(t)
+	t.Cleanup(InvalidateCache)
 
 	return db
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin"
 	"github.com/infrahq/secrets"
 
@@ -21,10 +22,10 @@ import (
 )
 
 type API struct {
-	t                        *Telemetry
-	server                   *Server
-	migrations               []apiMigration
-	disableOpenAPIGeneration bool
+	t          *Telemetry
+	server     *Server
+	migrations []apiMigration
+	openAPIDoc openapi3.T
 }
 
 func (a *API) ListUsers(c *gin.Context, r *api.ListUsersRequest) (*api.ListResponse[api.User], error) {

--- a/internal/server/openapi_test.go
+++ b/internal/server/openapi_test.go
@@ -8,14 +8,12 @@ import (
 )
 
 // TestWriteOpenAPISpec is not really a test. It's a way of ensuring the openapi
-// spec is updated.
-// TODO: replace this with a test that uses golden, and a CI check to make sure the
-// file in git matches the source code.
+// spec is updated when routes change.
 func TestWriteOpenAPISpec(t *testing.T) {
 	s := Server{}
-	s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
 	filename := "../../docs/api/openapi3.json"
-	err := WriteOpenAPISpecToFile(filename)
+	err := WriteOpenAPIDocToFile(routes.OpenAPIDocument, filename)
 	assert.NilError(t, err)
 }


### PR DESCRIPTION
## Summary

Package-level variables make testing more challenging and can make code harder to reason about. They introduce [side effects](https://en.wikipedia.org/wiki/Side_effect_(computer_science)) that could be avoided.

This commit replaces the boolean to skip generation in tests (which likely makes the tests less like production) and replaces it with an `openapi3.T` document on the `API` struct. The document is now returned from `GenerateRoutes`, which also removes the risk of something referencing the static variable before it is fully populated. 

With this change, it's not a lot more obvious that `GenerateRoutes` is responsible for constructing the document, and it makes it a lot more difficult for tests to make changes to the real production document (because that is only saved explicitly by one test).

Also has two commits which:
* add some guard rails to CI by checking for files that are modified, to prevent similar problems in the future
* fixes a problem with other package-level variables that I noticed while investigating this issue (opened #1939 to track alternatives to those)