### PR TITLE
fix: require user to have an email

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -5,7 +5,7 @@ type SignupEnabledResponse struct {
 }
 
 type SignupRequest struct {
-	Name     string `json:"name" validate:"required_without=Email"`
-	Email    string `json:"email" validate:"required_without=Name"` // #1825: remove, this is for migration
+	Name     string `json:"name" validate:"omitempty,email,required_without=Email"`
+	Email    string `json:"email" validate:"omitempty,email,required_without=Name"` // #1825: remove, this is for migration
 	Password string `json:"password" validate:"required"`
 }

--- a/api/user.go
+++ b/api/user.go
@@ -22,7 +22,7 @@ type ListUsersRequest struct {
 }
 
 type CreateUserRequest struct {
-	Name               string `json:"name" validate:"required"`
+	Name               string `json:"name" validate:"email,required"`
 	SetOneTimePassword bool   `json:"setOneTimePassword"`
 }
 

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -58,8 +58,8 @@ func TestLoginCmd(t *testing.T) {
 		})
 
 		exp := expector{console: console}
-		exp.ExpectString(t, "Username:")
-		exp.Send(t, "admin\n")
+		exp.ExpectString(t, "Email:")
+		exp.Send(t, "admin@example.com\n")
 		exp.ExpectString(t, "Password")
 		exp.Send(t, "password\n")
 		exp.ExpectString(t, "Confirm")
