### PR TITLE
fix: cli prevent connector from being deleted

### DIFF
--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/models"
 )
 
 func newUsersCmd(cli *CLI) *cobra.Command {
@@ -159,6 +160,12 @@ $ infra users remove janedoe@example.com`,
 
 			if users.Count == 0 && !force {
 				return Error{Message: fmt.Sprintf("No user named %q ", name)}
+			}
+
+			if name == models.InternalInfraConnectorIdentityName {
+				return Error{
+					Message: "The \"connector\" user cannot be deleted, as it is not modifiable.",
+				}
 			}
 
 			logging.S.Debugf("deleting %d users named %q...", users.Count, name)

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -163,7 +163,7 @@ $ infra users remove janedoe@example.com`,
 				return Error{Message: fmt.Sprintf("No user named %q ", name)}
 			}
 
-			if name == internalInfraConnectorName {
+			if name == InternalInfraConnectorName {
 				return Error{
 					Message: "The \"connector\" user cannot be deleted, as it is not modifiable.",
 				}

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/logging"
-	"github.com/infrahq/infra/internal/server/models"
 )
+
+const InternalInfraConnectorName = "connector"
 
 func newUsersCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
@@ -162,7 +163,7 @@ $ infra users remove janedoe@example.com`,
 				return Error{Message: fmt.Sprintf("No user named %q ", name)}
 			}
 
-			if name == models.InternalInfraConnectorIdentityName {
+			if name == internalInfraConnectorName {
 				return Error{
 					Message: "The \"connector\" user cannot be deleted, as it is not modifiable.",
 				}

--- a/internal/cmd/users_test.go
+++ b/internal/cmd/users_test.go
@@ -182,4 +182,15 @@ func TestUsersCmd(t *testing.T) {
 		assert.ErrorContains(t, err, `"infra users remove" requires exactly 1 argument`)
 		assert.ErrorContains(t, err, `Usage:  infra users remove USER`)
 	})
+
+	t.Run("remove connector fails", func(t *testing.T) {
+		users := setup(t)
+		ctx := context.Background()
+		err := Run(ctx, "users", "add", "connector")
+		assert.NilError(t, err)
+		assert.Equal(t, len(*users), 1)
+
+		err = Run(context.Background(), "users", "remove", "connector")
+		assert.ErrorContains(t, err, "The \"connector\" user cannot be deleted, as it is not modifiable.")
+	})
 }


### PR DESCRIPTION
## Summary

Part of #1445. For now, prevent connector user from being deleted (if it exists). 

If it does not exist, same error: 
```
$ dev users remove connector
No user named "connector"
```
If it exists, new error instead of success:
```
$ dev users remove connector
The "connector" user cannot be deleted, as it is not modifiable.
```

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Implements #1445
