### PR TITLE
maintain: skip file check on release branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,6 +32,8 @@ jobs:
           POSTGRESQL_CONNECTION: "host=localhost port=5432 user=postgres dbname=postgres password=password123"
 
       - name: Check that tests leave a clean git checkout
+        # Skip on the release branch, it is allowed to modify files like the openapi doc
+        if: ${{ ! startsWith(github.head_ref, 'release-please-') }}
         run: |
           # show and check changes to committed files
           git diff --exit-code


### PR DESCRIPTION
This check is failing on the release branch, because the version on the release branch is different.  

It's fine to skip this check because it's only to catch problems introduced by PRs. The check is to prevent problems for contributors, not quality issues in the release, so skipping it is safe.