### PR TITLE
fix: make testuserscmd more resilient

### DIFF
--- a/internal/cmd/users_test.go
+++ b/internal/cmd/users_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -80,8 +79,7 @@ func TestUsersCmd(t *testing.T) {
 					_, _ = resp.Write(b)
 					return
 				case http.MethodGet:
-					name, err := url.PathUnescape(req.URL.RawQuery[5:])
-					assert.NilError(t, err)
+					name := req.URL.Query().Get("name")
 
 					var apiUsers []api.User
 					for _, mu := range modifiedUsers {


### PR DESCRIPTION
## Summary

We were pulling the user name out of the URL path with RawQuery which can change if `ListUsers()` ever gets modified (which it will, and it's really hard to debug this when it does). This change just pulls the name directly out of the `URL.Query()`

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests

