### PR TITLE
fix: remove identity from CLI help

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -221,16 +221,16 @@ infra grants list [flags]
 
 ## `infra grants add`
 
-Grant an identity access to a destination
+Grant a user or group access to a destination
 
 ```
-infra grants add IDENTITY DESTINATION [flags]
+infra grants add USER|GROUP DESTINATION [flags]
 ```
 
 ### Examples
 
 ```
-# Grant an identity access to a destination
+# Grant a user access to a destination
 $ infra grants add johndoe@example.com docker-desktop
 
 # Grant a group access to a destination
@@ -248,8 +248,8 @@ $ infra grants add johndoe@example.com infra --role admin
 
 ```
       --force         Create grant even if requested user, destination, or role are unknown
-  -g, --group         Required if identity is of type 'group'
-      --role string   Type of access that identity will be given (default "connect")
+  -g, --group         Required if adding a grant for a group
+      --role string   Type of access that the user or group will be given (default "connect")
 ```
 
 ### Options inherited from parent commands
@@ -261,16 +261,16 @@ $ infra grants add johndoe@example.com infra --role admin
 
 ## `infra grants remove`
 
-Revoke an identity's access from a destination
+Revoke a user or group's access to a destination
 
 ```
-infra grants remove IDENTITY DESTINATION [flags]
+infra grants remove USER|GROUP DESTINATION [flags]
 ```
 
 ### Examples
 
 ```
-# Remove all grants of an identity in a destination
+# Remove all grants of a user in a destination
 $ infra grants remove janedoe@example.com docker-desktop
 
 # Remove all grants of a group in a destination
@@ -425,18 +425,21 @@ Create an access key
 
 ### Synopsis
 
-Create an access key for a user.
+Create an access key for a user or a connector.
 
 ```
-infra keys add USER [flags]
+infra keys add USER|CONNECTOR [flags]
 ```
 
 ### Examples
 
 ```
 
-# Create an access key named 'example-key' that expires in 12 hours
-$ infra keys add example-key identity@example.com --ttl=12h
+# Create an access key named 'example-key' for a user that expires in 12 hours
+$ infra keys add example-key user@example.com --ttl=12h
+
+# Create an access key to add a Kubernetes connection to Infra
+$ infra keys add connector
 
 ```
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -248,7 +248,7 @@ $ infra grants add johndoe@example.com infra --role admin
 
 ```
       --force         Create grant even if requested user, destination, or role are unknown
-  -g, --group         Required if adding a grant for a group
+  -g, --group         When set, creates a grant for a group instead of a user
       --role string   Type of access that the user or group will be given (default "connect")
 ```
 
@@ -428,7 +428,7 @@ Create an access key
 Create an access key for a user or a connector.
 
 ```
-infra keys add USER|CONNECTOR [flags]
+infra keys add USER|connector [flags]
 ```
 
 ### Examples

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -221,7 +221,7 @@ $ infra grants add johndoe@example.com infra --role admin
 		},
 	}
 
