### PR TITLE
data: use runDBTests in all tests

### DIFF
--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -15,14 +15,6 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-// TODO: replace all calls to setup with runDBTests, or setupDB
-func setup(t *testing.T) *gorm.DB {
-	t.Helper()
-	driver, err := NewSQLiteDriver("file::memory:")
-	assert.NilError(t, err)
-	return setupDB(t, driver)
-}
-
 func setupDB(t *testing.T, driver gorm.Dialector) *gorm.DB {
 	t.Helper()
 	db, err := NewRawDB(driver)

--- a/internal/server/data/encryption_key_test.go
+++ b/internal/server/data/encryption_key_test.go
@@ -3,30 +3,31 @@ package data
 import (
 	"testing"
 
+	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/models"
 )
 
 func TestEncryptionKeys(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		k, err := CreateEncryptionKey(db, &models.EncryptionKey{
+			Name:      "foo",
+			Encrypted: []byte{0x00},
+			Algorithm: "foo",
+		})
+		assert.NilError(t, err)
 
-	k, err := CreateEncryptionKey(db, &models.EncryptionKey{
-		Name:      "foo",
-		Encrypted: []byte{0x00},
-		Algorithm: "foo",
+		assert.Assert(t, k.KeyID != 0)
+
+		k2, err := GetEncryptionKey(db, ByEncryptionKeyID(k.KeyID))
+		assert.NilError(t, err)
+
+		assert.Equal(t, "foo", k2.Name)
+
+		k3, err := GetEncryptionKey(db, ByName("foo"))
+		assert.NilError(t, err)
+
+		assert.Equal(t, k.ID, k3.ID)
 	})
-	assert.NilError(t, err)
-
-	assert.Assert(t, k.KeyID != 0)
-
-	k2, err := GetEncryptionKey(db, ByEncryptionKeyID(k.KeyID))
-	assert.NilError(t, err)
-
-	assert.Equal(t, "foo", k2.Name)
-
-	k3, err := GetEncryptionKey(db, ByName("foo"))
-	assert.NilError(t, err)
-
-	assert.Equal(t, k.ID, k3.ID)
 }

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -10,31 +10,31 @@ import (
 )
 
 func TestGroup(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		everyone := models.Group{Name: "Everyone"}
 
-	everyone := models.Group{Name: "Everyone"}
+		err := db.Create(&everyone).Error
+		assert.NilError(t, err)
 
-	err := db.Create(&everyone).Error
-	assert.NilError(t, err)
-
-	var group models.Group
-	err = db.First(&group, &models.Group{Name: everyone.Name}).Error
-	assert.NilError(t, err)
-	assert.Assert(t, 0 != group.ID)
-	assert.Equal(t, everyone.Name, group.Name)
+		var group models.Group
+		err = db.First(&group, &models.Group{Name: everyone.Name}).Error
+		assert.NilError(t, err)
+		assert.Assert(t, 0 != group.ID)
+		assert.Equal(t, everyone.Name, group.Name)
+	})
 }
 
 func TestCreateGroup(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		everyone := models.Group{Name: "Everyone"}
 
-	everyone := models.Group{Name: "Everyone"}
+		err := CreateGroup(db, &everyone)
+		assert.NilError(t, err)
 
-	err := CreateGroup(db, &everyone)
-	assert.NilError(t, err)
-
-	group := everyone
-	assert.Assert(t, 0 != group.ID)
-	assert.Equal(t, everyone.Name, group.Name)
+		group := everyone
+		assert.Assert(t, 0 != group.ID)
+		assert.Equal(t, everyone.Name, group.Name)
+	})
 }
 
 func createGroups(t *testing.T, db *gorm.DB, groups ...models.Group) {
@@ -45,17 +45,18 @@ func createGroups(t *testing.T, db *gorm.DB, groups ...models.Group) {
 }
 
 func TestCreateGroupDuplicate(t *testing.T) {
-	var (
-		everyone  = models.Group{Name: "Everyone"}
-		engineers = models.Group{Name: "Engineering"}
-		product   = models.Group{Name: "Product"}
-	)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			everyone  = models.Group{Name: "Everyone"}
+			engineers = models.Group{Name: "Engineering"}
+			product   = models.Group{Name: "Product"}
+		)
 
-	db := setup(t)
-	createGroups(t, db, everyone, engineers, product)
+		createGroups(t, db, everyone, engineers, product)
 
-	err := CreateGroup(db, &models.Group{Name: "Everyone"})
-	assert.ErrorContains(t, err, "duplicate record")
+		err := CreateGroup(db, &models.Group{Name: "Everyone"})
+		assert.ErrorContains(t, err, "duplicate record")
+	})
 }
 
 func TestGetGroup(t *testing.T) {
@@ -95,48 +96,48 @@ func TestListGroups(t *testing.T) {
 }
 
 func TestDeleteGroup(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			everyone  = models.Group{Name: "Everyone"}
+			engineers = models.Group{Name: "Engineering"}
+			product   = models.Group{Name: "Product"}
+		)
 
-	var (
-		everyone  = models.Group{Name: "Everyone"}
-		engineers = models.Group{Name: "Engineering"}
-		product   = models.Group{Name: "Product"}
-	)
+		createGroups(t, db, everyone, engineers, product)
 
-	createGroups(t, db, everyone, engineers, product)
+		_, err := GetGroup(db, ByName(everyone.Name))
+		assert.NilError(t, err)
 
-	_, err := GetGroup(db, ByName(everyone.Name))
-	assert.NilError(t, err)
+		err = DeleteGroups(db, ByName(everyone.Name))
+		assert.NilError(t, err)
 
-	err = DeleteGroups(db, ByName(everyone.Name))
-	assert.NilError(t, err)
+		_, err = GetGroup(db, ByName(everyone.Name))
+		assert.Error(t, err, "record not found")
 
-	_, err = GetGroup(db, ByName(everyone.Name))
-	assert.Error(t, err, "record not found")
+		// deleting a nonexistent group should not fail
+		err = DeleteGroups(db, ByName(everyone.Name))
+		assert.NilError(t, err)
 
-	// deleting a nonexistent group should not fail
-	err = DeleteGroups(db, ByName(everyone.Name))
-	assert.NilError(t, err)
-
-	// deleting an group should not delete unrelated groups
-	_, err = GetGroup(db, ByName(engineers.Name))
-	assert.NilError(t, err)
+		// deleting an group should not delete unrelated groups
+		_, err = GetGroup(db, ByName(engineers.Name))
+		assert.NilError(t, err)
+	})
 }
 
 func TestRecreateGroupSameName(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			everyone  = models.Group{Name: "Everyone"}
+			engineers = models.Group{Name: "Engineering"}
+			product   = models.Group{Name: "Product"}
+		)
 
