### PR TITLE
handle data duplicate errors

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -14,7 +14,6 @@ var (
 	// ErrBadGateway means an invalid response was received from an upstream server (probably an OIDC provider)
 	ErrBadGateway = fmt.Errorf("bad gateway")
 
-	ErrDuplicate      = fmt.Errorf("duplicate record")
 	ErrNotFound       = fmt.Errorf("record not found")
 	ErrBadRequest     = fmt.Errorf("bad request")
 	ErrNotImplemented = fmt.Errorf("not implemented")

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -149,7 +149,7 @@ type UniqueConstraintError struct {
 }
 
 func (e UniqueConstraintError) Error() string {
-	return fmt.Sprintf("value for %v already exist in %v", e.Column, e.Table)
+	return fmt.Sprintf("value for %v already exists in %v", e.Column, e.Table)
 }
 
 // handleError looks for well known DB errors. If the error is recognized it

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -57,7 +57,7 @@ func TestCreateGroupDuplicate(t *testing.T) {
 		createGroups(t, db, &everyone, &engineers, &product)
 
 		err := CreateGroup(db, &models.Group{Name: "Everyone"})
-		assert.ErrorContains(t, err, "duplicate record")
+		assert.ErrorContains(t, err, "value for name already exists in groups")
 	})
 }
 

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -57,7 +57,7 @@ func TestCreateGroupDuplicate(t *testing.T) {
 		createGroups(t, db, &everyone, &engineers, &product)
 
 		err := CreateGroup(db, &models.Group{Name: "Everyone"})
-		assert.ErrorContains(t, err, "value for name already exists in groups")
+		assert.ErrorContains(t, err, "value for name already exists for groups")
 	})
 }
 

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -73,9 +73,7 @@ func AssignIdentityToGroups(db *gorm.DB, user *models.Identity, provider *models
 		// add user to group
 		err = db.Exec("insert into identities_groups (identity_id, group_id) values (?, ?)", user.ID, groupID).Error
 		if err != nil {
-			if !isUniqueConstraintViolation(err) {
-				return fmt.Errorf("insert: %w", err)
-			}
+			return fmt.Errorf("insert: %w", handleError(err))
 		}
 
 		user.Groups = append(user.Groups, models.Group{Model: models.Model{ID: groupID}, Name: name})

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -70,10 +70,17 @@ func AssignIdentityToGroups(db *gorm.DB, user *models.Identity, provider *models
 			groupID = group.ID
 		}
 
-		// add user to group
-		err = db.Exec("insert into identities_groups (identity_id, group_id) values (?, ?)", user.ID, groupID).Error
-		if err != nil {
-			return fmt.Errorf("insert: %w", handleError(err))
+		var ids []uid.ID
+		if err := db.Raw("SELECT identity_id FROM identities_groups WHERE identity_id = ? AND group_id = ?", user.ID, groupID).Scan(&ids).Error; err != nil {
+			return fmt.Errorf("select: %w", handleError(err))
+		}
+
+		if len(ids) == 0 {
+			// add user to group
+			err = db.Exec("insert into identities_groups (identity_id, group_id) values (?, ?)", user.ID, groupID).Error
+			if err != nil {
+				return fmt.Errorf("insert: %w", handleError(err))
+			}
 		}
 
 		user.Groups = append(user.Groups, models.Group{Model: models.Model{ID: groupID}, Name: name})

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -50,7 +50,7 @@ func TestCreateDuplicateUser(t *testing.T) {
 		b := bond
 		b.ID = 0
 		err := CreateIdentity(db, &b)
-		assert.ErrorContains(t, err, "value for name already exists in identities")
+		assert.ErrorContains(t, err, "value for name already exists for identities")
 	})
 }
 

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -50,7 +50,7 @@ func TestCreateDuplicateUser(t *testing.T) {
 		b := bond
 		b.ID = 0
 		err := CreateIdentity(db, &b)
-		assert.ErrorContains(t, err, "duplicate record")
+		assert.ErrorContains(t, err, "value for name already exists in identities")
 	})
 }
 
@@ -228,7 +228,7 @@ func TestAssignIdentityToGroups(t *testing.T) {
 				err = SaveIdentity(db, identity)
 				assert.NilError(t, err)
 
-				// setup provuderUser record
+				// setup providerUser record
 				provider := InfraProvider(db)
 				pu, err := CreateProviderUser(db, provider, identity)
 				assert.NilError(t, err)

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -463,6 +463,14 @@ func migrate(db *gorm.DB) error {
 				return nil
 			},
 		},
