### PR TITLE
fix: remove unneeded jwt nonce

### DIFF
--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -3,5 +3,4 @@ package claims
 type Custom struct {
 	Name   string   `json:"name" validate:"required"`
 	Groups []string `json:"groups"`
-	Nonce  string   `json:"nonce" validate:"required"`
 }

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -120,7 +120,6 @@ func generateJWT(priv *jose.JSONWebKey, email string, expiry time.Time) (string,
 	custom := claims.Custom{
 		Name:   email,
 		Groups: []string{"developers"},
-		Nonce:  "randomstring",
 	}
 
 	raw, err := jwt.Signed(signer).Claims(cl).Claims(custom).CompactSerialize()

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -9,7 +9,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/claims"
-	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -41,11 +40,6 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 		return "", err
 	}
 
-	nonce, err := generate.CryptoRandom(10)
-	if err != nil {
-		return "", err
-	}
-
 	now := time.Now().UTC()
 
 	claim := jwt.Claims{
@@ -57,7 +51,6 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 	custom := claims.Custom{
 		Name:   identity.Name,
 		Groups: groups,
-		Nonce:  nonce,
 	}
 
 	raw, err := jwt.Signed(signer).Claims(claim).Claims(custom).CompactSerialize()


### PR DESCRIPTION
## Summary
This nonce claim is not needed and never used, it is from a very early version of Infra. The nonce is useful when preventing replay attacks (ex: an implicit OAuth flow), but not useful on JWTs that will be used repeatedly. 

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2014