-	var (
-		everyone  = models.Group{Name: "Everyone"}
-		engineers = models.Group{Name: "Engineering"}
-		product   = models.Group{Name: "Product"}
-	)
+		createGroups(t, db, everyone, engineers, product)
 
-	createGroups(t, db, everyone, engineers, product)
+		err := DeleteGroups(db, ByName(everyone.Name))
+		assert.NilError(t, err)
 
-	err := DeleteGroups(db, ByName(everyone.Name))
-	assert.NilError(t, err)
-
-	err = CreateGroup(db, &models.Group{Name: everyone.Name})
-	assert.NilError(t, err)
+		err = CreateGroup(db, &models.Group{Name: everyone.Name})
+		assert.NilError(t, err)
+	})
 }

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -15,18 +15,18 @@ import (
 )
 
 func TestIdentity(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		bond := models.Identity{Name: "jbond@infrahq.com"}
 
-	bond := models.Identity{Name: "jbond@infrahq.com"}
+		err := db.Create(&bond).Error
+		assert.NilError(t, err)
 
-	err := db.Create(&bond).Error
-	assert.NilError(t, err)
-
-	var identity models.Identity
-	err = db.First(&identity, &models.Identity{Name: bond.Name}).Error
-	assert.NilError(t, err)
-	assert.Assert(t, 0 != identity.ID)
-	assert.Equal(t, bond.Name, identity.Name)
+		var identity models.Identity
+		err = db.First(&identity, &models.Identity{Name: bond.Name}).Error
+		assert.NilError(t, err)
+		assert.Assert(t, 0 != identity.ID)
+		assert.Equal(t, bond.Name, identity.Name)
+	})
 }
 
 func createIdentities(t *testing.T, db *gorm.DB, identities ...models.Identity) {
@@ -37,60 +37,61 @@ func createIdentities(t *testing.T, db *gorm.DB, identities ...models.Identity) 
 }
 
 func TestCreateDuplicateUser(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			bond   = models.Identity{Name: "jbond@infrahq.com"}
+			bourne = models.Identity{Name: "jbourne@infrahq.com"}
+			bauer  = models.Identity{Name: "jbauer@infrahq.com"}
+		)
 
