### PR TITLE
feat: introduce format flag, support json output

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -164,6 +164,12 @@ List connected destinations
 infra destinations list [flags]
 ```
 
+### Options
+
+```
+      --format string   Output format [text, json] (default "text")
+```
+
 ### Options inherited from parent commands
 
 ```
@@ -363,6 +369,12 @@ List users
 infra users list [flags]
 ```
 
+### Options
+
+```
+      --format string   Output format [text, json] (default "text")
+```
+
 ### Options inherited from parent commands
 
 ```
@@ -485,6 +497,12 @@ List connected identity providers
 
 ```
 infra providers list [flags]
+```
+
+### Options
+
+```
+      --format string   Output format [text, json] (default "text")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -167,7 +167,7 @@ infra destinations list [flags]
 ### Options
 
 ```
-      --format string   Output format [text, json] (default "text")
+      --format string   Output format [default, json] (default "default")
 ```
 
 ### Options inherited from parent commands
@@ -372,7 +372,7 @@ infra users list [flags]
 ### Options
 
 ```
-      --format string   Output format [text, json] (default "text")
+      --format string   Output format [default, json] (default "default")
 ```
 
 ### Options inherited from parent commands
@@ -502,7 +502,7 @@ infra providers list [flags]
 ### Options
 
 ```
-      --format string   Output format [text, json] (default "text")
+      --format string   Output format [default, json] (default "default")
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -288,6 +288,10 @@ func addNonInteractiveFlag(flags *pflag.FlagSet, bind *bool) {
 	flags.BoolVar(bind, "non-interactive", isNonInteractiveMode, "Disable all prompts for input")
 }
 
