### PR TITLE
api: add a library for declarative request validation

### DIFF
--- a/internal/validate/email.go
+++ b/internal/validate/email.go
@@ -3,7 +3,6 @@ package validate
 import (
 	"fmt"
 	"net/mail"
-	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -24,7 +23,7 @@ func (e email) Validate() *Failure {
 	}
 	addr, err := mail.ParseAddress(e.value)
 	if err != nil {
-		return fail(e.name, "invalid email address: "+strings.TrimPrefix(err.Error(), "mail: "))
+		return fail(e.name, "invalid email address")
 	}
 	if addr.Name != "" {
 		return fail(e.name, fmt.Sprintf("email address must not contain display name %q", addr.Name))

--- a/internal/validate/email.go
+++ b/internal/validate/email.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"fmt"
 	"net/mail"
 	"strings"
 
@@ -26,7 +27,7 @@ func (e email) Validate() *Failure {
 		return fail(e.name, "invalid email address: "+strings.TrimPrefix(err.Error(), "mail: "))
 	}
 	if addr.Name != "" {
-		return fail(e.name, "email address must not contain a name")
+		return fail(e.name, fmt.Sprintf("email address must not contain display name %q", addr.Name))
 	}
 	return nil
 }

--- a/internal/validate/email.go
+++ b/internal/validate/email.go
@@ -1,0 +1,37 @@
+package validate
+
+import (
+	"net/mail"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Email validates a field that should contain an email address.
+func Email(name string, value string) ValidationRule {
+	return email{name: name, value: value}
+}
+
+type email struct {
+	name  string
+	value string
+}
+
+func (e email) Validate() *Failure {
+	if e.value == "" {
+		return nil
+	}
+	addr, err := mail.ParseAddress(e.value)
+	if err != nil {
+		return fail(e.name, "invalid email address: "+strings.TrimPrefix(err.Error(), "mail: "))
+	}
+	if addr.Name != "" {
+		return fail(e.name, "email address must not contain a name")
+	}
+	return nil
+}
+
+func (e email) DescribeSchema(parent *openapi3.Schema) {
+	schema := schemaForProperty(parent, e.name)
+	schema.Format = "email"
+}

--- a/internal/validate/email_test.go
+++ b/internal/validate/email_test.go
@@ -1,0 +1,96 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"gotest.tools/v3/assert"
+)
+
+type EmailExample struct {
+	Address string
+}
+
+func (e EmailExample) ValidationRules() []ValidationRule {
+	return []ValidationRule{
+		Email("addr", e.Address),
+	}
+}
+
+func TestEmail_Validate(t *testing.T) {
+	type testCase struct {
+		name        string
+		email       string
+		expectedErr string
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		e := EmailExample{Address: tc.email}
+		err := Validate(e)
+		if tc.expectedErr == "" {
+			assert.NilError(t, err)
+			return
+		}
+		assert.ErrorContains(t, err, tc.expectedErr)
+	}
+
+	var testCases = []testCase{
+		{
+			name:  "standard",
+			email: "myaddr@extra.example.com",
+		},
+		{
+			name:  "short",
+			email: "m@e.tv",
+		},
+		{
+			name:  "with angles",
+			email: "<myaddr@example.com>",
+		},
+		{
+			name:        "no tld",
+			email:       "sam@",
+			expectedErr: "validation failed: addr: invalid email address: no angle-addr",
+		},
+		{
+			name:        "with name",
+			email:       "My Name <myaddr@example.com>",
+			expectedErr: "validation failed: addr: email address must not contain a name",
+		},
+		{
+			name:        "too many ats",
+			email:       "foo@what@example.com",
+			expectedErr: "validation failed: addr: invalid email address: expected single address",
+		},
+		{
+			name:        "missing username",
+			email:       "@example.com",
+			expectedErr: "validation failed: addr: invalid email address: no angle-addr",
+		},
+		{
+			name:        "missing at",
+			email:       "james",
+			expectedErr: "validation failed: addr: invalid email address: missing '@' or angle-addr",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestEmail_DescribeSchema(t *testing.T) {
+	e := Email("addrField", "")
+	var schema openapi3.Schema
+	e.DescribeSchema(&schema)
+	expected := openapi3.Schema{
+		Properties: openapi3.Schemas{
+			"addrField": &openapi3.SchemaRef{
+				Value: &openapi3.Schema{Format: "email"},
+			},
+		},
+	}
+	assert.DeepEqual(t, schema, expected, cmpSchema)
+}

--- a/internal/validate/email_test.go
+++ b/internal/validate/email_test.go
@@ -44,13 +44,8 @@ func TestEmail_Validate(t *testing.T) {
 			email: "m@e.tv",
 		},
 		{
-			name:  "with angles",
+			name:  "with angle brackets",
 			email: "<myaddr@example.com>",
-		},
-		{
-			name:        "no tld",
-			email:       "sam@",
-			expectedErr: "validation failed: addr: invalid email address: no angle-addr",
 		},
 		{
 			name:        "with name",
@@ -60,17 +55,22 @@ func TestEmail_Validate(t *testing.T) {
 		{
 			name:        "too many ats",
 			email:       "foo@what@example.com",
-			expectedErr: "validation failed: addr: invalid email address: expected single address",
+			expectedErr: "validation failed: addr: invalid email address",
 		},
 		{
 			name:        "missing username",
 			email:       "@example.com",
-			expectedErr: "validation failed: addr: invalid email address: no angle-addr",
+			expectedErr: "validation failed: addr: invalid email address",
+		},
+		{
+			name:        "no hostname",
+			email:       "sam@",
+			expectedErr: "validation failed: addr: invalid email address",
 		},
 		{
 			name:        "missing at",
 			email:       "james",
-			expectedErr: "validation failed: addr: invalid email address: missing '@' or angle-addr",
+			expectedErr: "validation failed: addr: invalid email address",
 		},
 	}
 

--- a/internal/validate/email_test.go
+++ b/internal/validate/email_test.go
@@ -55,7 +55,7 @@ func TestEmail_Validate(t *testing.T) {
 		{
 			name:        "with name",
 			email:       "My Name <myaddr@example.com>",
-			expectedErr: "validation failed: addr: email address must not contain a name",
+			expectedErr: `validation failed: addr: email address must not contain display name "My Name"`,
 		},
 		{
 			name:        "too many ats",

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -76,11 +76,11 @@ func (s StringRule) Validate() *Failure {
 		problems = append(problems, fmt.Sprintf(format, args...))
 	}
 	if s.MinLength > 0 && len(value) < s.MinLength {
-		add("length (%d) must be at least %d", len(value), s.MinLength)
+		add("length of string (%d) must be at least %d", len(value), s.MinLength)
 	}
 
 	if s.MaxLength > 0 && len(value) > s.MaxLength {
-		add("length (%d) must be no more than %d", len(value), s.MaxLength)
+		add("length of string (%d) must be no more than %d", len(value), s.MaxLength)
 	}
 
 	if len(s.CharacterRanges) > 0 {

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -1,0 +1,108 @@
+package validate
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+type StringRule struct {
+	// Value to Validate
+	Value string
+	// Name of the field in json.
+	Name string
+
+	// MinLength is the minimum allowed length of the string in bytes.
+	MinLength int
+	// MaxLength is the maximum allowed length of the string in bytes.
+	MaxLength int
+
+	// CharacterRanges is a list of character ranges. Every rune in value
+	// must bet within one of these ranges.
+	CharacterRanges []CharRange
+}
+
+type CharRange struct {
+	Low  rune
+	High rune
+}
+
+func (r CharRange) String() string {
+	if r.Low == r.High {
+		if r.Low == '-' {
+			return `\-`
+		}
+		return string(r.Low)
+	}
+	return string(r.Low) + "-" + string(r.High)
+}
+
+var (
+	AlphabetLower = CharRange{Low: 'a', High: 'z'}
+	AlphabetUpper = CharRange{Low: 'A', High: 'Z'}
+	Numbers       = CharRange{Low: '0', High: '9'}
+	Dash          = CharRange{Low: '-', High: '-'}
+	Underscore    = CharRange{Low: '_', High: '_'}
+	Dot           = CharRange{Low: '.', High: '.'}
+)
+
+func (s StringRule) DescribeSchema(parent *openapi3.Schema) {
+	schema := schemaForProperty(parent, s.Name)
+
+	schema.MinLength = uint64(s.MinLength)
+	if s.MaxLength > 0 {
+		max := uint64(s.MaxLength)
+		schema.MaxLength = &max
+	}
+
+	var buf bytes.Buffer
+	for _, r := range s.CharacterRanges {
+		buf.WriteString(r.String())
+	}
+	if buf.Len() > 0 {
+		schema.Format = "[" + buf.String() + "]"
+	}
+}
+
+func (s StringRule) Validate() *Failure {
+	value := s.Value
+	if value == "" {
+		return nil
+	}
+
+	var problems []string
+	add := func(format string, args ...any) {
+		problems = append(problems, fmt.Sprintf(format, args...))
+	}
+	if s.MinLength > 0 && len(value) < s.MinLength {
+		add("length (%d) must be at least %d", len(value), s.MinLength)
+	}
+
+	if s.MaxLength > 0 && len(value) > s.MaxLength {
+		add("length (%d) must be no more than %d", len(value), s.MaxLength)
+	}
+
+	if len(s.CharacterRanges) > 0 {
+		for i, c := range value {
+			if !inRange(s.CharacterRanges, c) {
+				add("character %c at position %v is not allowed", c, i)
+				break
+			}
+		}
+	}
+
+	if len(problems) > 0 {
+		return fail(s.Name, problems...)
+	}
+	return nil
+}
+
+func inRange(ranges []CharRange, c rune) bool {
+	for _, r := range ranges {
+		if c >= r.Low && c <= r.High {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -9,26 +9,41 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+type StringExample struct {
+	Field string
+}
+
+func (s StringExample) ValidationRules() []ValidationRule {
+	return []ValidationRule{
+		&StringRule{
+			Value:           s.Field,
+			Name:            "strField",
+			MinLength:       2,
+			MaxLength:       10,
+			CharacterRanges: []CharRange{AlphabetLower},
+		},
+	}
+}
+
 func TestStringRule_Validate(t *testing.T) {
 	t.Run("min length", func(t *testing.T) {
-		r := &ExampleRequest{RequiredString: "a"}
+		r := StringExample{Field: "a"}
 		err := Validate(r)
 		assert.ErrorContains(t, err, "length of string (1) must be at least 2")
 	})
 	t.Run("max length", func(t *testing.T) {
-		r := &ExampleRequest{RequiredString: "abcdefghijklm"}
+		r := StringExample{Field: "abcdefghijklm"}
 		err := Validate(r)
 		assert.ErrorContains(t, err, "length of string (13) must be no more than 10")
 	})
 	t.Run("character ranges", func(t *testing.T) {
-		r := &ExampleRequest{RequiredString: "almost~valid"}
+		r := StringExample{Field: "almost~valid"}
 		err := Validate(r)
 
 		var verr Error
 		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
 		expected := Error{
-			"fieldOne": {"a value is required"},
-			"strOne": {
+			"strField": {
 				"length of string (12) must be no more than 10",
 				"character ~ at position 6 is not allowed",
 			},

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -1,0 +1,69 @@
+package validate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"gotest.tools/v3/assert"
+)
+
+func TestStringRule_Validate(t *testing.T) {
+	t.Run("min length", func(t *testing.T) {
+		r := &ExampleRequest{RequiredString: "a"}
+		err := Validate(r)
+		assert.ErrorContains(t, err, "length (1) must be at least 2")
+	})
+	t.Run("max length", func(t *testing.T) {
+		r := &ExampleRequest{RequiredString: "abcdefghijklm"}
+		err := Validate(r)
+		assert.ErrorContains(t, err, "length (13) must be no more than 10")
+	})
+	t.Run("character ranges", func(t *testing.T) {
+		r := &ExampleRequest{RequiredString: "almost~valid"}
+		err := Validate(r)
+
+		var verr Error
+		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
+		expected := Error{
+			"fieldOne": {"a value is required"},
+			"strOne": {
+				"length (12) must be no more than 10",
+				"character ~ at position 6 is not allowed",
+			},
+		}
+		assert.DeepEqual(t, verr, expected)
+	})
+}
+
+func TestStringRule_DescribeSchema(t *testing.T) {
+	r := StringRule{
+		Name:      "street",
+		MinLength: 2,
+		MaxLength: 10,
+		CharacterRanges: []CharRange{
+			AlphabetUpper,
+			Dot, Dash,
+		},
+	}
+
+	var schema openapi3.Schema
+	r.DescribeSchema(&schema)
+
+	var max uint64 = 10
+	expected := openapi3.Schema{
+		Properties: openapi3.Schemas{
+			"street": &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					MinLength: 2,
+					MaxLength: &max,
+					Format:    `[A-Z.\-]`,
+				},
+			},
+		},
+	}
+	assert.DeepEqual(t, schema, expected, cmpSchema)
+}
+
+var cmpSchema = cmpopts.IgnoreUnexported(openapi3.Schema{})

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -13,12 +13,12 @@ func TestStringRule_Validate(t *testing.T) {
 	t.Run("min length", func(t *testing.T) {
 		r := &ExampleRequest{RequiredString: "a"}
 		err := Validate(r)
-		assert.ErrorContains(t, err, "length (1) must be at least 2")
+		assert.ErrorContains(t, err, "length of string (1) must be at least 2")
 	})
 	t.Run("max length", func(t *testing.T) {
 		r := &ExampleRequest{RequiredString: "abcdefghijklm"}
 		err := Validate(r)
-		assert.ErrorContains(t, err, "length (13) must be no more than 10")
+		assert.ErrorContains(t, err, "length of string (13) must be no more than 10")
 	})
 	t.Run("character ranges", func(t *testing.T) {
 		r := &ExampleRequest{RequiredString: "almost~valid"}
@@ -29,7 +29,7 @@ func TestStringRule_Validate(t *testing.T) {
 		expected := Error{
 			"fieldOne": {"a value is required"},
 			"strOne": {
-				"length (12) must be no more than 10",
+				"length of string (12) must be no more than 10",
 				"character ~ at position 6 is not allowed",
 			},
 		}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -105,7 +105,7 @@ func (r requiredRule) Validate() *Failure {
 	if !reflect.ValueOf(r.value).IsZero() {
 		return nil
 	}
-	return fail(r.name, "a value is required")
+	return fail(r.name, "is required")
 }
 
 // Field is used to construct validation rules that incorporate multiple fields.

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,175 @@
+package validate
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Validate that the values in the Request struct are valid according to the
+// validation rules defined on the struct.
+// If validation fails the error will be of type Error.
+func Validate(req Request) error {
+	err := make(Error)
+
+	for _, rule := range req.ValidationRules() {
+		if failure := rule.Validate(); failure != nil {
+			err[failure.Name] = append(err[failure.Name], failure.Problems...)
+		}
+	}
+
+	if len(err) > 0 {
+		return err
+	}
+	return nil
+}
+
+// ValidationRule performs validation on one or more struct fields and can
+// describe the validation for public API documentation.
+type ValidationRule interface {
+	// Validate should return nil if the validation passes. If the validation
+	// fails the Failure should contain the name of the field and the list of
+	// problems.
+	Validate() *Failure
+
+	// DescribeSchema should update schema to describe the values that are
+	// allowed by the validation. The schema is the parent schema of the request.
+	// To set the schema of a property, look it up from schema.Properties[name].
+	DescribeSchema(schema *openapi3.Schema)
+}
+
+// Failure describes a validation failures.
+type Failure struct {
+	// Name of the field. The name should be the user visible name as it appears
+	// in API documentation (often the json field name, or query parameter),
+	// not the name of the struct field.
+	Name string
+	// Problems is a list of messages that describe the validation failure. They
+	// will be part of the API response.
+	Problems []string
+}
+
+// Request is implemented by all request structs.
+type Request interface {
+	ValidationRules() []ValidationRule
+}
+
+// Error is a map of field names to errors associated with those fields. Errors
+// that are associated with the struct or multiple fields will have a key of
+// "".
+type Error map[string][]string
+
+func (e Error) Error() string {
+	var buf strings.Builder
+	buf.WriteString("validation failed: ")
+	i := 0
+	for k, v := range e {
+		if i != 0 {
+			buf.WriteString(", ")
+		}
+		i++
+		if k == "" {
+			buf.WriteString(strings.Join(v, ", "))
+			continue
+		}
+		buf.WriteString(k + ": " + strings.Join(v, ", "))
+	}
+	return buf.String()
+}
+
+func fail(name string, problems ...string) *Failure {
+	return &Failure{Name: name, Problems: problems}
+}
+
+type requiredRule struct {
+	name  string
+	value any
+}
+
+// Required checks that the value does not have a zero value.
+// Zero values are nil, "", 0, false, empty map, empty slice, or the zero value of
+// a struct.
+// Name is the name of the field as visible to the user, often the json field
+// name.
+func Required(name string, value any) ValidationRule {
+	return requiredRule{name: name, value: value}
+}
+
+func (r requiredRule) DescribeSchema(schema *openapi3.Schema) {
+	schema.Required = append(schema.Required, r.name)
+}
+
+func (r requiredRule) Validate() *Failure {
+	if !reflect.ValueOf(r.value).IsZero() {
+		return nil
+	}
+	return fail(r.name, "a value is required")
+}
+
+// Field is used to construct validation rules that incorporate multiple fields.
+type Field struct {
+	Name  string
+	Value interface{}
+}
+
+// MutuallyExclusive returns a validation rule that checks that at most one of
+// the fields is set to a non-zero value.
+func MutuallyExclusive(fields ...Field) ValidationRule {
+	return mutuallyExclusive(fields)
+}
+
+type mutuallyExclusive []Field
+
+func (m mutuallyExclusive) Validate() *Failure {
+	var nonZero []string
+	for _, field := range m {
+		if !reflect.ValueOf(field.Value).IsZero() {
+			nonZero = append(nonZero, field.Name)
+		}
+	}
+
+	if len(nonZero) > 1 {
+		return fail("", fmt.Sprintf("only one of (%v) can be set", strings.Join(nonZero, ", ")))
+	}
+	return nil
+}
+
+// TODO: use oneOf to DescribeSchema
+func (m mutuallyExclusive) DescribeSchema(_ *openapi3.Schema) {}
+
+// RequireOneOf returns a validation rule that checks that at least one of the
+// fields is set to a non-zero value.
+func RequireOneOf(fields ...Field) ValidationRule {
+	return requireOneOf(fields)
+}
+
+type requireOneOf []Field
+
+func (m requireOneOf) Validate() *Failure {
+	var zero []string
+	for _, field := range m {
+		if reflect.ValueOf(field.Value).IsZero() {
+			zero = append(zero, field.Name)
+		}
+	}
+
+	if len(zero) == len(m) {
+		return fail("", fmt.Sprintf("one of (%v) is required", strings.Join(zero, ", ")))
+	}
+	return nil
+}
+
+// TODO: use anyOf to DescribeSchema
+func (m requireOneOf) DescribeSchema(_ *openapi3.Schema) {}
+
+func schemaForProperty(parent *openapi3.Schema, prop string) *openapi3.Schema {
+	if parent.Properties == nil {
+		parent.Properties = make(openapi3.Schemas)
+	}
+	if parent.Properties[prop] == nil {
+		parent.Properties[prop] = &openapi3.SchemaRef{Value: &openapi3.Schema{}}
+	}
+	return parent.Properties[prop].Value
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -91,7 +91,7 @@ func TestValidate_AllRules(t *testing.T) {
 				"only one of (either, or) can be set",
 				"one of (first, second, third) is required",
 			},
-			"emailAddr":  {"invalid email address: missing '@' or angle-addr"},
+			"emailAddr":  {"invalid email address"},
 			"emailOther": {`email address must not contain display name "Display Name"`},
 			"tooFew":     {"length of string (1) must be at least 5"},
 			"tooMany":    {"length of string (6) must be no more than 5"},

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -66,7 +66,7 @@ func TestValidate(t *testing.T) {
 		expected := Error{
 			"fieldOne":           {"a value is required"},
 			"strOne":             {"a value is required"},
-			"subNested.fieldOne": {"length (20) must be no more than 10"},
+			"subNested.fieldOne": {"length of string (20) must be no more than 10"},
 		}
 		assert.DeepEqual(t, fieldError, expected)
 	})

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,151 @@
+package validate
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+type ExampleRequest struct {
+	RequiredString string `json:"strOne"`
+	SubNested      Sub    `json:"subNested"`
+	Sub                   // sub embedded
+}
+
+type Sub struct {
+	FieldOne string `json:"fieldOne"`
+}
+
+func (r *ExampleRequest) ValidationRules() []ValidationRule {
+	return []ValidationRule{
+		Required("strOne", r.RequiredString),
+		&StringRule{
+			Value:     r.RequiredString,
+			Name:      "strOne",
+			MinLength: 2,
+			MaxLength: 10,
+			CharacterRanges: []CharRange{
+				AlphabetLower,
+				AlphabetUpper,
+				Numbers,
+				Dot, Dash, Underscore,
+			},
+		},
+		Required("fieldOne", r.Sub.FieldOne),
+		&StringRule{
+			Value:     r.SubNested.FieldOne,
+			Name:      "subNested.fieldOne",
+			MaxLength: 10,
+		},
+	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		r := &ExampleRequest{
+			RequiredString: "not-zero",
+			Sub:            Sub{FieldOne: "not-zero2"},
+		}
+		err := Validate(r)
+		assert.NilError(t, err)
+	})
+
+	t.Run("with failures", func(t *testing.T) {
+		r := &ExampleRequest{
+			RequiredString: "",
+			SubNested: Sub{
+				FieldOne: "abcdefghijklmnopqrst",
+			},
+		}
+		err := Validate(r)
+		assert.ErrorContains(t, err, "validation failed: ")
+
+		var fieldError Error
+		assert.Assert(t, errors.As(err, &fieldError))
+		expected := Error{
+			"fieldOne":           {"a value is required"},
+			"strOne":             {"a value is required"},
+			"subNested.fieldOne": {"length (20) must be no more than 10"},
+		}
+		assert.DeepEqual(t, fieldError, expected)
+	})
+}
+
+type MutualExample struct {
+	First  string
+	Second bool
+	Third  int
+}
+
+func (m MutualExample) ValidationRules() []ValidationRule {
+	return []ValidationRule{
+		MutuallyExclusive(
+			Field{Name: "first", Value: m.First},
+			Field{Name: "second", Value: m.Second},
+			Field{Name: "third", Value: m.Third}),
+	}
+}
+
+func TestMutuallyExclusive_Validate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		e := MutualExample{First: "value"}
+		assert.NilError(t, Validate(e))
+
+		e = MutualExample{}
+		assert.NilError(t, Validate(e))
+
+		e = MutualExample{Second: true}
+		assert.NilError(t, Validate(e))
+
+		e = MutualExample{Third: 123}
+		assert.NilError(t, Validate(e))
+	})
+	t.Run("with failure two set", func(t *testing.T) {
+		e := MutualExample{First: "value", Second: true}
+		err := Validate(e)
+		assert.Error(t, err, "validation failed: only one of (first, second) can be set")
+	})
+	t.Run("with failure three set", func(t *testing.T) {
+		e := MutualExample{
+			First:  "value",
+			Second: true,
+			Third:  123,
+		}
+		err := Validate(e)
+		assert.Error(t, err, "validation failed: only one of (first, second, third) can be set")
+	})
+}
+
+type OneOfExample struct {
+	First  string
+	Second bool
+	Third  int
+}
+
+func (m OneOfExample) ValidationRules() []ValidationRule {
+	return []ValidationRule{
+		RequireOneOf(
+			Field{Name: "first", Value: m.First},
+			Field{Name: "second", Value: m.Second},
+			Field{Name: "third", Value: m.Third}),
+	}
+}
+
+func TestRequireOneOf_Validate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		e := OneOfExample{First: "value"}
+		assert.NilError(t, Validate(e))
+
+		e = OneOfExample{Second: true}
+		assert.NilError(t, Validate(e))
+
+		e = OneOfExample{Third: 123}
+		assert.NilError(t, Validate(e))
+	})
+	t.Run("with failure", func(t *testing.T) {
+		e := OneOfExample{}
+		err := Validate(e)
+		assert.Error(t, err, "validation failed: one of (first, second, third) is required")
+	})
+}


### PR DESCRIPTION
This is the first step in replacing our API request validation.

This PR adds a library with validation rules that we already use today. It does not integrate it into our API handler or openapi doc generation yet.

Follow up items:
* replace validate struct tags with this validation
* at the same time, integrate with openapi doc generation

Follow up PRs: #2501, #2527

Related to #1763