### PR TITLE
fix: revert client to report binary version, not api version

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -349,10 +349,6 @@ func (c Client) GetServerVersion() (*Version, error) {
 	return get[Version](c, "/api/version")
 }
 
-func GetClientVersion() string {
-	return clientVersion
-}
-
 func partialText(body []byte, limit int) string {
 	if len(body) <= limit {
 		return string(body)

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
 )
 
@@ -28,7 +28,7 @@ func version(cli *CLI) error {
 	defer w.Flush()
 
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Client:\t", strings.TrimPrefix(api.GetClientVersion(), "v"))
+	fmt.Fprintln(w, "Client:\t", strings.TrimPrefix(internal.FullVersion(), "v"))
 
 	// Note that we use the client to get this version, but it is in fact the server version
 	client, err := defaultAPIClient()


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

This reverts part of 3662a6fab75ca77570fb19175dca27e950daf3a9.

The command line should report its binary version. The API version is used to describe the target API version so it's not appropriate to report as the version of the CLI