### PR TITLE
fix: remove period from users cmd help

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -301,7 +301,7 @@ $ infra grants remove janedoe@example.com infra --role admin
 
 ## `infra users add`
 
-Create a user.
+Create a user
 
 ### Synopsis
 

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -36,7 +36,7 @@ func newUsersCmd(cli *CLI) *cobra.Command {
 func newUsersAddCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add USER",
-		Short: "Create a user.",
+		Short: "Create a user",
 		Long: `Create a user.
 
 Note: A new user must change their one time password before further usage.`,


### PR DESCRIPTION
## Summary
This period doesnt match the format of the rest of the command help outputs.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades
