### PR TITLE
fix: build for release candidates

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,8 +52,8 @@ jobs:
           go-version: '1.18'
       - name: Check generated docs are updated
         run: |
-          # if checking a release candidate pull request, unset `internal.Metadat`
-          if [[ "$GITHUB_REF_NAME" =~ ^release-please-.*$ ]]; then LDFLAGS='-X github.com/infrahq/infra/internal.Metadata='; fi
+          # if checking a release candidate pull request, unset `internal.Metadata`
+          if [[ "$GITHUB_HEAD_REF" =~ ^release-please-.*$ ]]; then LDFLAGS='-X github.com/infrahq/infra/internal.Metadata='; fi
           # fake a terminal to get the right defaults for non-interactive
           script -e -q -c "go run ${LDFLAGS:+-ldflags \"$LDFLAGS\"} ./internal/docgen"
           go run ${LDFLAGS:+-ldflags "$LDFLAGS"} ./internal/openapigen docs/api/openapi3.json

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 v ?= $(shell git describe --tags --abbrev=0)
-BUILDVERSION ?= $(v:v%=%)
 IMAGEVERSION ?= $(v:v%=%)
 
 generate:
@@ -42,7 +41,6 @@ build: goreleaser
 
 dev/docker:
 	docker build \
-		--build-arg BUILDVERSION=$(BUILDVERSION) \
 		--build-arg BUILDVERSION_METADATA=dev \
 		--build-arg TELEMETRY_WRITE_KEY=$(TELEMETRY_WRITE_KEY) \
 		-t infrahq/infra:dev \
@@ -77,7 +75,6 @@ dev/clean:
 docker:
 	docker buildx build --push \
 		--platform linux/amd64,linux/arm64 \
-		--build-arg BUILDVERSION=$(BUILDVERSION) \
 		--build-arg BUILDVERSION_PRERELEASE=$(BUILDVERSION_PRERELEASE) \
 		--build-arg TELEMETRY_WRITE_KEY=$(TELEMETRY_WRITE_KEY) \
 		--tag infrahq/infra:$(IMAGEVERSION) \
@@ -89,7 +86,6 @@ release: goreleaser
 release/docker:
 	docker buildx build --push \
 		--platform linux/amd64,linux/arm64 \
-		--build-arg BUILDVERSION=$(BUILDVERSION) \
 		--build-arg TELEMETRY_WRITE_KEY=$(TELEMETRY_WRITE_KEY) \
 		--tag infrahq/infra:$(IMAGEVERSION) \
 		--tag infrahq/infra \

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,6 +1,10 @@
 package internal
 
-import "github.com/Masterminds/semver/v3"
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+)
 
 var (
 	Branch = "main"
@@ -17,10 +21,15 @@ var (
 // This is because release-please keeps this at the released version, and not the upcoming next version.
 // While the next version may not match the patch release, it causes the right behavior for semver version comparisons.
 func FullVersion() string {
-	v, _ := semver.NewVersion(Version)
+	v, err := semver.NewVersion(Version)
+	if err != nil {
+		panic(fmt.Sprintf("invalid version %v: %v", Version, err))
+	}
+
 	if Metadata == "dev" {
 		*v = v.IncPatch()
 	}
+
 	*v, _ = v.SetPrerelease(Prerelease)
 	*v, _ = v.SetMetadata(Metadata)
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

- `BUILDVERSION` gets unset since the Makefile sets it to an empty string. Instead remove it as it's set statically in the Dockerfile
- Use `GITHUB_HEAD_REF` instead of `GITHUB_REF_NAME`
