### PR TITLE
fix: pass the userID arg to the request

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -254,7 +254,10 @@ func (c Client) ListUserGrants(id uid.ID) (*ListResponse[Grant], error) {
 }
 
 func (c Client) ListGroups(req ListGroupsRequest) (*ListResponse[Group], error) {
-	return list[ListResponse[Group]](c, "/api/groups", map[string][]string{"name": {req.Name}})
+	return list[ListResponse[Group]](c, "/api/groups", map[string][]string{
+		"name":   {req.Name},
+		"userID": {req.UserID.String()},
+	})
 }
 
 func (c Client) GetGroup(id uid.ID) (*Group, error) {


### PR DESCRIPTION
## Summary

The UserID arg to `Client.ListGroups` was not being passed to the query parameters map.

TODO: test coverage

The Client itself is pretty minimal. I suspect we'd be better off testing the CLI endpoint that uses it.