### PR TITLE
fix: update password before saving session configs

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -34,29 +33,6 @@ type ClientHostConfig struct {
 // checks if user is logged in to the given session (ClientHostConfig)
 func (c *ClientHostConfig) isLoggedIn() bool {
 	return c.AccessKey != "" && c.Name != "" && c.PolymorphicID != ""
-}
-
-// checks if user is logged in to the current session
-func isLoggedInCurrent() bool {
-	return getLoggedInIdentityName() != ""
-}
-
-// Retrieves current logged in user, empty if logged out
-func getLoggedInIdentityName() string {
-	hostConfig, err := currentHostConfig()
-	if err != nil {
-		logging.S.Debug(err)
-		return ""
-	}
-	if hostConfig == nil {
-		logging.S.Debug("No saved sessions found.")
-		return ""
-	}
-	if !hostConfig.isLoggedIn() {
-		logging.S.Debug("User is not logged in.")
-		return ""
-	}
-	return hostConfig.Name
 }
 
 func (c *ClientHostConfig) isExpired() bool {

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -3,6 +3,11 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/muesli/termenv"
+
+	"github.com/infrahq/infra/internal/logging"
 )
 
 // internal errors
@@ -29,31 +34,23 @@ var (
 	ErrTLSNotVerified = errors.New(`The authenticity of the host can't be established.`)
 )
 
-// User facing variable errors
-type FailedLoginError struct {
-	LoggedInIdentity string
-	LoginMethod      loginMethod
+type LoginError struct {
+	Message string
 }
 
-func (e *FailedLoginError) Error() string {
-	var errorReason string
+func (e *LoginError) Error() string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Login error: %s.", e.Message)
 
-	switch e.LoginMethod {
-	case localLogin:
-		errorReason = "your id or password may be incorrect"
-	case accessKeyLogin:
-		errorReason = "your access key is may not be valid"
-	case oidcLogin:
-		errorReason = "could not login to infra through this connected identity provider"
+	hostConfig, err := currentHostConfig()
+	if err != nil {
+		logging.S.Debugf("current host config: %v", err)
+		return sb.String()
 	}
 
-	msg := fmt.Sprintf("Login failed: %s.", errorReason)
-	if (isLoggedInCurrent() && e.LoggedInIdentity == "") || (!isLoggedInCurrent() && e.LoggedInIdentity != "") {
-		panic("LoggedInIdentity cannot be set unless user is logged in")
-	}
-	if isLoggedInCurrent() {
-		msg += fmt.Sprintf(" You are still logged in as [%s].", e.LoggedInIdentity)
+	if hostConfig.isLoggedIn() {
+		fmt.Fprintf(&sb, " Your session as %s to %s is still active.", termenv.String(hostConfig.Name).Bold().String(), termenv.String(hostConfig.Host).Bold().String())
 	}
 
-	return msg
+	return sb.String()
 }

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -18,17 +18,6 @@ var (
 	ErrUserNotFound      = errors.New(`no user found with this name`)
 )
 
-// Standard panic messages: it should not be possible for a user to arrive at this state - hence there is a bug in the code.
-var (
-	DuplicateEntryPanic = "more than one %s found with name '%s', which should not be possible"
-)
-
-// User facing messages: to let user know the state they are in
-var (
-	NoProviderFoundMsg = "No provider found with name %s"
-	NoUserFoundMsg     = "No user found with name %s"
-)
-
 // User facing constant errors: to let user know why their command failed. Not meant for a stack trace, but a readable output of the reason for failure.
 var (
 	ErrTLSNotVerified = errors.New(`The authenticity of the host can't be established.`)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Login will prompt user to change their password if server requires a new password. This should be set and updated before saving the session to disk. Otherwise the user can interrupt the password update and still end up with a valid session.

Update login errors to not inform users of their previous session. It's not possible to know definitively whether the session is valid from the client alone so to avoid misleading the user, omit this message completely.