### PR TITLE
fix: openapi gen should not set -dev version in release branches

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,9 +52,11 @@ jobs:
           go-version: '1.18'
       - name: Check generated docs are updated
         run: |
+          # if checking a release candidate pull request, unset `internal.Metadat`
+          if [[ "$GITHUB_REF_NAME" =~ ^release-please-.*$ ]]; then LDFLAGS='-X github.com/infrahq/infra/internal.Metadata='; fi
           # fake a terminal to get the right defaults for non-interactive
-          script -e -q -c "go run ./internal/docgen"
-          go run ./internal/openapigen docs/api/openapi3.json
+          script -e -q -c "go run ${LDFLAGS:+-ldflags \"$LDFLAGS\"} ./internal/docgen"
+          go run ${LDFLAGS:+-ldflags "$LDFLAGS"} ./internal/openapigen docs/api/openapi3.json
           git diff --exit-code
       - name: Check go mod is tidy
         run: |


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

If the check is run from the release branch pull request, unset `Metadata` so the version is set correctly