### PR TITLE
maintain: add user-agent to connector requests

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -10,6 +10,8 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+type Query map[string][]string
+
 type Resource struct {
 	ID uid.ID `uri:"id" validate:"required"`
 }

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -699,7 +699,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "Infra API",
-    "version": "0.13.3"
+    "version": "0.13.4+dev"
   },
   "paths": {
     "/api/access-keys": {

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -145,7 +145,15 @@ func writeAgentConfig(pid int) error {
 
 // syncKubeConfig updates the local kubernetes configuration from Infra grants
 func syncKubeConfig(ctx context.Context, cancel context.CancelFunc) {
-	user, destinations, grants, err := getUserDestinationGrants()
+	client, err := defaultAPIClient()
+	if err != nil {
+		fileLogger.Sugar().Errorf("api client: %v\n", err)
+		cancel()
+	}
+
+	client.Name = "agent"
+
+	user, destinations, grants, err := getUserDestinationGrants(client)
 	if err != nil {
 		fileLogger.Sugar().Errorf("agent failed to get user destination grants: %v\n", err)
 		cancel()

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -90,11 +89,9 @@ func apiClient(host string, accessKey string, skipTLSVerify bool) (*api.Client, 
 
 	u.Scheme = "https"
 
-	headers := http.Header{}
-	ua := fmt.Sprintf("Infra CLI/%v (%v/%v)", internal.Version, runtime.GOOS, runtime.GOARCH)
-	headers.Add("User-Agent", ua)
-
 	return &api.Client{
+		Name:      "cli",
+		Version:   internal.Version,
 		URL:       fmt.Sprintf("%s://%s", u.Scheme, u.Host),
 		AccessKey: accessKey,
 		HTTP: http.Client{
@@ -106,7 +103,6 @@ func apiClient(host string, accessKey string, skipTLSVerify bool) (*api.Client, 
 				},
 			},
 		},
-		Headers: headers,
 	}, nil
 }
 

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -30,7 +30,12 @@ func newListCmd(cli *CLI) *cobra.Command {
 }
 
 func list(cli *CLI) error {
-	user, destinations, grants, err := getUserDestinationGrants()
+	client, err := defaultAPIClient()
+	if err != nil {
+		return err
+	}
+
+	user, destinations, grants, err := getUserDestinationGrants(client)
 	if err != nil {
 		return err
 	}
@@ -102,12 +107,7 @@ func list(cli *CLI) error {
 	return writeKubeconfig(user, destinations.Items, grants.Items)
 }
 
-func getUserDestinationGrants() (*api.User, *api.ListResponse[api.Destination], *api.ListResponse[api.Grant], error) {
-	client, err := defaultAPIClient()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
+func getUserDestinationGrants(client *api.Client) (*api.User, *api.ListResponse[api.Destination], *api.ListResponse[api.Grant], error) {
 	config, err := currentHostConfig()
 	if err != nil {
 		return nil, nil, nil, err

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -454,6 +454,8 @@ func Run(ctx context.Context, options Options) error {
 	}
 
 	client := &api.Client{
+		Name:      "connector",
+		Version:   internal.Version,
 		URL:       u.String(),
 		AccessKey: accessKey,
 		HTTP: http.Client{


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

- automatically add User-Agent header to all api.Client requests
- refactor api client requests to use a single request func since there's duplication between existing `get`, `list`, and `request`
- update user agent string to include type of client
- update user agent to include api version
