### PR TITLE
maintain: make the agent optional

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -30,6 +30,10 @@
 
 Login to Infra
 
+### Synopsis
+
+Login to Infra and start a background agent to keep local configuration up-to-date
+
 ```
 infra login [SERVER] [flags]
 ```
@@ -54,6 +58,7 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy
 
 ```
       --key string        Login with an access key
+      --no-agent          Skip starting the Infra agent in the background
       --non-interactive   Disable all prompts for input
       --provider string   Login with an identity provider
       --skip-tls-verify   Skip verifying server TLS certificates

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -97,6 +97,8 @@ func execAgent() error {
 		return err
 	}
 
+	logging.S.Debugf("agent started, pid: %d", cmd.Process.Pid)
+
 	return writeAgentConfig(cmd.Process.Pid)
 }
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -28,11 +28,12 @@ import (
 )
 
 type loginCmdOptions struct {
-	Server         string
-	AccessKey      string
-	Provider       string
-	SkipTLSVerify  bool
-	NonInteractive bool
+	Server            string
+	AccessKey         string
+	Provider          string
+	SkipTLSVerify     bool
+	NoBackgroundAgent bool
+	NonInteractive    bool
 }
 
 type loginMethod int8
@@ -51,6 +52,7 @@ func newLoginCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login [SERVER]",
 		Short: "Login to Infra",
+		Long:  "Login to Infra and start a background agent to keep local configuration up-to-date",
 		Example: `# By default, login will prompt for all required information.
 $ infra login
 
@@ -76,6 +78,7 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy`,
 	cmd.Flags().StringVar(&options.AccessKey, "key", "", "Login with an access key")
 	cmd.Flags().StringVar(&options.Provider, "provider", "", "Login with an identity provider")
 	cmd.Flags().BoolVar(&options.SkipTLSVerify, "skip-tls-verify", false, "Skip verifying server TLS certificates")
+	cmd.Flags().BoolVar(&options.NoBackgroundAgent, "no-agent", false, "Skip starting the Infra agent in the background")
 	addNonInteractiveFlag(cmd.Flags(), &options.NonInteractive)
 	return cmd
 }
@@ -111,7 +114,7 @@ func login(cli *CLI, options loginCmdOptions) error {
 			return err
 		}
 
-		return loginToInfra(cli, client, loginReq)
+		return loginToInfra(cli, client, loginReq, options.NoBackgroundAgent)
 	}
 
 	switch {
@@ -153,10 +156,10 @@ func login(cli *CLI, options loginCmdOptions) error {
 		}
 	}
 
-	return loginToInfra(cli, client, loginReq)
+	return loginToInfra(cli, client, loginReq, options.NoBackgroundAgent)
 }
 
-func loginToInfra(cli *CLI, client *api.Client, loginReq *api.LoginRequest) error {
+func loginToInfra(cli *CLI, client *api.Client, loginReq *api.LoginRequest, skipAgent bool) error {
 	logging.S.Debug("call server: login")
 	loginRes, err := client.Login(loginReq)
 	if err != nil {
@@ -206,22 +209,22 @@ func loginToInfra(cli *CLI, client *api.Client, loginReq *api.LoginRequest) erro
 		return err
 	}
 
-	fmt.Fprintf(cli.Stderr, "  Logged in as %s\n", termenv.String(loginRes.Name).Bold().String())
-
 	backgroundAgentRunning, err := configAgentRunning()
 	if err != nil {
 		// do not block login, just proceed, potentially without the agent
 		logging.S.Errorf("unable to check background agent: %v", err)
 	}
 
-	if !backgroundAgentRunning {
+	if !backgroundAgentRunning && !skipAgent {
 		// the agent is started in a separate command so that it continues after the login command has finished
 		if err := execAgent(); err != nil {
 			// user still has a valid session, so do not fail
 			logging.S.Errorf("Unable to start agent, destinations will not be updated automatically: %w", err)
 		}
+		fmt.Fprintf(cli.Stderr, "  Infra is now running in the background\n")
 	}
 
+	fmt.Fprintf(cli.Stderr, "  Logged in as %s\n", termenv.String(loginRes.Name).Bold().String())
 	return nil
 }
 

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -60,7 +60,7 @@ func TestLoginCmdSignup(t *testing.T) {
 		exp.Send(t, "password\n")
 		exp.ExpectString(t, "Confirm")
 		exp.Send(t, "password\n")
-		exp.ExpectString(t, "Infra is now running in the background")
+		exp.ExpectString(t, "Infra Agent is now running in the background")
 		exp.ExpectString(t, "Logged in as")
 
 		assert.NilError(t, g.Wait())


### PR DESCRIPTION
- add no-agent flag to disable the background process
- Inform the user that Infra is running in the background

## Summary
> As part of infra login we start a desktop agent to keep the kubernetes config up-to-date. The user needs to be aware of this agent in case they need to stop it, and so that if it ever conflicts with another change to the kube config, they are not puzzle by why their change was dropped.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2175 
