### PR TITLE
cli: prompt to accept the server TLS certificate for manual verification

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -110,7 +110,7 @@ func SelfSignedOrLetsEncryptCert(manager *autocert.Manager, serverName string) f
 			}
 
 			logging.L.Info("new server certificate",
-				zap.String("SHA256 fingerprint", Fingerprint(PEMDecode(certBytes))))
+				zap.String("SHA256 fingerprint", Fingerprint(pemDecode(certBytes))))
 		}
 
 		keypair, err := tls.X509KeyPair(certBytes, keyBytes)
@@ -131,7 +131,7 @@ func Fingerprint(raw []byte) string {
 	return strings.ToUpper(s)
 }
 
-func PEMDecode(raw []byte) []byte {
+func pemDecode(raw []byte) []byte {
 	block, _ := pem.Decode(raw)
 	return block.Bytes
 }

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -61,7 +61,7 @@ func GenerateCertificate(hosts []string, caCert *x509.Certificate, caKey crypto.
 	}
 
 	keyBytes := pemEncodePrivateKey(x509.MarshalPKCS1PrivateKey(key))
-	return pemEncodeCertificate(certBytes), keyBytes, nil
+	return PEMEncodeCertificate(certBytes), keyBytes, nil
 }
 
 func SelfSignedOrLetsEncryptCert(manager *autocert.Manager, serverName string) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
@@ -110,7 +110,7 @@ func SelfSignedOrLetsEncryptCert(manager *autocert.Manager, serverName string) f
 			}
 
 			logging.L.Info("new server certificate",
-				zap.String("SHA256 fingerprint", Fingerprint(pemDecode(certBytes))))
+				zap.String("SHA256 fingerprint", Fingerprint(PEMDecode(certBytes))))
 		}
 
 		keypair, err := tls.X509KeyPair(certBytes, keyBytes)
@@ -131,14 +131,14 @@ func Fingerprint(raw []byte) string {
 	return strings.ToUpper(s)
 }
 
