### PR TITLE
improve: refactor api migrator to work nice with redirects

### DIFF
--- a/internal/server/apimigrator_test.go
+++ b/internal/server/apimigrator_test.go
@@ -200,7 +200,7 @@ func TestRedirectOfRequestAndResponseRewriteWithStackedRedirects(t *testing.T) {
 	t.Run("v0.1.3", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/awesometest?vegetableCount=12", nil)
-		req.Header.Add("Infra-Version", "0.1.2")
+		req.Header.Add("Infra-Version", "0.1.3")
 		router.ServeHTTP(resp, req)
 
 		assert.Equal(t, resp.Result().StatusCode, 200)
@@ -210,6 +210,24 @@ func TestRedirectOfRequestAndResponseRewriteWithStackedRedirects(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, lr.Loafers, 5)
 		assert.Equal(t, lr.Sneakers, 3)
+	})
+	t.Run("living in the past: select the 0.1.3 path for v0.1.4", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/superbettertest?vegetableCount=12", nil)
+		req.Header.Add("Infra-Version", "0.1.4")
+		router.ServeHTTP(resp, req)
+
+		assert.Equal(t, resp.Result().StatusCode, 404)
+	})
+	t.Run("living in the future: select the 0.1.3 path for v0.1.2", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/awesometest?vegetableCount=12", nil)
+		req.Header.Add("Infra-Version", "0.1.2")
+		router.ServeHTTP(resp, req)
+
+		// I guess this is okay.
+		// As long as the client knows how to handle the request this will work.
+		assert.Equal(t, resp.Result().StatusCode, 200)
 	})
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -233,7 +233,7 @@ func TestListKeys(t *testing.T) {
 
 	t.Run("no version header", func(t *testing.T) {
 		resp := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "/api/access-keys", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/access-keys", nil)
 		assert.NilError(t, err)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 
@@ -249,7 +249,7 @@ func TestListKeys(t *testing.T) {
 
 	t.Run("old version upgrades", func(t *testing.T) {
 		resp := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "/api/access-keys", nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/access-keys", nil)
 		assert.NilError(t, err)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", "0.12.2")
@@ -655,7 +655,7 @@ func TestAPI_CreateGrantV0_12_2_Success(t *testing.T) {
 		}`)
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodPost, "/api/grants", reqBody)
+	req, err := http.NewRequest(http.MethodPost, "/v1/grants", reqBody)
 	assert.NilError(t, err)
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 	req.Header.Add("Infra-Version", "0.12.2")
@@ -690,7 +690,7 @@ func TestAPI_CreateGrantV0_12_2_Success(t *testing.T) {
 
 	runStep(t, "grant exists", func(t *testing.T) {
 		resp := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "/api/grants/"+newGrant.ID.String(), nil)
+		req, err := http.NewRequest(http.MethodGet, "/v1/grants/"+newGrant.ID.String(), nil)
 		assert.NilError(t, err)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", "0.12.2")
@@ -710,7 +710,7 @@ func TestAPI_ListGrantsV0_12_2(t *testing.T) {
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodGet, "/api/grants?privilege=admin", nil)
+	req, err := http.NewRequest(http.MethodGet, "/v1/grants?privilege=admin", nil)
 	assert.NilError(t, err)
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 	req.Header.Add("Infra-Version", "0.12.2")


### PR DESCRIPTION
## Summary

The general idea is that we build the list of redirect/rewrite middleware backwards from the defined migrations, and this lets us do the right thing when we encounter redirects etc. Redirects now basically fork the path and end up with multiple paths, and all of them get bound to gin. Before there was no way to make each path have its own middleware, but now each is selected so it will exactly have the correct versioning middleware for that particular path/version

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades
