### PR TITLE
improve: resetting passwords for other users should create a temp password

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -20,6 +20,12 @@ var apiVersion = "0.13.0"
 
 var ErrTimeout = errors.New("client timed out waiting for response from server")
 
+const (
+	InfraAdminRole     = "admin"
+	InfraViewRole      = "view"
+	InfraConnectorRole = "connector"
+)
+
 type Client struct {
 	Name      string
 	Version   string

--- a/api/user.go
+++ b/api/user.go
@@ -24,9 +24,9 @@ type ListUsersRequest struct {
 	PaginationRequest
 }
 
+// CreateUserRequest is only for creating users with the Infra provider
 type CreateUserRequest struct {
-	Name               string `json:"name" validate:"email,required"`
-	SetOneTimePassword bool   `json:"setOneTimePassword"`
+	Name string `json:"name" validate:"email,required"`
 }
 
 type CreateUserResponse struct {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -3468,9 +3468,6 @@
                   "name": {
                     "format": "email",
                     "type": "string"
-                  },
-                  "setOneTimePassword": {
-                    "type": "boolean"
                   }
                 },
                 "required": [

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -1,11 +1,13 @@
 package access
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -17,12 +19,12 @@ func CreateCredential(c *gin.Context, user models.Identity) (string, error) {
 		return "", err
 	}
 
-	oneTimePassword, err := generate.CryptoRandom(10)
+	tmpPassword, err := generate.CryptoRandom(12, generate.CharsetPassword)
 	if err != nil {
 		return "", fmt.Errorf("generate: %w", err)
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(oneTimePassword), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(tmpPassword), bcrypt.DefaultCost)
 	if err != nil {
 		return "", fmt.Errorf("hash: %w", err)
 	}
@@ -38,11 +40,16 @@ func CreateCredential(c *gin.Context, user models.Identity) (string, error) {
 		return "", err
 	}
 
-	return oneTimePassword, nil
+	return tmpPassword, nil
 }
 
 func UpdateCredential(c *gin.Context, user *models.Identity, newPassword string) error {
 	db, err := hasAuthorization(c, user.ID, isIdentitySelf, models.InfraAdminRole)
+	if err != nil {
+		return err
+	}
+
+	isSelf, err := isIdentitySelf(c, user.ID)
 	if err != nil {
 		return err
 	}
@@ -54,21 +61,26 @@ func UpdateCredential(c *gin.Context, user *models.Identity, newPassword string)
 
 	userCredential, err := data.GetCredential(db, data.ByIdentityID(user.ID))
 	if err != nil {
+		if errors.Is(err, internal.ErrNotFound) && !isSelf {
+			if err := data.CreateCredential(db, &models.Credential{
+				IdentityID:          user.ID,
+				PasswordHash:        hash,
+				OneTimePassword:     true,
+				OneTimePasswordUsed: false,
+			}); err != nil {
+				return fmt.Errorf("creating credentials: %w", err)
+			}
+			return nil
+		}
 		return fmt.Errorf("existing credential: %w", err)
 	}
 
 	userCredential.PasswordHash = hash
-	userCredential.OneTimePassword = false
+	userCredential.OneTimePassword = !isSelf
 	userCredential.OneTimePasswordUsed = false
 
-	if user.ID != AuthenticatedIdentity(c).ID {
-		// an admin can only set a one time password for a user
-		userCredential.OneTimePassword = true
-		userCredential.OneTimePasswordUsed = false
-	}
-
 	if err := data.SaveCredential(db, userCredential); err != nil {
-		return err
+		return fmt.Errorf("saving credentials: %w", err)
 	}
 
 	return nil

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -16,9 +16,9 @@ import (
 )
 
 // isIdentitySelf is used by authorization checks to see if the calling identity is requesting their own attributes
-func isIdentitySelf(c *gin.Context, requestedResourceID uid.ID) (bool, error) {
+func isIdentitySelf(c *gin.Context, userID uid.ID) (bool, error) {
 	identity := AuthenticatedIdentity(c)
-	return identity != nil && identity.ID == requestedResourceID, nil
+	return identity != nil && identity.ID == userID, nil
 }
 
 // AuthenticatedIdentity returns the identity that is associated with the access key

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -54,7 +54,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 
 	// create some resources for this identity
 
-	keyID := generate.MathRandom(models.AccessKeyKeyLength)
+	keyID := generate.MathRandom(models.AccessKeyKeyLength, generate.CharsetAlphaNumeric)
 	_, err = data.CreateAccessKey(db, &models.AccessKey{KeyID: keyID, IssuedFor: identity.ID, ProviderID: infraProvider.ID})
 	assert.NilError(t, err)
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -148,12 +148,7 @@ $ infra use development.kube-system`,
 				return err
 			}
 
-			id, err := config.PolymorphicID.ID()
-			if err != nil {
-				return err
-			}
-
-			err = updateKubeConfig(client, id)
+			err = updateKubeConfig(client, config.UserID)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -268,10 +268,12 @@ func newTestClientConfig(srv *httptest.Server, user api.User) ClientConfig {
 		user.ID = uid.New()
 	}
 	return ClientConfig{
-		Version: clientConfigVersion,
+		ClientConfigVersion: ClientConfigVersion{
+			Version: clientConfigVersion,
+		},
 		Hosts: []ClientHostConfig{
 			{
-				PolymorphicID:      uid.NewIdentityPolymorphicID(user.ID),
+				UserID:             user.ID,
 				Name:               user.Name,
 				Host:               srv.Listener.Addr().String(),
 				TrustedCertificate: string(certs.PEMEncodeCertificate(srv.Certificate().Raw)),

--- a/internal/cmd/config_migration.go
+++ b/internal/cmd/config_migration.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "github.com/infrahq/infra/uid"
+import (
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/uid"
+)
 
 type ClientConfigV0dot1 struct {
 	Version       string `json:"version"` // always blank in v0.1
@@ -25,6 +28,22 @@ type ClientHostConfigV0dot2 struct {
 	Current       bool   `json:"current"`
 }
 
+type ClientConfigV0dot3 struct {
+	Version string                   `json:"version"`
+	Hosts   []ClientHostConfigV0dot3 `json:"hosts"`
+}
+
+type ClientHostConfigV0dot3 struct {
+	PolymorphicID uid.PolymorphicID `json:"polymorphic-id"`
+	Name          string            `json:"name"` // user name
+	Host          string            `json:"host"`
+	AccessKey     string            `json:"access-key,omitempty"`
+	SkipTLSVerify bool              `json:"skip-tls-verify"` // where is the other cert info stored?
+	ProviderID    uid.ID            `json:"provider-id,omitempty"`
+	Expires       api.Time          `json:"expires"`
+	Current       bool              `json:"current"`
+}
+
 // ToV0dot2 upgrades the config to the 0.2 version
 func (c ClientConfigV0dot1) ToV0dot2() *ClientConfigV0dot2 {
 	return &ClientConfigV0dot2{
@@ -42,8 +61,8 @@ func (c ClientConfigV0dot1) ToV0dot2() *ClientConfigV0dot2 {
 }
 
 // ToV0dot3 upgrades the config to the 0.3 version
-func (c ClientConfigV0dot2) ToV0dot3() *ClientConfig {
-	conf := &ClientConfig{
+func (c ClientConfigV0dot2) ToV0dot3() *ClientConfigV0dot3 {
+	conf := &ClientConfigV0dot3{
 		Version: "0.3",
 	}
 
@@ -51,12 +70,37 @@ func (c ClientConfigV0dot2) ToV0dot3() *ClientConfig {
 		providerID := uid.New()
 		h.SourceID = providerID
 
-		conf.Hosts = append(conf.Hosts, ClientHostConfig{
+		conf.Hosts = append(conf.Hosts, ClientHostConfigV0dot3{
 			Name:          h.Name,
 			Host:          h.Host,
 			AccessKey:     h.Token,
 			SkipTLSVerify: h.SkipTLSVerify,
 			ProviderID:    providerID,
+			Current:       h.Current,
+		})
+	}
+
+	return conf
+}
+
+// ToV0dot4 upgrades the config to the 0.4 version
+func (c ClientConfigV0dot3) ToV0dot4() *ClientConfig {
+	conf := &ClientConfig{
+		ClientConfigVersion: ClientConfigVersion{
+			Version: "0.4",
+		},
+	}
+
+	for _, h := range c.Hosts {
+		userID, _ := h.PolymorphicID.ID()
+		conf.Hosts = append(conf.Hosts, ClientHostConfig{
+			UserID:        userID,
+			Name:          h.Name,
+			Host:          h.Host,
+			AccessKey:     h.AccessKey,
+			SkipTLSVerify: h.SkipTLSVerify,
+			ProviderID:    h.ProviderID,
+			Expires:       h.Expires,
 			Current:       h.Current,
 		})
 	}

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -15,7 +15,7 @@ var (
 	//lint:ignore ST1005, user facing error
 	ErrConfigNotFound    = errors.New(`Could not read local credentials. Are you logged in? Use "infra login" to login`)
 	ErrProviderNotUnique = errors.New(`more than one provider exists with this name`)
-	ErrUserNotFound      = errors.New(`no user found with this name`)
+	ErrUserNotFound      = errors.New(`user not found`)
 )
 
 type LoginError struct {

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -315,7 +315,7 @@ func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 	}
 
 	if userID == 0 && !cmdOptions.IsGroup {
-		user, err := createUser(client, cmdOptions.Name, false)
+		user, err := createUser(client, cmdOptions.Name)
 		if err != nil {
 			if api.ErrorStatusCode(err) == 403 {
 				logging.S.Debug(err)

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -42,17 +42,11 @@ func info(cli *CLI) error {
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "Server:\t %s\n", config.Host)
 
-	id := config.PolymorphicID
-	if id == "" {
+	if config.UserID == 0 {
 		return fmt.Errorf("no active user")
 	}
 
-	identityID, err := id.ID()
-	if err != nil {
-		return err
-	}
-
-	user, err := client.GetUser(identityID)
+	user, err := client.GetUser(config.UserID)
 	if err != nil {
 		return err
 	}
@@ -68,7 +62,7 @@ func info(cli *CLI) error {
 		fmt.Fprintf(w, "Identity Provider:\t %s (%s)\n", provider.Name, provider.URL)
 	}
 
-	userGroups, err := client.ListGroups(api.ListGroupsRequest{UserID: identityID})
+	userGroups, err := client.ListGroups(api.ListGroupsRequest{UserID: config.UserID})
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -113,27 +113,21 @@ func getUserDestinationGrants(client *api.Client) (*api.User, *api.ListResponse[
 		return nil, nil, nil, err
 	}
 
-	id := config.PolymorphicID
-	if id == "" {
+	if config.UserID == 0 {
 		return nil, nil, nil, fmt.Errorf("no active identity")
 	}
 
-	identityID, err := id.ID()
+	user, err := client.GetUser(config.UserID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	user, err := client.GetUser(identityID)
+	grants, err := client.ListGrants(api.ListGrantsRequest{User: config.UserID})
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	grants, err := client.ListGrants(api.ListGrantsRequest{User: identityID})
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	groups, err := client.ListGroups(api.ListGroupsRequest{UserID: identityID})
+	groups, err := client.ListGroups(api.ListGroupsRequest{UserID: config.UserID})
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/server"
-	"github.com/infrahq/infra/uid"
 )
 
 func TestListCmd(t *testing.T) {
@@ -78,10 +77,10 @@ func TestListCmd(t *testing.T) {
 	t.Run("with no grants", func(t *testing.T) {
 		user := userMap["nogrants@example.com"]
 		err := writeConfig(&ClientConfig{
-			Version: clientConfigVersion,
+			ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion},
 			Hosts: []ClientHostConfig{
 				{
-					PolymorphicID: uid.NewIdentityPolymorphicID(user.ID),
+					UserID:        user.ID,
 					Name:          user.Name,
 					Host:          srv.Addrs.HTTPS.String(),
 					AccessKey:     "0000000002.notadminsecretnotadmin02",
@@ -104,10 +103,10 @@ func TestListCmd(t *testing.T) {
 	t.Run("with many grants", func(t *testing.T) {
 		user := userMap["manygrants@example.com"]
 		err := writeConfig(&ClientConfig{
-			Version: clientConfigVersion,
+			ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion},
 			Hosts: []ClientHostConfig{
 				{
-					PolymorphicID: uid.NewIdentityPolymorphicID(user.ID),
+					UserID:        user.ID,
 					Name:          user.Name,
 					Host:          srv.Addrs.HTTPS.String(),
 					AccessKey:     "0000000003.notadminsecretnotadmin03",

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -26,7 +26,6 @@ import (
 	"github.com/infrahq/infra/internal/certs"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/logging"
-	"github.com/infrahq/infra/uid"
 )
 
 type loginCmdOptions struct {
@@ -254,11 +253,11 @@ func loginToInfra(cli *CLI, lc loginClient, loginReq *api.LoginRequest, noAgent 
 // Updates all configs with the current logged in session
 func updateInfraConfig(lc loginClient, loginReq *api.LoginRequest, loginRes *api.LoginResponse) error {
 	clientHostConfig := ClientHostConfig{
-		Current:       true,
-		PolymorphicID: uid.NewIdentityPolymorphicID(loginRes.UserID),
-		Name:          loginRes.Name,
-		AccessKey:     loginRes.AccessKey,
-		Expires:       loginRes.Expires,
+		Current:   true,
+		UserID:    loginRes.UserID,
+		Name:      loginRes.Name,
+		AccessKey: loginRes.AccessKey,
+		Expires:   loginRes.Expires,
 	}
 
 	t, ok := lc.APIClient.HTTP.Transport.(*http.Transport)
@@ -318,7 +317,7 @@ func oidcflow(host string, clientId string) (string, error) {
 	}
 
 	// the state makes sure we are getting the correct response for our request
-	state, err := generate.CryptoRandom(12)
+	state, err := generate.CryptoRandom(12, generate.CharsetAlphaNumeric)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+var anyUID = uid.ID(-1)
+
 func TestLoginCmd_SetupAdminOnFirstLogin(t *testing.T) {
 	dir := setupEnv(t)
 
@@ -73,7 +75,7 @@ func TestLoginCmd_SetupAdminOnFirstLogin(t *testing.T) {
 			{
 				Name:          "admin@example.com",
 				AccessKey:     "any-access-key",
-				PolymorphicID: "any-id",
+				UserID:        anyUID,
 				Host:          srv.Addrs.HTTPS.String(),
 				SkipTLSVerify: true,
 				Expires:       api.Time(time.Now().UTC().Add(opts.SessionDuration)),
@@ -100,7 +102,7 @@ func TestLoginCmd_SetupAdminOnFirstLogin(t *testing.T) {
 			{
 				Name:          "admin@example.com",
 				AccessKey:     "any-access-key",
-				PolymorphicID: "any-id",
+				UserID:        anyUID,
 				Host:          srv.Addrs.HTTPS.String(),
 				SkipTLSVerify: true,
 				Expires:       api.Time(time.Now().UTC().Add(opts.SessionDuration)),
@@ -158,12 +160,11 @@ func TestLoginCmd_Options(t *testing.T) {
 	runStep(t, "login updated infra config", func(t *testing.T) {
 		cfg, err := readConfig()
 		assert.NilError(t, err)
-
 		expected := []ClientHostConfig{
 			{
 				Name:          "admin@example.com",
 				AccessKey:     adminAccessKey,
-				PolymorphicID: "any-id",
+				UserID:        anyUID,
 				Host:          srv.Addrs.HTTPS.String(),
 				SkipTLSVerify: true,
 				Expires:       api.Time(time.Now().UTC().Add(opts.SessionDuration)),
@@ -188,8 +189,8 @@ var cmpClientHostConfig = cmp.Options{
 		opt.PathField(ClientHostConfig{}, "AccessKey"),
 		cmpStringNotZero),
 	cmp.FilterPath(
-		opt.PathField(ClientHostConfig{}, "PolymorphicID"),
-		cmpPolymorphicIDNotZero),
+		opt.PathField(ClientHostConfig{}, "UserID"),
+		cmpUserIDNotZero),
 	cmp.FilterPath(
 		opt.PathField(ClientHostConfig{}, "Expires"),
 		cmpApiTimeWithThreshold(20*time.Second)),
@@ -210,8 +211,8 @@ var cmpStringNotZero = cmp.Comparer(func(x, y string) bool {
 	return x != "" && y != ""
 })
 
-var cmpPolymorphicIDNotZero = cmp.Comparer(func(x, y uid.PolymorphicID) bool {
-	return x != "" && y != ""
+var cmpUserIDNotZero = cmp.Comparer(func(x, y uid.ID) bool {
+	return x != 0 && y != 0
 })
 
 func runStep(t *testing.T, name string, fn func(t *testing.T)) {
@@ -374,7 +375,7 @@ func TestLoginCmd_PromptForTLSVerify(t *testing.T) {
 			{
 				Name:               "admin@example.com",
 				AccessKey:          "any-access-key",
-				PolymorphicID:      "any-id",
+				UserID:             anyUID,
 				Host:               srv.Addrs.HTTPS.String(),
 				Expires:            api.Time(time.Now().UTC().Add(opts.SessionDuration)),
 				Current:            true,
@@ -404,7 +405,7 @@ func TestLoginCmd_PromptForTLSVerify(t *testing.T) {
 			{
 				Name:               "admin@example.com",
 				AccessKey:          "any-access-key",
-				PolymorphicID:      "any-id",
+				UserID:             anyUID,
 				Host:               srv.Addrs.HTTPS.String(),
 				Expires:            api.Time(time.Now().UTC().Add(opts.SessionDuration)),
 				Current:            true,

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -71,7 +71,7 @@ func logoutOfServer(hostConfig *ClientHostConfig) (success bool) {
 	client := apiClient(hostConfig.Host, hostConfig.AccessKey, httpTransportForHostConfig(hostConfig))
 
 	hostConfig.AccessKey = ""
-	hostConfig.PolymorphicID = ""
+	hostConfig.UserID = 0
 	hostConfig.Name = ""
 
 	err := client.Logout()

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -46,13 +46,13 @@ func TestLogout(t *testing.T) {
 		t.Cleanup(srv2.Close)
 
 		cfg := ClientConfig{
-			Version: clientConfigVersion,
+			ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion},
 			Hosts: []ClientHostConfig{
 				{
 					Name:          "user1",
 					Host:          srv.Listener.Addr().String(),
 					AccessKey:     "the-access-key",
-					PolymorphicID: "pid1",
+					UserID:        1,
 					SkipTLSVerify: true,
 					Current:       true,
 				},
@@ -60,7 +60,7 @@ func TestLogout(t *testing.T) {
 					Name:          "user2",
 					Host:          srv2.Listener.Addr().String(),
 					AccessKey:     "the-access-key",
-					PolymorphicID: "pid2",
+					UserID:        2,
 					SkipTLSVerify: true,
 				},
 			},
@@ -108,13 +108,13 @@ func TestLogout(t *testing.T) {
 		t.Cleanup(srv.Close)
 
 		cfg := ClientConfig{
-			Version: clientConfigVersion,
+			ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion},
 			Hosts: []ClientHostConfig{
 				{
 					Name:          "user1",
 					Host:          srv.Listener.Addr().String(),
 					AccessKey:     "the-access-key",
-					PolymorphicID: "pid1",
+					UserID:        1,
 					SkipTLSVerify: true,
 					Current:       true,
 				},
@@ -172,7 +172,7 @@ func TestLogout(t *testing.T) {
 		expected := testFields.config
 		expected.Hosts[0].AccessKey = ""
 		expected.Hosts[0].Name = ""
-		expected.Hosts[0].PolymorphicID = ""
+		expected.Hosts[0].UserID = 0
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
@@ -193,7 +193,7 @@ func TestLogout(t *testing.T) {
 		expected := testFields.config
 		expected.Hosts[0].AccessKey = ""
 		expected.Hosts[0].Name = ""
-		expected.Hosts[0].PolymorphicID = ""
+		expected.Hosts[0].UserID = 0
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
@@ -214,7 +214,7 @@ func TestLogout(t *testing.T) {
 		expected := testFields.config
 		expected.Hosts[0].AccessKey = ""
 		expected.Hosts[0].Name = ""
-		expected.Hosts[0].PolymorphicID = ""
+		expected.Hosts[0].UserID = 0
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		kubeconfig := expectedKubeCfg
@@ -256,10 +256,10 @@ func TestLogout(t *testing.T) {
 		expected := testFields.config
 		expected.Hosts[0].AccessKey = ""
 		expected.Hosts[0].Name = ""
-		expected.Hosts[0].PolymorphicID = ""
+		expected.Hosts[0].UserID = 0
 		expected.Hosts[1].AccessKey = ""
 		expected.Hosts[1].Name = ""
-		expected.Hosts[1].PolymorphicID = ""
+		expected.Hosts[1].UserID = 0
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
@@ -277,7 +277,7 @@ func TestLogout(t *testing.T) {
 		updatedCfg, err := readConfig()
 		assert.NilError(t, err)
 
-		expected := ClientConfig{Version: clientConfigVersion}
+		expected := ClientConfig{ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion}}
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		updatedKubeCfg, err := clientConfig().RawConfig()

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -8,26 +8,29 @@ import (
 	"time"
 )
 
-const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+const (
+	CharsetAlphaNumeric = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	CharsetPassword     = CharsetAlphaNumeric + `!@#$%^&*()_+-=[]|;:,./<>?`
+)
 
 func init() {
 	mathrand.Seed(time.Now().UnixNano())
 }
 
-// CryptoRandom generates a cryptographically-safe random number
-func CryptoRandom(n int) (string, error) {
+// CryptoRandom generates a cryptographically-safe random number. defaults to alphanumeric charset.
+func CryptoRandom(n int, charset string) (string, error) {
 	if n <= 0 {
 		return "", nil
 	}
 
 	bytes := make([]byte, n)
 	for i := range bytes {
-		bigint, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphanum))))
+		bigint, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
 		if err != nil {
 			return "", fmt.Errorf("couldn't generate random string of len %d: %w", n, err)
 		}
 
-		bytes[i] = alphanum[bigint.Int64()]
+		bytes[i] = charset[bigint.Int64()]
 	}
 
 	return string(bytes), nil
