### PR TITLE
fix: set logLevel from helm chart values

### DIFF
--- a/helm/charts/infra/templates/connector/deployment.yaml
+++ b/helm/charts/infra/templates/connector/deployment.yaml
@@ -31,7 +31,15 @@ spec:
 {{- toYaml .Values.connector.securityContext | nindent 12 }}
           image: "{{ include "connector.image.repository" . }}:{{ include "connector.image.tag" . }}"
           imagePullPolicy: {{ include "connector.image.pullPolicy" . }}
-          args: ["connector", "-f", "/etc/infrahq/infra.yaml"]
+          args:
+            - connector
+            - -f
+            - /etc/infrahq/infra.yaml
+# set log level through command line parameters since its not possible to set using configuration file values
+{{- with .Values.server.config.logLevel }}
+            - --log-level
+            - {{ . }}
+{{- end }}
           env:
 {{- include "connector.env" . | nindent 12 }}
           envFrom:

--- a/helm/charts/infra/templates/server/deployment.yaml
+++ b/helm/charts/infra/templates/server/deployment.yaml
@@ -31,7 +31,15 @@ spec:
 {{- toYaml .Values.server.securityContext | nindent 12 }}
           image: "{{ include "server.image.repository" . }}:{{ include "server.image.tag" . }}"
           imagePullPolicy: {{ include "server.image.pullPolicy" . }}
-          args: ["server", "-f", "/etc/infrahq/infra.yaml"]
+          args:
+            - server
+            - -f
+            - /etc/infrahq/infra.yaml
+# set log level through command line parameters since its not possible to set using configuration file values
+{{- with .Values.server.config.logLevel }}
+            - --log-level
+            - {{ . }}
+{{- end }}
           env:
 {{- include "server.env" . | nindent 12 }}
           envFrom:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Provide a way for users to set log level using helm values. This change is necessary because `logLevel` is not read from config but retrieved directly from env var or command line parameter

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2079
