### PR TITLE
maintain: remove http path, method from api errors

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -108,7 +108,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("bad request", func(t *testing.T) {
 		_, err := get[stubResponse](c, "/bad")
-		assert.Error(t, err, `GET /bad failed: bad request: it failed because`)
+		assert.Error(t, err, `bad request: it failed because`)
 		req := <-requestCh
 		assert.Equal(t, req.Method, http.MethodGet)
 		assert.Equal(t, req.URL.Path, "/bad")
@@ -120,7 +120,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("server error", func(t *testing.T) {
 		_, err := get[stubResponse](c, "/invalid")
-		assert.Error(t, err, `GET /invalid failed: 500 internal server error`)
+		assert.Error(t, err, `500 internal server error`)
 		req := <-requestCh
 		assert.Equal(t, req.Method, http.MethodGet)
 		assert.Equal(t, req.URL.Path, "/invalid")

--- a/api/errors.go
+++ b/api/errors.go
@@ -9,6 +9,10 @@ import (
 // Error is used as the response body for failed HTTP requests. It is also
 // the error returned by api.Client methods when the request fails.
 type Error struct {
+	// Method is the HTTP request method.
+	Method string `json:"method"`
+	// Path is the HTTP request path.
+	Path string `json:"path"`
 	// Code is the HTTP status of the response.
 	Code int32 `json:"code"`
 	// Message contains the full text of the failure as a single string. The

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -163,6 +163,12 @@
           },
           "message": {
             "type": "string"
+          },
+          "method": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
           }
         }
       },

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -55,22 +55,6 @@ func mustBeLoggedIn() error {
 	return nil
 }
 
-func infraHomeDir() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	infraDir := filepath.Join(homeDir, ".infra")
-
-	err = os.MkdirAll(infraDir, os.ModePerm)
-	if err != nil {
-		return "", err
-	}
-
-	return infraDir, nil
-}
-
 func printTable(data interface{}, out io.Writer) {
 	table := tableprinter.New(out)
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -90,7 +90,7 @@ func printTable(data interface{}, out io.Writer) {
 
 // Creates a new API Client from the current config
 func defaultAPIClient() (*api.Client, error) {
-	config, err := readHostConfig()
+	config, err := currentHostConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -118,10 +118,6 @@ func writeConfig(config *ClientConfig) error {
 	return nil
 }
 
-func currentHostConfig() (*ClientHostConfig, error) {
-	return readHostConfig()
-}
-
 // Save (create or update) the current hostconfig
 func saveHostConfig(hostConfig ClientHostConfig) error {
 	config, err := readOrCreateClientConfig()
@@ -150,7 +146,7 @@ func saveHostConfig(hostConfig ClientHostConfig) error {
 	return nil
 }
 
-func readHostConfig() (*ClientHostConfig, error) {
+func currentHostConfig() (*ClientHostConfig, error) {
 	cfg, err := readConfig()
 	if err != nil {
 		return nil, err

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -522,7 +522,7 @@ func promptServer(options loginCmdOptions) (string, error) {
 		return "", fmt.Errorf("Non-interactive login requires the [SERVER] argument")
 	}
 
-	config, err := readOrCreateClientConfig()
+	config, err := readConfig()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Move HTTP Path and Method to struct fields so they can still be referenced but keep them out of the error message.

Refactor `cmd/config.go`, removing duplication since some functions have been refactored

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2009
