### PR TITLE
fix: keep jwt nonce for version compatibility

### DIFF
--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -3,5 +3,5 @@ package claims
 type Custom struct {
 	Name   string   `json:"name" validate:"required"`
 	Groups []string `json:"groups"`
-	Nonce  string   `json:"nonce" validate:"required"`
+	Nonce  string   `json:"nonce"`
 }

--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -3,4 +3,5 @@ package claims
 type Custom struct {
 	Name   string   `json:"name" validate:"required"`
 	Groups []string `json:"groups"`
+	Nonce  string   `json:"nonce" validate:"required"`
 }

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -120,6 +120,7 @@ func generateJWT(priv *jose.JSONWebKey, email string, expiry time.Time) (string,
 	custom := claims.Custom{
 		Name:   email,
 		Groups: []string{"developers"},
+		Nonce:  "randomstring",
 	}
 
 	raw, err := jwt.Signed(signer).Claims(cl).Claims(custom).CompactSerialize()

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/claims"
+	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -40,6 +41,11 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 		return "", err
 	}
 
+	nonce, err := generate.CryptoRandom(10)
+	if err != nil {
+		return "", err
+	}
+
 	now := time.Now().UTC()
 
 	claim := jwt.Claims{
@@ -51,6 +57,7 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 	custom := claims.Custom{
 		Name:   identity.Name,
 		Groups: groups,
+		Nonce:  nonce,
 	}
 
 	raw, err := jwt.Signed(signer).Claims(claim).Claims(custom).CompactSerialize()

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -41,11 +41,6 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 		return "", err
 	}
 
-	nonce, err := generate.CryptoRandom(10)
-	if err != nil {
-		return "", err
-	}
-
 	now := time.Now().UTC()
 
 	claim := jwt.Claims{
@@ -57,7 +52,7 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 	custom := claims.Custom{
 		Name:   identity.Name,
 		Groups: groups,
-		Nonce:  nonce,
+		Nonce:  generate.MathRandom(10),
 	}
 
 	raw, err := jwt.Signed(signer).Claims(claim).Claims(custom).CompactSerialize()


### PR DESCRIPTION
## Summary
This JWT nonce is not needed, but it is marked as required on the claims struct so the struct will fail validation on previous versions of infra without this field. This is a transitional change that makes the `nonce` not required, we can remove it fully in a few versions when 0.13.0 connectors have been phased out.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2081
Re-opened #2014 to track removing this completely. 
