### PR TITLE
improve: wording of force flag

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -188,7 +188,7 @@ $ infra destinations remove docker-desktop
 ### Options
 
 ```
-      --force   Remove destination even if it does not exist
+      --force   Exit successfully even if destination does not exist
 ```
 
 ### Options inherited from parent commands
@@ -247,7 +247,7 @@ $ infra grants add johndoe@example.com infra --role admin
 ### Options
 
 ```
-      --force         Create grant even if requested resources are missing
+      --force         Create grant even if requested user, destination, or role are unknown
   -g, --group         Required if identity is of type 'group'
       --role string   Type of access that identity will be given (default "connect")
 ```
@@ -287,7 +287,7 @@ $ infra grants remove janedoe@example.com infra --role admin
 ### Options
 
 ```
-      --force         Remove grant even if it does not exist
+      --force         Exit successfully even if grant does not exist
   -g, --group         Group to revoke access from
       --role string   Role to revoke
 ```
@@ -388,7 +388,7 @@ $ infra users remove janedoe@example.com
 ### Options
 
 ```
-      --force   Remove user even if it does not exist
+      --force   Exit successfully even if user does not exist
 ```
 
 ### Options inherited from parent commands
@@ -466,7 +466,7 @@ infra keys remove KEY [flags]
 ### Options
 
 ```
-      --force   Remove access key even if it does not exist
+      --force   Exit successfully even if access key does not exist
 ```
 
 ### Options inherited from parent commands
@@ -543,7 +543,7 @@ $ infra providers remove okta
 ### Options
 
 ```
-      --force   Remove provider even if it does not exist
+      --force   Exit successfully even if provider does not exist
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -106,7 +106,7 @@ func newDestinationsRemoveCmd(cli *CLI) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&force, "force", false, "Remove destination even if it does not exist")
+	cmd.Flags().BoolVar(&force, "force", false, "Exit successfully even if destination does not exist")
 
 	return cmd
 }

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -154,7 +154,7 @@ $ infra grants remove janedoe@example.com infra --role admin
 
 	cmd.Flags().BoolVarP(&options.IsGroup, "group", "g", false, "Group to revoke access from")
 	cmd.Flags().StringVar(&options.Role, "role", "", "Role to revoke")
-	cmd.Flags().BoolVar(&options.Force, "force", false, "Remove grant even if it does not exist")
+	cmd.Flags().BoolVar(&options.Force, "force", false, "Exit successfully even if grant does not exist")
 
 	return cmd
 }
@@ -224,7 +224,7 @@ $ infra grants add johndoe@example.com infra --role admin
 
 	cmd.Flags().BoolVarP(&options.IsGroup, "group", "g", false, "Required if identity is of type 'group'")
 	cmd.Flags().StringVar(&options.Role, "role", models.BasePermissionConnect, "Type of access that identity will be given")
-	cmd.Flags().BoolVar(&options.Force, "force", false, "Create grant even if requested resources are missing")
+	cmd.Flags().BoolVar(&options.Force, "force", false, "Create grant even if requested user, destination, or role are unknown")
 	return cmd
 }
 

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -134,7 +134,7 @@ func newKeysRemoveCmd(cli *CLI) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&force, "force", false, "Remove access key even if it does not exist")
+	cmd.Flags().BoolVar(&force, "force", false, "Exit successfully even if access key does not exist")
 
 	return cmd
 }

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -174,7 +174,7 @@ func newProvidersRemoveCmd(cli *CLI) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&force, "force", false, "Remove provider even if it does not exist")
+	cmd.Flags().BoolVar(&force, "force", false, "Exit successfully even if provider does not exist")
 
 	return cmd
 }

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -171,7 +171,7 @@ $ infra users remove janedoe@example.com`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&force, "force", false, "Remove user even if it does not exist")
+	cmd.Flags().BoolVar(&force, "force", false, "Exit successfully even if user does not exist")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Changed wording to be more explicit. 

For remove, the force flag changes the output status from 0 to 1, so explicitly state "exit successfully". 

For add, the force flag allows bypassing restrictions, not just based on the resource/destination, but also user and role restrictions, so all the restrictions it will bypass in the flag. 


Reason to be explicit here is that the flag is to be used by someone who knows what exactly this means, and cannot have room to be vague. 

## Checklist

- [ ] ~Wrote appropriate unit tests~
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] ~Updated associated configuration where necessary~
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [ ] ~Considered data migrations for smooth upgrades~


## Related Issues

Resolves #
