### PR TITLE
fix: do not warn about the connector identity

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -753,9 +753,11 @@ func (s Server) loadUser(db *gorm.DB, input User) (*models.Identity, error) {
 			return nil, err
 		}
 
-		_, err := mail.ParseAddress(name)
-		if err != nil {
-			logging.S.Warnf("user name %q in server configuration is not a valid email, please update this name to a valid email", name)
+		if name != models.InternalInfraConnectorIdentityName {
+			_, err := mail.ParseAddress(name)
+			if err != nil {
+				logging.S.Warnf("user name %q in server configuration is not a valid email, please update this name to a valid email", name)
+			}
 		}
 
 		identity = &models.Identity{

--- a/internal/server/models/identity.go
+++ b/internal/server/models/identity.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	InternalInfraAdminIdentityName     = "admin"
 	InternalInfraConnectorIdentityName = "connector"
 )
 


### PR DESCRIPTION
## Summary
With the users requiring email change the connector loaded in config was logging a warning. For now this is the only identity that we won't want to log this warning for.

Also remove an admin identity name that is no longer used.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1878
