### PR TITLE
improve: remove error return from apiClient

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/goware/urlx"
 	"github.com/lensesio/tableprinter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -78,21 +77,14 @@ func defaultAPIClient() (*api.Client, error) {
 		return nil, err
 	}
 
-	return apiClient(config.Host, config.AccessKey, config.SkipTLSVerify)
+	return apiClient(config.Host, config.AccessKey, config.SkipTLSVerify), nil
 }
 
-func apiClient(host string, accessKey string, skipTLSVerify bool) (*api.Client, error) {
-	u, err := urlx.Parse(host)
-	if err != nil {
-		return nil, err
-	}
-
-	u.Scheme = "https"
-
+func apiClient(host string, accessKey string, skipTLSVerify bool) *api.Client {
 	return &api.Client{
 		Name:      "cli",
 		Version:   internal.Version,
-		URL:       fmt.Sprintf("%s://%s", u.Scheme, u.Host),
+		URL:       "https://" + host,
 		AccessKey: accessKey,
 		HTTP: http.Client{
 			Timeout: 60 * time.Second,
@@ -103,7 +95,7 @@ func apiClient(host string, accessKey string, skipTLSVerify bool) (*api.Client, 
 				},
 			},
 		},
-	}, nil
+	}
 }
 
 func newUseCmd(_ *CLI) *cobra.Command {

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -47,8 +47,7 @@ func TestListCmd(t *testing.T) {
 		assert.Check(t, srv.Run(ctx))
 	}()
 
-	c, err := apiClient(srv.Addrs.HTTPS.String(), "0000000001.adminadminadminadmin1234", true)
-	assert.NilError(t, err)
+	c := apiClient(srv.Addrs.HTTPS.String(), "0000000001.adminadminadminadmin1234", true)
 
 	_, err = c.CreateDestination(&api.CreateDestinationRequest{
 		UniqueID: "space",

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -398,11 +398,7 @@ func newAPIClient(cli *CLI, options loginCmdOptions) (*api.Client, error) {
 		}
 	}
 
-	client, err := apiClient(options.Server, "", options.SkipTLSVerify)
-	if err != nil {
-		return nil, err
-	}
-
+	client := apiClient(options.Server, "", options.SkipTLSVerify)
 	return client, nil
 }
 

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -68,17 +68,13 @@ func logoutOfServer(hostConfig *ClientHostConfig) (success bool) {
 		return false
 	}
 
-	client, err := apiClient(hostConfig.Host, hostConfig.AccessKey, hostConfig.SkipTLSVerify)
-	if err != nil {
-		logging.S.Debugf("err: %s", err)
-		return false
-	}
+	client := apiClient(hostConfig.Host, hostConfig.AccessKey, hostConfig.SkipTLSVerify)
 
 	hostConfig.AccessKey = ""
 	hostConfig.PolymorphicID = ""
 	hostConfig.Name = ""
 
-	err = client.Logout()
+	err := client.Logout()
 	switch {
 	case api.ErrorStatusCode(err) == http.StatusUnauthorized:
 		logging.S.Debugf("err: %s", err)


### PR DESCRIPTION
## Summary

Parsing the url here does not do much. We always force the scheme to https, and most other errors won't be noticed until the request is performed.

I looked at using `types.url` as an arg to `apiClient`, but it turns out we expect a hostname in these places instead of a full url. So removing the error return accomplished the same thing with a much smaller change.

## Related Issues


Resolves #1627
