### PR TITLE
fix: prevent 'invalid cross-device link' error on login

### DIFF
--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/goware/urlx"
@@ -208,9 +209,11 @@ func writeKubeconfig(user *api.User, destinations []api.Destination, grants []ap
 		}
 	}
 
+	configPath := defaultConfig.ConfigAccess().GetDefaultFilename()
+
 	// write the new config to a temporary file then move it in an atomic operation
 	// this ensures we don't wipe the kube config in the case of an interrupt
-	tmpFile, err := ioutil.TempFile("", "infra-kube-config-")
+	tmpFile, err := ioutil.TempFile(filepath.Dir(configPath), "infra-kube-config-")
 	if err != nil {
 		return fmt.Errorf("cannot create temporary config file: %w", err)
 	}
@@ -220,7 +223,7 @@ func writeKubeconfig(user *api.User, destinations []api.Destination, grants []ap
 	}
 
 	// move the temp file to overwrite the kube config
-	err = os.Rename(tmpFile.Name(), defaultConfig.ConfigAccess().GetDefaultFilename())
+	err = os.Rename(tmpFile.Name(), configPath)
 	if err != nil {
 		return fmt.Errorf("could not overwrite kube config: %w", err)
 	}


### PR DESCRIPTION
## Summary

This can happen on login if the temporary directory is on a different device from the kube config directory.

Fixed by creating a temporary file in the same directory as the target kube config, so that the files will never be on different devices. We could use another directory (like `~/.infra`), but I have a slight preference for using the kube config directory for a few reasons:
* there's a very unlikely, but possible, change that `~/.infra` is on a different device from whatever directory contains the kubeconfig, so the problem could still exist (but I admit that is very very unlikely)
* if the process exits before the rename (the scenario that prompted this change to use rename) then the temporary file is left next to the target file. I believe I've seen other tools do this with a `.bak` file. I think it might be more expected for that file to be next to the target, rather than in the `~/.infra` directory.

I don't know of any way to test this with an automated test, because we don't have any control over the devices in CI. I tested it locally and confirmed I was able to signup and login where as previously I ran into the error reported in the issue.

## Related Issues


Resolves #2084
