### PR TITLE
maintain: document default connector key lifetime

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -81,7 +81,7 @@ infra login <INFRA_SERVER_HOSTNAME> --skip-tls-verify
 
 ### 3. Connect your first Kubernetes cluster
 
-Generate an access key:
+Generate an access key with a 30 day time-to-live:
 
 ```
 infra keys add connector

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -81,11 +81,12 @@ infra login <INFRA_SERVER_HOSTNAME> --skip-tls-verify
 
 ### 3. Connect your first Kubernetes cluster
 
-Generate an access key with a 30 day time-to-live:
+Generate an access key:
 
 ```
 infra keys add connector
 ```
+Note: This key is valid for 30 days.
 
 Next, use this access key to connect your first cluster via `helm`. **Note:** this can be the same cluster used to install Infra in step 2.
 


### PR DESCRIPTION
## Summary
It's not clear in the quickstart that the access key you create for the connector will expire in 30 days. Note it at the time of creation.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)


