### PR TITLE
fix: add singular alias for users

### DIFF
--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -13,9 +13,10 @@ import (
 
 func newUsersCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "users",
-		Short: "Manage user identities",
-		Group: "Management commands:",
+		Use:     "users",
+		Short:   "Manage user identities",
+		Aliases: []string{"user"},
+		Group:   "Management commands:",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {
 				return err


### PR DESCRIPTION
## Summary
Other commands such as `infra providers` also have a singular alias `infra provider`. `infra user` got missed in the migration from `infra id`.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1949
