### PR TITLE
fix: fix replica count variable name

### DIFF
--- a/helm/charts/infra/templates/connector/deployment.yaml
+++ b/helm/charts/infra/templates/connector/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 {{- include "connector.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.connector.autoscaling.enabled }}
-  replicas: {{ .Values.connector.replicaCount }}
+  replicas: {{ .Values.connector.replicas }}
 {{- end }}
   selector:
     matchLabels:

--- a/helm/charts/infra/templates/server/deployment.yaml
+++ b/helm/charts/infra/templates/server/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 {{- include "server.labels" . | nindent 4 }}
 spec:
 {{- if not .Values.server.autoscaling.enabled }}
-  replicas: {{ .Values.server.replicaCount }}
+  replicas: {{ .Values.server.replicas }}
 {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary

Fixes issue where template doesn't use the right variable name for the replica count.

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2188
