### PR TITLE
fix: modify set-password help text

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -338,14 +338,14 @@ infra users edit USER [flags]
 ### Examples
 
 ```
-# Set a new one time password for a user
+# Set a new password for a user
 $ infra users edit janedoe@example.com --password
 ```
 
 ### Options
 
 ```
-      --password   Set a new one time password
+      --password   Set a new password
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -73,7 +73,7 @@ func newUsersEditCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit USER",
 		Short: "Update a user",
-		Example: `# Set a new one time password for a user
+		Example: `# Set a new password for a user
 $ infra users edit janedoe@example.com --password`,
 		Args: ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,7 +85,7 @@ $ infra users edit janedoe@example.com --password`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&editPassword, "password", false, "Set a new one time password")
+	cmd.Flags().BoolVar(&editPassword, "password", false, "Set a new password")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

`infra users edit` incorrectly mentions that `--password` sets the users' "one-time password" when it sets their permanent password. "one-time" has been removed from the help text to resolve the ambiguity.

## Related Issues

Resolves #2146 