@@ -36,7 +39,7 @@ func CryptoRandom(n int) (string, error) {
 // MathRandom generates a random string that does not need to be cryptographically secure
 // This is preferred to CryptoRandom when you don't need the cryptographic security as it is
 // not a drain on the entropy pool.
-func MathRandom(n int) string {
+func MathRandom(n int, charset string) string {
 	if n <= 0 {
 		return ""
 	}
@@ -44,8 +47,8 @@ func MathRandom(n int) string {
 	bytes := make([]byte, n)
 	for i := range bytes {
 		//nolint:gosec // We purposely use mathrand to avoid draining the entropy pool
-		j := mathrand.Int31n(int32(len(alphanum)))
-		bytes[i] = alphanum[j]
+		j := mathrand.Int31n(int32(len(charset)))
+		bytes[i] = charset[j]
 	}
 
 	return string(bytes)

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestCryptoRandomNegativeLen(t *testing.T) {
-	s, err := CryptoRandom(-1)
+	s, err := CryptoRandom(-1, CharsetAlphaNumeric)
 	assert.NilError(t, err)
 	assert.Equal(t, s, "")
 }
 
 func TestCryptoRandomLen(t *testing.T) {
-	s, err := CryptoRandom(20)
+	s, err := CryptoRandom(20, CharsetAlphaNumeric)
 	assert.NilError(t, err)
 	assert.Equal(t, len(s), 20)
 }
@@ -23,9 +23,9 @@ func TestCryptoRandomCanGenerateEdgeCharacters(t *testing.T) {
 	// check for off-by-one errors by making sure the random string generated can contain
 	// both the first character in the list, and the last.
 	// this test will time out or error on exhausting the entropy pool if it fails.
-	testForCharacters := []byte{alphanum[0], alphanum[len(alphanum)-1]}
+	testForCharacters := []byte{CharsetAlphaNumeric[0], CharsetAlphaNumeric[len(CharsetAlphaNumeric)-1]}
 	for _, char := range testForCharacters {
-		s, err := CryptoRandom(50)
+		s, err := CryptoRandom(50, CharsetAlphaNumeric)
 		assert.NilError(t, err)
 
 		if strings.Contains(s, string(char)) {
@@ -35,7 +35,7 @@ func TestCryptoRandomCanGenerateEdgeCharacters(t *testing.T) {
 }
 
 func TestSeedHasBeenInitialized(t *testing.T) {
-	s := MathRandom(10)
+	s := MathRandom(10, CharsetAlphaNumeric)
 	// the default seed of 1 will always generate RFbD56TI2s.
 	assert.Assert(t, "RFbD56TI2s" != s)
 }

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -22,7 +22,7 @@ func secretChecksum(secret string) []byte {
 
 func CreateAccessKey(db *gorm.DB, accessKey *models.AccessKey) (body string, err error) {
 	if accessKey.KeyID == "" {
-		accessKey.KeyID = generate.MathRandom(models.AccessKeyKeyLength)
+		accessKey.KeyID = generate.MathRandom(models.AccessKeyKeyLength, generate.CharsetAlphaNumeric)
 	}
 
 	if len(accessKey.KeyID) != models.AccessKeyKeyLength {
@@ -30,7 +30,7 @@ func CreateAccessKey(db *gorm.DB, accessKey *models.AccessKey) (body string, err
 	}
 
 	if accessKey.Secret == "" {
-		secret, err := generate.CryptoRandom(models.AccessKeySecretLength)
+		secret, err := generate.CryptoRandom(models.AccessKeySecretLength, generate.CharsetAlphaNumeric)
 		if err != nil {
 			return "", err
 		}

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -109,7 +109,7 @@ func TestCheckAccessKeySecret(t *testing.T) {
 		_, err := ValidateAccessKey(db, body)
 		assert.NilError(t, err)
 
-		random := generate.MathRandom(models.AccessKeySecretLength)
+		random := generate.MathRandom(models.AccessKeySecretLength, generate.CharsetAlphaNumeric)
 		authorization := fmt.Sprintf("%s.%s", strings.Split(body, ".")[0], random)
 
 		_, err = ValidateAccessKey(db, authorization)

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -194,11 +194,23 @@ func handleError(err error) error {
 		})
 
 		// fields = [UNIQUE, constraint, failed:, <table>, column>]
-		if len(fields) == 5 {
-			return UniqueConstraintError{Table: fields[3], Column: fields[4]}
-		}
+		switch len(fields) {
+		case 5, 7, 9, 11:
+			col := fields[4]
+			i := 6
+			for i < len(fields) {
+				col += fields[i]
+				i += 2
+			}
+			return UniqueConstraintError{
+				Table:  fields[3],
+				Column: col,
+			}
+		default:
+			logging.S.Warnf("unhandled unique constraint error format: %q", err.Error())
 
-		return UniqueConstraintError{}
+			return UniqueConstraintError{}
+		}
 	}
 
 	return err

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -42,8 +42,8 @@ func ListProviderUsers(db *gorm.DB, selectors ...SelectorFunc) ([]models.Provide
 	return list[models.ProviderUser](db, selectors...)
 }
 
-func DeleteProviderUsers(db *gorm.DB, selector SelectorFunc) error {
-	return deleteAll[models.ProviderUser](db, selector)
+func DeleteProviderUsers(db *gorm.DB, selectors ...SelectorFunc) error {
+	return deleteAll[models.ProviderUser](db, selectors...)
 }
 
 func GetProviderUser(db *gorm.DB, providerID, userID uid.ID) (*models.ProviderUser, error) {

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -52,7 +52,7 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 	custom := claims.Custom{
 		Name:   identity.Name,
 		Groups: groups,
-		Nonce:  generate.MathRandom(10),
+		Nonce:  generate.MathRandom(10, generate.CharsetAlphaNumeric),
 	}
 
 	raw, err := jwt.Signed(signer).Claims(claim).Claims(custom).CompactSerialize()

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -149,7 +149,7 @@ func TestRequireAuthentication(t *testing.T) {
 		},
 		"AccessKeyNoMatch": {
 			"authFunc": func(t *testing.T, db *gorm.DB, c *gin.Context) {
-				authentication := fmt.Sprintf("%s.%s", uid.New().String(), generate.MathRandom(models.AccessKeySecretLength))
+				authentication := fmt.Sprintf("%s.%s", uid.New().String(), generate.MathRandom(models.AccessKeySecretLength, generate.CharsetAlphaNumeric))
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.Header.Add("Authorization", "Bearer "+authentication)
 				c.Request = r
@@ -161,7 +161,7 @@ func TestRequireAuthentication(t *testing.T) {
 		"AccessKeyInvalidSecret": {
 			"authFunc": func(t *testing.T, db *gorm.DB, c *gin.Context) {
 				token := issueToken(t, db, "existing@infrahq.com", time.Minute*1)
-				authentication := fmt.Sprintf("%s.%s", strings.Split(token, ".")[0], generate.MathRandom(models.AccessKeySecretLength))
+				authentication := fmt.Sprintf("%s.%s", strings.Split(token, ".")[0], generate.MathRandom(models.AccessKeySecretLength, generate.CharsetAlphaNumeric))
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.Header.Add("Authorization", "Bearer "+authentication)
 				c.Request = r
@@ -172,7 +172,7 @@ func TestRequireAuthentication(t *testing.T) {
 		},
 		"UnknownAuthenticationMethod": {
 			"authFunc": func(t *testing.T, db *gorm.DB, c *gin.Context) {
-				authentication, err := generate.CryptoRandom(32)
+				authentication, err := generate.CryptoRandom(32, generate.CharsetAlphaNumeric)
 				assert.NilError(t, err)
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.Header.Add("Authorization", "Bearer "+authentication)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

## Examples 

```
# in this example, joe@example.com is an existing IDP user, and the current user is logged in as an admin.

$ ./infra users edit joe@example.com --password
Error: existing credential: record not found

# we can't add a password for joe because he's not a local user. Let's add him as a local user

$ ./infra users add joe@example.com
Added user "joe@example.com"
Password: SJXiwhr1Kvcy

$ ./infra users edit joe@example.com --password
  Temporary password for user "joe@example.com" set to: Y*Wv?|Ugv@mX

# logging in as joe, we can set our own password.
$ ./infra login localhost
? Select a login method: Login with username and password
? Username: joe@example.com
? Password: ************
  Your password has expired. Please update your password (min. length 8).
? Password: *************
? Confirm Password: *************
  Updated password.
  Logged in as joe@example.com

# now joe can edit his own password, which will not be temporary.

$ ./infra users edit joe@example.com --password
  Enter a new password (min. length 8):
? Password: ********
? Confirm Password: ********
  Updated password

```

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2145
