### PR TITLE
fix: set correct version for release and release candidate builds

### DIFF
--- a/.github/release-please.json
+++ b/.github/release-please.json
@@ -14,6 +14,7 @@
     ".": {
       "release-type": "go",
       "extra-files": [
+        "Dockerfile",
         "helm/charts/infra/Chart.yaml",
         "internal/version.go",
         "docs/install/upgrading.md",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,10 @@ jobs:
         with:
           path: /root/.cache/
           key: ${{ runner.os }}-go-build
+      # TODO: use goreleaser github action: https://github.com/goreleaser/goreleaser-action
       - run: |
           go install github.com/goreleaser/goreleaser@v1.7.0
-          make release tag=${{ needs.release-please.outputs.release_name }}
+          make release
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           GEMFURY_TOKEN: ${{ secrets.GORELEASER_GEMFURY_TOKEN }}
@@ -58,7 +59,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: make release/docker tag=${{ needs.release-please.outputs.release_name }}
+      - run: make release/docker v=${{ needs.release-please.outputs.release_name }}
         env:
           TELEMETRY_WRITE_KEY: ${{ secrets.TELEMETRY_WRITE_KEY }}
 
@@ -75,7 +76,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
       - run: |
-          make helm tag=${{ needs.release-please.outputs.release_name }}
+          make helm v=${{ needs.release-please.outputs.release_name }}
           aws s3 sync helm s3://helm.infrahq.com --exclude "*" --include "index.yaml" --include "*.tgz"
 
   readme:

--- a/.github/workflows/release_pull_request.yml
+++ b/.github/workflows/release_pull_request.yml
@@ -4,20 +4,6 @@ on:
   pull_request:
 
 jobs:
-  codeql-analysis:
-    if: startsWith(github.head_ref, 'release-please-') == true
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.18'
-      - uses: github/codeql-action/init@v2
-        with:
-          config-file: .github/codeql-config.yaml
-      - run: go build github.com/$GITHUB_REPOSITORY
-      - uses: github/codeql-action/analyze@v2
-
   docker:
     if: startsWith(github.head_ref, 'release-please-') == true
     runs-on: ubuntu-latest

--- a/.github/workflows/release_pull_request.yml
+++ b/.github/workflows/release_pull_request.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - run: make docker tag=next
+      - run: make docker IMAGEVERSION=next BUILDVERSION_PRERELEASE=rc
         env:
           TELEMETRY_WRITE_KEY: ${{ secrets.TELEMETRY_WRITE_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,11 @@ RUN apt-get update && \
 RUN CGO_ENABLED=0 GOOS=linux go install -v -installsuffix cgo -a std
 
 ARG TARGETARCH
-ARG BUILDVERSION=0.0.0-development
+# {x-release-please-start-version}
+ARG BUILDVERSION=0.13.0
+# {x-release-please-end}
+ARG BUILDVERSION_PRERELEASE
+ARG BUILDVERSION_METADATA
 ARG TELEMETRY_WRITE_KEY
 WORKDIR /go/src/github.com/infrahq/infra
 
@@ -26,7 +30,7 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
     CGO_ENABLED=1 GOOS=linux GOARCH=$TARGETARCH \
     CC=$TARGETARCH-linux-gnu-gcc \
     go build \
-    -ldflags '-s -X github.com/infrahq/infra/internal.Version='"$BUILDVERSION"' -X github.com/infrahq/infra/internal.TelemetryWriteKey='"$TELEMETRY_WRITE_KEY"' -linkmode external -extldflags "-static"' \
+    -ldflags '-s -X github.com/infrahq/infra/internal.Version='"$BUILDVERSION"' -X github.com/infrahq/infra/internal.Prerelease='"$BUILDVERSION_PRERELEASE"' -X github.com/infrahq/infra/internal.Metadata='"$BUILDVERSION_METADATA"' -X github.com/infrahq/infra/internal.TelemetryWriteKey='"$TELEMETRY_WRITE_KEY"' -linkmode external -extldflags "-static"' \
     .
 
 FROM alpine

--- a/api/client.go
+++ b/api/client.go
@@ -345,8 +345,12 @@ func (c Client) Signup(req *SignupRequest) (*CreateAccessKeyResponse, error) {
 	return post[SignupRequest, CreateAccessKeyResponse](c, "/api/signup", req)
 }
 
-func (c Client) GetVersion() (*Version, error) {
+func (c Client) GetServerVersion() (*Version, error) {
 	return get[Version](c, "/api/version")
+}
+
+func GetClientVersion() string {
+	return clientVersion
 }
 
 func partialText(body []byte, limit int) string {

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -2,4 +2,7 @@ version: "3.9"
 
 services:
   server:
-    build: .
+    build:
+      context: .
+      args:
+        BUILDVERSION_METADATA: dev

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/logging"
 )
 
@@ -28,7 +28,7 @@ func version(cli *CLI) error {
 	defer w.Flush()
 
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Client:\t", strings.TrimPrefix(internal.Version, "v"))
+	fmt.Fprintln(w, "Client:\t", strings.TrimPrefix(api.GetClientVersion(), "v"))
 
 	// Note that we use the client to get this version, but it is in fact the server version
 	client, err := defaultAPIClient()
@@ -40,7 +40,7 @@ func version(cli *CLI) error {
 		return nil
 	}
 
-	version, err := client.GetVersion()
+	version, err := client.GetServerVersion()
 	if err != nil {
 		fmt.Fprintln(w, "Server:\t", "disconnected")
 		logging.S.Debug(err)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -588,7 +588,7 @@ func (a *API) Logout(c *gin.Context, r *api.EmptyRequest) (*api.EmptyResponse, e
 }
 
 func (a *API) Version(c *gin.Context, r *api.EmptyRequest) (*api.Version, error) {
-	return &api.Version{Version: internal.Version}, nil
+	return &api.Version{Version: internal.FullVersion()}, nil
 }
 
 // UpdateIdentityInfoFromProvider calls the identity provider used to authenticate this user session to update their current information

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,10 +7,10 @@ var (
 	// {x-release-please-start-version}
 	Version = "0.13.0"
 	// {x-release-please-end}
-	PrereleaseTag = ""
-	Metadata      = "dev"
-	Commit        = ""
-	Date          = ""
+	Prerelease = ""
+	Metadata   = "dev"
+	Commit     = ""
+	Date       = ""
 )
 
 // FullVersion returns the full semver version string, however it also increments the patch version if you're working on a pre-release.
@@ -21,7 +21,7 @@ func FullVersion() string {
 	if Metadata == "dev" {
 		*v = v.IncPatch()
 	}
-	*v, _ = v.SetPrerelease(PrereleaseTag)
+	*v, _ = v.SetPrerelease(Prerelease)
 	*v, _ = v.SetMetadata(Metadata)
 
 	return v.String()


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

- Unset `Prerelease` and `Metadata` fields when building release
- Set `Prerelease` to `rc` and unset `Metadata` when building release candidate
- Unset `Prerelease` and set `Metadata` to `dev` when building local docker image
- Update version string for server to `internal.FullVersion()` and client to `api.GetClientVersion()`
- Update `api.GetVersion()` to `api.GetServerVersion()`
- Split `BUILDVERSION` and `IMAGEVERSION` since they may be different
- Remove codeql-analysis since the value add is minimal at this point in time

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1952
