### PR TITLE
maintain: remove BUILDVERSION from helm target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test/update:
 
 .PHONY: helm
 helm:
-	helm package -d $@ helm/charts/* --version $(BUILDVERSION) --app-version $(IMAGEVERSION)
+	helm package -d $@ helm/charts/* --app-version $(IMAGEVERSION)
 	helm repo index helm
 
 helm/lint:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`BUILDVERSION` was removed in an earlier commit. It's not necessary to set `--version` as it's set statically in `Chart.yaml` and incremented by the release