### PR TITLE
maintain: validate contents of user info response

### DIFF
--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -272,3 +272,16 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 		})
 	}
 }
+
+func TestUserInfo(t *testing.T) {
+	t.Run("no email and no name fails validation", func(t *testing.T) {
+		claims := &InfoClaims{}
+		err := claims.validate()
+		assert.ErrorContains(t, err, "name or email are required")
+	})
+	t.Run("groups are not required", func(t *testing.T) {
+		claims := &InfoClaims{Email: "hello@example.com"}
+		err := claims.validate()
+		assert.NilError(t, err)
+	})
+}


### PR DESCRIPTION
- if user info response does not have required fields fail
- require the email claim on the id token to fail at the right spot
- check user info name for azure user validity

## Summary
When a user is deleted from Azure active directory the user info endpoint continues to successfully respond. We use a failure response from this endpoint to determine if a user is still valid. Update this validity check to make sure that the expected fields are returned from the user-info response. This works to revoke Azure user access upon deletion as the user-info endpoint no longer returns their name on deletion. 
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2227 
