### PR TITLE
improve: modified notfoundhandler to check accept header

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -140,6 +140,7 @@ func request[Req, Res any](client Client, method string, path string, req *Req) 
 	addHeaders(httpReq, client.Headers)
 	httpReq.Header.Add("Authorization", "Bearer "+client.AccessKey)
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
 
 	resp, err := client.HTTP.Do(httpReq)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -252,6 +252,7 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		req.Header.Set("Accept", tc.name)
 		resp := httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
 
@@ -263,7 +264,7 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "/api path prefix",
+			name: "application/json",
 			path: "/api/not/found",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				contentType := resp.Header().Get("Content-Type")
@@ -272,13 +273,21 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 			},
 		},
 		{
-			name: "ui path",
+			name: "text/html",
 			path: "/not/found",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				// response should have an html body
 				assert.Assert(t, is.Contains(resp.Body.String(), "404 - example"))
+
 			},
 		},
+		{
+			name: "other (this will give plaintext)",
+			path: "/not/found",
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				// response should have an html body
+				assert.Equal(t, "404 not found", resp.Body.String())
+			}},
 	}
 
 	for _, tc := range testCases {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -252,7 +252,11 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
-		req.Header.Set("Accept", tc.name)
+
+		if tc.name != "no header" {
+			req.Header.Set("Accept", tc.name)
+		}
+
 		resp := httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
 
@@ -287,7 +291,16 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				// response should have an html body
 				assert.Equal(t, "404 not found", resp.Body.String())
-			}},
+			},
+		},
+		{
+			name: "no header",
+			path: "/not/found/again",
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				// response should have an html body
+				assert.Equal(t, "404 not found", resp.Body.String())
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

notFoundHandler no longer assumes how to send the response based on path, but based on the header of the request itself. Users should now specify `application/json`, `text/html` in the Accept header to receive the proper 404.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
<!--
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
-->
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
<!-- - [ ] Considered data migrations for smooth upgrades -->


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1610 
