### PR TITLE
improve: require Infra-Version header

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: readmeio/rdme@7.2.0
         with:
-          rdme: openapi ./docs/api/openapi3.json --key=${{ secrets.README_API_KEY }} --id=624662df6803f800981a5464
+          rdme: openapi ./docs/api/openapi3.json --key=${{ secrets.README_API_KEY }} --version==${{ needs.release-please.outputs.release_name }}
 
   docs:
     runs-on: ubuntu-latest

--- a/docs/api/guidelines.md
+++ b/docs/api/guidelines.md
@@ -81,6 +81,15 @@ resources which do not have deep, nested hierarchies. As a rule of thumb,
 if modifying a child resource also requires modifying the parent resource,
 you should probably make your resource higher up in the hierarchy.
 
+## Version Control
+
+The Infra API is versioned. Requests to the API must contain a header named "Infra-Version".
+The best practice is to set this to the version matching the API docs reference you're using, or the version of the server you're using.
+Once you set this value you can forget about it until you want to use features from newer API versions.
+A valid version header looks like this:
+
+    Infra-Version: 0.13.0
+
 ## Method Calls
 
 Method calls are the 'verbs' which determine how to interact with resources. Our API uses standard CRUD (Create, Read,

--- a/docs/api/guidelines.md
+++ b/docs/api/guidelines.md
@@ -81,15 +81,6 @@ resources which do not have deep, nested hierarchies. As a rule of thumb,
 if modifying a child resource also requires modifying the parent resource,
 you should probably make your resource higher up in the hierarchy.
 
-## Version Control
-
-The Infra API is versioned. Requests to the API must contain a header named "Infra-Version".
-The best practice is to set this to the version matching the API docs reference you're using, or the version of the server you're using.
-Once you set this value you can forget about it until you want to use features from newer API versions.
-A valid version header looks like this:
-
-    Infra-Version: 0.13.0
-
 ## Method Calls
 
 Method calls are the 'verbs' which determine how to interact with resources. Our API uses standard CRUD (Create, Read,

--- a/docs/api/making-requests.md
+++ b/docs/api/making-requests.md
@@ -1,0 +1,11 @@
+# Making API Requests
+
+## Version Control
+
+The Infra API is versioned. Requests to the API must contain a header named "Infra-Version".
+The best practice is to set this to the version matching the API docs reference you're using, or the version of the server you're using.
+Once you set this value you can forget about it until you want to use features from newer API versions.
+A valid version header looks like this:
+
+    Infra-Version: 0.13.0
+

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -699,7 +699,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "Infra API",
-    "version": "0.13.2"
+    "version": "0.13.3+dev"
   },
   "paths": {
     "/api/access-keys": {
@@ -713,7 +713,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -814,7 +814,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -936,7 +936,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -1033,7 +1033,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -1130,7 +1130,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -1263,7 +1263,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -1358,7 +1358,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -1453,7 +1453,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -1598,7 +1598,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -1721,7 +1721,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -1843,7 +1843,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -1938,7 +1938,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2035,7 +2035,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2136,7 +2136,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2238,7 +2238,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2335,7 +2335,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2473,7 +2473,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2558,7 +2558,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2650,7 +2650,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2768,7 +2768,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2863,7 +2863,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -2958,7 +2958,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -3088,7 +3088,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -3171,7 +3171,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -3279,7 +3279,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -3364,7 +3364,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -3478,7 +3478,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -3583,7 +3583,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -3678,7 +3678,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -3773,7 +3773,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
@@ -3888,7 +3888,7 @@
             "required": true,
             "schema": {
               "description": "Version of the API being requested",
-              "example": "0.13.2+dev",
+              "example": "0.13.3+dev",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -708,6 +708,17 @@
         "operationId": "ListAccessKeys",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "query",
             "name": "user_id",
@@ -796,6 +807,19 @@
       "post": {
         "description": "CreateAccessKey",
         "operationId": "CreateAccessKey",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -907,6 +931,17 @@
         "operationId": "DeleteAccessKey",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
@@ -993,6 +1028,17 @@
         "operationId": "ListDestinations",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "in": "query",
             "name": "name",
             "schema": {
@@ -1077,6 +1123,19 @@
       "post": {
         "description": "CreateDestination",
         "operationId": "CreateDestination",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1199,6 +1258,17 @@
         "operationId": "DeleteDestination",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
@@ -1283,6 +1353,17 @@
         "operationId": "GetDestination",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
@@ -1366,6 +1447,17 @@
         "description": "UpdateDestination",
         "operationId": "UpdateDestination",
         "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
           {
             "example": "4yJ3n3D8E2",
             "in": "path",
@@ -1501,6 +1593,17 @@
         "operationId": "ListGrants",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "query",
             "name": "user",
@@ -1611,6 +1714,19 @@
       "post": {
         "description": "CreateGrant",
         "operationId": "CreateGrant",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -1722,6 +1838,17 @@
         "operationId": "DeleteGrant",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
@@ -1805,6 +1932,17 @@
         "description": "GetGrant",
         "operationId": "GetGrant",
         "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
           {
             "example": "4yJ3n3D8E2",
             "in": "path",
@@ -1891,6 +2029,17 @@
         "description": "ListGroups",
         "operationId": "ListGroups",
         "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
           {
             "in": "query",
             "name": "name",
@@ -1980,6 +2129,19 @@
       "post": {
         "description": "CreateGroup",
         "operationId": "CreateGroup",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2071,6 +2233,17 @@
         "operationId": "GetGroup",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
@@ -2155,6 +2328,19 @@
       "post": {
         "description": "Login",
         "operationId": "Login",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2280,6 +2466,19 @@
       "post": {
         "description": "Logout",
         "operationId": "Logout",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "400": {
             "content": {
@@ -2353,6 +2552,17 @@
         "description": "ListProviders",
         "operationId": "ListProviders",
         "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
           {
             "example": "okta",
             "in": "query",
@@ -2433,6 +2643,19 @@
       "post": {
         "description": "CreateProvider",
         "operationId": "CreateProvider",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2540,6 +2763,17 @@
         "operationId": "DeleteProvider",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
@@ -2624,6 +2858,17 @@
         "operationId": "GetProvider",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
@@ -2707,6 +2952,17 @@
         "description": "UpdateProvider",
         "operationId": "UpdateProvider",
         "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
           {
             "example": "4yJ3n3D8E2",
             "in": "path",
@@ -2825,6 +3081,19 @@
       "get": {
         "description": "SignupEnabled",
         "operationId": "SignupEnabled",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "400": {
             "content": {
@@ -2895,6 +3164,19 @@
       "post": {
         "description": "Signup",
         "operationId": "Signup",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2990,6 +3272,19 @@
       "post": {
         "description": "CreateToken",
         "operationId": "CreateToken",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "400": {
             "content": {
@@ -3063,6 +3358,17 @@
         "description": "ListUsers",
         "operationId": "ListUsers",
         "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
           {
             "in": "query",
             "name": "name",
@@ -3165,6 +3471,19 @@
       "post": {
         "description": "CreateUser",
         "operationId": "CreateUser",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -3259,6 +3578,17 @@
         "operationId": "DeleteUser",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
@@ -3343,6 +3673,17 @@
         "operationId": "GetUser",
         "parameters": [
           {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
             "in": "path",
             "name": "id",
             "required": true,
@@ -3426,6 +3767,17 @@
         "description": "UpdateUser",
         "operationId": "UpdateUser",
         "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
           {
             "example": "4yJ3n3D8E2",
             "in": "path",
@@ -3529,6 +3881,19 @@
       "get": {
         "description": "Version",
         "operationId": "Version",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.13.2+dev",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "400": {
             "content": {

--- a/internal/server/apimigrator.go
+++ b/internal/server/apimigrator.go
@@ -82,16 +82,12 @@ func addRequestRewrite[oldReq any, newReq any](a *API, method, path, version str
 func rewriteRequired(c *gin.Context, migrationVersion *semver.Version) bool {
 	headerVer := c.Request.Header.Get("Infra-Version")
 	if headerVer == "" {
-		// remove this conditional in v0.15.0
-		headerVer = "0.0.0"
-	}
-	if headerVer == "" {
-		sendAPIError(c, fmt.Errorf("%w: Infra-Version header required", internal.ErrBadRequest))
+		sendAPIError(c, fmt.Errorf("%w: Infra-Version header required. Current version is %s", internal.ErrBadRequest, internal.FullVersion()))
 		return false
 	}
 	reqVer, err := semver.NewVersion(headerVer)
 	if err != nil {
-		sendAPIError(c, fmt.Errorf("%w: invalid Infra-Version header: %s", internal.ErrBadRequest, err))
+		sendAPIError(c, fmt.Errorf("%w: invalid Infra-Version header: %q. Current version is %s", internal.ErrBadRequest, err, internal.FullVersion()))
 		return false
 	}
 

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -32,6 +32,7 @@ func TestAPI_ListGroups(t *testing.T) {
 		req, err := http.NewRequest(http.MethodPost, "/v1/identities", &buf)
 		assert.NilError(t, err)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
+		req.Header.Add("Infra-Version", "0.12.0")
 
 		resp := httptest.NewRecorder()
 		routes.ServeHTTP(resp, req)

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -269,13 +269,14 @@ func TestListKeys(t *testing.T) {
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 
 		routes.ServeHTTP(resp, req)
-		assert.Equal(t, resp.Code, http.StatusOK)
+		assert.Equal(t, resp.Code, http.StatusBadRequest)
 
-		resp1 := []api.AccessKey{}
-		err = json.Unmarshal(resp.Body.Bytes(), &resp1)
+		errMsg := api.Error{}
+		err = json.Unmarshal(resp.Body.Bytes(), &errMsg)
 		assert.NilError(t, err)
 
-		assert.Assert(t, len(resp1) > 0)
+		assert.Assert(t, strings.Contains(errMsg.Message, "Infra-Version header required"))
+		assert.Equal(t, errMsg.Code, int32(400))
 	})
 
 	t.Run("old version upgrades", func(t *testing.T) {

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -420,6 +420,20 @@ func buildResponse(schemas openapi3.Schemas, rst reflect.Type) openapi3.Response
 func buildRequest(r reflect.Type, op *openapi3.Operation) {
 	op.Parameters = openapi3.NewParameters()
 
+	op.AddParameter(&openapi3.Parameter{
+		Name:     "Infra-Version",
+		In:       "header",
+		Required: true,
+		Schema: &openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				Example:     internal.FullVersion(),
+				Format:      `\d+\.\d+\(.\d+)?(-.\w(+\w)?)?`,
+				Type:        "string",
+				Description: "Version of the API being requested",
+			},
+		},
+	})
+
 	schema := &openapi3.Schema{
 		Type:       "object",
 		Properties: openapi3.Schemas{},


### PR DESCRIPTION
## Summary

The Infra-Version header works best if clients are required to supply it. This PR makes the header required and errors with a helpful message if it is not supplied.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades
