### PR TITLE
fix: release build should not contain dev

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,16 +4,19 @@ env:
   # TODO (https://github.com/infrahq/infra/issues/65)
   - CGO_ENABLED=0
   - GO111MODULE=on
+  - BUILDVERSION_PRERELEASE={{ if index .Env "BUILDVERSION_PRERELEASE" }}{{ .Env.BUILDVERSION_PRERELEASE }}{{ end }}
+  - BUILDVERSION_METADATA={{ if index .Env "BUILDVERSION_METADATA" }}{{ .Env.BUILDVERSION_METADATA }}{{ end }}
 project_name: infra
 builds:
   - id: infra
     ldflags:
       - -s -w
         -X github.com/infrahq/infra/internal.Branch={{ .Branch }}
-        -X github.com/infrahq/infra/internal.Version={{ .Version }}
+        -X github.com/infrahq/infra/internal.Version={{ .RawVersion }}
         -X github.com/infrahq/infra/internal.Commit={{ .FullCommit }}
         -X github.com/infrahq/infra/internal.Date={{ .Date }}
-        -X github.com/infrahq/infra/internal.PrereleaseTag=
+        -X github.com/infrahq/infra/internal.Prerelease={{ .Env.BUILDVERSION_PRERELEASE }}
+        -X github.com/infrahq/infra/internal.Metadata={{ .Env.BUILDVERSION_METADATA }}
     binary: infra
     main: ./main.go
     goos:

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -687,7 +687,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "Infra API",
-    "version": "0.13.1"
+    "version": "0.13.2+dev"
   },
   "paths": {
     "/api/access-keys": {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Goreleaser configs should also inject `Prerelease` and `Metadata` vars. Use env vars `BUILDVERSION_PRERELEASE` and and `BUILDVERSION_METADATA` but set reasonable defaults (empty strings) 