-func pemDecode(raw []byte) []byte {
+func PEMDecode(raw []byte) []byte {
 	block, _ := pem.Decode(raw)
 	return block.Bytes
 }
 
-// pemEncodeCertificate accepts the bytes of a x509 certificate in ASN.1 DER form
+// PEMEncodeCertificate accepts the bytes of a x509 certificate in ASN.1 DER form
 // and returns a PEM encoded representation of that certificate.
-func pemEncodeCertificate(raw []byte) []byte {
+func PEMEncodeCertificate(raw []byte) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: raw})
 }
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -104,7 +104,7 @@ func httpTransportForHostConfig(config *ClientHostConfig) *http.Transport {
 	if config.TrustedCertificate != "" {
 		ok := pool.AppendCertsFromPEM([]byte(config.TrustedCertificate))
 		if !ok {
-			logging.S.Warnf("Failed to read trusted certificates for server: %v", err)
+			logging.S.Warnf("Failed to read trusted certificates for server")
 		}
 	}
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -153,7 +153,7 @@ $ infra use development.kube-system`,
 				return err
 			}
 
-			err = updateKubeconfig(client, id)
+			err = updateKubeConfig(client, id)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/certs"
 	"github.com/infrahq/infra/internal/cmd/cliopts"
 	"github.com/infrahq/infra/internal/connector"
 	"github.com/infrahq/infra/internal/logging"
@@ -97,15 +98,17 @@ func apiClient(host string, accessKey string, transport *http.Transport) *api.Cl
 func httpTransportForHostConfig(config *ClientHostConfig) *http.Transport {
 	pool, err := x509.SystemCertPool()
 	if err != nil {
-		// TODO: print warning about this case
+		logging.S.Warnf("Failed to load trusted certificates from system: %v", err)
 		pool = x509.NewCertPool()
 	}
 
 	if len(config.TrustedCertificate) > 0 {
-		// TODO: log or return the error
-		// TODO: read this in PEM format
-		cert, _ := x509.ParseCertificate(config.TrustedCertificate)
-		pool.AddCert(cert)
+		cert, err := x509.ParseCertificate(certs.PEMDecode(config.TrustedCertificate))
+		if err != nil {
+			logging.S.Warnf("Failed to read trusted certificates for server: %v", err)
+		} else {
+			pool.AddCert(cert)
+		}
 	}
 
 	return &http.Transport{

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -77,23 +77,27 @@ func defaultAPIClient() (*api.Client, error) {
 		return nil, err
 	}
 
-	return apiClient(config.Host, config.AccessKey, config.SkipTLSVerify), nil
+	return apiClient(config.Host, config.AccessKey, defaultHTTPTransport(config.SkipTLSVerify)), nil
 }
 
-func apiClient(host string, accessKey string, skipTLSVerify bool) *api.Client {
+func apiClient(host string, accessKey string, transport *http.Transport) *api.Client {
 	return &api.Client{
 		Name:      "cli",
 		Version:   internal.Version,
 		URL:       "https://" + host,
 		AccessKey: accessKey,
 		HTTP: http.Client{
-			Timeout: 60 * time.Second,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					//nolint:gosec // We may purposely set insecureskipverify via a flag
-					InsecureSkipVerify: skipTLSVerify,
-				},
-			},
+			Timeout:   60 * time.Second,
+			Transport: transport,
+		},
+	}
+}
+
+func defaultHTTPTransport(skipTLSVerify bool) *http.Transport {
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			//nolint:gosec // We may purposely set insecureskipverify via a flag
+			InsecureSkipVerify: skipTLSVerify,
 		},
 	}
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
-	"github.com/infrahq/infra/internal/certs"
 	"github.com/infrahq/infra/internal/cmd/cliopts"
 	"github.com/infrahq/infra/internal/connector"
 	"github.com/infrahq/infra/internal/logging"
@@ -102,12 +101,10 @@ func httpTransportForHostConfig(config *ClientHostConfig) *http.Transport {
 		pool = x509.NewCertPool()
 	}
 
-	if len(config.TrustedCertificate) > 0 {
-		cert, err := x509.ParseCertificate(certs.PEMDecode(config.TrustedCertificate))
-		if err != nil {
+	if config.TrustedCertificate != "" {
+		ok := pool.AppendCertsFromPEM([]byte(config.TrustedCertificate))
+		if !ok {
 			logging.S.Warnf("Failed to read trusted certificates for server: %v", err)
-		} else {
-			pool.AddCert(cert)
 		}
 	}
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -77,7 +78,7 @@ func defaultAPIClient() (*api.Client, error) {
 		return nil, err
 	}
 
-	return apiClient(config.Host, config.AccessKey, defaultHTTPTransport(config.SkipTLSVerify)), nil
+	return apiClient(config.Host, config.AccessKey, httpTransportForHostConfig(config)), nil
 }
 
 func apiClient(host string, accessKey string, transport *http.Transport) *api.Client {
@@ -93,11 +94,25 @@ func apiClient(host string, accessKey string, transport *http.Transport) *api.Cl
 	}
 }
 
-func defaultHTTPTransport(skipTLSVerify bool) *http.Transport {
+func httpTransportForHostConfig(config *ClientHostConfig) *http.Transport {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		// TODO: print warning about this case
+		pool = x509.NewCertPool()
+	}
+
+	if len(config.TrustedCertificate) > 0 {
+		// TODO: log or return the error
+		// TODO: read this in PEM format
+		cert, _ := x509.ParseCertificate(config.TrustedCertificate)
+		pool.AddCert(cert)
+	}
+
 	return &http.Transport{
 		TLSClientConfig: &tls.Config{
 			//nolint:gosec // We may purposely set insecureskipverify via a flag
-			InsecureSkipVerify: skipTLSVerify,
+			InsecureSkipVerify: config.SkipTLSVerify,
+			RootCAs:            pool,
 		},
 	}
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -273,6 +273,7 @@ func newTestClientConfig(srv *httptest.Server, user api.User) ClientConfig {
 				PolymorphicID: uid.NewIdentityPolymorphicID(user.ID),
 				Name:          user.Name,
 				Host:          srv.Listener.Addr().String(),
+				// TODO: change to using TrustedCertificate
 				SkipTLSVerify: true,
 				AccessKey:     "the-access-key",
 				Expires:       api.Time(time.Now().Add(time.Hour)),

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -19,6 +19,7 @@ import (
 	"gotest.tools/v3/fs"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/certs"
 	"github.com/infrahq/infra/internal/connector"
 	"github.com/infrahq/infra/uid"
 )
@@ -270,14 +271,13 @@ func newTestClientConfig(srv *httptest.Server, user api.User) ClientConfig {
 		Version: clientConfigVersion,
 		Hosts: []ClientHostConfig{
 			{
-				PolymorphicID: uid.NewIdentityPolymorphicID(user.ID),
-				Name:          user.Name,
-				Host:          srv.Listener.Addr().String(),
-				// TODO: change to using TrustedCertificate
-				SkipTLSVerify: true,
-				AccessKey:     "the-access-key",
-				Expires:       api.Time(time.Now().Add(time.Hour)),
-				Current:       true,
+				PolymorphicID:      uid.NewIdentityPolymorphicID(user.ID),
+				Name:               user.Name,
+				Host:               srv.Listener.Addr().String(),
+				TrustedCertificate: string(certs.PEMEncodeCertificate(srv.Certificate().Raw)),
+				AccessKey:          "the-access-key",
+				Expires:            api.Time(time.Now().Add(time.Hour)),
+				Current:            true,
 			},
 		},
 	}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -267,7 +267,7 @@ func newTestClientConfig(srv *httptest.Server, user api.User) ClientConfig {
 		user.ID = uid.New()
 	}
 	return ClientConfig{
-		Version: "0.3",
+		Version: clientConfigVersion,
 		Hosts: []ClientHostConfig{
 			{
 				PolymorphicID: uid.NewIdentityPolymorphicID(user.ID),

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -32,7 +32,7 @@ type ClientHostConfig struct {
 	Current       bool              `json:"current"`
 	// TrustedCertificate is the PEM encoded TLS certificate used by the server
 	// that was verified and trusted by the user as part of login.
-	TrustedCertificate []byte `json:"trusted-certificate"`
+	TrustedCertificate string `json:"trusted-certificate"`
 }
 
 // checks if user is logged in to the given session (ClientHostConfig)

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -11,13 +11,16 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-// current: v0.3
+// clientConfigVersion is the current version of the client configuration file.
+// Use this constant when referring to a value in tests or code that should
+// always use latest.
+const clientConfigVersion = "0.3"
+
 type ClientConfig struct {
 	Version string             `json:"version"`
 	Hosts   []ClientHostConfig `json:"hosts"`
 }
 
-// current: v0.3
 type ClientHostConfig struct {
 	PolymorphicID uid.PolymorphicID `json:"polymorphic-id"` // identity pid TODO: name this. what's it an ID of?
 	Name          string            `json:"name"`           // identity name
@@ -68,7 +71,7 @@ func readConfig() (*ClientConfig, error) {
 	}
 
 	if len(contents) == 0 {
-		return &ClientConfig{Version: "0.3"}, nil
+		return &ClientConfig{Version: clientConfigVersion}, nil
 	}
 
 	config := &ClientConfig{}
@@ -109,11 +112,7 @@ func writeConfig(config *ClientConfig) error {
 		return err
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(infraDir, "config"), []byte(contents), 0o600); err != nil {
-		return err
-	}
-
-	return nil
+	return ioutil.WriteFile(filepath.Join(infraDir, "config"), contents, 0o600)
 }
 
 // Save (create or update) the current hostconfig

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -27,7 +27,8 @@ type ClientHostConfig struct {
 	ProviderID    uid.ID            `json:"provider-id,omitempty"`
 	Expires       api.Time          `json:"expires"`
 	Current       bool              `json:"current"`
-	// TODO: should we store this in a separate file?
+	// TrustedCertificate is the PEM encoded TLS certificate used by the server
+	// that was verified and trusted by the user as part of login.
 	TrustedCertificate []byte `json:"trusted-certificate"`
 }
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -27,6 +27,8 @@ type ClientHostConfig struct {
 	ProviderID    uid.ID            `json:"provider-id,omitempty"`
 	Expires       api.Time          `json:"expires"`
 	Current       bool              `json:"current"`
+	// TODO: should we store this in a separate file?
+	TrustedCertificate []byte `json:"trusted-certificate"`
 }
 
 // checks if user is logged in to the given session (ClientHostConfig)

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -18,11 +18,6 @@ var (
 	ErrUserNotFound      = errors.New(`no user found with this name`)
 )
 
-// User facing constant errors: to let user know why their command failed. Not meant for a stack trace, but a readable output of the reason for failure.
-var (
-	ErrTLSNotVerified = errors.New(`The authenticity of the host can't be established.`)
-)
-
 type LoginError struct {
 	Message string
 }

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -56,10 +56,10 @@ func kubernetesSetContext(cluster, namespace string) error {
 	return nil
 }
 