+func addFormatFlag(flags *pflag.FlagSet, bind *string) {
+	flags.StringVar(bind, "format", "text", "Output format [text, json]")
+}
+
 func usageTemplate() string {
 	return `Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -289,7 +289,7 @@ func addNonInteractiveFlag(flags *pflag.FlagSet, bind *bool) {
 }
 
 func addFormatFlag(flags *pflag.FlagSet, bind *string) {
-	flags.StringVar(bind, "format", "text", "Output format [text, json]")
+	flags.StringVar(bind, "format", "default", "Output format [default, json]")
 }
 
 func usageTemplate() string {

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -30,7 +31,8 @@ func newDestinationsCmd(cli *CLI) *cobra.Command {
 }
 
 func newDestinationsListCmd(cli *CLI) *cobra.Command {
-	return &cobra.Command{
+	var format string
+	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List connected destinations",
@@ -47,28 +49,39 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
-			type row struct {
-				Name string `header:"NAME"`
-				URL  string `header:"URL"`
-			}
+			switch format {
+			case "text":
+				type row struct {
+					Name string `header:"NAME"`
+					URL  string `header:"URL"`
+				}
 
-			var rows []row
-			for _, d := range destinations.Items {
-				rows = append(rows, row{
-					Name: d.Name,
-					URL:  d.Connection.URL,
-				})
-			}
-
-			if len(rows) > 0 {
-				printTable(rows, cli.Stdout)
-			} else {
-				cli.Output("No destinations connected")
+				var rows []row
+				for _, d := range destinations.Items {
+					rows = append(rows, row{
+						Name: d.Name,
+						URL:  d.Connection.URL,
+					})
+				}
+				if len(rows) > 0 {
+					printTable(rows, cli.Stdout)
+				} else {
+					cli.Output("No destinations connected")
+				}
+			case "json":
+				jsonOutput, err := json.Marshal(destinations)
+				if err != nil {
+					return err
+				}
+				cli.Output(string(jsonOutput))
 			}
 
 			return nil
 		},
 	}
+
+	addFormatFlag(cmd.Flags(), &format)
+	return cmd
 }
 
 func newDestinationsRemoveCmd(cli *CLI) *cobra.Command {

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -50,7 +50,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 			}
 
 			switch format {
-			case "text":
+			case "default":
 				type row struct {
 					Name string `header:"NAME"`
 					URL  string `header:"URL"`

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -53,7 +53,7 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 			}
 
 			switch format {
-			case "text":
+			case "default":
 				type row struct {
 					Name string `header:"NAME"`
 					URL  string `header:"URL"`

--- a/internal/cmd/providers_test.go
+++ b/internal/cmd/providers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -21,19 +22,37 @@ func TestProvidersAddCmd(t *testing.T) {
 		requestCh := make(chan api.CreateProviderRequest, 1)
 
 		handler := func(resp http.ResponseWriter, req *http.Request) {
-			defer close(requestCh)
-			if !requestMatches(req, http.MethodPost, "/api/providers") {
+			if !strings.Contains(req.URL.Path, "/api/providers") {
 				resp.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 
-			var createRequest api.CreateProviderRequest
-			err := json.NewDecoder(req.Body).Decode(&createRequest)
-			assert.Check(t, err)
+			switch req.Method {
+			case http.MethodPost:
+				var createRequest api.CreateProviderRequest
+				err := json.NewDecoder(req.Body).Decode(&createRequest)
+				assert.Check(t, err)
 
-			requestCh <- createRequest
+				requestCh <- createRequest
 
-			_, _ = resp.Write([]byte(`{}`))
+				_, _ = resp.Write([]byte(`{}`))
+				return
+			case http.MethodGet:
+				var apiProviders []api.Provider
+				apiProviders = append(apiProviders, api.Provider{
+					Name:     "okta",
+					URL:      "https://okta.com/path",
+					ClientID: "okta-client-id",
+				})
+				b, err := json.Marshal(api.ListResponse[api.Provider]{
+					Items: apiProviders,
+					Count: len(apiProviders),
+				})
+				assert.NilError(t, err)
+				_, _ = resp.Write(b)
+				return
+			}
+
 		}
 		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
 		t.Cleanup(srv.Close)
@@ -90,5 +109,23 @@ func TestProvidersAddCmd(t *testing.T) {
 	t.Run("missing require flags", func(t *testing.T) {
 		err := Run(context.Background(), "providers", "add", "okta")
 		assert.ErrorContains(t, err, "missing value for required flags: url, client-id, client-secret")
+	})
+
+	t.Run("list with json", func(t *testing.T) {
+		setup(t)
+		ctx, bufs := PatchCLI(context.Background())
+
+		t.Setenv("INFRA_PROVIDER_URL", "https://okta.com/path")
+		t.Setenv("INFRA_PROVIDER_CLIENT_ID", "okta-client-id")
+		t.Setenv("INFRA_PROVIDER_CLIENT_SECRET", "okta-client-secret")
+
+		err := Run(ctx, "providers", "add", "okta")
+		assert.NilError(t, err)
+
+		err = Run(ctx, "providers", "list", "--format=json")
+		assert.NilError(t, err)
+
+		strings.Contains(bufs.Stdout.String(), `{"items":[{"id":"","name":"okta","created":null,"updated":null,"url":"https://okta.com/path","clientID":"okta-client-id"}],"count":1}`)
+		assert.NilError(t, err)
 	})
 }

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -91,7 +92,9 @@ $ infra users edit janedoe@example.com --password`,
 }
 
 func newUsersListCmd(cli *CLI) *cobra.Command {
-	return &cobra.Command{
+	var format string
+
+	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List users",
@@ -115,22 +118,34 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
-			for _, user := range users.Items {
-				rows = append(rows, row{
-					Name:       user.Name,
-					LastSeenAt: user.LastSeenAt.Relative("never"),
-				})
-			}
+			switch format {
+			case "text":
+				for _, user := range users.Items {
+					rows = append(rows, row{
+						Name:       user.Name,
+						LastSeenAt: user.LastSeenAt.Relative("never"),
+					})
+				}
 
-			if len(rows) > 0 {
-				printTable(rows, cli.Stdout)
-			} else {
-				cli.Output("No users found")
+				if len(rows) > 0 {
+					printTable(rows, cli.Stdout)
+				} else {
+					cli.Output("No users found")
+				}
+			case "json":
+				jsonOutput, err := json.Marshal(users)
+				if err != nil {
+					return err
+				}
+				cli.Output(string(jsonOutput))
 			}
 
 			return nil
 		},
 	}
+
+	addFormatFlag(cmd.Flags(), &format)
+	return cmd
 }
 
 func newUsersRemoveCmd(cli *CLI) *cobra.Command {

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -119,7 +119,7 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 			}
 
 			switch format {
-			case "text":
+			case "default":
 				for _, user := range users.Items {
 					rows = append(rows, row{
 						Name:       user.Name,


### PR DESCRIPTION
## Summary

Introduces the `format` flag. Eg. `--format=json`. 
Introduces the json output for the existing table outputs. It is exactly 1-1 with the API. 


## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests - **IN PROGRESS**
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Implements #972
