### PR TITLE
fix: allow password and accesskey on config user

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -36,10 +36,10 @@ type Grant struct {
 
 type User struct {
 	Name      string `mapstructure:"name" validate:"excluded_with=Email"`
-	AccessKey string `mapstructure:"accessKey" validate:"excluded_with=Password"`
-	Password  string `mapstructure:"password" validate:"excluded_with=AccessKey"`
+	AccessKey string `mapstructure:"accessKey"`
+	Password  string `mapstructure:"password"`
 
-	Email string `mapstructure:"email" validate:"excluded_with=Name"`
+	Email string `mapstructure:"email" validate:"excluded_with=Name"` // deprecated
 }
 
 type Config struct {

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -1,10 +1,15 @@
 package server
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
+	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/yaml.v2"
+	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
@@ -385,6 +390,60 @@ func TestLoadConfigWithProviders(t *testing.T) {
 	assert.Equal(t, models.EncryptedAtRest("client-secret"), provider.ClientSecret)
 }
 
+func TestLoadConfigWithUsers(t *testing.T) {
+	s := setupServer(t)
+
+	config := Config{
+		Users: []User{
+			{
+				Name: "bob",
+			},
+			{
+				Name:     "alice",
+				Password: "password",
+			},
+			{
+				Name:      "sue",
+				AccessKey: "aaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb",
+			},
+			{
+				Name:      "jim",
+				Password:  "password",
+				AccessKey: "bbbbbbbbbb.bbbbbbbbbbbbbbbbbbbbbbbb",
+			},
+		},
+	}
+
+	err := s.loadConfig(config)
+	assert.NilError(t, err)
+
+	user, _, _, err := getTestUserDetails(s.db, "bob")
+	assert.NilError(t, err)
+	assert.Equal(t, "bob", user.Name)
+
+	user, creds, _, err := getTestUserDetails(s.db, "alice")
+	assert.NilError(t, err)
+	assert.Equal(t, "alice", user.Name)
+	err = bcrypt.CompareHashAndPassword(creds.PasswordHash, []byte("password"))
+	assert.NilError(t, err)
+
+	user, _, key, err := getTestUserDetails(s.db, "sue")
+	assert.NilError(t, err)
+	assert.Equal(t, "sue", user.Name)
+	assert.Equal(t, key.KeyID, "aaaaaaaaaa")
+	chksm := sha256.Sum256([]byte("bbbbbbbbbbbbbbbbbbbbbbbb"))
+	assert.Equal(t, bytes.Compare(key.SecretChecksum, chksm[:]), 0) // 0 means the byte slices are equal
+
+	user, creds, key, err = getTestUserDetails(s.db, "jim")
+	assert.NilError(t, err)
+	assert.Equal(t, "jim", user.Name)
+	err = bcrypt.CompareHashAndPassword(creds.PasswordHash, []byte("password"))
+	assert.NilError(t, err)
+	assert.Equal(t, key.KeyID, "bbbbbbbbbb")
+	chksm = sha256.Sum256([]byte("bbbbbbbbbbbbbbbbbbbbbbbb"))
+	assert.Equal(t, bytes.Compare(key.SecretChecksum, chksm[:]), 0) // 0 means the byte slices are equal
+}
+
 func TestLoadConfigWithUserGrants_OptionalRole(t *testing.T) {
 	s := setupServer(t)
 
@@ -472,6 +531,7 @@ func TestLoadConfigWithGroupGrants(t *testing.T) {
 	assert.Equal(t, "admin", grant.Privilege)
 	assert.Equal(t, "test-cluster", grant.Resource)
 }
+
 func TestLoadConfigPruneConfig(t *testing.T) {
 	s := setupServer(t)
 
@@ -713,4 +773,28 @@ func TestLoadConfigUpdate(t *testing.T) {
 	var group models.Group
 	err = s.db.Where("name = ?", "Everyone").First(&group).Error
 	assert.NilError(t, err)
+}
+
+// getTestUserDetails gets the attributes of a user created from a config file
+func getTestUserDetails(db *gorm.DB, name string) (*models.Identity, *models.Credential, *models.AccessKey, error) {
+	var user models.Identity
+	var credential models.Credential
+	var accessKey models.AccessKey
+
+	err := db.Where("name = ?", name).First(&user).Error
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	err = db.Where("identity_id = ?", user.ID).First(&credential).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil, nil, err
+	}
+
+	err = db.Where("issued_for = ?", user.ID).First(&accessKey).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil, nil, err
+	}
+
+	return &user, &credential, &accessKey, nil
 }


### PR DESCRIPTION
## Summary
It is now valid for a user identity to be assigned both a password and an access key in config. Updating to allow that and adding some more tests around config users.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1958 
