### PR TITLE
fix: respect context namespace if overwritten by user

### DIFF
--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
+	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/infrahq/infra/api"
@@ -64,4 +65,112 @@ func TestWriteKubeconfig(t *testing.T) {
 		cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"),
 		cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "Exec"),
 	)
+}
+
+func TestWriteKubeconfig_UserNamespaceOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	kubeconfig := filepath.Join(home, "kubeconfig")
+	t.Setenv("KUBECONFIG", kubeconfig)
+
+	expected := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"infra:cluster": {
+				Server:                   "https://cluster.example.com",
+				CertificateAuthorityData: []byte(destinationCA),
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"infra:cluster": {
+				AuthInfo:  "user",
+				Cluster:   "infra:cluster",
+				Namespace: "override",
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"user": {},
+		},
+	}
+
+	err := clientcmd.WriteToFile(expected, kubeconfig)
+	assert.NilError(t, err)
+
+	user := api.User{Name: "user"}
+	destinations := []api.Destination{
+		{
+			Name: "cluster",
+			Connection: api.DestinationConnection{
+				URL: "cluster.example.com",
+				CA:  destinationCA,
+			},
+		},
+	}
+	grants := []api.Grant{
+		{
+			Resource: "cluster",
+		},
+	}
+
+	err = writeKubeconfig(&user, destinations, grants)
+	assert.NilError(t, err)
+
+	actual, err := clientConfig().RawConfig()
+	assert.NilError(t, err)
+	assert.Equal(t, actual.Contexts["infra:cluster"].Namespace, "override")
+}
+
+func TestWriteKubeconfig_UserNamespaceOverrideResetNamespacedContext(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	kubeconfig := filepath.Join(home, "kubeconfig")
+	t.Setenv("KUBECONFIG", kubeconfig)
+
+	expected := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"infra:cluster:default": {
+				Server:                   "https://cluster.example.com",
+				CertificateAuthorityData: []byte(destinationCA),
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"infra:cluster:default": {
+				AuthInfo:  "user",
+				Cluster:   "infra:cluster",
+				Namespace: "override",
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"user": {},
+		},
+	}
+
+	err := clientcmd.WriteToFile(expected, kubeconfig)
+	assert.NilError(t, err)
+
+	user := api.User{Name: "user"}
+	destinations := []api.Destination{
+		{
+			Name: "cluster",
+			Connection: api.DestinationConnection{
+				URL: "cluster.example.com",
+				CA:  destinationCA,
+			},
+		},
+	}
+	grants := []api.Grant{
+		{
+			Resource: "cluster.default",
+		},
+	}
+
+	err = writeKubeconfig(&user, destinations, grants)
+	assert.NilError(t, err)
+
+	actual, err := clientConfig().RawConfig()
+	assert.NilError(t, err)
+	assert.Equal(t, actual.Contexts["infra:cluster:default"].Namespace, "default")
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Respect the users namespace configuration for contexts that do not specify a namespace. Note, if the context is removed through logout or session timeout, the namespace configuration will also be reset. 

If a context managed by infra should have a context, reset it if there's a mismatch.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2259
