### PR TITLE
fix: fail fast on duplicate config access key

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -859,6 +859,10 @@ func (s Server) loadAccessKey(db *gorm.DB, identity *models.Identity, key string
 		return nil
 	}
 
+	if accessKey.IssuedFor != identity.ID {
+		return fmt.Errorf("access key assigned to %q is already assigned to another user, a user's access key must have a unique ID", identity.Name)
+	}
+
 	accessKey.Secret = secret
 
 	if err := data.SaveAccessKey(db, accessKey); err != nil {

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -800,7 +800,7 @@ func TestLoadAccessKey(t *testing.T) {
 		assert.NilError(t, err)
 
 		err = s.loadAccessKey(s.db, alice, testAccessKey)
-		assert.Error(t, err, "access key assigned to alice is already assigned to another user, a user's access key must have a unique ID")
+		assert.Error(t, err, "access key assigned to \"alice\" is already assigned to another user, a user's access key must have a unique ID")
 	})
 }
 

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -775,6 +775,35 @@ func TestLoadConfigUpdate(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestLoadAccessKey(t *testing.T) {
+	s := setupServer(t)
+
+	// access key that we will attempt to assign to multiple users
+	testAccessKey := "aaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb"
+
+	// create a user and assign them an access key
+	bob := &models.Identity{Name: "bob"}
+	err := data.CreateIdentity(s.db, bob)
+	assert.NilError(t, err)
+
+	err = s.loadAccessKey(s.db, bob, testAccessKey)
+	assert.NilError(t, err)
+
+	t.Run("access key can be reloaded for the same identity it was issued for", func(t *testing.T) {
+		err = s.loadAccessKey(s.db, bob, testAccessKey)
+		assert.NilError(t, err)
+	})
+
+	t.Run("duplicate access key ID is rejected", func(t *testing.T) {
+		alice := &models.Identity{Name: "alice"}
+		err = data.CreateIdentity(s.db, alice)
+		assert.NilError(t, err)
+
+		err = s.loadAccessKey(s.db, alice, testAccessKey)
+		assert.Error(t, err, "access key assigned to alice is already assigned to another user, a user's access key must have a unique ID")
+	})
+}
+
 // getTestUserDetails gets the attributes of a user created from a config file
 func getTestUserDetails(db *gorm.DB, name string) (*models.Identity, *models.Credential, *models.AccessKey, error) {
 	var user models.Identity


### PR DESCRIPTION
## Summary
When an access key that is specified for a user in config is already specified for another user, fail fast. Access keys can only be linked to one user so this is an invalid configuration.

Ex:
```
users:
      - name: test
        accessKey: aaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb
      - name: anotherTest
        accessKey: aaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb
```
```
{"level":"error","ts":1653485595.127271,"caller":"infra/main.go:17","msg":"creating server: configs: load users: access key assigned to \"anotherTest\" is already assigned to another user, a user's access key must have a unique ID"}
```
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1983
