### PR TITLE
cmd/login: add --tls-trusted-cert flag 

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -39,12 +39,13 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy
 #### Options
 
 ```
-      --key string                   Login with an access key
-      --no-agent                     Skip starting the Infra agent in the background
-      --non-interactive              Disable all prompts for input
-      --provider string              Login with an identity provider
-      --skip-tls-verify              Skip verifying server TLS certificates
-      --tls-trusted-cert file path   TLS certificate or CA used by the server
+      --key string                       Login with an access key
+      --no-agent                         Skip starting the Infra agent in the background
+      --non-interactive                  Disable all prompts for input
+      --provider string                  Login with an identity provider
+      --skip-tls-verify                  Skip verifying server TLS certificates
+      --tls-trusted-cert filepath        TLS certificate or CA used by the server
+      --tls-trusted-fingerprint string   SHA256 fingerprint of the server TLS certificate
 ```
 
 #### Options inherited from parent commands

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -39,11 +39,12 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy
 #### Options
 
 ```
-      --key string        Login with an access key
-      --no-agent          Skip starting the Infra agent in the background
-      --non-interactive   Disable all prompts for input
-      --provider string   Login with an identity provider
-      --skip-tls-verify   Skip verifying server TLS certificates
+      --key string                   Login with an access key
+      --no-agent                     Skip starting the Infra agent in the background
+      --non-interactive              Disable all prompts for input
+      --provider string              Login with an identity provider
+      --skip-tls-verify              Skip verifying server TLS certificates
+      --tls-trusted-cert file path   TLS certificate or CA used by the server
 ```
 
 #### Options inherited from parent commands

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -268,9 +268,7 @@ func newTestClientConfig(srv *httptest.Server, user api.User) ClientConfig {
 		user.ID = uid.New()
 	}
 	return ClientConfig{
-		ClientConfigVersion: ClientConfigVersion{
-			Version: clientConfigVersion,
-		},
+		ClientConfigVersion: clientConfigVersion,
 		Hosts: []ClientHostConfig{
 			{
 				UserID:             user.ID,

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -15,7 +15,7 @@ import (
 // clientConfigVersion is the current version of the client configuration file.
 // Use this constant when referring to a value in tests or code that should
 // always use latest.
-const clientConfigVersion = "0.4"
+var clientConfigVersion = ClientConfigVersion{Version: "0.4"}
 
 type ClientConfigVersion struct {
 	Version string `json:"version"`
@@ -76,7 +76,7 @@ func readConfig() (*ClientConfig, error) {
 	}
 
 	if len(contents) == 0 {
-		return &ClientConfig{ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion}}, nil
+		return &ClientConfig{ClientConfigVersion: clientConfigVersion}, nil
 	}
 
 	config := &ClientConfigVersion{}

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -77,7 +77,7 @@ func TestListCmd(t *testing.T) {
 	t.Run("with no grants", func(t *testing.T) {
 		user := userMap["nogrants@example.com"]
 		err := writeConfig(&ClientConfig{
-			ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion},
+			ClientConfigVersion: clientConfigVersion,
 			Hosts: []ClientHostConfig{
 				{
 					UserID:        user.ID,
@@ -103,7 +103,7 @@ func TestListCmd(t *testing.T) {
 	t.Run("with many grants", func(t *testing.T) {
 		user := userMap["manygrants@example.com"]
 		err := writeConfig(&ClientConfig{
-			ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion},
+			ClientConfigVersion: clientConfigVersion,
 			Hosts: []ClientHostConfig{
 				{
 					UserID:        user.ID,

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -35,6 +35,7 @@ type loginCmdOptions struct {
 	Provider           string
 	SkipTLSVerify      bool
 	TrustedCertificate string
+	TrustedFingerprint string
 	NonInteractive     bool
 	NoAgent            bool
 }
@@ -82,6 +83,7 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy`,
 	cmd.Flags().StringVar(&options.Provider, "provider", "", "Login with an identity provider")
 	cmd.Flags().BoolVar(&options.SkipTLSVerify, "skip-tls-verify", false, "Skip verifying server TLS certificates")
 	cmd.Flags().Var((*types.StringOrFile)(&options.TrustedCertificate), "tls-trusted-cert", "TLS certificate or CA used by the server")
+	cmd.Flags().StringVar(&options.TrustedFingerprint, "tls-trusted-fingerprint", "", "SHA256 fingerprint of the server TLS certificate")
 	cmd.Flags().BoolVar(&options.NoAgent, "no-agent", false, "Skip starting the Infra agent in the background")
 	addNonInteractiveFlag(cmd.Flags(), &options.NonInteractive)
 	return cmd
@@ -427,19 +429,21 @@ func newLoginClient(cli *CLI, options loginCmdOptions) (loginClient, error) {
 			return c, err
 		}
 
-		if options.NonInteractive {
-			if options.TrustedCertificate != "" {
+		if !fingerprintMatch(cli, options.TrustedFingerprint, uaErr.Cert) {
+			if options.NonInteractive {
+				if options.TrustedCertificate != "" {
+					return c, err
+				}
+				return c, Error{
+					Message: "The authenticity of the server could not be verified. " +
+						"Use the --tls-trusted-cert flag to specify a trusted CA, or run " +
+						"in interactive mode.",
+				}
+			}
+
+			if err := promptVerifyTLSCert(cli, uaErr.Cert); err != nil {
 				return c, err
 			}
-			return c, Error{
-				Message: "The authenticity of the server could not be verified. " +
-					"Use the --tls-trusted-cert flag to specify a trusted CA, or run " +
-					"in interactive mode.",
-			}
-		}
-
-		if err = promptVerifyTLSCert(cli, uaErr.Cert); err != nil {
-			return c, err
 		}
 
 		pool, err := x509.SystemCertPool()
@@ -458,6 +462,28 @@ func newLoginClient(cli *CLI, options loginCmdOptions) (loginClient, error) {
 		c.TrustedCertificate = string(certs.PEMEncodeCertificate(uaErr.Cert.Raw))
 	}
 	return c, nil
+}
+
+func fingerprintMatch(cli *CLI, fingerprint string, cert *x509.Certificate) bool {
+	fingerprint = strings.TrimSpace(fingerprint)
+	if fingerprint == "" {
+		return false
+	}
+
+	if strings.EqualFold(fingerprint, certs.Fingerprint(cert.Raw)) {
+		return true
+	}
+
+	fmt.Fprintf(cli.Stderr, `
+%v TLS fingerprint from server does not match the trusted fingerprint.
+
+Trusted: %v
+Server:  %v
+`,
+		termenv.String("WARNING").Bold().String(),
+		fingerprint,
+		certs.Fingerprint(cert.Raw))
+	return false
 }
 
 func attemptTLSRequest(options loginCmdOptions) error {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -24,16 +24,16 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/certs"
+	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/logging"
 )
 
 type loginCmdOptions struct {
-	Server        string
-	AccessKey     string
-	Provider      string
-	SkipTLSVerify bool
-	// TODO: add flag for trusted certificate
+	Server             string
+	AccessKey          string
+	Provider           string
+	SkipTLSVerify      bool
 	TrustedCertificate string
 	NonInteractive     bool
 	NoAgent            bool
@@ -81,6 +81,7 @@ $ infra login --key 1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy`,
 	cmd.Flags().StringVar(&options.AccessKey, "key", "", "Login with an access key")
 	cmd.Flags().StringVar(&options.Provider, "provider", "", "Login with an identity provider")
 	cmd.Flags().BoolVar(&options.SkipTLSVerify, "skip-tls-verify", false, "Skip verifying server TLS certificates")
+	cmd.Flags().Var((*types.StringOrFile)(&options.TrustedCertificate), "tls-trusted-cert", "TLS certificate or CA used by the server")
 	cmd.Flags().BoolVar(&options.NoAgent, "no-agent", false, "Skip starting the Infra agent in the background")
 	addNonInteractiveFlag(cmd.Flags(), &options.NonInteractive)
 	return cmd
@@ -427,11 +428,12 @@ func newLoginClient(cli *CLI, options loginCmdOptions) (loginClient, error) {
 		}
 
 		if options.NonInteractive {
-			// TODO: add the --tls-ca flag
-			// TODO: give a different error if the flag was set
+			if options.TrustedCertificate != "" {
+				return c, err
+			}
 			return c, Error{
 				Message: "The authenticity of the server could not be verified. " +
-					"Use the --tls-ca flag to specify a trusted CA, or run " +
+					"Use the --tls-trusted-cert flag to specify a trusted CA, or run " +
 					"in interactive mode.",
 			}
 		}

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,15 +18,17 @@ import (
 	"golang.org/x/sync/errgroup"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/opt"
+	"gotest.tools/v3/golden"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/certs"
 	"github.com/infrahq/infra/internal/race"
 	"github.com/infrahq/infra/internal/server"
 	"github.com/infrahq/infra/uid"
 )
 
-var anyUID = uid.ID(-1)
+var anyUID = uid.ID(99)
 
 func TestLoginCmd_SetupAdminOnFirstLogin(t *testing.T) {
 	dir := setupEnv(t)
@@ -212,7 +215,7 @@ var cmpStringNotZero = cmp.Comparer(func(x, y string) bool {
 })
 
 var cmpUserIDNotZero = cmp.Comparer(func(x, y uid.ID) bool {
-	return x != 0 && y != 0
+	return x > 0 && y > 0
 })
 
 func runStep(t *testing.T, name string, fn func(t *testing.T)) {
@@ -298,7 +301,7 @@ func setupCertManager(t *testing.T, dir string, serverName string) {
 	assert.NilError(t, err)
 }
 
-func TestLoginCmd_PromptForTLSVerify(t *testing.T) {
+func TestLoginCmd_TLSVerify(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("USERPROFILE", dir) // Windows
@@ -415,7 +418,7 @@ func TestLoginCmd_PromptForTLSVerify(t *testing.T) {
 		assert.DeepEqual(t, cfg.Hosts, expected, cmpClientHostConfig)
 	})
 
-	runStep(t, "login with trusted cert", func(t *testing.T) {
+	t.Run("login with trusted cert", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		t.Cleanup(cancel)
 
@@ -438,7 +441,7 @@ func TestLoginCmd_PromptForTLSVerify(t *testing.T) {
 			{
 				Name:               "admin@example.com",
 				AccessKey:          "any-access-key",
-				PolymorphicID:      "any-id",
+				UserID:             anyUID,
 				Host:               srv.Addrs.HTTPS.String(),
 				Expires:            api.Time(time.Now().UTC().Add(opts.SessionDuration)),
 				Current:            true,
@@ -446,5 +449,65 @@ func TestLoginCmd_PromptForTLSVerify(t *testing.T) {
 			},
 		}
 		assert.DeepEqual(t, cfg.Hosts, expected, cmpClientHostConfig)
+	})
+
+	t.Run("login with trusted fingerprint", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		t.Cleanup(cancel)
+
+		err := Run(ctx, "logout", "--clear")
+		assert.NilError(t, err)
+
+		cert, err := os.ReadFile("testdata/pki/localhost.crt")
+		assert.NilError(t, err)
+
+		block, _ := pem.Decode(cert)
+		fingerprint := certs.Fingerprint(block.Bytes)
+
+		err = Run(ctx, "login",
+			"--tls-trusted-fingerprint", fingerprint,
+			"--key", accessKey,
+			srv.Addrs.HTTPS.String())
+		assert.NilError(t, err)
+
+		// Check the client config
+		cfg, err := readConfig()
+		assert.NilError(t, err)
+		expected := []ClientHostConfig{
+			{
+				Name:               "admin@example.com",
+				AccessKey:          "any-access-key",
+				UserID:             anyUID,
+				Host:               srv.Addrs.HTTPS.String(),
+				Expires:            api.Time(time.Now().UTC().Add(opts.SessionDuration)),
+				Current:            true,
+				TrustedCertificate: string(cert),
+			},
+		}
+		assert.DeepEqual(t, cfg.Hosts, expected, cmpClientHostConfig)
+	})
+
+	t.Run("login with wrong fingerprint", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		t.Cleanup(cancel)
+
+		err := Run(ctx, "logout", "--clear")
+		assert.NilError(t, err)
+
+		ctx, bufs := PatchCLI(ctx)
+
+		err = Run(ctx, "login",
+			"--tls-trusted-fingerprint", "BA::D0::FF",
+			"--key", accessKey,
+			srv.Addrs.HTTPS.String())
+		assert.ErrorContains(t, err, "authenticity of the server could not be verified")
+
+		// Check the client config is empty
+		cfg, err := readConfig()
+		assert.NilError(t, err)
+		expected := &ClientConfig{ClientConfigVersion: clientConfigVersion}
+		assert.DeepEqual(t, cfg, expected, cmpopts.EquateEmpty())
+
+		golden.Assert(t, bufs.Stderr.String(), t.Name())
 	})
 }

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -46,7 +46,7 @@ func TestLogout(t *testing.T) {
 		t.Cleanup(srv2.Close)
 
 		cfg := ClientConfig{
-			ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion},
+			ClientConfigVersion: clientConfigVersion,
 			Hosts: []ClientHostConfig{
 				{
 					Name:          "user1",
@@ -108,7 +108,7 @@ func TestLogout(t *testing.T) {
 		t.Cleanup(srv.Close)
 
 		cfg := ClientConfig{
-			ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion},
+			ClientConfigVersion: clientConfigVersion,
 			Hosts: []ClientHostConfig{
 				{
 					Name:          "user1",
@@ -277,7 +277,7 @@ func TestLogout(t *testing.T) {
 		updatedCfg, err := readConfig()
 		assert.NilError(t, err)
 
-		expected := ClientConfig{ClientConfigVersion: ClientConfigVersion{Version: clientConfigVersion}}
+		expected := ClientConfig{ClientConfigVersion: clientConfigVersion}
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		updatedKubeCfg, err := clientConfig().RawConfig()

--- a/internal/cmd/testdata/TestLoginCmd_TLSVerify/login_with_wrong_fingerprint
+++ b/internal/cmd/testdata/TestLoginCmd_TLSVerify/login_with_wrong_fingerprint
@@ -1,0 +1,5 @@
+
+[1mWARNING[0m TLS fingerprint from server does not match the trusted fingerprint.
+
+Trusted: BA::D0::FF
+Server:  AE:31:2D:E2:21:90:15:03:99:49:C5:98:ED:A3:2E:B9:88:FE:F6:6A:CE:6E:D9:FE:2B:A4:5D:07:8B:7B:BD:C8

--- a/internal/cmd/types/file.go
+++ b/internal/cmd/types/file.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"io"
+	"os"
+)
+
+// StringOrFile is a pflag.Value type that can be used to read a value either
+// from the command line flag, or as path to a file.
+// If the value is not an existing filepath, it will be used as the literal
+// string.
+type StringOrFile string
+
+func (s *StringOrFile) String() string {
+	if s == nil {
+		return ""
+	}
+	return string(*s)
+}
+
+func (s *StringOrFile) Set(raw string) error {
+	fh, err := os.Open(raw)
+	if err != nil {
+		*s = StringOrFile(raw)
+		return nil
+	}
+
+	content, err := io.ReadAll(fh)
+	if err != nil {
+		return err
+	}
+	*s = StringOrFile(content)
+	return nil
+}
+
+func (s *StringOrFile) Type() string {
+	return "file path"
+}

--- a/internal/cmd/types/file.go
+++ b/internal/cmd/types/file.go
@@ -34,5 +34,5 @@ func (s *StringOrFile) Set(raw string) error {
 }
 
 func (s *StringOrFile) Type() string {
-	return "file path"
+	return "filepath"
 }


### PR DESCRIPTION
## Summary

This PR adds a new `--tls-trusted-cert` flag to `infra login`. The flag can be used to specify either the server TLS certificate, or a CA that was used to create the certificate.

This PR is branched from #2177, which adds most of the support that was needed. That PR will need to merge first.

## Related Issues

Resolves #2177
