### PR TITLE
feat: added optional pagination to list endpoints

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -19,6 +19,7 @@ type ListAccessKeysRequest struct {
 	UserID      uid.ID `form:"user_id"`
 	Name        string `form:"name"`
 	ShowExpired bool   `form:"show_expired"`
+	PaginationRequest
 }
 
 type CreateAccessKeyRequest struct {

--- a/api/destination.go
+++ b/api/destination.go
@@ -22,6 +22,7 @@ type DestinationConnection struct {
 }
 
 type ListDestinationsRequest struct {
+	PaginationRequest
 	Name     string `form:"name"`
 	UniqueID string `form:"unique_id"`
 }

--- a/api/destination.go
+++ b/api/destination.go
@@ -22,9 +22,9 @@ type DestinationConnection struct {
 }
 
 type ListDestinationsRequest struct {
-	PaginationRequest
 	Name     string `form:"name"`
 	UniqueID string `form:"unique_id"`
+	PaginationRequest
 }
 
 type CreateDestinationRequest struct {

--- a/api/grant.go
+++ b/api/grant.go
@@ -18,6 +18,7 @@ type Grant struct {
 }
 
 type ListGrantsRequest struct {
+	PaginationRequest
 	User      uid.ID `form:"user" validate:"excluded_with=Group"`
 	Group     uid.ID `form:"group" validate:"excluded_with=User"`
 	Resource  string `form:"resource" example:"production"`

--- a/api/grant.go
+++ b/api/grant.go
@@ -18,11 +18,11 @@ type Grant struct {
 }
 
 type ListGrantsRequest struct {
-	PaginationRequest
 	User      uid.ID `form:"user" validate:"excluded_with=Group"`
 	Group     uid.ID `form:"group" validate:"excluded_with=User"`
 	Resource  string `form:"resource" example:"production"`
 	Privilege string `form:"privilege" example:"view"`
+	PaginationRequest
 }
 
 type CreateGrantRequest struct {

--- a/api/group.go
+++ b/api/group.go
@@ -12,6 +12,7 @@ type Group struct {
 }
 
 type ListGroupsRequest struct {
+	PaginationRequest
 	// Name filters the results to only the group matching this name.
 	Name string `form:"name"`
 	// UserID filters the results to only groups where this user is a member.

--- a/api/group.go
+++ b/api/group.go
@@ -12,11 +12,11 @@ type Group struct {
 }
 
 type ListGroupsRequest struct {
-	PaginationRequest
 	// Name filters the results to only the group matching this name.
 	Name string `form:"name"`
 	// UserID filters the results to only groups where this user is a member.
 	UserID uid.ID `form:"userID"`
+	PaginationRequest
 }
 
 type CreateGroupRequest struct {

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -1,0 +1,13 @@
+package api
+
+type PaginationRequest struct {
+	Page  int `form:"page" validate:"min=0"`
+	Limit int `form:"limit" validate:"min=0,max=1000"`
+}
+
+type PaginationResponse struct {
+	Page  int `json:"page,omitempty"`
+	Limit int `json:"limit,omitempty"`
+
+	//TODO: add some indication of number of records/pages or if a next page exists
+}

--- a/api/provider.go
+++ b/api/provider.go
@@ -29,5 +29,6 @@ type UpdateProviderRequest struct {
 }
 
 type ListProvidersRequest struct {
+	PaginationRequest
 	Name string `form:"name" example:"okta"`
 }

--- a/api/provider.go
+++ b/api/provider.go
@@ -29,6 +29,6 @@ type UpdateProviderRequest struct {
 }
 
 type ListProvidersRequest struct {
-	PaginationRequest
 	Name string `form:"name" example:"okta"`
+	PaginationRequest
 }

--- a/api/types.go
+++ b/api/types.go
@@ -105,14 +105,16 @@ func (d Duration) String() string {
 }
 
 type ListResponse[T any] struct {
-	Items []T `json:"items"`
-	Count int `json:"count"`
+	PaginationInfo PaginationResponse `json:"pagination_info"`
+	Items          []T                `json:"items"`
+	Count          int                `json:"count"`
 }
 
-func NewListResponse[T, M any](items []M, fn func(item M) T) *ListResponse[T] {
+func NewListResponse[T, M any](items []M, pr PaginationResponse, fn func(item M) T) *ListResponse[T] {
 	result := &ListResponse[T]{
-		Items: make([]T, 0, len(items)),
-		Count: len(items),
+		Items:          make([]T, 0, len(items)),
+		Count:          len(items),
+		PaginationInfo: pr,
 	}
 
 	for _, item := range items {

--- a/api/user.go
+++ b/api/user.go
@@ -18,6 +18,7 @@ type User struct {
 }
 
 type ListUsersRequest struct {
+	PaginationRequest
 	Name  string   `form:"name"`
 	Group uid.ID   `form:"group"`
 	IDs   []uid.ID `form:"ids"`

--- a/api/user.go
+++ b/api/user.go
@@ -18,10 +18,10 @@ type User struct {
 }
 
 type ListUsersRequest struct {
-	PaginationRequest
 	Name  string   `form:"name"`
 	Group uid.ID   `form:"group"`
 	IDs   []uid.ID `form:"ids"`
+	PaginationRequest
 }
 
 type CreateUserRequest struct {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -301,6 +301,19 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "pagination_info": {
+            "properties": {
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         }
       },
@@ -370,6 +383,19 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "pagination_info": {
+            "properties": {
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         }
       },
@@ -431,6 +457,19 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "pagination_info": {
+            "properties": {
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         }
       },
@@ -468,6 +507,19 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "pagination_info": {
+            "properties": {
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         }
       },
@@ -518,6 +570,19 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "pagination_info": {
+            "properties": {
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         }
       },
@@ -570,6 +635,19 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "pagination_info": {
+            "properties": {
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              }
+            },
+            "type": "object"
           }
         }
       },
@@ -730,6 +808,22 @@
             "name": "show_expired",
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
             }
           }
         ],
@@ -999,6 +1093,22 @@
         "description": "ListDestinations",
         "operationId": "ListDestinations",
         "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
           {
             "in": "query",
             "name": "name",
@@ -1508,6 +1618,22 @@
         "operationId": "ListGrants",
         "parameters": [
           {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
             "example": "4yJ3n3D8E2",
             "in": "query",
             "name": "user",
@@ -1898,6 +2024,22 @@
         "description": "ListGroups",
         "operationId": "ListGroups",
         "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
           {
             "in": "query",
             "name": "name",
@@ -2360,6 +2502,22 @@
         "description": "ListProviders",
         "operationId": "ListProviders",
         "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
           {
             "example": "okta",
             "in": "query",
@@ -3072,6 +3230,22 @@
         "description": "ListUsers",
         "operationId": "ListUsers",
         "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
           {
             "in": "query",
             "name": "name",

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1095,6 +1095,20 @@
         "parameters": [
           {
             "in": "query",
+            "name": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "unique_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "page",
             "schema": {
               "format": "int",
@@ -1107,20 +1121,6 @@
             "schema": {
               "format": "int",
               "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "name",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "unique_id",
-            "schema": {
-              "type": "string"
             }
           }
         ],
@@ -1618,22 +1618,6 @@
         "operationId": "ListGrants",
         "parameters": [
           {
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "format": "int",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "format": "int",
-              "type": "integer"
-            }
-          },
-          {
             "example": "4yJ3n3D8E2",
             "in": "query",
             "name": "user",
@@ -1671,6 +1655,22 @@
             "schema": {
               "example": "view",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
             }
           }
         ],
@@ -2026,22 +2026,6 @@
         "parameters": [
           {
             "in": "query",
-            "name": "page",
-            "schema": {
-              "format": "int",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "format": "int",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
             "name": "name",
             "schema": {
               "type": "string"
@@ -2056,6 +2040,22 @@
               "format": "uid",
               "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
             }
           }
         ],
@@ -2503,6 +2503,15 @@
         "operationId": "ListProviders",
         "parameters": [
           {
+            "example": "okta",
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "example": "okta",
+              "type": "string"
+            }
+          },
+          {
             "in": "query",
             "name": "page",
             "schema": {
@@ -2516,15 +2525,6 @@
             "schema": {
               "format": "int",
               "type": "integer"
-            }
-          },
-          {
-            "example": "okta",
-            "in": "query",
-            "name": "name",
-            "schema": {
-              "example": "okta",
-              "type": "string"
             }
           }
         ],
@@ -3232,22 +3232,6 @@
         "parameters": [
           {
             "in": "query",
-            "name": "page",
-            "schema": {
-              "format": "int",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "format": "int",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
             "name": "name",
             "schema": {
               "type": "string"
@@ -3275,6 +3259,22 @@
                 "type": "string"
               },
               "type": "array"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
             }
           }
         ],

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -19,13 +19,13 @@ func currentAccessKey(c *gin.Context) *models.AccessKey {
 	return accessKey
 }
 
-func ListAccessKeys(c *gin.Context, identityID uid.ID, name string, showExpired bool) ([]models.AccessKey, error) {
+func ListAccessKeys(c *gin.Context, identityID uid.ID, name string, showExpired bool, pg models.Pagination) ([]models.AccessKey, error) {
 	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole)
 	if err != nil {
 		return nil, err
 	}
 
-	s := []data.SelectorFunc{data.ByOptionalIssuedFor(identityID), data.ByOptionalName(name)}
+	s := []data.SelectorFunc{data.ByOptionalIssuedFor(identityID), data.ByOptionalName(name), data.ByPagination(pg)}
 	if !showExpired {
 		s = append(s, data.ByNotExpired())
 	}

--- a/internal/access/destination.go
+++ b/internal/access/destination.go
@@ -31,9 +31,10 @@ func GetDestination(c *gin.Context, id uid.ID) (*models.Destination, error) {
 	return data.GetDestination(db, data.ByID(id))
 }
 
-func ListDestinations(c *gin.Context, uniqueID, name string) ([]models.Destination, error) {
+func ListDestinations(c *gin.Context, uniqueID, name string, pg models.Pagination) ([]models.Destination, error) {
 	db := getDB(c)
-	return data.ListDestinations(db, data.ByOptionalUniqueID(uniqueID), data.ByOptionalName(name))
+	return data.ListDestinations(db, data.ByOptionalUniqueID(uniqueID),
+		data.ByOptionalName(name), data.ByPagination(pg))
 }
 
 func DeleteDestination(c *gin.Context, id uid.ID) error {

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -21,10 +21,11 @@ func GetGrant(c *gin.Context, id uid.ID) (*models.Grant, error) {
 	return data.GetGrant(db, data.ByID(id))
 }
 
-func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, privilege string) ([]models.Grant, error) {
+func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, privilege string, pg models.Pagination) ([]models.Grant, error) {
 	selectors := []data.SelectorFunc{
 		data.ByOptionalResource(resource),
 		data.ByOptionalPrivilege(privilege),
+		data.ByPagination(pg),
 	}
 
 	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole)

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -22,8 +22,8 @@ func isUserInGroup(c *gin.Context, requestedResourceID uid.ID) (bool, error) {
 	return false, nil
 }
 
-func ListGroups(c *gin.Context, name string, userID uid.ID) ([]models.Group, error) {
-	var selectors []data.SelectorFunc
+func ListGroups(c *gin.Context, name string, userID uid.ID, pg models.Pagination) ([]models.Group, error) {
+	var selectors []data.SelectorFunc = []data.SelectorFunc{data.ByPagination(pg)}
 	if name != "" {
 		selectors = append(selectors, data.ByName(name))
 	}

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -100,7 +100,7 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 	return data.DeleteIdentity(db, id)
 }
 
-func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID) ([]models.Identity, error) {
+func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID, pg models.Pagination) ([]models.Identity, error) {
 	db, err := RequireInfraRole(c, models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole)
 	if err != nil {
 		return nil, err
@@ -109,6 +109,7 @@ func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID) (
 	selectors := []data.SelectorFunc{
 		data.ByOptionalName(name),
 		data.ByOptionalIDs(ids),
+		data.ByPagination(pg),
 	}
 
 	if groupID != 0 {

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -29,7 +29,7 @@ func TestListIdentities(t *testing.T) {
 	assert.NilError(t, err)
 
 	// test fetch all identities
-	ids, err := ListIdentities(c, "", 0, nil)
+	ids, err := ListIdentities(c, "", 0, nil, models.Pagination{})
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(ids), 4) // the two identities created, the admin one used to call these access functions, and the internal connector identity

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -24,11 +24,12 @@ func GetProvider(c *gin.Context, id uid.ID) (*models.Provider, error) {
 	return data.GetProvider(db, data.ByID(id))
 }
 
-func ListProviders(c *gin.Context, name string, excludeByName []string) ([]models.Provider, error) {
+func ListProviders(c *gin.Context, name string, excludeByName []string, pg models.Pagination) ([]models.Provider, error) {
 	db := getDB(c)
 
 	selectors := []data.SelectorFunc{
 		data.ByOptionalName(name),
+		data.ByPagination(pg),
 	}
 
 	for _, exclude := range excludeByName {

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -131,11 +131,11 @@ func ByNotExpired() SelectorFunc {
 }
 
 func ByPagination(pg models.Pagination) SelectorFunc {
-	if pg.Page == 0 {
-		pg.Page = 1
-	}
-
 	return func(db *gorm.DB) *gorm.DB {
+
+		if pg.Page == 0 && pg.Limit == 0 {
+			return db
+		}
 		resultsForPage := pg.Limit * (pg.Page - 1)
 		return db.Offset(resultsForPage).Limit(pg.Limit)
 	}

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -129,6 +129,21 @@ func TestAPI_ListGroups(t *testing.T) {
 				assert.Equal(t, len(actual.Items), 3)
 			},
 		},
+		"page 2": {
+			urlPath: "/api/groups?page=2&limit=2",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+
+				var actual api.ListResponse[api.Group]
+				err := json.NewDecoder(resp.Body).Decode(&actual)
+				assert.NilError(t, err)
+				assert.Equal(t, len(actual.Items), 1)
+				assert.Equal(t, api.PaginationResponse{Page: 2, Limit: 2}, actual.PaginationInfo)
+			},
+		},
 		"authorized by group membership": {
 			urlPath: "/api/groups?userID=" + idInGroup.String(),
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -175,6 +190,7 @@ func TestAPI_ListGroups(t *testing.T) {
 
 				expected := jsonUnmarshal(t, fmt.Sprintf(`
 {
+	"pagination_info": {},
 	"count": 2,
 	"items": [{
 		"id": "%[1]v",
@@ -207,6 +223,7 @@ func TestAPI_ListGroups(t *testing.T) {
 
 				expected := jsonUnmarshal(t, fmt.Sprintf(`
 {
+	"pagination_info":{},
 	"count": 1,
 	"items": [{
 		"id": "%[1]v",

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -132,8 +132,8 @@ func (a *API) deprecatedListUserGroups(c *gin.Context, r *api.Resource) (*api.Li
 }
 
 func (a *API) ListGroups(c *gin.Context, r *api.ListGroupsRequest) (*api.ListResponse[api.Group], error) {
-	groups, err := access.ListGroups(c, r.Name, r.UserID)
 	pg := models.RequestToPagination(r.PaginationRequest)
+	groups, err := access.ListGroups(c, r.Name, r.UserID, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (a *API) CreateGroup(c *gin.Context, r *api.CreateGroupRequest) (*api.Group
 func (a *API) ListProviders(c *gin.Context, r *api.ListProvidersRequest) (*api.ListResponse[api.Provider], error) {
 	exclude := []string{models.InternalInfraProviderName}
 	pg := models.RequestToPagination(r.PaginationRequest)
-	providers, err := access.ListProviders(c, r.Name, exclude)
+	providers, err := access.ListProviders(c, r.Name, exclude, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (a *API) DeleteProvider(c *gin.Context, r *api.Resource) (*api.EmptyRespons
 
 func (a *API) ListDestinations(c *gin.Context, r *api.ListDestinationsRequest) (*api.ListResponse[api.Destination], error) {
 	pg := models.RequestToPagination(r.PaginationRequest)
-	destinations, err := access.ListDestinations(c, r.UniqueID, r.Name)
+	destinations, err := access.ListDestinations(c, r.UniqueID, r.Name, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (a *API) ListGrants(c *gin.Context, r *api.ListGrantsRequest) (*api.ListRes
 		subject = uid.NewGroupPolymorphicID(r.Group)
 	}
 
-	grants, err := access.ListGrants(c, subject, r.Resource, r.Privilege)
+	grants, err := access.ListGrants(c, subject, r.Resource, r.Privilege, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +450,7 @@ func (a *API) DeleteGrant(c *gin.Context, r *api.Resource) (*api.EmptyResponse, 
 	}
 
 	if grant.Resource == access.ResourceInfraAPI && grant.Privilege == models.InfraAdminRole {
-		infraAdminGrants, err := access.ListGrants(c, "", grant.Resource, grant.Privilege)
+		infraAdminGrants, err := access.ListGrants(c, "", grant.Resource, grant.Privilege, models.Pagination{})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -163,7 +163,7 @@ func TestAPI_ListUsers(t *testing.T) {
 				assert.Equal(t, resp.Code, http.StatusUnauthorized)
 			},
 		},
-		"Pagination": {
+		"page 2 limit 2": {
 			urlPath: "/api/users?limit=2&page=2",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK)
@@ -183,6 +183,18 @@ func TestAPI_ListUsers(t *testing.T) {
 					},
 				}
 				assert.DeepEqual(t, actual, expected, cmpAPIUserShallow)
+			},
+		},
+		"invalid limit": {
+			urlPath: "/api/users?limit=1001",
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusBadRequest)
+			},
+		},
+		"invalid page": {
+			urlPath: "/api/users?page=-1",
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusBadRequest)
 			},
 		},
 		// TODO: assert full JSON response

--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -112,7 +112,7 @@ func (a *API) addResponseRewrites() {
 	})
 	addResponseRewrite(a, http.MethodGet, "/v1/grants/:id", "0.12.2", migrateUserGrantToIdentity)
 	addResponseRewrite(a, http.MethodGet, "/v1/grants", "0.12.2", func(newResponse *api.ListResponse[api.Grant]) []identityGrant {
-		return api.NewListResponse(newResponse.Items, migrateUserGrantToIdentity).Items
+		return api.NewListResponse(newResponse.Items, api.PaginationResponse{}, migrateUserGrantToIdentity).Items
 	})
 	addResponseRewrite(a, http.MethodPost, "/v1/grants", "0.12.2", func(newResponse *api.Grant) identityGrant {
 		return migrateUserGrantToIdentity(*newResponse)

--- a/internal/server/models/pagination.go
+++ b/internal/server/models/pagination.go
@@ -1,7 +1,36 @@
 package models
 
+import "github.com/infrahq/infra/api"
+
 // Internal Pagination Data
 type Pagination struct {
 	Page  int
 	Limit int
+}
+
+func RequestToPagination(pr api.PaginationRequest) Pagination {
+	if pr.Limit == 0 && pr.Page == 0 {
+		return Pagination{} // temporary so pagination is disabled by default
+	}
+	page, limit := 1, 100
+
+	if pr.Limit != 0 {
+		limit = pr.Limit
+	}
+
+	if pr.Page != 0 {
+		page = pr.Page
+	}
+
+	return Pagination{
+		Page:  page,
+		Limit: limit,
+	}
+}
+
+func PaginationToResponse(pr Pagination) api.PaginationResponse {
+	return api.PaginationResponse{
+		Page:  pr.Page,
+		Limit: pr.Limit,
+	}
 }


### PR DESCRIPTION
## Summary

All lists can now be (optionally) paginated by specifying the page or limit as a query parameter. Later, pagination can be the default and entire-list queries can be done using multiple requests, but it is optional now.

## Example
```bash
$ curl --request GET \
     --url "http://localhost/api/grants?page=1&limit=3" \
     --header 'Accept: application/json' --header "Authorization: Bearer $ACCESSKEY" --header 'Infra-Version: 0.13.4' -k

{
  "pagination_info": {
    "page": 1,
    "limit": 3
  },
  "items": [
    {
      "id": "7Yvd3ELXfs",
      ...
    },
    {
      "id": "7YvgA9zUSW",
      ...
    },
    {
      "id": "7YwqCVP4yL",
      ...
    }
  ],
  "count": 3
}
```
## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->