### PR TITLE
fix: migrate destination request CA from string

### DIFF
--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -170,7 +170,7 @@ func (a *API) addResponseRewrites() {
 			Expires:                newResponse.Expires,
 		}
 	})
-	addResponseRewrite(a, http.MethodGet, "/v1/destinations", "0.13.1", func(newResponse *api.ListResponse[api.Destination]) api.ListResponse[destinationV0_13_1] {
+	addResponseRewrite(a, http.MethodGet, "/api/destinations", "0.13.1", func(newResponse *api.ListResponse[api.Destination]) api.ListResponse[destinationV0_13_1] {
 		var resp api.ListResponse[destinationV0_13_1]
 		var items []destinationV0_13_1
 
@@ -183,13 +183,13 @@ func (a *API) addResponseRewrites() {
 
 		return resp
 	})
-	addResponseRewrite(a, http.MethodPost, "/v1/destinations/", "0.13.1", func(newResponse *api.Destination) destinationV0_13_1 {
+	addResponseRewrite(a, http.MethodPost, "/api/destinations/", "0.13.1", func(newResponse *api.Destination) destinationV0_13_1 {
 		return translateDestinationCertBytesToString(*newResponse)
 	})
-	addResponseRewrite(a, http.MethodGet, "/v1/destinations/:id", "0.13.1", func(newResponse *api.Destination) destinationV0_13_1 {
+	addResponseRewrite(a, http.MethodGet, "/api/destinations/:id", "0.13.1", func(newResponse *api.Destination) destinationV0_13_1 {
 		return translateDestinationCertBytesToString(*newResponse)
 	})
-	addResponseRewrite(a, http.MethodPut, "/v1/destinations/:id", "0.13.1", func(newResponse *api.Destination) destinationV0_13_1 {
+	addResponseRewrite(a, http.MethodPut, "/api/destinations/:id", "0.13.1", func(newResponse *api.Destination) destinationV0_13_1 {
 		return translateDestinationCertBytesToString(*newResponse)
 	})
 	// next migration...


### PR DESCRIPTION
## Summary
When using a connector on versions `0.13.1` and earlier they were unable to parse the CA response on destination requests as they were expecting a string. This PR adds migrations to convert the CA on destination request/responses for `0.13.1` and below.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2200 
