### PR TITLE
maintain: atomic kube config updates

### DIFF
--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -210,7 +210,7 @@ func writeKubeconfig(user *api.User, destinations []api.Destination, grants []ap
 
 	// write the new config to a temporary file then move it in an atomic operation
 	// this ensures we don't wipe the kube config in the case of an interrupt
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "infra-kube-config-")
+	tmpFile, err := ioutil.TempFile("", "infra-kube-config-")
 	if err != nil {
 		return fmt.Errorf("cannot create temporary config file: %w", err)
 	}

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -207,10 +208,21 @@ func writeKubeconfig(user *api.User, destinations []api.Destination, grants []ap
 		}
 	}
 
-	kubeConfigFilename := defaultConfig.ConfigAccess().GetDefaultFilename()
+	// write the new config to a temporary file then move it in an atomic operation
+	// this ensures we don't wipe the kube config in the case of an interrupt
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "infra-kube-config-")
+	if err != nil {
+		return fmt.Errorf("cannot create temporary config file: %w", err)
+	}
 
-	if err := clientcmd.WriteToFile(kubeConfig, kubeConfigFilename); err != nil {
+	if err := clientcmd.WriteToFile(kubeConfig, tmpFile.Name()); err != nil {
 		return err
+	}
+
+	// move the temp file to overwrite the kube config
+	err = os.Rename(tmpFile.Name(), defaultConfig.ConfigAccess().GetDefaultFilename())
+	if err != nil {
+		return fmt.Errorf("could not overwrite kube config: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
When writing to the kube config file directly we run the risk of the write operation being terminated unexpectedly. This means we would be at risk of leaving the kube config file in an invalid state. Instead this change writes the new config file to a temp file, then moves that file to overwrite the `~/.kube/config` in an atomic operation.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2030
