### PR TITLE
fix: specify email fields in the API doc

### DIFF
--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -2901,9 +2901,11 @@
               "schema": {
                 "properties": {
                   "email": {
+                    "format": "email",
                     "type": "string"
                   },
                   "name": {
+                    "format": "email",
                     "type": "string"
                   },
                   "password": {
@@ -3171,6 +3173,7 @@
               "schema": {
                 "properties": {
                   "name": {
+                    "format": "email",
                     "type": "string"
                   },
                   "setOneTimePassword": {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -699,7 +699,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "Infra API",
-    "version": "0.13.2"
+    "version": "0.13.3+dev"
   },
   "paths": {
     "/api/access-keys": {

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -256,6 +256,10 @@ func setTagInfo(f reflect.StructField, t, parent reflect.Type, schema, parentSch
 				parentSchema.Required = append(parentSchema.Required, getFieldName(f, parent))
 			}
 
+			if val == "email" {
+				schema.Format = "email"
+			}
+
 			if strings.HasPrefix(val, "min=") {
 				schema.MinLength = parseMinLength(val)
 			}
@@ -487,6 +491,10 @@ func buildRequest(r reflect.Type, op *openapi3.Operation) {
 				for _, val := range strings.Split(validate, ",") {
 					if val == "required" {
 						p.Required = true
+					}
+
+					if val == "email" {
+						schema.Format = "email"
 					}
 
 					if strings.HasPrefix(val, "min=") {


### PR DESCRIPTION
## Summary
When users name became required as email I missed updating the generated API doc from a string field. Update the OpenAPI generation to specify that the name is of format "email".

<img width="700" alt="Screen Shot 2022-06-09 at 3 10 25 PM" src="https://user-images.githubusercontent.com/5853428/172925970-60330d73-163b-4a2f-9ecd-b9d877d4e694.png">

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

