### PR TITLE
fix: unset CurrentContext on infra logout

### DIFF
--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -240,6 +240,10 @@ func clearKubeconfig() error {
 		delete(kubeConfig.AuthInfos, c)
 	}
 
+	if strings.HasPrefix(kubeConfig.CurrentContext, "infra:") {
+		kubeConfig.CurrentContext = ""
+	}
+
 	kubeConfigFilename := defaultConfig.ConfigAccess().GetDefaultFilename()
 	if err := clientcmd.WriteToFile(kubeConfig, kubeConfigFilename); err != nil {
 		return err

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -28,7 +28,7 @@ func TestLogout(t *testing.T) {
 	kubeConfigPath := filepath.Join(homeDir, "kube.config")
 	t.Setenv("KUBECONFIG", kubeConfigPath)
 
-	setup := func(t *testing.T) testFields {
+	setup := func(t *testing.T, currentContext string) testFields {
 		var count int32
 		handler := func(resp http.ResponseWriter, req *http.Request) {
 			if req.URL.Path != "/api/logout" {
@@ -69,6 +69,7 @@ func TestLogout(t *testing.T) {
 		assert.NilError(t, err)
 
 		kubeCfg := clientcmdapi.Config{
+			CurrentContext: currentContext,
 			Clusters: map[string]*clientcmdapi.Cluster{
 				"keep:not-infra": {Server: "https://keep:8080"},
 				"infra:prod":     {Server: "https://infraprod:8080"},
@@ -91,7 +92,7 @@ func TestLogout(t *testing.T) {
 		}
 	}
 
-	setupError := func(t *testing.T) testFields {
+	setupError := func(t *testing.T, currentContext string) testFields {
 		var count int32
 		handler := func(resp http.ResponseWriter, req *http.Request) {
 			if req.URL.Path != "/api/logout" {
@@ -123,6 +124,7 @@ func TestLogout(t *testing.T) {
 		assert.NilError(t, err)
 
 		kubeCfg := clientcmdapi.Config{
+			CurrentContext: currentContext,
 			Clusters: map[string]*clientcmdapi.Cluster{
 				"keep:not-infra": {Server: "https://keep:8080"},
 				"infra:prod":     {Server: "https://infraprod:8080"},
@@ -158,7 +160,7 @@ func TestLogout(t *testing.T) {
 	}
 
 	t.Run("default", func(t *testing.T) {
-		testFields := setup(t)
+		testFields := setup(t, "infra:prod")
 		err := Run(context.Background(), "logout")
 		assert.NilError(t, err)
 
@@ -178,8 +180,53 @@ func TestLogout(t *testing.T) {
 		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
 	})
 
+	t.Run("current infra", func(t *testing.T) {
+		testFields := setup(t, "infra:prod")
+		err := Run(context.Background(), "logout")
+		assert.NilError(t, err)
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(testFields.count), "calls to API")
+
+		updatedCfg, err := readConfig()
+		assert.NilError(t, err)
+
+		expected := testFields.config
+		expected.Hosts[0].AccessKey = ""
+		expected.Hosts[0].Name = ""
+		expected.Hosts[0].PolymorphicID = ""
+		assert.DeepEqual(t, &expected, updatedCfg)
+
+		updatedKubeCfg, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+	})
+
+	t.Run("current non-infra", func(t *testing.T) {
+		testFields := setup(t, "keep:non-infra")
+		err := Run(context.Background(), "logout")
+		assert.NilError(t, err)
+
+		assert.Equal(t, int32(1), atomic.LoadInt32(testFields.count), "calls to API")
+
+		updatedCfg, err := readConfig()
+		assert.NilError(t, err)
+
+		expected := testFields.config
+		expected.Hosts[0].AccessKey = ""
+		expected.Hosts[0].Name = ""
+		expected.Hosts[0].PolymorphicID = ""
+		assert.DeepEqual(t, &expected, updatedCfg)
+
+		kubeconfig := expectedKubeCfg
+		kubeconfig.CurrentContext = "keep:non-infra"
+
+		updatedKubeCfg, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+		assert.DeepEqual(t, kubeconfig, updatedKubeCfg, cmpopts.EquateEmpty())
+	})
+
 	t.Run("with clear", func(t *testing.T) {
-		testFields := setup(t)
+		testFields := setup(t, "infra:prod")
 		err := Run(context.Background(), "logout", "--clear")
 		assert.NilError(t, err)
 
@@ -197,7 +244,7 @@ func TestLogout(t *testing.T) {
 	})
 
 	t.Run("with all", func(t *testing.T) {
-		testFields := setup(t)
+		testFields := setup(t, "infra:prod")
 		err := Run(context.Background(), "logout", "--all")
 		assert.NilError(t, err)
 
@@ -221,7 +268,7 @@ func TestLogout(t *testing.T) {
 	})
 
 	t.Run("with clear all", func(t *testing.T) {
-		testFields := setup(t)
+		testFields := setup(t, "infra:prod")
 		err := Run(context.Background(), "logout", "--clear", "--all")
 		assert.NilError(t, err)
 
@@ -239,7 +286,7 @@ func TestLogout(t *testing.T) {
 	})
 
 	t.Run("with one and all", func(t *testing.T) {
-		testFields := setup(t)
+		testFields := setup(t, "infra:prod")
 		err := Run(context.Background(), "logout", testFields.serverURLs[0], "--all")
 		assert.Error(t, err, "Argument [SERVER] and flag [--all] cannot be both specified.")
 
@@ -251,7 +298,7 @@ func TestLogout(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
-		testFields := setupError(t)
+		testFields := setupError(t, "infra:prod")
 		err := Run(context.Background(), "logout", testFields.serverURLs[0])
 		assert.NilError(t, err)
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Unset the current kubeconfig context if it's a infra context on logout. Otherwise leave it alone

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1855 
