### PR TITLE
improve(docs): update ingress config examples

### DIFF
--- a/docs/reference/helm-chart.md
+++ b/docs/reference/helm-chart.md
@@ -108,6 +108,8 @@ server:
 # example values.yaml
 ---
 server:
+  service:
+    type: ClusterIP
   ingress:
     enabled: true
     hosts:
@@ -130,6 +132,8 @@ server:
 # example values.yaml
 ---
 server:
+  service:
+    type: ClusterIP
   ingress:
     enabled: true
     hosts:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Explicitly set service type to ClusterIP when configuring server Ingress. By default, server users service type LoadBalancer. This is unnecessary/undesirable when using Ingress so set it to ClusterIP instead

Resolves #2010