### PR TITLE
ci: add daily schedule job to run fuzzing

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -88,3 +88,7 @@
 - name: "status/never-stale"
   color: "dddddd"
   description: Indicates to actions/stale that the issue or PR should never be marked stale.
+
+- name: "action/fuzz"
+  color: "dddddd"
+  description: Run fuzzing on this pull request.

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,14 +1,14 @@
 name: Fuzzing
 
 on:
-  # TODO: remove push, replace with pull_request label
-  push:
-    branches: [dnephin/ci-fuzz]
+  pull_request:
+    types: [labeled]
   schedule:
     - cron: "14 3 * * *"
 
 jobs:
   fuzz-matrix:
+    if: ${{ github.event.label.name == 'action/fuzz' }}
     runs-on: ubuntu-latest
     outputs:
       fuzz-names: ${{ steps.list-fuzz.outputs.list }}
@@ -45,11 +45,14 @@ jobs:
           restore-keys: go-fuzz-corpus-${{ matrix.name }}-
           path: /tmp/go/cache/fuzz
 
+      - name: Set fuzz time
+        run: echo "fuzz_time=5m" >> $GITHUB_ENV
+        if: "${{ github.event_name == 'pull_request' }}"
+
       - name: Run fuzzing
         run: |
           name=${{ matrix.name }}
           # fuzz won't run with ./..., so lookup the package name
           dir="$(git grep -l "^func ${name}" | xargs dirname)"
-          # TODO: change fuzztime
-          go test -v -fuzz=${name} -fuzztime 5m "./${dir}"
+          go test -v -fuzz=${name} -fuzztime "${fuzz_time:-30m}" "./${dir}"
 

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -30,11 +30,21 @@ jobs:
     strategy:
       matrix:
         name: ${{ fromJson(needs.fuzz-matrix.outputs.fuzz-names) }}
+    env:
+      GOCACHE: /tmp/go/cache
     steps:
+      - run: mkdir -p ${GOCACHE}
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
+
+      - uses: actions/cache@v3
+        with:
+          key: go-fuzz-corpus-${{ matrix.name }}-${{ github.run_number }}
+          restore-keys: go-fuzz-corpus-${{ matrix.name }}-
+          path: /tmp/go/cache/fuzz
+
       - name: Run fuzzing
         run: |
           name=${{ matrix.name }}

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,45 @@
+name: Fuzzing
+
+on:
+  # TODO: remove push, replace with pull_request label
+  push:
+    branches: [dnephin/ci-fuzz]
+  schedule:
+    - cron: "14 3 * * *"
+
+jobs:
+  fuzz-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      fuzz-names: ${{ steps.list-fuzz.outputs.list }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+      - id: list-fuzz
+        run: |
+          list="$(go test -list '^Fuzz' ./... | \
+                  grep '^Fuzz' | \
+                  xargs jq -n '$ARGS.positional' --compact-output --args)"
+          echo "::set-output name=list::${list}"
+
+  fuzz:
+    needs: fuzz-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        name: ${{ fromJson(needs.fuzz-matrix.outputs.fuzz-names) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+      - name: Run fuzzing
+        run: |
+          name=${{ matrix.name }}
+          # fuzz won't run with ./..., so lookup the package name
+          dir="$(git grep -l "^func ${name}" | xargs dirname)"
+          # TODO: change fuzztime
+          go test -v -fuzz=${name} -fuzztime 5m "./${dir}"
+


### PR DESCRIPTION
This PR adds a github workflow for running all the fuzz tests. The workflow runs daily (at 3am UTC), and can also be triggered on a PR by adding the `action/fuzz` label (also added in this PR).

The `go test -fuzz` flag can only be used to run a single Fuzz test at a time, so the fuzz workflow does this:
* start by finding all the fuzz tests
* uses the list of fuzz tests to create a `matrix` for the actual fuzz job
* runs a separate job for every fuzz test it finds
* the fuzz corpus should be cached, so each run should resume from where it stopped last time

The fuzzing will run for 30s in the nightly run, but only 5 minutes for the PR runs. We can change those times if we want.