### PR TITLE
maintain: update cli outputs

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -90,7 +90,7 @@ func printTable(data interface{}, out io.Writer) {
 
 // Creates a new API Client from the current config
 func defaultAPIClient() (*api.Client, error) {
-	config, err := readHostConfig("")
+	config, err := readHostConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -143,7 +143,7 @@ func writeConfig(config *ClientConfig) error {
 }
 
 func currentHostConfig() (*ClientHostConfig, error) {
-	return readHostConfig("")
+	return readHostConfig()
 }
 
 // Save (create or update) the current hostconfig
@@ -174,18 +174,14 @@ func saveHostConfig(hostConfig ClientHostConfig) error {
 	return nil
 }
 
-func readHostConfig(host string) (*ClientHostConfig, error) {
+func readHostConfig() (*ClientHostConfig, error) {
 	cfg, err := readConfig()
 	if err != nil {
 		return nil, err
 	}
 
 	for i, c := range cfg.Hosts {
-		if len(host) == 0 && c.Current {
-			return &cfg.Hosts[i], nil
-		}
-
-		if c.Host == host {
+		if c.Current {
 			return &cfg.Hosts[i], nil
 		}
 	}

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -55,7 +55,7 @@ func info(cli *CLI) error {
 		return err
 	}
 
-	fmt.Fprintf(w, "Identity:\t %s (%s)\n", identity.Name, identity.ID)
+	fmt.Fprintf(w, "User:\t %s (%s)\n", identity.Name, identity.ID)
 
 	if config.ProviderID != 0 {
 		provider, err := client.GetProvider(config.ProviderID)

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -167,9 +167,9 @@ $ infra users remove janedoe@example.com`,
 				if err != nil {
 					return err
 				}
-			}
 
-			fmt.Fprintf(cli.Stderr, "Deleted user %q\n", name)
+				cli.Output("Removed user %q", name)
+			}
 
 			return nil
 		},


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Update `infra providers` outputs to also print the OIDC URL for additional context. Removing providers should only say "removed" if something was found and removed. If nothing is found, it should not say it's been removed. In the future, not finding a match may error