### PR TITLE
fix: loading of dbUsername field for server config

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -38,12 +38,12 @@ import (
 )
 
 type Options struct {
-	Server        string `mapstructure:"server"`
-	Name          string `mapstructure:"name"`
-	AccessKey     string `mapstructure:"accessKey"`
-	CACert        string `mapstructure:"caCert"`
-	CAKey         string `mapstructure:"caKey"`
-	SkipTLSVerify bool   `mapstructure:"skipTLSVerify"`
+	Server        string
+	Name          string
+	AccessKey     string
+	CACert        string
+	CAKey         string
+	SkipTLSVerify bool
 }
 
 type jwkCache struct {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -20,87 +20,87 @@ import (
 )
 
 type Provider struct {
-	Name         string `mapstructure:"name" validate:"required"`
-	URL          string `mapstructure:"url" validate:"required"`
-	ClientID     string `mapstructure:"clientID" validate:"required"`
-	ClientSecret string `mapstructure:"clientSecret" validate:"required"`
+	Name         string `validate:"required"`
+	URL          string `validate:"required"`
+	ClientID     string `validate:"required"`
+	ClientSecret string `validate:"required"`
 }
 
 type Grant struct {
-	User     string `mapstructure:"user" validate:"excluded_with=Group,excluded_with=Machine"`
-	Group    string `mapstructure:"group" validate:"excluded_with=User,excluded_with=Machine"`
-	Machine  string `mapstructure:"machine" validate:"excluded_with=User,excluded_with=Group"` // deprecated
-	Resource string `mapstructure:"resource" validate:"required"`
-	Role     string `mapstructure:"role"`
+	User     string `validate:"excluded_with=Group,excluded_with=Machine"`
+	Group    string `validate:"excluded_with=User,excluded_with=Machine"`
+	Machine  string `validate:"excluded_with=User,excluded_with=Group"` // deprecated
+	Resource string `validate:"required"`
+	Role     string
 }
 
 type User struct {
-	Name      string `mapstructure:"name" validate:"excluded_with=Email"`
-	AccessKey string `mapstructure:"accessKey"`
-	Password  string `mapstructure:"password"`
+	Name      string `validate:"excluded_with=Email"`
+	AccessKey string
+	Password  string
 
-	Email string `mapstructure:"email" validate:"excluded_with=Name"` // deprecated
+	Email string `validate:"excluded_with=Name"` // deprecated
 }
 
 type Config struct {
-	Providers []Provider `mapstructure:"providers" validate:"dive"`
-	Grants    []Grant    `mapstructure:"grants" validate:"dive"`
-	Users     []User     `mapstructure:"users" validate:"dive"`
+	Providers []Provider `validate:"dive"`
+	Grants    []Grant    `validate:"dive"`
+	Users     []User     `validate:"dive"`
 }
 
 type KeyProvider struct {
-	Kind   string      `mapstructure:"kind" validate:"required"`
+	Kind   string      `validate:"required"`
 	Config interface{} // contains secret-provider-specific config
 }
 
 type nativeKeyProviderConfig struct {
-	SecretProvider string `mapstructure:"secretProvider"`
+	SecretProvider string
 }
 
 type AWSConfig struct {
-	Endpoint        string `mapstructure:"endpoint" validate:"required"`
-	Region          string `mapstructure:"region" validate:"required"`
-	AccessKeyID     string `mapstructure:"accessKeyID" validate:"required"`
-	SecretAccessKey string `mapstructure:"secretAccessKey" validate:"required"`
+	Endpoint        string `validate:"required"`
+	Region          string `validate:"required"`
+	AccessKeyID     string `validate:"required"`
+	SecretAccessKey string `validate:"required"`
 }
 
 type AWSKMSConfig struct {
-	AWSConfig `mapstructure:",squash"`
+	AWSConfig
 
-	EncryptionAlgorithm string `mapstructure:"encryptionAlgorithm"`
+	EncryptionAlgorithm string
 	// aws tags?
 }
 
 type AWSSecretsManagerConfig struct {
-	AWSConfig `mapstructure:",squash"`
+	AWSConfig
 }
 
 type AWSSSMConfig struct {
-	AWSConfig `mapstructure:",squash"`
-	KeyID     string `mapstructure:"keyID" validate:"required"` // KMS key to use for decryption
+	AWSConfig
+	KeyID string `validate:"required"` // KMS key to use for decryption
 }
 
 type GenericConfig struct {
-	Base64           bool `mapstructure:"base64"`
-	Base64URLEncoded bool `mapstructure:"base64UrlEncoded"`
-	Base64Raw        bool `mapstructure:"base64Raw"`
+	Base64           bool
+	Base64URLEncoded bool
+	Base64Raw        bool
 }
 
 type FileConfig struct {
-	GenericConfig `mapstructure:",squash"`
-	Path          string `mapstructure:"path" validate:"required"`
+	GenericConfig
+	Path string `validate:"required"`
 }
 
 type KubernetesConfig struct {
-	Namespace string `mapstructure:"namespace"`
+	Namespace string
 }
 
 type VaultConfig struct {
-	TransitMount string `mapstructure:"transitMount"`              // mounting point. defaults to /transit
-	SecretMount  string `mapstructure:"secretMount"`               // mounting point. defaults to /secret
-	Token        string `mapstructure:"token" validate:"required"` // vault token
-	Namespace    string `mapstructure:"namespace"`
-	Address      string `mapstructure:"address" validate:"required"`
+	TransitMount string // mounting point. defaults to /transit
+	SecretMount  string // mounting point. defaults to /secret
+	Token        string `validate:"required"`
+	Namespace    string
+	Address      string `validate:"required"`
 }
 
 func importKeyProviders(

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -34,6 +34,7 @@ keys:
       endpoint: /endpoint
       region: the-region
       accessKeyID: the-key-id
+      secretAccessKey: the-secret
   - kind: native
     config:
       secretProvider: the-storage
@@ -62,9 +63,10 @@ keys:
 				Kind: "awskms",
 				Config: AWSKMSConfig{
 					AWSConfig: AWSConfig{
-						Endpoint:    "/endpoint",
-						Region:      "the-region",
-						AccessKeyID: "the-key-id",
+						Endpoint:        "/endpoint",
+						Region:          "the-region",
+						AccessKeyID:     "the-key-id",
+						SecretAccessKey: "the-secret",
 					},
 					EncryptionAlgorithm: "aes_512",
 				},
@@ -87,6 +89,7 @@ secrets:
   - name: the-vault
     kind: vault
     config:
+      transitMount: /some-mount
       token: the-token
       namespace: the-namespace
       secretMount: secret-mount
@@ -146,7 +149,7 @@ secrets:
 				Kind: "vault",
 				Name: "the-vault",
 				Config: VaultConfig{
-					TransitMount: "",
+					TransitMount: "/some-mount",
 					SecretMount:  "secret-mount",
 					Token:        "the-token",
 					Namespace:    "the-namespace",

--- a/internal/server/options_migrations.go
+++ b/internal/server/options_migrations.go
@@ -8,7 +8,7 @@ import (
 )
 
 type OptionsDiffV0dot1 struct {
-	Identities []User `mapstructure:"identities" validate:"dive"`
+	Identities []User `validate:"dive"`
 }
 
 // ToV0dot2 applies the 0.1 options to the 0.2 version

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,26 +34,26 @@ import (
 )
 
 type Options struct {
-	Version         float64       `mapstructure:"version"`
-	TLSCache        string        `mapstructure:"tlsCache"`
-	EnableTelemetry bool          `mapstructure:"enableTelemetry"`
-	EnableSignup    bool          `mapstructure:"enableSignup"`
-	SessionDuration time.Duration `mapstructure:"sessionDuration"`
+	Version         float64
+	TLSCache        string
+	EnableTelemetry bool
+	EnableSignup    bool
+	SessionDuration time.Duration
 
-	DBFile                  string `mapstructure:"dbFile"`
-	DBEncryptionKey         string `mapstructure:"dbEncryptionKey"`
-	DBEncryptionKeyProvider string `mapstructure:"dbEncryptionKeyProvider"`
-	DBHost                  string `mapstructure:"dbHost" `
-	DBPort                  int    `mapstructure:"dbPort"`
-	DBName                  string `mapstructure:"dbName"`
-	DBUser                  string `mapstructure:"dbUsername"`
-	DBPassword              string `mapstructure:"dbPassword"`
-	DBParameters            string `mapstructure:"dbParameters"`
+	DBFile                  string
+	DBEncryptionKey         string
+	DBEncryptionKeyProvider string
+	DBHost                  string
+	DBPort                  int
+	DBName                  string
+	DBUsername              string
+	DBPassword              string
+	DBParameters            string
 
-	Keys    []KeyProvider    `mapstructure:"keys"`
-	Secrets []SecretProvider `mapstructure:"secrets"`
+	Keys    []KeyProvider
+	Secrets []SecretProvider
 
-	Config `mapstructure:",squash"`
+	Config
 
 	Addr ListenerOptions
 	UI   UIOptions
@@ -67,9 +67,9 @@ type ListenerOptions struct {
 
 type UIOptions struct {
 	Enabled  bool
-	ProxyURL types.URL `mapstructure:"proxyURL"`
+	ProxyURL types.URL
 	// FS is the filesystem which contains the static files for the UI.
-	FS fs.FS `mapstructure:"-"`
+	FS fs.FS `config:"-"`
 }
 
 type Server struct {
@@ -307,8 +307,8 @@ func (s *Server) getPostgresConnectionString() (string, error) {
 		// config has separate postgres parameters set, combine them into a connection DSN now
 		fmt.Fprintf(&pgConn, "host=%s ", s.options.DBHost)
 
-		if s.options.DBUser != "" {
-			fmt.Fprintf(&pgConn, "user=%s ", s.options.DBUser)
+		if s.options.DBUsername != "" {
+			fmt.Fprintf(&pgConn, "user=%s ", s.options.DBUsername)
 
 			if s.options.DBPassword != "" {
 				pass, err := secrets.GetSecret(s.options.DBPassword, s.secrets)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -83,7 +83,7 @@ func TestGetPostgresConnectionURL(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, "host=localhost port=5432", url)
 
-	r.options.DBUser = "user"
+	r.options.DBUsername = "user"
 
 	url, err = r.getPostgresConnectionString()
 	assert.NilError(t, err)


### PR DESCRIPTION
In #1755 we changed from using `mapstructure` tags to using `config` tags, but I forgot to remove or update all the existing struct tags.

Every other field continued to work because the struct field name matched the convention. Unfortunately `dbUsername` was the one case where it did not match convention and required the struct tag. A workaround was to use `dbUser` or `INFRA_SERVER_DB_USER`.

This PR fixes the bug by renaming the field to `DBUsername`.

It also adds test coverage for every field in `server.Options` to show this is the only field with the problem. 

I also removed the struct tags, since they no longer do anything and keeping them would be confusing. I'll leave some inline comments for where each of the fields is tested.