-	var (
-		bond   = models.Identity{Name: "jbond@infrahq.com"}
-		bourne = models.Identity{Name: "jbourne@infrahq.com"}
-		bauer  = models.Identity{Name: "jbauer@infrahq.com"}
-	)
+		createIdentities(t, db, bond, bourne, bauer)
 
-	createIdentities(t, db, bond, bourne, bauer)
-
-	b := bond
-	b.ID = 0
-	err := CreateIdentity(db, &b)
-	assert.ErrorContains(t, err, "duplicate record")
+		b := bond
+		b.ID = 0
+		err := CreateIdentity(db, &b)
+		assert.ErrorContains(t, err, "duplicate record")
+	})
 }
 
 func TestGetIdentity(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			bond   = models.Identity{Name: "jbond@infrahq.com"}
+			bourne = models.Identity{Name: "jbourne@infrahq.com"}
+			bauer  = models.Identity{Name: "jbauer@infrahq.com"}
+		)
 
-	var (
-		bond   = models.Identity{Name: "jbond@infrahq.com"}
-		bourne = models.Identity{Name: "jbourne@infrahq.com"}
-		bauer  = models.Identity{Name: "jbauer@infrahq.com"}
-	)
+		createIdentities(t, db, bond, bourne, bauer)
 
-	createIdentities(t, db, bond, bourne, bauer)
-
-	identity, err := GetIdentity(db, ByName(bond.Name))
-	assert.NilError(t, err)
-	assert.Assert(t, 0 != identity.ID)
+		identity, err := GetIdentity(db, ByName(bond.Name))
+		assert.NilError(t, err)
+		assert.Assert(t, 0 != identity.ID)
+	})
 }
 
 func TestListIdentities(t *testing.T) {
-	db := setup(t)
-	var (
-		bond   = models.Identity{Name: "jbond@infrahq.com"}
-		bourne = models.Identity{Name: "jbourne@infrahq.com"}
-		bauer  = models.Identity{Name: "jbauer@infrahq.com"}
-	)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			bond   = models.Identity{Name: "jbond@infrahq.com"}
+			bourne = models.Identity{Name: "jbourne@infrahq.com"}
+			bauer  = models.Identity{Name: "jbauer@infrahq.com"}
+		)
 
-	createIdentities(t, db, bond, bourne, bauer)
+		createIdentities(t, db, bond, bourne, bauer)
 
