### PR TITLE
fix: nil check for AccessKey.IssuedForIdentity

### DIFF
--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -699,7 +699,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "Infra API",
-    "version": "0.13.3"
+    "version": "0.13.4+dev"
   },
   "paths": {
     "/api/access-keys": {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -337,16 +337,7 @@ func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api
 	}
 
 	result := api.NewListResponse(accessKeys, func(accessKey models.AccessKey) api.AccessKey {
-		return api.AccessKey{
-			ID:                accessKey.ID,
-			Name:              accessKey.Name,
-			Created:           api.Time(accessKey.CreatedAt),
-			IssuedFor:         accessKey.IssuedFor,
-			IssuedForName:     accessKey.IssuedForIdentity.Name,
-			ProviderID:        accessKey.ProviderID,
-			Expires:           api.Time(accessKey.ExpiresAt),
-			ExtensionDeadline: api.Time(accessKey.ExtensionDeadline),
-		}
+		return *accessKey.ToAPI()
 	})
 
 	return result, nil

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -26,4 +27,22 @@ type AccessKey struct {
 	KeyID          string `gorm:"<-;uniqueIndex:idx_access_keys_key_id,where:deleted_at is NULL"`
 	Secret         string `gorm:"-"`
 	SecretChecksum []byte
+}
+
+func (ak *AccessKey) ToAPI() *api.AccessKey {
+	issuedForName := ""
+	if ak.IssuedForIdentity != nil {
+		issuedForName = ak.IssuedForIdentity.Name
+	}
+
+	return &api.AccessKey{
+		ID:                ak.ID,
+		Name:              ak.Name,
+		Created:           api.Time(ak.CreatedAt),
+		IssuedFor:         ak.IssuedFor,
+		IssuedForName:     issuedForName,
+		ProviderID:        ak.ProviderID,
+		Expires:           api.Time(ak.ExpiresAt),
+		ExtensionDeadline: api.Time(ak.ExtensionDeadline),
+	}
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

There's an edge case where IssuedFor may either not exist or not set. In this case IssuedForIdentity will be nil and cause a nil pointer dereference. Check if IssuedForIdentity is nil, default to empty string if identity is not found.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2185