-	cmd.Flags().BoolVarP(&options.IsGroup, "group", "g", false, "Required if adding a grant for a group")
+	cmd.Flags().BoolVarP(&options.IsGroup, "group", "g", false, "When set, creates a grant for a group instead of a user")
 	cmd.Flags().StringVar(&options.Role, "role", models.BasePermissionConnect, "Type of access that the user or group will be given")
 	cmd.Flags().BoolVar(&options.Force, "force", false, "Create grant even if requested user, destination, or role are unknown")
 	return cmd

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -73,15 +73,14 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 			var userRows []userRow
 			var groupRows []groupRow
 			for _, g := range grants.Items {
-
 				switch {
 				case g.User != 0:
-					identity, err := client.GetUser(g.User)
+					user, err := client.GetUser(g.User)
 					if err != nil {
 						return err
 					}
 					userRows = append(userRows, userRow{
-						User:     identity.Name,
+						User:     user.Name,
 						Access:   g.Privilege,
 						Resource: g.Resource,
 					})
@@ -129,10 +128,10 @@ func newGrantRemoveCmd(cli *CLI) *cobra.Command {
 	var options grantsCmdOptions
 
 	cmd := &cobra.Command{
-		Use:     "remove IDENTITY DESTINATION",
+		Use:     "remove USER|GROUP DESTINATION",
 		Aliases: []string{"rm"},
-		Short:   "Revoke an identity's access from a destination",
-		Example: `# Remove all grants of an identity in a destination
+		Short:   "Revoke a user or group's access to a destination",
+		Example: `# Remove all grants of a user in a destination
 $ infra grants remove janedoe@example.com docker-desktop
 
 # Remove all grants of a group in a destination
@@ -200,9 +199,9 @@ func newGrantAddCmd(cli *CLI) *cobra.Command {
 	var options grantsCmdOptions
 
 	cmd := &cobra.Command{
-		Use:   "add IDENTITY DESTINATION",
-		Short: "Grant an identity access to a destination",
-		Example: `# Grant an identity access to a destination
+		Use:   "add USER|GROUP DESTINATION",
+		Short: "Grant a user or group access to a destination",
+		Example: `# Grant a user access to a destination
 $ infra grants add johndoe@example.com docker-desktop
 
 # Grant a group access to a destination
@@ -222,8 +221,8 @@ $ infra grants add johndoe@example.com infra --role admin
 		},
 	}
 
-	cmd.Flags().BoolVarP(&options.IsGroup, "group", "g", false, "Required if identity is of type 'group'")
-	cmd.Flags().StringVar(&options.Role, "role", models.BasePermissionConnect, "Type of access that identity will be given")
+	cmd.Flags().BoolVarP(&options.IsGroup, "group", "g", false, "Required if adding a grant for a group")
+	cmd.Flags().StringVar(&options.Role, "role", models.BasePermissionConnect, "Type of access that the user or group will be given")
 	cmd.Flags().BoolVar(&options.Force, "force", false, "Create grant even if requested user, destination, or role are unknown")
 	return cmd
 }

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -44,7 +44,7 @@ func info(cli *CLI) error {
 
 	id := config.PolymorphicID
 	if id == "" {
-		return fmt.Errorf("no active identity")
+		return fmt.Errorf("no active user")
 	}
 
 	identityID, err := id.ID()
@@ -52,12 +52,12 @@ func info(cli *CLI) error {
 		return err
 	}
 
-	identity, err := client.GetUser(identityID)
+	user, err := client.GetUser(identityID)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(w, "User:\t %s (%s)\n", identity.Name, identity.ID)
+	fmt.Fprintf(w, "User:\t %s (%s)\n", user.Name, user.ID)
 
 	if config.ProviderID != 0 {
 		provider, err := client.GetProvider(config.ProviderID)
@@ -68,17 +68,17 @@ func info(cli *CLI) error {
 		fmt.Fprintf(w, "Identity Provider:\t %s (%s)\n", provider.Name, provider.URL)
 	}
 
-	identityGroups, err := client.ListGroups(api.ListGroupsRequest{UserID: identityID})
+	userGroups, err := client.ListGroups(api.ListGroupsRequest{UserID: identityID})
 	if err != nil {
 		return err
 	}
 
 	groups := "(none)"
 
-	if identityGroups.Count > 0 {
-		g := make([]string, 0, identityGroups.Count)
-		for _, identityGroup := range identityGroups.Items {
-			g = append(g, identityGroup.Name)
+	if userGroups.Count > 0 {
+		g := make([]string, 0, userGroups.Count)
+		for _, userGroup := range userGroups.Items {
+			g = append(g, userGroup.Name)
 		}
 
 		groups = strings.Join(g, ", ")

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -43,7 +43,7 @@ func newKeysAddCmd(cli *CLI) *cobra.Command {
 	var options keyCreateOptions
 
 	cmd := &cobra.Command{
-		Use:   "add USER|CONNECTOR",
+		Use:   "add USER|connector",
 		Short: "Create an access key",
 		Long:  `Create an access key for a user or a connector.`,
 		Example: `

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -43,12 +43,15 @@ func newKeysAddCmd(cli *CLI) *cobra.Command {
 	var options keyCreateOptions
 
 	cmd := &cobra.Command{
-		Use:   "add USER",
+		Use:   "add USER|CONNECTOR",
 		Short: "Create an access key",
-		Long:  `Create an access key for a user.`,
+		Long:  `Create an access key for a user or a connector.`,
 		Example: `
-# Create an access key named 'example-key' that expires in 12 hours
-$ infra keys add example-key identity@example.com --ttl=12h
+# Create an access key named 'example-key' for a user that expires in 12 hours
+$ infra keys add example-key user@example.com --ttl=12h
+
+# Create an access key to add a Kubernetes connection to Infra
+$ infra keys add connector
 `,
 		Args: ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
- update keys command help to show the connector case

## Summary
The help for grants commands was out of date, referencing "identities" rather than "users".

The help for adding a key was confusing in the case of adding a connector. Updated to reflect that common use-case.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2104
Resolves #2004