-func updateKubeconfig(client *api.Client, id uid.ID) error {
+func updateKubeConfig(client *api.Client, id uid.ID) error {
 	destinations, err := client.ListDestinations(api.ListDestinationsRequest{})
 	if err != nil {
-		return nil
+		return err
 	}
 
 	user, err := client.GetUser(id)

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -47,7 +47,8 @@ func TestListCmd(t *testing.T) {
 		assert.Check(t, srv.Run(ctx))
 	}()
 
-	c := apiClient(srv.Addrs.HTTPS.String(), "0000000001.adminadminadminadmin1234", defaultHTTPTransport(true))
+	httpTransport := httpTransportForHostConfig(&ClientHostConfig{SkipTLSVerify: true})
+	c := apiClient(srv.Addrs.HTTPS.String(), "0000000001.adminadminadminadmin1234", httpTransport)
 
 	_, err = c.CreateDestination(&api.CreateDestinationRequest{
 		UniqueID: "space",

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -47,7 +47,7 @@ func TestListCmd(t *testing.T) {
 		assert.Check(t, srv.Run(ctx))
 	}()
 
-	c := apiClient(srv.Addrs.HTTPS.String(), "0000000001.adminadminadminadmin1234", true)
+	c := apiClient(srv.Addrs.HTTPS.String(), "0000000001.adminadminadminadmin1234", defaultHTTPTransport(true))
 
 	_, err = c.CreateDestination(&api.CreateDestinationRequest{
 		UniqueID: "space",

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -78,7 +78,7 @@ func TestListCmd(t *testing.T) {
 	t.Run("with no grants", func(t *testing.T) {
 		user := userMap["nogrants@example.com"]
 		err := writeConfig(&ClientConfig{
-			Version: "0.3",
+			Version: clientConfigVersion,
 			Hosts: []ClientHostConfig{
 				{
 					PolymorphicID: uid.NewIdentityPolymorphicID(user.ID),
@@ -104,7 +104,7 @@ func TestListCmd(t *testing.T) {
 	t.Run("with many grants", func(t *testing.T) {
 		user := userMap["manygrants@example.com"]
 		err := writeConfig(&ClientConfig{
-			Version: "0.3",
+			Version: clientConfigVersion,
 			Hosts: []ClientHostConfig{
 				{
 					PolymorphicID: uid.NewIdentityPolymorphicID(user.ID),

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -397,11 +398,20 @@ func newAPIClient(cli *CLI, options loginCmdOptions) (*api.Client, error) {
 				return nil, err
 			}
 			// TODO: save cert for future requests
-
+			// TODO: cleanup
+			pool, err := x509.SystemCertPool()
+			if err != nil {
+				return nil, err
+			}
+			pool.AddCert(uaErr.Cert)
+			transport := &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: pool},
+			}
+			return apiClient(options.Server, "", transport), nil
 		}
 	}
 
-	client := apiClient(options.Server, "", options.SkipTLSVerify)
+	client := apiClient(options.Server, "", defaultHTTPTransport(options.SkipTLSVerify))
 	return client, nil
 }
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -206,6 +206,8 @@ func loginToInfra(cli *CLI, lc loginClient, loginReq *api.LoginRequest, noAgent 
 
 		return err
 	}
+	// Update the API client with the new access key from login
+	lc.APIClient.AccessKey = loginRes.AccessKey
 
 	if loginRes.PasswordUpdateRequired {
 		fmt.Fprintf(cli.Stderr, "  Your password has expired. Please update your password (min. length 8).\n")
@@ -216,7 +218,6 @@ func loginToInfra(cli *CLI, lc loginClient, loginReq *api.LoginRequest, noAgent 
 		}
 
 		logging.S.Debugf("call server: update user %s", loginRes.UserID)
-		lc.APIClient.AccessKey = loginRes.AccessKey
 		if _, err := lc.APIClient.UpdateUser(&api.UpdateUserRequest{ID: loginRes.UserID, Password: password}); err != nil {
 			return err
 		}
@@ -228,7 +229,7 @@ func loginToInfra(cli *CLI, lc loginClient, loginReq *api.LoginRequest, noAgent 
 		return err
 	}
 
-	if err := updateKubeconfig(lc.APIClient, loginRes.UserID); err != nil {
+	if err := updateKubeConfig(lc.APIClient, loginRes.UserID); err != nil {
 		return err
 	}
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -546,6 +546,7 @@ func promptLoginOptions(cli *CLI, client *api.Client) (loginMethod loginMethod, 
 func promptVerifyTLSCert(cli *CLI, cert *x509.Certificate) error {
 	// TODO: improve this message
 	// TODO: use color/bold to highlight important parts
+	// TODO: test format with golden
 	fmt.Fprintf(cli.Stderr, `The certificate presented by the server could not be automatically verified.
 
 Subject: %[1]s

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -204,21 +203,18 @@ func TestLoginCmd(t *testing.T) {
 		cert, err := os.ReadFile("testdata/pki/localhost.crt")
 		assert.NilError(t, err)
 
-		// TODO: remove once stored as PEM encoded
-		block, _ := pem.Decode(cert)
-
 		// Check the client config
 		cfg, err = readConfig()
 		assert.NilError(t, err)
 		expected := []ClientHostConfig{
 			{
-				Name:               "admin",
+				Name:               "admin@example.com",
 				AccessKey:          "any-access-key",
 				PolymorphicID:      "any-id",
 				Host:               srv.Addrs.HTTPS.String(),
 				Expires:            api.Time(time.Now().UTC().Add(opts.SessionDuration)),
 				Current:            true,
-				TrustedCertificate: block.Bytes,
+				TrustedCertificate: cert,
 			},
 		}
 		// TODO: where is the extra entry coming from?
@@ -269,7 +265,7 @@ func newConsole(t *testing.T) *expect.Console {
 	pseudoTY, tty, err := pty.Open()
 	assert.NilError(t, err, "failed to open pseudo tty")
 
-	timeout := time.Hour // TODO: time.Second
+	timeout := time.Second
 	if os.Getenv("CI") != "" {
 		// CI takes much longer than local dev, use a much longer timeout
 		timeout = 20 * time.Second

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -184,7 +184,7 @@ func TestLoginCmd(t *testing.T) {
 		accessKey := resp.AccessKey
 
 		// Erase local data for previous login session
-		assert.NilError(t, writeConfig(&ClientConfig{}))
+		assert.NilError(t, writeConfig(&ClientConfig{Version: clientConfigVersion}))
 
 		console := newConsole(t)
 		ctx = PatchCLIWithPTY(ctx, console.Tty())
@@ -217,7 +217,6 @@ func TestLoginCmd(t *testing.T) {
 				TrustedCertificate: cert,
 			},
 		}
-		// TODO: where is the extra entry coming from?
 		assert.DeepEqual(t, cfg.Hosts, expected, cmpClientHostConfig)
 	})
 }

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func TestLoginCmdSignup(t *testing.T) {
+func TestLoginCmd_SetupAdminOnFirstLogin(t *testing.T) {
 	dir := setupEnv(t)
 
 	opts := defaultServerOptions(dir)
@@ -40,30 +40,6 @@ func TestLoginCmdSignup(t *testing.T) {
 	go func() {
 		assert.Check(t, srv.Run(ctx))
 	}()
-
-	runStep(t, "reject server certificate", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(ctx)
-		t.Cleanup(cancel)
-
-		console := newConsole(t)
-		ctx = PatchCLIWithPTY(ctx, console.Tty())
-
-		g, ctx := errgroup.WithContext(ctx)
-		g.Go(func() error {
-			// TODO: why isn't this working without --non-interactive=false? the other test works
-			return Run(ctx, "login", "--non-interactive=false", srv.Addrs.HTTPS.String())
-		})
-		exp := expector{console: console}
-		exp.ExpectString(t, "verify the certificate can be trusted")
-		exp.Send(t, "I do not trust this certificate\n")
-
-		assert.ErrorIs(t, g.Wait(), terminal.InterruptErr)
-
-		// Check we haven't persisted any certificates
-		cfg, err := readConfig()
-		assert.NilError(t, err)
-		assert.Equal(t, len(cfg.Hosts), 0)
-	})
 
 	runStep(t, "first login prompts for setup", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
@@ -89,9 +65,36 @@ func TestLoginCmdSignup(t *testing.T) {
 
 		assert.NilError(t, g.Wait())
 	})
+
+	runStep(t, "login updated infra config", func(t *testing.T) {
+		cfg, err := readConfig()
+		assert.NilError(t, err)
+
+		expected := []ClientHostConfig{
+			{
+				Name:          "admin@example.com",
+				AccessKey:     "any-access-key",
+				PolymorphicID: "any-id",
+				Host:          srv.Addrs.HTTPS.String(),
+				SkipTLSVerify: true,
+				Expires:       api.Time(time.Now().UTC().Add(opts.SessionDuration)),
+				Current:       true,
+			},
+		}
+		assert.DeepEqual(t, cfg.Hosts, expected, cmpClientHostConfig)
+	})
+
+	runStep(t, "login updated kube config", func(t *testing.T) {
+		kubeCfg, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+
+		// config is empty because there are no grants yet
+		expected := clientcmdapi.Config{}
+		assert.DeepEqual(t, expected, kubeCfg, cmpopts.EquateEmpty())
+	})
 }
 
-func TestLoginCmd(t *testing.T) {
+func TestLoginCmd_Options(t *testing.T) {
 	dir := setupEnv(t)
 
 	opts := defaultServerOptions(dir)
@@ -161,63 +164,6 @@ func TestLoginCmd(t *testing.T) {
 		// config is empty because there are no grants yet
 		expected := clientcmdapi.Config{}
 		assert.DeepEqual(t, expected, kubeCfg, cmpopts.EquateEmpty())
-	})
-
-	runStep(t, "trust server certificate", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(ctx)
-		t.Cleanup(cancel)
-
-		// Create an access key for login
-		cfg, err := readConfig()
-		assert.NilError(t, err)
-		assert.Equal(t, len(cfg.Hosts), 1)
-		userID, _ := cfg.Hosts[0].PolymorphicID.ID()
-		client, err := defaultAPIClient()
-		assert.NilError(t, err)
-
-		resp, err := client.CreateAccessKey(&api.CreateAccessKeyRequest{
-			UserID:            userID,
-			TTL:               api.Duration(opts.SessionDuration + time.Minute),
-			ExtensionDeadline: api.Duration(time.Minute),
-		})
-		assert.NilError(t, err)
-		accessKey := resp.AccessKey
-
-		// Erase local data for previous login session
-		assert.NilError(t, writeConfig(&ClientConfig{Version: clientConfigVersion}))
-
-		console := newConsole(t)
-		ctx = PatchCLIWithPTY(ctx, console.Tty())
-
-		g, ctx := errgroup.WithContext(ctx)
-		g.Go(func() error {
-			// TODO: why isn't this working without --non-interactive=false? the other test works
-			return Run(ctx, "login", "--non-interactive=false", "--key", accessKey, srv.Addrs.HTTPS.String())
-		})
-		exp := expector{console: console}
-		exp.ExpectString(t, "verify the certificate can be trusted")
-		exp.Send(t, "Trust and save the certificate\n")
-
-		assert.NilError(t, g.Wait())
-
-		cert, err := os.ReadFile("testdata/pki/localhost.crt")
-		assert.NilError(t, err)
-
-		// Check the client config
-		cfg, err = readConfig()
-		assert.NilError(t, err)
-		expected := []ClientHostConfig{
-			{
-				Name:               "admin@example.com",
-				AccessKey:          "any-access-key",
-				PolymorphicID:      "any-id",
-				Host:               srv.Addrs.HTTPS.String(),
-				Expires:            api.Time(time.Now().UTC().Add(opts.SessionDuration)),
-				Current:            true,
-				TrustedCertificate: cert,
-			},
-		}
-		assert.DeepEqual(t, cfg.Hosts, expected, cmpClientHostConfig)
 	})
 }
 
@@ -333,4 +279,122 @@ func setupCertManager(t *testing.T, dir string, serverName string) {
 	assert.NilError(t, err)
 	err = cache.Put(ctx, serverName+".crt", cert)
 	assert.NilError(t, err)
+}
+
+func TestLoginCmd_PromptForTLSVerify(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // Windows
+	// k8s.io/tools/clientcmd reads HOME at import time, so this must be patched too
+	kubeConfigPath := filepath.Join(dir, "kube.config")
+	t.Setenv("KUBECONFIG", kubeConfigPath)
+
+	opts := defaultServerOptions(dir)
+	accessKey := "0000000001.adminadminadminadmin1234"
+	opts.Users = []server.User{
+		{Name: "admin@example.com", AccessKey: accessKey},
+	}
+	opts.Addr = server.ListenerOptions{HTTPS: "127.0.0.1:0", HTTP: "127.0.0.1:0"}
+	srv, err := server.New(opts)
+	assert.NilError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	setupCertManager(t, opts.TLSCache, srv.Addrs.HTTPS.String())
+	go func() {
+		assert.Check(t, srv.Run(ctx))
+	}()
+
+	runStep(t, "reject server certificate", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		t.Cleanup(cancel)
+
+		console := newConsole(t)
+		ctx = PatchCLIWithPTY(ctx, console.Tty())
+
+		g, ctx := errgroup.WithContext(ctx)
+		g.Go(func() error {
+			// TODO: why isn't this working without --non-interactive=false? the other test works
+			return Run(ctx, "login", "--non-interactive=false", srv.Addrs.HTTPS.String())
+		})
+		exp := expector{console: console}
+		exp.ExpectString(t, "verify the certificate can be trusted")
+		exp.Send(t, "NO\n")
+
+		assert.ErrorIs(t, g.Wait(), terminal.InterruptErr)
+
+		// Check we haven't persisted any certificates
+		cfg, err := readConfig()
+		assert.NilError(t, err)
+		assert.Equal(t, len(cfg.Hosts), 0)
+	})
+
+	runStep(t, "trust server certificate", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		t.Cleanup(cancel)
+
+		console := newConsole(t)
+		ctx = PatchCLIWithPTY(ctx, console.Tty())
+
+		g, ctx := errgroup.WithContext(ctx)
+		g.Go(func() error {
+			// TODO: why isn't this working without --non-interactive=false? the other test works
+			return Run(ctx, "login", "--non-interactive=false", "--key", accessKey, srv.Addrs.HTTPS.String())
+		})
+		exp := expector{console: console}
+		exp.ExpectString(t, "verify the certificate can be trusted")
+		exp.Send(t, "TRUST\n")
+
+		assert.NilError(t, g.Wait())
+
+		cert, err := os.ReadFile("testdata/pki/localhost.crt")
+		assert.NilError(t, err)
+
+		// Check the client config
+		cfg, err := readConfig()
+		assert.NilError(t, err)
+		expected := []ClientHostConfig{
+			{
+				Name:               "admin@example.com",
+				AccessKey:          "any-access-key",
+				PolymorphicID:      "any-id",
+				Host:               srv.Addrs.HTTPS.String(),
+				Expires:            api.Time(time.Now().UTC().Add(opts.SessionDuration)),
+				Current:            true,
+				TrustedCertificate: string(cert),
+			},
+		}
+		assert.DeepEqual(t, cfg.Hosts, expected, cmpClientHostConfig)
+	})
+
+	runStep(t, "next login should still trust the server", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		t.Cleanup(cancel)
+
+		err := Run(ctx, "logout")
+		assert.NilError(t, err)
+
+		err = Run(ctx, "login", "--key", accessKey, srv.Addrs.HTTPS.String())
+		assert.NilError(t, err)
+
+		cert, err := os.ReadFile("testdata/pki/localhost.crt")
+		assert.NilError(t, err)
+
+		// Check the client config
+		cfg, err := readConfig()
+		assert.NilError(t, err)
+		expected := []ClientHostConfig{
+			{
+				Name:               "admin@example.com",
+				AccessKey:          "any-access-key",
+				PolymorphicID:      "any-id",
+				Host:               srv.Addrs.HTTPS.String(),
+				Expires:            api.Time(time.Now().UTC().Add(opts.SessionDuration)),
+				Current:            true,
+				TrustedCertificate: string(cert),
+			},
+		}
+		assert.DeepEqual(t, cfg.Hosts, expected, cmpClientHostConfig)
+	})
 }

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -68,7 +68,7 @@ func logoutOfServer(hostConfig *ClientHostConfig) (success bool) {
 		return false
 	}
 
-	client := apiClient(hostConfig.Host, hostConfig.AccessKey, hostConfig.SkipTLSVerify)
+	client := apiClient(hostConfig.Host, hostConfig.AccessKey, defaultHTTPTransport(hostConfig.SkipTLSVerify))
 
 	hostConfig.AccessKey = ""
 	hostConfig.PolymorphicID = ""

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -68,7 +68,7 @@ func logoutOfServer(hostConfig *ClientHostConfig) (success bool) {
 		return false
 	}
 
-	client := apiClient(hostConfig.Host, hostConfig.AccessKey, defaultHTTPTransport(hostConfig.SkipTLSVerify))
+	client := apiClient(hostConfig.Host, hostConfig.AccessKey, httpTransportForHostConfig(hostConfig))
 
 	hostConfig.AccessKey = ""
 	hostConfig.PolymorphicID = ""

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -46,7 +46,7 @@ func TestLogout(t *testing.T) {
 		t.Cleanup(srv2.Close)
 
 		cfg := ClientConfig{
-			Version: "0.3",
+			Version: clientConfigVersion,
 			Hosts: []ClientHostConfig{
 				{
 					Name:          "user1",
@@ -108,7 +108,7 @@ func TestLogout(t *testing.T) {
 		t.Cleanup(srv.Close)
 
 		cfg := ClientConfig{
-			Version: "0.3",
+			Version: clientConfigVersion,
 			Hosts: []ClientHostConfig{
 				{
 					Name:          "user1",
@@ -277,7 +277,7 @@ func TestLogout(t *testing.T) {
 		updatedCfg, err := readConfig()
 		assert.NilError(t, err)
 
-		expected := ClientConfig{Version: "0.3"}
+		expected := ClientConfig{Version: clientConfigVersion}
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		updatedKubeCfg, err := clientConfig().RawConfig()


### PR DESCRIPTION
## Summary

This PR adds a new prompt to `infra login` when the servers TLS certificate is not already trusted. The prompt gives the user information about the server certificate and allows them to manually trust it.

Once trusted, the user will be able to login again to the same server without being prompted again.

This is a significant enhancement over `--skip-tls-verify` because even if the user doesn't properly inspect the fingerprint, the only opportunity for a man-in-the-middle attack is on that first request. Every subsequent request is secure.

In a follow up PR I will:
* add a command line flag to specify a trusted certificate
* add the same flag to the connector
* update the quickstart to remove `--skip-tls-verify`

## Related Issues


Resolves #1541
