### PR TITLE
maintain: replace v1 with api

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -207,73 +207,73 @@ func (c Client) ListUsers(req ListUsersRequest) (*ListResponse[User], error) {
 	ids := slice.Map[uid.ID, string](req.IDs, func(id uid.ID) string {
 		return id.String()
 	})
-	return list[ListResponse[User]](c, "/v1/users", map[string][]string{"name": {req.Name}, "ids": ids})
+	return list[ListResponse[User]](c, "/api/users", map[string][]string{"name": {req.Name}, "ids": ids})
 }
 
 func (c Client) GetUser(id uid.ID) (*User, error) {
-	return get[User](c, fmt.Sprintf("/v1/users/%s", id))
+	return get[User](c, fmt.Sprintf("/api/users/%s", id))
 }
 
 func (c Client) CreateUser(req *CreateUserRequest) (*CreateUserResponse, error) {
-	return post[CreateUserRequest, CreateUserResponse](c, "/v1/users", req)
+	return post[CreateUserRequest, CreateUserResponse](c, "/api/users", req)
 }
 
 func (c Client) UpdateUser(req *UpdateUserRequest) (*User, error) {
-	return put[UpdateUserRequest, User](c, fmt.Sprintf("/v1/users/%s", req.ID.String()), req)
+	return put[UpdateUserRequest, User](c, fmt.Sprintf("/api/users/%s", req.ID.String()), req)
 }
 
 func (c Client) DeleteUser(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/v1/users/%s", id))
+	return delete(c, fmt.Sprintf("/api/users/%s", id))
 }
 
 // Deprecated: use ListGrants
 func (c Client) ListUserGrants(id uid.ID) (*ListResponse[Grant], error) {
-	return list[ListResponse[Grant]](c, fmt.Sprintf("/v1/users/%s/grants", id), nil)
+	return list[ListResponse[Grant]](c, fmt.Sprintf("/api/users/%s/grants", id), nil)
 }
 
 func (c Client) ListUserGroups(id uid.ID) (*ListResponse[Group], error) {
-	return list[ListResponse[Group]](c, fmt.Sprintf("/v1/users/%s/groups", id), nil)
+	return list[ListResponse[Group]](c, fmt.Sprintf("/api/users/%s/groups", id), nil)
 }
 
 func (c Client) ListGroups(req ListGroupsRequest) (*ListResponse[Group], error) {
-	return list[ListResponse[Group]](c, "/v1/groups", map[string][]string{"name": {req.Name}})
+	return list[ListResponse[Group]](c, "/api/groups", map[string][]string{"name": {req.Name}})
 }
 
 func (c Client) GetGroup(id uid.ID) (*Group, error) {
-	return get[Group](c, fmt.Sprintf("/v1/groups/%s", id))
+	return get[Group](c, fmt.Sprintf("/api/groups/%s", id))
 }
 
 func (c Client) CreateGroup(req *CreateGroupRequest) (*Group, error) {
-	return post[CreateGroupRequest, Group](c, "/v1/groups", req)
+	return post[CreateGroupRequest, Group](c, "/api/groups", req)
 }
 
 // Deprecated: use ListGrants
 func (c Client) ListGroupGrants(id uid.ID) (*ListResponse[Grant], error) {
-	return list[ListResponse[Grant]](c, fmt.Sprintf("/v1/groups/%s/grants", id), nil)
+	return list[ListResponse[Grant]](c, fmt.Sprintf("/api/groups/%s/grants", id), nil)
 }
 
 func (c Client) ListProviders(name string) (*ListResponse[Provider], error) {
-	return list[ListResponse[Provider]](c, "/v1/providers", map[string][]string{"name": {name}})
+	return list[ListResponse[Provider]](c, "/api/providers", map[string][]string{"name": {name}})
 }
 
 func (c Client) GetProvider(id uid.ID) (*Provider, error) {
-	return get[Provider](c, fmt.Sprintf("/v1/providers/%s", id))
+	return get[Provider](c, fmt.Sprintf("/api/providers/%s", id))
 }
 
 func (c Client) CreateProvider(req *CreateProviderRequest) (*Provider, error) {
-	return post[CreateProviderRequest, Provider](c, "/v1/providers", req)
+	return post[CreateProviderRequest, Provider](c, "/api/providers", req)
 }
 
 func (c Client) UpdateProvider(req UpdateProviderRequest) (*Provider, error) {
-	return put[UpdateProviderRequest, Provider](c, fmt.Sprintf("/v1/providers/%s", req.ID.String()), &req)
+	return put[UpdateProviderRequest, Provider](c, fmt.Sprintf("/api/providers/%s", req.ID.String()), &req)
 }
 
 func (c Client) DeleteProvider(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/v1/providers/%s", id))
+	return delete(c, fmt.Sprintf("/api/providers/%s", id))
 }
 
 func (c Client) ListGrants(req ListGrantsRequest) (*ListResponse[Grant], error) {
-	return list[ListResponse[Grant]](c, "/v1/grants", map[string][]string{
+	return list[ListResponse[Grant]](c, "/api/grants", map[string][]string{
 		"user":      {req.User.String()},
 		"group":     {req.Group.String()},
 		"resource":  {req.Resource},
@@ -282,70 +282,70 @@ func (c Client) ListGrants(req ListGrantsRequest) (*ListResponse[Grant], error) 
 }
 
 func (c Client) CreateGrant(req *CreateGrantRequest) (*Grant, error) {
-	return post[CreateGrantRequest, Grant](c, "/v1/grants", req)
+	return post[CreateGrantRequest, Grant](c, "/api/grants", req)
 }
 
 func (c Client) DeleteGrant(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/v1/grants/%s", id))
+	return delete(c, fmt.Sprintf("/api/grants/%s", id))
 }
 
 func (c Client) ListDestinations(req ListDestinationsRequest) (*ListResponse[Destination], error) {
-	return list[ListResponse[Destination]](c, "/v1/destinations", map[string][]string{
+	return list[ListResponse[Destination]](c, "/api/destinations", map[string][]string{
 		"name":      {req.Name},
 		"unique_id": {req.UniqueID},
 	})
 }
 
 func (c Client) CreateDestination(req *CreateDestinationRequest) (*Destination, error) {
-	return post[CreateDestinationRequest, Destination](c, "/v1/destinations", req)
+	return post[CreateDestinationRequest, Destination](c, "/api/destinations", req)
 }
 
 func (c Client) UpdateDestination(req UpdateDestinationRequest) (*Destination, error) {
-	return put[UpdateDestinationRequest, Destination](c, fmt.Sprintf("/v1/destinations/%s", req.ID.String()), &req)
+	return put[UpdateDestinationRequest, Destination](c, fmt.Sprintf("/api/destinations/%s", req.ID.String()), &req)
 }
 
 func (c Client) DeleteDestination(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/v1/destinations/%s", id))
+	return delete(c, fmt.Sprintf("/api/destinations/%s", id))
 }
 
 func (c Client) ListAccessKeys(req ListAccessKeysRequest) (*ListResponse[AccessKey], error) {
-	return list[ListResponse[AccessKey]](c, "/v1/access-keys", map[string][]string{
+	return list[ListResponse[AccessKey]](c, "/api/access-keys", map[string][]string{
 		"user_id": {req.UserID.String()},
 		"name":    {req.Name},
 	})
 }
 
 func (c Client) CreateAccessKey(req *CreateAccessKeyRequest) (*CreateAccessKeyResponse, error) {
-	return post[CreateAccessKeyRequest, CreateAccessKeyResponse](c, "/v1/access-keys", req)
+	return post[CreateAccessKeyRequest, CreateAccessKeyResponse](c, "/api/access-keys", req)
 }
 
 func (c Client) DeleteAccessKey(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/v1/access-keys/%s", id))
+	return delete(c, fmt.Sprintf("/api/access-keys/%s", id))
 }
 
 func (c Client) CreateToken() (*CreateTokenResponse, error) {
-	return post[EmptyRequest, CreateTokenResponse](c, "/v1/tokens", &EmptyRequest{})
+	return post[EmptyRequest, CreateTokenResponse](c, "/api/tokens", &EmptyRequest{})
 }
 
 func (c Client) Login(req *LoginRequest) (*LoginResponse, error) {
-	return post[LoginRequest, LoginResponse](c, "/v1/login", req)
+	return post[LoginRequest, LoginResponse](c, "/api/login", req)
 }
 
 func (c Client) Logout() error {
-	_, err := post[EmptyRequest, EmptyResponse](c, "/v1/logout", &EmptyRequest{})
+	_, err := post[EmptyRequest, EmptyResponse](c, "/api/logout", &EmptyRequest{})
 	return err
 }
 
 func (c Client) SignupEnabled() (*SignupEnabledResponse, error) {
-	return get[SignupEnabledResponse](c, "/v1/signup")
+	return get[SignupEnabledResponse](c, "/api/signup")
 }
 
 func (c Client) Signup(req *SignupRequest) (*CreateAccessKeyResponse, error) {
-	return post[SignupRequest, CreateAccessKeyResponse](c, "/v1/signup", req)
+	return post[SignupRequest, CreateAccessKeyResponse](c, "/api/signup", req)
 }
 
 func (c Client) GetVersion() (*Version, error) {
-	return get[Version](c, "/v1/version")
+	return get[Version](c, "/api/version")
 }
 
 func partialText(body []byte, limit int) string {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -684,7 +684,7 @@
     "version": "0.12.2"
   },
   "paths": {
-    "/v1/access-keys": {
+    "/api/access-keys": {
       "get": {
         "description": "ListAccessKeys",
         "operationId": "ListAccessKeys",
@@ -883,7 +883,7 @@
         ]
       }
     },
-    "/v1/access-keys/{id}": {
+    "/api/access-keys/{id}": {
       "delete": {
         "description": "DeleteAccessKey",
         "operationId": "DeleteAccessKey",
@@ -969,7 +969,7 @@
         ]
       }
     },
-    "/v1/destinations": {
+    "/api/destinations": {
       "get": {
         "description": "ListDestinations",
         "operationId": "ListDestinations",
@@ -1175,7 +1175,7 @@
         ]
       }
     },
-    "/v1/destinations/{id}": {
+    "/api/destinations/{id}": {
       "delete": {
         "description": "DeleteDestination",
         "operationId": "DeleteDestination",
@@ -1477,7 +1477,7 @@
         ]
       }
     },
-    "/v1/grants": {
+    "/api/grants": {
       "get": {
         "description": "ListGrants",
         "operationId": "ListGrants",
@@ -1698,7 +1698,7 @@
         ]
       }
     },
-    "/v1/grants/{id}": {
+    "/api/grants/{id}": {
       "delete": {
         "description": "DeleteGrant",
         "operationId": "DeleteGrant",
@@ -1868,7 +1868,7 @@
         ]
       }
     },
-    "/v1/groups": {
+    "/api/groups": {
       "get": {
         "description": "ListGroups",
         "operationId": "ListGroups",
@@ -2036,7 +2036,7 @@
         ]
       }
     },
-    "/v1/groups/{id}": {
+    "/api/groups/{id}": {
       "get": {
         "description": "GetGroup",
         "operationId": "GetGroup",
@@ -2122,94 +2122,7 @@
         ]
       }
     },
-    "/v1/groups/{id}/grants": {
-      "get": {
-        "description": "ListGroupGrants",
-        "operationId": "ListGroupGrants",
-        "parameters": [
-          {
-            "example": "4yJ3n3D8E2",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "example": "4yJ3n3D8E2",
-              "format": "uid",
-              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Unauthorized: Requestor is not authenticated"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Forbidden: Requestor does not have the right permissions"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Duplicate Record"
-          },
-          "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResponse[Grant]"
-                }
-              }
-            },
-            "description": "Success"
-          }
-        },
-        "summary": "ListGroupGrants",
-        "tags": [
-          "Grants",
-          "Groups"
-        ]
-      }
-    },
-    "/v1/login": {
+    "/api/login": {
       "post": {
         "description": "Login",
         "operationId": "Login",
@@ -2334,7 +2247,7 @@
         ]
       }
     },
-    "/v1/logout": {
+    "/api/logout": {
       "post": {
         "description": "Logout",
         "operationId": "Logout",
@@ -2406,7 +2319,7 @@
         ]
       }
     },
-    "/v1/providers": {
+    "/api/providers": {
       "get": {
         "description": "ListProviders",
         "operationId": "ListProviders",
@@ -2592,7 +2505,7 @@
         ]
       }
     },
-    "/v1/providers/{id}": {
+    "/api/providers/{id}": {
       "delete": {
         "description": "DeleteProvider",
         "operationId": "DeleteProvider",
@@ -2879,7 +2792,7 @@
         ]
       }
     },
-    "/v1/signup": {
+    "/api/signup": {
       "get": {
         "description": "SignupEnabled",
         "operationId": "SignupEnabled",
@@ -3044,7 +2957,7 @@
         ]
       }
     },
-    "/v1/tokens": {
+    "/api/tokens": {
       "post": {
         "description": "CreateToken",
         "operationId": "CreateToken",
@@ -3116,7 +3029,7 @@
         ]
       }
     },
-    "/v1/users": {
+    "/api/users": {
       "get": {
         "description": "ListUsers",
         "operationId": "ListUsers",
@@ -3300,7 +3213,7 @@
         ]
       }
     },
-    "/v1/users/{id}": {
+    "/api/users/{id}": {
       "delete": {
         "description": "DeleteUser",
         "operationId": "DeleteUser",
@@ -3572,93 +3485,7 @@
         ]
       }
     },
-    "/v1/users/{id}/grants": {
-      "get": {
-        "description": "ListUserGrants",
-        "operationId": "ListUserGrants",
-        "parameters": [
-          {
-            "example": "4yJ3n3D8E2",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "example": "4yJ3n3D8E2",
-              "format": "uid",
-              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Unauthorized: Requestor is not authenticated"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Forbidden: Requestor does not have the right permissions"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Duplicate Record"
-          },
-          "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListResponse[Grant]"
-                }
-              }
-            },
-            "description": "Success"
-          }
-        },
-        "summary": "ListUserGrants",
-        "tags": [
-          "Grants"
-        ]
-      }
-    },
-    "/v1/users/{id}/groups": {
+    "/api/users/{id}/groups": {
       "get": {
         "description": "ListUserGroups",
         "operationId": "ListUserGroups",
@@ -3744,7 +3571,7 @@
         ]
       }
     },
-    "/v1/version": {
+    "/api/version": {
       "get": {
         "description": "Version",
         "operationId": "Version",
@@ -3813,6 +3640,179 @@
         "summary": "Version",
         "tags": [
           "Misc"
+        ]
+      }
+    },
+    "/v1/groups/{id}/grants": {
+      "get": {
+        "description": "ListGroupGrants",
+        "operationId": "ListGroupGrants",
+        "parameters": [
+          {
+            "example": "4yJ3n3D8E2",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "4yJ3n3D8E2",
+              "format": "uid",
+              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse[Grant]"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "ListGroupGrants",
+        "tags": [
+          "Grants",
+          "Groups"
+        ]
+      }
+    },
+    "/v1/users/{id}/grants": {
+      "get": {
+        "description": "ListUserGrants",
+        "operationId": "ListUserGrants",
+        "parameters": [
+          {
+            "example": "4yJ3n3D8E2",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "4yJ3n3D8E2",
+              "format": "uid",
+              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse[Grant]"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "ListUserGrants",
+        "tags": [
+          "Grants"
         ]
       }
     }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -105,7 +105,7 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 	setup := func(t *testing.T) *ClientConfig {
 		handler := func(resp http.ResponseWriter, req *http.Request) {
 			switch {
-			case req.URL.Path == "/v1/destinations":
+			case req.URL.Path == "/api/destinations":
 				destinations := api.ListResponse[api.Destination]{
 					Items: []api.Destination{
 						{
@@ -125,7 +125,7 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 
 				_, err = resp.Write(bytes)
 				assert.NilError(t, err)
-			case req.URL.Path == "/v1/grants":
+			case req.URL.Path == "/api/grants":
 				grants := api.ListResponse[api.Grant]{
 					Items: []api.Grant{
 						{
@@ -148,14 +148,14 @@ XlW7KilKI5YkcszGoPB4RePiHsH+7trf7l8IQq5r5kRq7SKsZ41BI6s1E1PQVW93
 
 				_, err = resp.Write(bytes)
 				assert.NilError(t, err)
-			case req.URL.Path == fmt.Sprintf("/v1/users/%s/groups", userID):
+			case req.URL.Path == fmt.Sprintf("/api/users/%s/groups", userID):
 				groups := api.ListResponse[api.Group]{}
 				bytes, err := json.Marshal(groups)
 				assert.NilError(t, err)
 
 				_, err = resp.Write(bytes)
 				assert.NilError(t, err)
-			case req.URL.Path == fmt.Sprintf("/v1/users/%s", userID):
+			case req.URL.Path == fmt.Sprintf("/api/users/%s", userID):
 				user := api.User{
 					ID:   userID,
 					Name: "testuser@example.com",

--- a/internal/cmd/grants_test.go
+++ b/internal/cmd/grants_test.go
@@ -26,7 +26,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		handler := func(resp http.ResponseWriter, req *http.Request) {
 			query := req.URL.Query()
 
-			if requestMatches(req, http.MethodGet, "/v1/users") {
+			if requestMatches(req, http.MethodGet, "/api/users") {
 				resp.WriteHeader(http.StatusOK)
 				switch query.Get("name") {
 				case "existing@example.com":
@@ -39,7 +39,7 @@ func TestGrantsAddCmd(t *testing.T) {
 				return
 			}
 
-			if requestMatches(req, http.MethodGet, "/v1/groups") {
+			if requestMatches(req, http.MethodGet, "/api/groups") {
 				resp.WriteHeader(http.StatusOK)
 				if query.Get("name") == "existingGroup" {
 					writeResponse(t, resp, api.ListResponse[api.Group]{Count: 1, Items: []api.Group{{ID: 4000}}})
@@ -49,7 +49,7 @@ func TestGrantsAddCmd(t *testing.T) {
 				return
 			}
 
-			if requestMatches(req, http.MethodGet, "/v1/destinations") {
+			if requestMatches(req, http.MethodGet, "/api/destinations") {
 				resp.WriteHeader(http.StatusOK)
 				if query.Get("name") == "the-destination" {
 					writeResponse(t, resp, api.ListResponse[api.Destination]{Count: 1, Items: []api.Destination{{ID: 5000, Roles: []string{"role"}, Resources: []string{"default"}}}})
@@ -59,7 +59,7 @@ func TestGrantsAddCmd(t *testing.T) {
 				return
 			}
 
-			if !requestMatches(req, http.MethodPost, "/v1/grants") {
+			if !requestMatches(req, http.MethodPost, "/api/grants") {
 				resp.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -179,7 +179,7 @@ func TestGrantRemoveCmd(t *testing.T) {
 		handler := func(resp http.ResponseWriter, req *http.Request) {
 			query := req.URL.Query()
 
-			if requestMatches(req, http.MethodGet, "/v1/users") {
+			if requestMatches(req, http.MethodGet, "/api/users") {
 				resp.WriteHeader(http.StatusOK)
 				if query.Get("name") == "existing@example.com" {
 					writeResponse(t, resp, api.ListResponse[api.User]{Count: 1, Items: []api.User{{ID: 3000}}})
@@ -189,7 +189,7 @@ func TestGrantRemoveCmd(t *testing.T) {
 				return
 			}
 
-			if requestMatches(req, http.MethodGet, "/v1/groups") {
+			if requestMatches(req, http.MethodGet, "/api/groups") {
 				resp.WriteHeader(http.StatusOK)
 				if query.Get("name") == "existingGroup" {
 					writeResponse(t, resp, api.ListResponse[api.Group]{Count: 1, Items: []api.Group{{ID: 4000}}})
@@ -199,7 +199,7 @@ func TestGrantRemoveCmd(t *testing.T) {
 				return
 			}
 
-			if requestMatches(req, http.MethodGet, "/v1/grants") {
+			if requestMatches(req, http.MethodGet, "/api/grants") {
 				resp.WriteHeader(http.StatusOK)
 				if query.Get("resource") != "the-destination" {
 					writeResponse(t, resp, api.ListResponse[api.Grant]{})
@@ -240,7 +240,7 @@ func TestGrantRemoveCmd(t *testing.T) {
 				return
 			}
 
-			if requestMatchesPrefix(req, http.MethodDelete, "/v1/grants") {
+			if requestMatchesPrefix(req, http.MethodDelete, "/api/grants") {
 				resp.WriteHeader(http.StatusOK)
 
 				requestCh <- path.Base(req.URL.Path)

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -25,7 +25,7 @@ func TestKeysAddCmd(t *testing.T) {
 
 		handler := func(resp http.ResponseWriter, req *http.Request) {
 			// the command does a lookup for user ID
-			if requestMatches(req, http.MethodGet, "/v1/users") {
+			if requestMatches(req, http.MethodGet, "/api/users") {
 				if req.URL.Query().Get("name") != "my-user" {
 					resp.WriteHeader(http.StatusBadRequest)
 					return
@@ -41,7 +41,7 @@ func TestKeysAddCmd(t *testing.T) {
 				return
 			}
 
-			if !requestMatches(req, http.MethodPost, "/v1/access-keys") {
+			if !requestMatches(req, http.MethodPost, "/api/access-keys") {
 				resp.WriteHeader(http.StatusBadRequest)
 				return
 			}
@@ -120,7 +120,7 @@ func TestKeysListCmd(t *testing.T) {
 			query := req.URL.Query()
 
 			// the command does a lookup for user ID
-			if requestMatches(req, http.MethodGet, "/v1/users") {
+			if requestMatches(req, http.MethodGet, "/api/users") {
 				if query.Get("name") != "my-user" {
 					resp.WriteHeader(http.StatusBadRequest)
 					return
@@ -136,7 +136,7 @@ func TestKeysListCmd(t *testing.T) {
 				return
 			}
 
-			if !requestMatches(req, http.MethodGet, "/v1/access-keys") {
+			if !requestMatches(req, http.MethodGet, "/api/access-keys") {
 				resp.WriteHeader(http.StatusBadRequest)
 				return
 			}

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -31,7 +31,7 @@ func TestLogout(t *testing.T) {
 	setup := func(t *testing.T) testFields {
 		var count int32
 		handler := func(resp http.ResponseWriter, req *http.Request) {
-			if req.URL.Path != "/v1/logout" {
+			if req.URL.Path != "/api/logout" {
 				resp.WriteHeader(http.StatusBadRequest)
 				return
 			}
@@ -94,7 +94,7 @@ func TestLogout(t *testing.T) {
 	setupError := func(t *testing.T) testFields {
 		var count int32
 		handler := func(resp http.ResponseWriter, req *http.Request) {
-			if req.URL.Path != "/v1/logout" {
+			if req.URL.Path != "/api/logout" {
 				resp.WriteHeader(http.StatusBadRequest)
 				return
 			}

--- a/internal/cmd/providers_test.go
+++ b/internal/cmd/providers_test.go
@@ -22,7 +22,7 @@ func TestProvidersAddCmd(t *testing.T) {
 
 		handler := func(resp http.ResponseWriter, req *http.Request) {
 			defer close(requestCh)
-			if !requestMatches(req, http.MethodPost, "/v1/providers") {
+			if !requestMatches(req, http.MethodPost, "/api/providers") {
 				resp.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/internal/cmd/users_test.go
+++ b/internal/cmd/users_test.go
@@ -40,7 +40,7 @@ func TestUsersCmd(t *testing.T) {
 		modifiedUsers := []models.Identity{}
 
 		handler := func(resp http.ResponseWriter, req *http.Request) {
-			if strings.Contains(req.URL.Path, "/v1/providers") {
+			if strings.Contains(req.URL.Path, "/api/providers") {
 				resp.WriteHeader(http.StatusOK)
 
 				providers := []*api.Provider{
@@ -55,7 +55,7 @@ func TestUsersCmd(t *testing.T) {
 				return
 			}
 
-			if strings.Contains(req.URL.Path, "/v1/users") {
+			if strings.Contains(req.URL.Path, "/api/users") {
 				switch req.Method {
 				case http.MethodPost:
 					createUserReq := api.CreateUserRequest{}
@@ -80,7 +80,7 @@ func TestUsersCmd(t *testing.T) {
 					_, _ = resp.Write(b)
 					return
 				case http.MethodDelete:
-					id := req.URL.Path[len("/v1/users/"):]
+					id := req.URL.Path[len("/api/users/"):]
 
 					uid, err := uid.Parse([]byte(id))
 					assert.NilError(t, err)

--- a/internal/server/debug.go
+++ b/internal/server/debug.go
@@ -23,6 +23,6 @@ func (a *API) pprofHandler(c *gin.Context) {
 		pprof.Profile(c.Writer, c.Request)
 	default:
 		// All other types of profiles are served from Index
-		http.StripPrefix("/v1", http.HandlerFunc(pprof.Index)).ServeHTTP(c.Writer, c.Request)
+		http.StripPrefix("/api", http.HandlerFunc(pprof.Index)).ServeHTTP(c.Writer, c.Request)
 	}
 }

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -30,7 +30,8 @@ func TestAPI_PProfHandler(t *testing.T) {
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
 	run := func(t *testing.T, tc testCase) {
-		req, err := http.NewRequest(http.MethodGet, "/v1/debug/pprof/heap?debug=1", nil)
+		req, err := http.NewRequest(http.MethodGet, "/api/debug/pprof/heap?debug=1", nil)
+		req.Header.Add("Infra-Version", "0.12.3")
 		assert.NilError(t, err)
 
 		if tc.setupRequest != nil {

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -30,7 +30,7 @@ func TestAPI_ListGrants(t *testing.T) {
 		err := json.NewEncoder(&buf).Encode(body)
 		assert.NilError(t, err)
 
-		req, err := http.NewRequest(http.MethodPost, "/v1/users", &buf)
+		req, err := http.NewRequest(http.MethodPost, "/api/users", &buf)
 		assert.NilError(t, err)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", "0.12.3")
@@ -55,7 +55,7 @@ func TestAPI_ListGrants(t *testing.T) {
 		err := json.NewEncoder(&buf).Encode(body)
 		assert.NilError(t, err)
 
-		req, err := http.NewRequest(http.MethodPost, "/v1/grants", &buf)
+		req, err := http.NewRequest(http.MethodPost, "/api/grants", &buf)
 		assert.NilError(t, err)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", "0.12.3")
@@ -122,7 +122,7 @@ func TestAPI_ListGrants(t *testing.T) {
 
 	testCases := map[string]testCase{
 		"not authenticated": {
-			urlPath: "/v1/grants?subject=i:" + idOther.String(),
+			urlPath: "/api/grants?subject=i:" + idOther.String(),
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Del("Authorization")
 			},
@@ -131,25 +131,25 @@ func TestAPI_ListGrants(t *testing.T) {
 			},
 		},
 		"not authorized, wrong identity": {
-			urlPath: "/v1/grants?subject=i:" + idOther.String(),
+			urlPath: "/api/grants?subject=i:" + idOther.String(),
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusForbidden, resp.Body.String())
 			},
 		},
 		"not authorized, wrong group": {
-			urlPath: "/v1/grants?subject=g:abcde",
+			urlPath: "/api/grants?subject=g:abcde",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusForbidden, resp.Body.String())
 			},
 		},
 		"not authorized, no subject in query": {
-			urlPath: "/v1/grants?resource=res1",
+			urlPath: "/api/grants?resource=res1",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusForbidden, resp.Body.String())
 			},
 		},
 		"authorized by grant": {
-			urlPath: "/v1/grants?resource=none",
+			urlPath: "/api/grants?resource=none",
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 			},
@@ -162,7 +162,7 @@ func TestAPI_ListGrants(t *testing.T) {
 			},
 		},
 		"authorized by identity matching subject": {
-			urlPath: "/v1/grants?user=" + idInGroup.String(),
+			urlPath: "/api/grants?user=" + idInGroup.String(),
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
 				var grants api.ListResponse[api.Grant]
@@ -179,7 +179,7 @@ func TestAPI_ListGrants(t *testing.T) {
 			},
 		},
 		"authorized by group matching subject": {
-			urlPath: "/v1/grants?group=" + groupID.String(),
+			urlPath: "/api/grants?group=" + groupID.String(),
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
 				var grants api.ListResponse[api.Grant]
@@ -190,7 +190,7 @@ func TestAPI_ListGrants(t *testing.T) {
 			},
 		},
 		"no filters": {
-			urlPath: "/v1/grants",
+			urlPath: "/api/grants",
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 			},
@@ -229,7 +229,7 @@ func TestAPI_ListGrants(t *testing.T) {
 			},
 		},
 		"filter by resource": {
-			urlPath: "/v1/grants?resource=res1",
+			urlPath: "/api/grants?resource=res1",
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 				req.Header.Add("Infra-Version", "0.12.3")
@@ -256,7 +256,7 @@ func TestAPI_ListGrants(t *testing.T) {
 			},
 		},
 		"filter by resource and privilege": {
-			urlPath: "/v1/grants?resource=res1&privilege=custom1",
+			urlPath: "/api/grants?resource=res1&privilege=custom1",
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 			},
@@ -277,7 +277,7 @@ func TestAPI_ListGrants(t *testing.T) {
 			},
 		},
 		"full JSON response": {
-			urlPath: "/v1/grants?user=" + idInGroup.String(),
+			urlPath: "/api/grants?user=" + idInGroup.String(),
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
 

--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -147,6 +147,49 @@ func (a *API) addRedirects() {
 
 	addRedirect(a, http.MethodGet, "/v1/identities/:id/groups", "/v1/users/:id/groups", "0.12.2")
 	addRedirect(a, http.MethodGet, "/v1/identities/:id/grants", "/v1/users/:id/grants", "0.12.2")
+
+	addRedirect(a, http.MethodGet, "/v1/users", "/api/users", "0.12.2")
+	addRedirect(a, http.MethodPost, "/v1/users", "/api/users", "0.12.2")
+	addRedirect(a, http.MethodGet, "/v1/users/:id", "/api/users/:id", "0.12.2")
+	addRedirect(a, http.MethodPut, "/v1/users/:id", "/api/users/:id", "0.12.2")
+	addRedirect(a, http.MethodDelete, "/v1/users/:id", "/api/users/:id", "0.12.2")
+	addRedirect(a, http.MethodGet, "/v1/users/:id/groups", "/api/users/:id/groups", "0.12.2")
+
+	addRedirect(a, http.MethodGet, "/v1/access-keys", "/api/access-keys", "0.12.2")
+	addRedirect(a, http.MethodPost, "/v1/access-keys", "/api/access-keys", "0.12.2")
+	addRedirect(a, http.MethodDelete, "/v1/access-keys/:id", "/api/access-keys/:id", "0.12.2")
+
+	addRedirect(a, http.MethodGet, "/v1/groups", "/api/groups", "0.12.2")
+	addRedirect(a, http.MethodPost, "/v1/groups", "/api/groups", "0.12.2")
+	addRedirect(a, http.MethodGet, "/v1/groups/:id", "/api/groups/:id", "0.12.2")
+
+	addRedirect(a, http.MethodGet, "/v1/grants", "/api/grants", "0.12.2")
+	addRedirect(a, http.MethodGet, "/v1/grants/:id", "/api/grants/:id", "0.12.2")
+	addRedirect(a, http.MethodPost, "/v1/grants", "/api/grants", "0.12.2")
+	addRedirect(a, http.MethodDelete, "/v1/grants/:id", "/api/grants/:id", "0.12.2")
+
+	addRedirect(a, http.MethodPost, "/v1/providers", "/api/providers", "0.12.2")
+	addRedirect(a, http.MethodPut, "/v1/providers/:id", "/api/providers/:id", "0.12.2")
+	addRedirect(a, http.MethodDelete, "/v1/providers/:id", "/api/providers/:id", "0.12.2")
+
+	addRedirect(a, http.MethodGet, "/v1/destinations", "/api/destinations", "0.12.2")
+	addRedirect(a, http.MethodGet, "/v1/destinations/:id", "/api/destinations/:id", "0.12.2")
+	addRedirect(a, http.MethodPost, "/v1/destinations", "/api/destinations", "0.12.2")
+	addRedirect(a, http.MethodPut, "/v1/destinations/:id", "/api/destinations/:id", "0.12.2")
+	addRedirect(a, http.MethodDelete, "/v1/destinations/:id", "/api/destinations/:id", "0.12.2")
+
+	addRedirect(a, http.MethodPost, "/v1/tokens", "/api/tokens", "0.12.2")
+	addRedirect(a, http.MethodPost, "/v1/logout", "/api/logout", "0.12.2")
+
+	addRedirect(a, http.MethodGet, "/v1/signup", "/api/signup", "0.12.2")
+	addRedirect(a, http.MethodPost, "/v1/signup", "/api/signup", "0.12.2")
+
+	addRedirect(a, http.MethodPost, "/v1/login", "/api/login", "0.12.2")
+
+	addRedirect(a, http.MethodGet, "/v1/providers", "/api/providers", "0.12.2")
+	addRedirect(a, http.MethodGet, "/v1/providers/:id", "/api/providers/:id", "0.12.2")
+
+	addRedirect(a, http.MethodGet, "/v1/version", "/api/version", "0.12.2")
 }
 
 type identityGrant struct {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -323,7 +323,7 @@ func healthHandler(c *gin.Context) {
 // TODO: use the HTTP Accept header instead of the path to determine the
 // format of the response body. https://github.com/infrahq/infra/issues/1610
 func (a *API) notFoundHandler(c *gin.Context) {
-	if strings.HasPrefix(c.Request.URL.Path, "/v1") {
+	if strings.HasPrefix(c.Request.URL.Path, "/api") {
 		sendAPIError(c, internal.ErrNotFound)
 		return
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -52,52 +52,52 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) *gin.Engine 
 
 	authn := api.Group("/", AuthenticationMiddleware(a))
 
-	get(a, authn, "/v1/users", a.ListUsers)
-	post(a, authn, "/v1/users", a.CreateUser)
-	get(a, authn, "/v1/users/:id", a.GetUser)
-	put(a, authn, "/v1/users/:id", a.UpdateUser)
-	delete(a, authn, "/v1/users/:id", a.DeleteUser)
-	get(a, authn, "/v1/users/:id/groups", a.ListUserGroups)
+	get(a, authn, "/api/users", a.ListUsers)
+	post(a, authn, "/api/users", a.CreateUser)
+	get(a, authn, "/api/users/:id", a.GetUser)
+	put(a, authn, "/api/users/:id", a.UpdateUser)
+	delete(a, authn, "/api/users/:id", a.DeleteUser)
+	get(a, authn, "/api/users/:id/groups", a.ListUserGroups)
 
-	get(a, authn, "/v1/access-keys", a.ListAccessKeys)
-	post(a, authn, "/v1/access-keys", a.CreateAccessKey)
-	delete(a, authn, "/v1/access-keys/:id", a.DeleteAccessKey)
+	get(a, authn, "/api/access-keys", a.ListAccessKeys)
+	post(a, authn, "/api/access-keys", a.CreateAccessKey)
+	delete(a, authn, "/api/access-keys/:id", a.DeleteAccessKey)
 
-	get(a, authn, "/v1/groups", a.ListGroups)
-	post(a, authn, "/v1/groups", a.CreateGroup)
-	get(a, authn, "/v1/groups/:id", a.GetGroup)
+	get(a, authn, "/api/groups", a.ListGroups)
+	post(a, authn, "/api/groups", a.CreateGroup)
+	get(a, authn, "/api/groups/:id", a.GetGroup)
 
-	get(a, authn, "/v1/grants", a.ListGrants)
-	get(a, authn, "/v1/grants/:id", a.GetGrant)
-	post(a, authn, "/v1/grants", a.CreateGrant)
-	delete(a, authn, "/v1/grants/:id", a.DeleteGrant)
+	get(a, authn, "/api/grants", a.ListGrants)
+	get(a, authn, "/api/grants/:id", a.GetGrant)
+	post(a, authn, "/api/grants", a.CreateGrant)
+	delete(a, authn, "/api/grants/:id", a.DeleteGrant)
 
-	post(a, authn, "/v1/providers", a.CreateProvider)
-	put(a, authn, "/v1/providers/:id", a.UpdateProvider)
-	delete(a, authn, "/v1/providers/:id", a.DeleteProvider)
+	post(a, authn, "/api/providers", a.CreateProvider)
+	put(a, authn, "/api/providers/:id", a.UpdateProvider)
+	delete(a, authn, "/api/providers/:id", a.DeleteProvider)
 
-	get(a, authn, "/v1/destinations", a.ListDestinations)
-	get(a, authn, "/v1/destinations/:id", a.GetDestination)
-	post(a, authn, "/v1/destinations", a.CreateDestination)
-	put(a, authn, "/v1/destinations/:id", a.UpdateDestination)
-	delete(a, authn, "/v1/destinations/:id", a.DeleteDestination)
+	get(a, authn, "/api/destinations", a.ListDestinations)
+	get(a, authn, "/api/destinations/:id", a.GetDestination)
+	post(a, authn, "/api/destinations", a.CreateDestination)
+	put(a, authn, "/api/destinations/:id", a.UpdateDestination)
+	delete(a, authn, "/api/destinations/:id", a.DeleteDestination)
 
-	post(a, authn, "/v1/tokens", a.CreateToken)
-	post(a, authn, "/v1/logout", a.Logout)
+	post(a, authn, "/api/tokens", a.CreateToken)
+	post(a, authn, "/api/logout", a.Logout)
 
-	authn.GET("/v1/debug/pprof/*profile", a.pprofHandler)
+	authn.GET("/api/debug/pprof/*profile", a.pprofHandler)
 
 	// these endpoints do not require authentication
 	noAuthn := api.Group("/")
-	get(a, noAuthn, "/v1/signup", a.SignupEnabled)
-	post(a, noAuthn, "/v1/signup", a.Signup)
+	get(a, noAuthn, "/api/signup", a.SignupEnabled)
+	post(a, noAuthn, "/api/signup", a.Signup)
 
-	post(a, noAuthn, "/v1/login", a.Login)
+	post(a, noAuthn, "/api/login", a.Login)
 
-	get(a, noAuthn, "/v1/providers", a.ListProviders)
-	get(a, noAuthn, "/v1/providers/:id", a.GetProvider)
+	get(a, noAuthn, "/api/providers", a.ListProviders)
+	get(a, noAuthn, "/api/providers/:id", a.GetProvider)
 
-	get(a, noAuthn, "/v1/version", a.Version)
+	get(a, noAuthn, "/api/version", a.Version)
 
 	// Deprecated in 0.12
 	// TODO: remove after a couple versions

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -129,7 +129,7 @@ func TestServer_Run(t *testing.T) {
 
 	t.Run("metrics server started", func(t *testing.T) {
 		// perform one API call to populate metrics
-		resp, err := http.Get("http://" + srv.Addrs.HTTP.String() + "/v1/version")
+		resp, err := http.Get("http://" + srv.Addrs.HTTP.String() + "/api/version")
 		assert.NilError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -221,7 +221,7 @@ func TestServer_Run_UIProxy(t *testing.T) {
 	})
 
 	t.Run("api routes are available", func(t *testing.T) {
-		resp, err := http.Get("http://" + srv.Addrs.HTTP.String() + "/v1/signup")
+		resp, err := http.Get("http://" + srv.Addrs.HTTP.String() + "/api/signup")
 		assert.NilError(t, err)
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -257,8 +257,8 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "/v1 path prefix",
-			path: "/v1/not/found",
+			name: "/api path prefix",
+			path: "/api/not/found",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				contentType := resp.Header().Get("Content-Type")
 				expected := "application/json; charset=utf-8"
@@ -375,7 +375,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 	err := json.NewEncoder(&buf).Encode(signupReq)
 	assert.NilError(t, err)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/signup", &buf)
+	req := httptest.NewRequest(http.MethodPost, "/api/signup", &buf)
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
 	assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
@@ -389,7 +389,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 	err = json.NewEncoder(&buf).Encode(loginReq)
 	assert.NilError(t, err)
 
-	req = httptest.NewRequest(http.MethodPost, "/v1/login", &buf)
+	req = httptest.NewRequest(http.MethodPost, "/api/login", &buf)
 	resp = httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
 	assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
@@ -399,7 +399,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 	assert.NilError(t, err)
 
 	checkAuthenticated := func() {
-		req = httptest.NewRequest(http.MethodGet, "/v1/users", nil)
+		req = httptest.NewRequest(http.MethodGet, "/api/users", nil)
 		req.Header.Set("Authorization", "Bearer "+loginResp.AccessKey)
 		resp = httptest.NewRecorder()
 		routes.ServeHTTP(resp, req)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Replace API path `v1` with `api` since the API is no longer versioned by the path. Depends on #1943

TODO:

- [x] update api/client.go

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1828 