+		// drop old Groups constraint; new constraint will be created automatically
+		{
+			ID: "202206081027",
+			Migrate: func(tx *gorm.DB) error {
+				_ = tx.Migrator().DropConstraint(&models.Group{}, "idx_groups_name_provider_id")
+				return nil
+			},
+		},
 		// next one here
 	})
 

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -1,12 +1,12 @@
 package data
 
 import (
+	"errors"
 	"testing"
 
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
-	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -42,7 +42,11 @@ func TestCreateProviderDuplicate(t *testing.T) {
 		createProviders(t, db, providerDevelop, providerProduction)
 
 		err := CreateProvider(db, &providerDevelop)
-		assert.ErrorIs(t, err, internal.ErrDuplicate)
+
+		var uniqueConstraintErr UniqueConstraintError
+		assert.Assert(t, errors.As(err, &uniqueConstraintErr), "error is wrong type %T", err)
+		expected := UniqueConstraintError{Column: "name", Table: "providers"}
+		assert.DeepEqual(t, uniqueConstraintErr, expected)
 	})
 }
 

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/server/data"
 )
 
 func TestSendAPIError(t *testing.T) {
@@ -47,23 +48,19 @@ func TestSendAPIError(t *testing.T) {
 			result: api.Error{Code: http.StatusForbidden, Message: "forbidden"},
 		},
 		{
-			err:    internal.ErrDuplicate,
-			result: api.Error{Code: http.StatusConflict, Message: "duplicate record"},
-		},
-		{
-			err: fmt.Errorf("%w: nope too many", internal.ErrDuplicate),
-			result: api.Error{
-				Code:    http.StatusConflict,
-				Message: "duplicate record: nope too many",
-			},
-		},
-		{
 			err:    internal.ErrNotFound,
 			result: api.Error{Code: http.StatusNotFound, Message: "record not found"},
 		},
 		{
 			err:    internal.ErrNotImplemented,
 			result: api.Error{Code: http.StatusNotImplemented, Message: "not implemented"},
+		},
+		{
+			err: data.UniqueConstraintError{Table: "user", Column: "name"},
+			result: api.Error{
+				Code:    http.StatusConflict,
+				Message: "value for name already exists in user",
+			},
 		},
 		{
 			err: validate.Struct(struct {

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -59,7 +59,7 @@ func TestSendAPIError(t *testing.T) {
 			err: data.UniqueConstraintError{Table: "user", Column: "name"},
 			result: api.Error{
 				Code:    http.StatusConflict,
-				Message: "value for name already exists in user",
+				Message: "value for name already exists for user",
 			},
 		},
 		{

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -14,7 +14,7 @@ var (
 // AccessKey is a session token presented to the Infra server as proof of authentication
 type AccessKey struct {
 	Model
-	Name              string    `gorm:"uniqueIndex:,where:deleted_at is NULL" validate:"excludes= "`
+	Name              string    `gorm:"uniqueIndex:idx_access_keys_name,where:deleted_at is NULL" validate:"excludes= "`
 	IssuedFor         uid.ID    `validate:"required"` // the ID of the identity that this access key was created for
 	IssuedForIdentity *Identity `gorm:"foreignKey:IssuedFor"`
 	ProviderID        uid.ID    `validate:"required"`
@@ -23,7 +23,7 @@ type AccessKey struct {
 	Extension         time.Duration // how long to increase the lifetime extension deadline by
 	ExtensionDeadline time.Time
 
-	KeyID          string `gorm:"<-;uniqueIndex:,where:deleted_at is NULL"`
+	KeyID          string `gorm:"<-;uniqueIndex:idx_access_keys_key_id,where:deleted_at is NULL"`
 	Secret         string `gorm:"-"`
 	SecretChecksum []byte
 }

--- a/internal/server/models/credential.go
+++ b/internal/server/models/credential.go
@@ -5,7 +5,7 @@ import "github.com/infrahq/infra/uid"
 type Credential struct {
 	Model
 
-	IdentityID          uid.ID `gorm:"<-;uniqueIndex:,where:deleted_at is NULL"`
+	IdentityID          uid.ID `gorm:"<-;uniqueIndex:idx_credentials_identity_id,where:deleted_at is NULL"`
 	PasswordHash        []byte `validate:"required"`
 	OneTimePassword     bool
 	OneTimePasswordUsed bool

--- a/internal/server/models/destination.go
+++ b/internal/server/models/destination.go
@@ -8,7 +8,7 @@ type Destination struct {
 	Model
 
 	Name     string `validate:"required"`
-	UniqueID string `gorm:"uniqueIndex:,where:deleted_at is NULL"`
+	UniqueID string `gorm:"uniqueIndex:idx_destinations_unique_id,where:deleted_at is NULL"`
 
 	ConnectionURL string
 	ConnectionCA  string

--- a/internal/server/models/encryption_key.go
+++ b/internal/server/models/encryption_key.go
@@ -3,7 +3,7 @@ package models
 type EncryptionKey struct {
 	Model
 
-	KeyID     int32 `gorm:"uniqueIndex"` // a short identifier for the key that can be embedded with the encrypted payload
+	KeyID     int32 `gorm:"uniqueIndex:idx_encryption_keys_key_id"` // a short identifier for the key that can be embedded with the encrypted payload
 	Name      string
 	Encrypted []byte
 	Algorithm string

--- a/internal/server/models/group.go
+++ b/internal/server/models/group.go
@@ -8,7 +8,7 @@ import (
 type Group struct {
 	Model
 
-	Name      string `gorm:"uniqueIndex:idx_groups_name_provider_id,where:deleted_at is NULL"`
+	Name      string `gorm:"uniqueIndex:idx_groups_name,where:deleted_at is NULL"`
 	CreatedBy uid.ID
 
 	Identities []Identity `gorm:"many2many:identities_groups"`

--- a/internal/server/models/provider.go
+++ b/internal/server/models/provider.go
@@ -10,7 +10,7 @@ const InternalInfraProviderName = "infra"
 type Provider struct {
 	Model
 
-	Name         string `gorm:"uniqueIndex:,where:deleted_at is NULL" validate:"required"`
+	Name         string `gorm:"uniqueIndex:idx_providers_name,where:deleted_at is NULL" validate:"required"`
 	URL          string
 	ClientID     string
 	ClientSecret EncryptedAtRest


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Inspect data errors to detect duplication and provide more details to user when unique constraints are violated.

Update `CreateUser` to _only_ create users and credentials. Previously it will accept the request if the user already exists and update their credentials. This use case should be fulfilled by the UpdateUser endpoint.

## TODO

- [x] Unit tests for sqlite3 and postgres unique constraint violations

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1686 
