### PR TITLE
fix: remove incorrect connection field until we support this in the API

### DIFF
--- a/ui/pages/destinations/index.js
+++ b/ui/pages/destinations/index.js
@@ -51,8 +51,8 @@ function SidebarContent ({ destination, admin, setSelectedDestination }) {
             <div className='text-2xs'>{destination?.created ? dayjs(destination.created).fromNow() : '-'}</div>
           </div>
           <div className='flex flex-row items-center'>
-            <div className='text-gray-400 text-2xs w-1/3'>Last Seen</div>
-            <div className='text-2xs'>{destination?.lastSeen ? dayjs(destination.lastSeen).fromNow() : '-'}</div>
+            <div className='text-gray-400 text-2xs w-1/3'>Updated</div>
+            <div className='text-2xs'>{destination.updated ? dayjs(destination.updated).fromNow() : '-'}</div>
           </div>
         </div>
       </section>
@@ -99,31 +99,8 @@ const columns = [{
     </div>
   )
 }, {
-  id: 'connected',
-  Header: () => (
-    <div className='text-right'>Connection</div>
-  ),
-  accessor: 'updated',
-  Cell: ({ value: updated }) => {
-    const connected = (new Date() - new Date(updated)) < 24 * 60 * 60 * 1000
-    return (
-      <div className='flex items-center text-gray-400 justify-end'>
-        {connected
-          ? (
-            <>
-              <div className='w-[7px] h-[7px] bg-green-400 rounded-full mr-1.5' />
-              Connected
-            </>
-            )
-          : (
-            <div className='flex items-center'>
-              <div className='w-[7px] h-[7px] bg-gray-600 rounded-full mr-1.5' />
-              Disconnected
-            </div>
-            )}
-      </div>
-    )
-  }
+  Header: 'Kind',
+  Cell: () => <span className='text-gray-400'>Cluster</span>
 }]
 
 export default function Destinations () {


### PR DESCRIPTION
The Infra Connector `updated` field is no longer updated if nothing has changed in cluster metadata. Using this field to signal cluster connectivity is no longer correct – removing this until we add the correct data in our API for this, and replacing the table column with a `Kind` field

<img width="1476" alt="Screen Shot 2022-05-25 at 3 50 56 PM" src="https://user-images.githubusercontent.com/251292/170355764-edf14152-184c-41d8-8314-0a95a4245062.png">

<img width="1476" alt="Screen Shot 2022-05-25 at 3 50 50 PM" src="https://user-images.githubusercontent.com/251292/170355769-79efbe21-c364-4b9a-9256-1b2e90722a5e.png">