-	t.Run("list all", func(t *testing.T) {
-		identities, err := ListIdentities(db)
-		assert.NilError(t, err)
-		expected := []models.Identity{bauer, bond, bourne}
-		assert.DeepEqual(t, identities, expected, cmpModelsIdentityShallow)
-	})
+		t.Run("list all", func(t *testing.T) {
+			identities, err := ListIdentities(db)
+			assert.NilError(t, err)
+			expected := []models.Identity{bauer, bond, bourne}
+			assert.DeepEqual(t, identities, expected, cmpModelsIdentityShallow)
+		})
 
-	t.Run("filter by name", func(t *testing.T) {
-		identities, err := ListIdentities(db, ByName(bourne.Name))
-		assert.NilError(t, err)
-		expected := []models.Identity{bourne}
-		assert.DeepEqual(t, identities, expected, cmpModelsIdentityShallow)
+		t.Run("filter by name", func(t *testing.T) {
+			identities, err := ListIdentities(db, ByName(bourne.Name))
+			assert.NilError(t, err)
+			expected := []models.Identity{bourne}
+			assert.DeepEqual(t, identities, expected, cmpModelsIdentityShallow)
+		})
 	})
 }
 
@@ -99,50 +100,50 @@ var cmpModelsIdentityShallow = cmp.Comparer(func(x, y models.Identity) bool {
 })
 
 func TestDeleteIdentity(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			bond   = models.Identity{Name: "jbond@infrahq.com"}
+			bourne = models.Identity{Name: "jbourne@infrahq.com"}
+			bauer  = models.Identity{Name: "jbauer@infrahq.com"}
+		)
 
-	var (
-		bond   = models.Identity{Name: "jbond@infrahq.com"}
-		bourne = models.Identity{Name: "jbourne@infrahq.com"}
-		bauer  = models.Identity{Name: "jbauer@infrahq.com"}
-	)
+		createIdentities(t, db, bond, bourne, bauer)
 
-	createIdentities(t, db, bond, bourne, bauer)
+		_, err := GetIdentity(db, ByName(bond.Name))
+		assert.NilError(t, err)
 
-	_, err := GetIdentity(db, ByName(bond.Name))
-	assert.NilError(t, err)
+		err = DeleteIdentities(db, ByName(bond.Name))
+		assert.NilError(t, err)
 
-	err = DeleteIdentities(db, ByName(bond.Name))
-	assert.NilError(t, err)
+		_, err = GetIdentity(db, ByName(bond.Name))
+		assert.Error(t, err, "record not found")
 
-	_, err = GetIdentity(db, ByName(bond.Name))
-	assert.Error(t, err, "record not found")
+		// deleting a nonexistent identity should not fail
+		err = DeleteIdentities(db, ByName(bond.Name))
+		assert.NilError(t, err)
 
-	// deleting a nonexistent identity should not fail
-	err = DeleteIdentities(db, ByName(bond.Name))
-	assert.NilError(t, err)
-
-	// deleting a identity should not delete unrelated identities
-	_, err = GetIdentity(db, ByName(bourne.Name))
-	assert.NilError(t, err)
+		// deleting a identity should not delete unrelated identities
+		_, err = GetIdentity(db, ByName(bourne.Name))
+		assert.NilError(t, err)
+	})
 }
 
 func TestReCreateIdentitySameName(t *testing.T) {
-	db := setup(t)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var (
+			bond   = models.Identity{Name: "jbond@infrahq.com"}
+			bourne = models.Identity{Name: "jbourne@infrahq.com"}
+			bauer  = models.Identity{Name: "jbauer@infrahq.com"}
+		)
 
-	var (
-		bond   = models.Identity{Name: "jbond@infrahq.com"}
-		bourne = models.Identity{Name: "jbourne@infrahq.com"}
-		bauer  = models.Identity{Name: "jbauer@infrahq.com"}
-	)
+		createIdentities(t, db, bond, bourne, bauer)
 
-	createIdentities(t, db, bond, bourne, bauer)
+		err := DeleteIdentities(db, ByName(bond.Name))
+		assert.NilError(t, err)
 
-	err := DeleteIdentities(db, ByName(bond.Name))
-	assert.NilError(t, err)
-
-	err = CreateIdentity(db, &models.Identity{Name: bond.Name})
-	assert.NilError(t, err)
+		err = CreateIdentity(db, &models.Identity{Name: bond.Name})
+		assert.NilError(t, err)
+	})
 }
 
 func TestAssignIdentityToGroups(t *testing.T) {
@@ -169,48 +170,48 @@ func TestAssignIdentityToGroups(t *testing.T) {
 		},
 	}
 
