### PR TITLE
fix: inconsistencies between role and access terms in `infra grants add` and `infra grants list`

### DIFF
--- a/docs/configuration/granting-access.md
+++ b/docs/configuration/granting-access.md
@@ -37,11 +37,11 @@ infra grants remove user@example.com staging --role edit
 
 ```
 infra grants list
-  USER                 ACCESS   DESTINATION
+  USER                 ROLE     DESTINATION
   jeff@infrahq.com     edit     development
   michael@infrahq.com  view     production
 
-  GROUP          ACCESS    DESTINATION
+  GROUP          ROLE      DESTINATION
   Engineering    edit      development.monitoring
   Engineering    view      production
   Design         edit      development.web

--- a/docs/getting-started/what-is-infra.md
+++ b/docs/getting-started/what-is-infra.md
@@ -172,12 +172,12 @@ Admins can inspect access in a single place, for all users & groups across all d
 
 ```
 $ infra grants list
-  USER (6)            ACCESS     DESTINATION
+  USER (6)            ROLE       DESTINATION
   jeff@infrahq.com    view       development-72f9584e
   mike@infrahq.com    edit       development-72f9584e.infrahq
   eva@infrahq.com     admin      digital_ocean_toronto
 
-  GROUP (5)    ACCESS  DESTINATION
+  GROUP (5)    ROLE    DESTINATION
   Everyone     view    development-72f9584e
   Engineering  edit    development-72f9584e.infrahq
   Design       edit    development-72f9584e.web

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -109,7 +109,7 @@ func userGrants(cli *CLI, client *api.Client, grants *api.ListResponse[api.Grant
 
 	type row struct {
 		User     string `header:"USER"`
-		Access   string `header:"ACCESS"`
+		Role     string `header:"ROLE"`
 		Resource string `header:"DESTINATION"`
 	}
 
@@ -122,7 +122,7 @@ func userGrants(cli *CLI, client *api.Client, grants *api.ListResponse[api.Grant
 
 		rows = append(rows, row{
 			User:     user.Name,
-			Access:   item.Privilege,
+			Role:     item.Privilege,
 			Resource: item.Resource,
 		})
 	}
@@ -149,7 +149,7 @@ func groupGrants(cli *CLI, client *api.Client, grants *api.ListResponse[api.Gran
 
 	type row struct {
 		Group    string `header:"GROUP"`
-		Access   string `header:"ACCESS"`
+		Role     string `header:"ROLE"`
 		Resource string `header:"DESTINATION"`
 	}
 
@@ -162,7 +162,7 @@ func groupGrants(cli *CLI, client *api.Client, grants *api.ListResponse[api.Gran
 
 		rows = append(rows, row{
 			Group:    group.Name,
-			Access:   item.Privilege,
+			Role:     item.Privilege,
 			Resource: item.Resource,
 		})
 	}


### PR DESCRIPTION
## Summary

Changed wording to be more consistent in `infra grants add` and `infra grants list` commands.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] ~Wrote appropriate unit tests~
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] ~Updated associated configuration where necessary~
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [ ] ~Considered data migrations for smooth upgrades~


## Related Issues

Resolves #2105
