### PR TITLE
fix: set the auth cookie to the bearer value

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -556,7 +556,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 		return nil, internal.ErrUnauthorized
 	}
 
-	setAuthCookie(c, key.Secret, expires)
+	setAuthCookie(c, bearer, expires)
 
 	a.t.Event("login", key.IssuedFor.String(), Properties{"method": loginMethod.Name()})
 


### PR DESCRIPTION
## Summary
Set the auth cookie to the bearer value not just the secret.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2252
