### PR TITLE
fix: optional grant role

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -30,8 +30,8 @@ type Grant struct {
 	User     string `mapstructure:"user" validate:"excluded_with=Group,excluded_with=Machine"`
 	Group    string `mapstructure:"group" validate:"excluded_with=User,excluded_with=Machine"`
 	Machine  string `mapstructure:"machine" validate:"excluded_with=User,excluded_with=Group"` // deprecated
-	Role     string `mapstructure:"role" validate:"required"`
 	Resource string `mapstructure:"resource" validate:"required"`
+	Role     string `mapstructure:"role"`
 }
 
 type User struct {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Grant role is optional. In the case a grant does not have a role, Infra will grant it `connect` privileges, allowing the user to authenticate with Infra but does not configure any authorization for the destination infrastructure