@@ -75,7 +75,7 @@ func TestLoginCmd(t *testing.T) {
 
 		expected := []ClientHostConfig{
 			{
-				Name:          "admin",
+				Name:          "admin@example.com",
 				AccessKey:     "any-access-key",
 				PolymorphicID: "any-id",
 				Host:          srv.Addrs.HTTPS.String(),

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net/mail"
 
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
@@ -43,6 +44,13 @@ Note: A new user must change their one time password before further usage.`,
 		Example: `# Create a user
 $ infra users add johndoe@example.com`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			email := args[0]
+
+			_, err := mail.ParseAddress(email)
+			if err != nil {
+				return fmt.Errorf("username must be a valid email")
+			}
+
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err

--- a/internal/cmd/users_test.go
+++ b/internal/cmd/users_test.go
@@ -120,6 +120,12 @@ func TestUsersCmd(t *testing.T) {
 		assert.Equal(t, len(*modifiedUsers), 1)
 	})
 
+	t.Run("add user, not an email", func(t *testing.T) {
+		_ = setup(t)
+		err := Run(context.Background(), "users", "add", "new-user")
+		assert.ErrorContains(t, err, "username must be a valid email")
+	})
+
 	t.Run("add without required argument", func(t *testing.T) {
 		err := Run(context.Background(), "users", "add")
 		assert.ErrorContains(t, err, `"infra users add" requires exactly 1 argument`)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"net/mail"
 	"os"
 	"strings"
 	"time"
@@ -744,6 +745,11 @@ func (s Server) loadUser(db *gorm.DB, input User) (*models.Identity, error) {
 			logging.S.Warn("please update 'email' config identity to 'name', the 'email' identity label is deprecated and will be removed in a future release")
 			name = input.Email
 		}
+	}
+
+	_, err := mail.ParseAddress(name)
+	if err != nil {
+		logging.S.Warnf("user name %q in server configuration is not a valid email, please update this name to a valid email", name)
 	}
 
 	identity, err := data.GetIdentity(db, data.ByName(name))

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -96,7 +96,7 @@ func TestAPI_ListGrants(t *testing.T) {
 	accessKey, err := data.CreateAccessKey(srv.db, token)
 	assert.NilError(t, err)
 
-	admin, err := data.GetIdentity(srv.db, data.ByName("admin"))
+	admin, err := data.GetIdentity(srv.db, data.ByName("admin@example.com"))
 	assert.NilError(t, err)
 
 	type testCase struct {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -23,7 +23,7 @@ import (
 
 func adminAccessKey(s *Server) string {
 	for _, id := range s.options.Users {
-		if id.Name == "admin" {
+		if id.Name == "admin@example.com" {
 			return id.AccessKey
 		}
 	}
@@ -57,8 +57,8 @@ func TestAPI_ListUsers(t *testing.T) {
 	}
 	id1 := createID(t, "me@example.com")
 	id2 := createID(t, "other@example.com")
-	id3 := createID(t, "HAL")
-	_ = createID(t, "other-HAL")
+	id3 := createID(t, "HAL@example.com")
+	_ = createID(t, "other-HAL@example.com")
 
 	type testCase struct {
 		urlPath  string
@@ -118,7 +118,7 @@ func TestAPI_ListUsers(t *testing.T) {
 				expected := api.ListResponse[api.User]{
 					Count: 3,
 					Items: []api.User{
-						{Name: "HAL"},
+						{Name: "HAL@example.com"},
 						{Name: "me@example.com"},
 						{Name: "other@example.com"},
 					},
@@ -137,11 +137,11 @@ func TestAPI_ListUsers(t *testing.T) {
 				expected := api.ListResponse[api.User]{
 					Count: 6,
 					Items: []api.User{
-						{Name: "HAL"},
-						{Name: "admin"},
+						{Name: "HAL@example.com"},
+						{Name: "admin@example.com"},
 						{Name: "connector"},
 						{Name: "me@example.com"},
-						{Name: "other-HAL"},
+						{Name: "other-HAL@example.com"},
 						{Name: "other@example.com"},
 					},
 				}
@@ -377,11 +377,11 @@ func TestAPI_DeleteProvider(t *testing.T) {
 // with an admin identity and access key
 func withAdminUser(_ *testing.T, opts *Options) {
 	opts.Users = append(opts.Users, User{
-		Name:      "admin",
+		Name:      "admin@example.com",
 		AccessKey: "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb",
 	})
 	opts.Grants = append(opts.Grants, Grant{
-		User:     "admin",
+		User:     "admin@example.com",
 		Role:     "admin",
 		Resource: "infra",
 	})
@@ -446,7 +446,7 @@ func TestCreateIdentity(t *testing.T) {
 				var apiError api.Error
 				err := json.NewDecoder(resp.Body).Decode(&apiError)
 				assert.NilError(t, err)
-				assert.Equal(t, apiError.Message, "Name: is required")
+				assert.Equal(t, apiError.Message, "Name: failed the \"email\" check")
 			},
 		},
 		"create new unlinked user": {
@@ -718,7 +718,7 @@ func TestAPI_ListGrantsV0_12_2(t *testing.T) {
 	routes.ServeHTTP(resp, req)
 	assert.Equal(t, resp.Code, http.StatusOK)
 
-	admin, err := data.ListIdentities(srv.db, data.ByName("admin"))
+	admin, err := data.ListIdentities(srv.db, data.ByName("admin@example.com"))
 	assert.NilError(t, err)
 
 	expected := jsonUnmarshal(t, fmt.Sprintf(`
@@ -879,7 +879,7 @@ func TestAPI_GetUser(t *testing.T) {
 		return respObj.ID
 	}
 	idMe := createID(t, "me@example.com")
-	idHal := createID(t, "HAL")
+	idHal := createID(t, "HAL@example.com")
 
 	token := &models.AccessKey{
 		IssuedFor:  idMe,

--- a/ui/components/admin.js
+++ b/ui/components/admin.js
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import useSWR, { useSWRConfig } from 'swr'
 import { PlusIcon } from '@heroicons/react/outline'
 
+import { validateEmail } from '../lib/email'
+
 import InputDropdown from './input'
 import DeleteModal from './modals/delete'
 import ErrorMessage from './error-message'
@@ -57,7 +59,7 @@ export default function () {
   const { data: { items: grants } = {} } = useSWR(() => '/api/grants?resource=infra&privilege=admin', { fallbackData: [] })
   const { mutate } = useSWRConfig()
 
-  const [name, setName] = useState('')
+  const [adminEmail, setAdminEmail] = useState('')
   const [error, setError] = useState('')
 
   const grantAdminAccess = id => {
@@ -67,39 +69,43 @@ export default function () {
     })
       .then(() => {
         mutate('/api/grants?resource=infra&privilege=admin')
-        setName('')
+        setAdminEmail('')
       }).catch((e) => setError(e.message || 'something went wrong, please try again later.'))
   }
 
   const handleInputChange = (value) => {
-    setName(value)
+    setAdminEmail(value)
     setError('')
   }
 
   const handleKeyDownEvent = (key) => {
-    if (key === 'Enter' && name.length > 0) {
+    if (key === 'Enter' && adminEmail.length > 0) {
       handleAddAdmin()
     }
   }
 
   const handleAddAdmin = () => {
-    setError('')
+    if (validateEmail(adminEmail)) {
+      setError('')
 
-    fetch(`/api/users?name=${name}`)
-      .then((response) => response.json())
-      .then(({ items = [] }) => {
-        if (items.length === 0) {
-          fetch('/api/users', {
-            method: 'POST',
-            body: JSON.stringify({ name })
-          })
-            .then((response) => response.json())
-            .then((user) => grantAdminAccess(user.id))
-            .catch((error) => console.error(error))
-        } else {
-          grantAdminAccess(items[0].id)
-        }
-      })
+      fetch(`/api/users?name=${adminEmail}`)
+        .then((response) => response.json())
+        .then(({ items = [] }) => {
+          if (items.length === 0) {
+            fetch('/api/users', {
+              method: 'POST',
+              body: JSON.stringify({ name: adminEmail })
+            })
+              .then((response) => response.json())
+              .then((user) => grantAdminAccess(user.id))
+              .catch((error) => console.error(error))
+          } else {
+            grantAdminAccess(items[0].id)
+          }
+        })
+    } else {
+      setError('Invalid email')
+    }
   }
 
   return (
@@ -108,8 +114,9 @@ export default function () {
       <div className={`flex flex-col sm:flex-row ${error ? 'mt-6 mb-2' : 'mt-6 mb-14'}`}>
         <div className='sm:flex-1'>
           <InputDropdown
-            value={name}
-            placeholder='Username'
+            type='email'
+            value={adminEmail}
+            placeholder='Email address'
             hasDropdownSelection={false}
             handleInputChange={e => handleInputChange(e.target.value)}
             handleKeyDown={(e) => handleKeyDownEvent(e.key)}
@@ -118,7 +125,7 @@ export default function () {
         </div>
         <button
           onClick={() => handleAddAdmin()}
-          disabled={name.length === 0}
+          disabled={adminEmail.length === 0}
           type='button'
           className='flex items-center cursor-pointer border border-violet-300 px-5 mt-4 text-2xs sm:ml-4 sm:mt-0 rounded-md disabled:pointer-events-none disabled:opacity-30'
         >

--- a/ui/components/grant.js
+++ b/ui/components/grant.js
@@ -2,6 +2,8 @@ import useSWR, { useSWRConfig } from 'swr'
 import { useState } from 'react'
 import { PlusIcon } from '@heroicons/react/outline'
 
+import { validateEmail } from '../lib/email'
+
 import InputDropdown from '../components/input'
 import ErrorMessage from '../components/error-message'
 
@@ -23,7 +25,7 @@ export default function ({ id }) {
   const { mutate } = useSWRConfig()
   const list = items?.filter(item => !!item.user)
 
-  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
   const [error, setError] = useState('')
   const [grantError, setGrantError] = useState('')
   const [role, setRole] = useState('view')
@@ -43,7 +45,7 @@ export default function ({ id }) {
         await fetch(`/api/grants/${deleteGrantId}`, { method: 'DELETE' })
       }
 
-      setName('')
+      setEmail('')
       setRole('view')
 
       return { items: [...grants.filter(grant => grant?.user !== user), data] }
@@ -51,33 +53,37 @@ export default function ({ id }) {
   }
 
   const handleInputChange = value => {
-    setName(value)
+    setEmail(value)
     setError('')
   }
 
   const handleKeyDownEvent = key => {
-    if (key === 'Enter' && name.length > 0) {
+    if (key === 'Enter' && email.length > 0) {
       handleShareGrant()
     }
   }
 
   const handleShareGrant = async () => {
-    setError('')
-    try {
-      const res = await fetch(`/api/users?name=${name}`)
-      const data = await res.json()
+    if (validateEmail(email)) {
+      setError('')
+      try {
+        const res = await fetch(`/api/users?name=${name}`)
+        const data = await res.json()
 
-      if (!res.ok) {
-        throw data
-      }
+        if (!res.ok) {
+          throw data
+        }
 
-      if (data?.items?.length === 0) {
-        setError('User does not exist')
-      } else {
-        grantPrivilege(data?.items?.[0]?.id)
+        if (data?.items?.length === 0) {
+          setError('User does not exist')
+        } else {
+          grantPrivilege(data?.items?.[0]?.id)
+        }
+      } catch (e) {
+        setGrantError(e.message || 'something went wrong, please try again later.')
       }
-    } catch (e) {
-      setGrantError(e.message || 'something went wrong, please try again later.')
+    } else {
+      setError('Invalid email')
     }
   }
 
@@ -97,8 +103,9 @@ export default function ({ id }) {
       <div className={`flex gap-1 mt-3 ${error ? 'mb-2' : 'mb-4'}`}>
         <div className='flex-1'>
           <InputDropdown
-            value={name}
-            placeholder='Username'
+            type='email'
+            value={email}
+            placeholder='Email'
             error={error}
             optionType='role'
             options={options.filter((item) => item !== 'remove')}
@@ -110,7 +117,7 @@ export default function ({ id }) {
         </div>
         <button
           onClick={() => handleShareGrant()}
-          disabled={name.length === 0}
+          disabled={email.length === 0}
           type='button'
           className='flex items-center border border-violet-300 disabled:opacity-30 disabled:transform-none disabled:transition-none cursor-pointer disabled:cursor-default mt-4 mr-auto sm:ml-4 sm:mt-0 rounded-md text-2xs px-3 py-3'
         >

--- a/ui/lib/email.js
+++ b/ui/lib/email.js
@@ -1,0 +1,7 @@
+export const validateEmail = email => {
+  return String(email)
+    .toLowerCase()
+    .match(
+      /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+    )?.length > 0
+}

--- a/ui/lib/email.test.js
+++ b/ui/lib/email.test.js
@@ -1,0 +1,9 @@
+import { validateEmail } from './email'
+
+test('validates email', () => {
+  expect(validateEmail('example@example.com')).toBe(true)
+})
+
+test('rejects non-email', () => {
+  expect(validateEmail('example')).toBe(false)
+})

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -16,7 +16,7 @@ import DeleteModal from '../../components/modals/delete'
 import ResourcesGrant from '../../components/resources-grant'
 
 const columns = [{
-  Header: 'Name',
+  Header: 'Email',
   accessor: u => u,
   Cell: ({ value: user }) => (
     <div className='flex items-center py-1.5'>


### PR DESCRIPTION
## Summary
After the unification of user/machine identities it was no longer required for users to have an email as their identifier. We discussed this a bit internally and it seems more future-proof to require users created in Infra to have an email. This change requires users created through the Infra API to have an email, it also updates the UI and CLI to prompt for an email (and validate it).

Backwards compatibility:
- Users created through config will not require an email yet, just log a warning.
- Users previously created without an email will still work, you just can't create more.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1878