-	db := setup(t)
-
-	for i, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			// setup identity
-			identity := &models.Identity{Name: fmt.Sprintf("foo+%d@example.com", i)}
-			err := CreateIdentity(db, identity)
-			assert.NilError(t, err)
-
-			// setup identity's groups
-			for _, gn := range test.StartingGroups {
-				g, err := GetGroup(db, ByName(gn))
-				if errors.Is(err, internal.ErrNotFound) {
-					g = &models.Group{Name: gn}
-					err = CreateGroup(db, g)
-				}
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		for i, test := range tests {
+			t.Run(test.Name, func(t *testing.T) {
+				// setup identity
+				identity := &models.Identity{Name: fmt.Sprintf("foo+%d@example.com", i)}
+				err := CreateIdentity(db, identity)
 				assert.NilError(t, err)
-				identity.Groups = append(identity.Groups, *g)
-			}
-			err = SaveIdentity(db, identity)
-			assert.NilError(t, err)
 
-			// setup provuderUser record
-			provider := InfraProvider(db)
-			pu, err := CreateProviderUser(db, provider, identity)
-			assert.NilError(t, err)
+				// setup identity's groups
+				for _, gn := range test.StartingGroups {
+					g, err := GetGroup(db, ByName(gn))
+					if errors.Is(err, internal.ErrNotFound) {
+						g = &models.Group{Name: gn}
+						err = CreateGroup(db, g)
+					}
+					assert.NilError(t, err)
+					identity.Groups = append(identity.Groups, *g)
+				}
+				err = SaveIdentity(db, identity)
+				assert.NilError(t, err)
 
-			pu.Groups = test.ExistingGroups
-			err = UpdateProviderUser(db, pu)
-			assert.NilError(t, err)
+				// setup provuderUser record
+				provider := InfraProvider(db)
+				pu, err := CreateProviderUser(db, provider, identity)
+				assert.NilError(t, err)
 
-			err = AssignIdentityToGroups(db, identity, provider, test.IncomingGroups)
-			assert.NilError(t, err)
+				pu.Groups = test.ExistingGroups
+				err = UpdateProviderUser(db, pu)
+				assert.NilError(t, err)
 
-			// reload identity and check groups
-			id, err := GetIdentity(db.Preload("Groups"), ByID(identity.ID))
-			assert.NilError(t, err)
-			groupNames := slice.Map[models.Group, string](id.Groups, func(g models.Group) string {
-				return g.Name
+				err = AssignIdentityToGroups(db, identity, provider, test.IncomingGroups)
+				assert.NilError(t, err)
+
+				// reload identity and check groups
+				id, err := GetIdentity(db.Preload("Groups"), ByID(identity.ID))
+				assert.NilError(t, err)
+				groupNames := slice.Map[models.Group, string](id.Groups, func(g models.Group) string {
+					return g.Name
+				})
+
+				assert.DeepEqual(t, slice.Sort(groupNames), slice.Sort(test.ExpectedGroups))
 			})
-
-			assert.DeepEqual(t, slice.Sort(groupNames), slice.Sort(test.ExpectedGroups))
-		})
-	}
+		}
+	})
 }


### PR DESCRIPTION
Follow up to #1922

Applies the new helper to all tests.

Best viewed with [hide whitespace](https://github.com/infrahq/infra/pull/1989/files?diff=split&w=1).