### PR TITLE
ci: add timing and caching to go steps

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
+          cache: true
+      - run: go mod download -x
       - id: list-fuzz
         run: |
           list="$(go test -list '^Fuzz' ./... | \
@@ -30,20 +32,12 @@ jobs:
     strategy:
       matrix:
         name: ${{ fromJson(needs.fuzz-matrix.outputs.fuzz-names) }}
-    env:
-      GOCACHE: /tmp/go/cache
     steps:
-      - run: mkdir -p ${GOCACHE}
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-
-      - uses: actions/cache@v3
-        with:
-          key: go-fuzz-corpus-${{ matrix.name }}-${{ github.run_number }}
-          restore-keys: go-fuzz-corpus-${{ matrix.name }}-
-          path: /tmp/go/cache/fuzz
+          cache: true
 
       - name: Set fuzz time
         run: echo "fuzz_time=5m" >> $GITHUB_ENV

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,8 +23,9 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
+          cache: true
+      - run: go mod download -x
       - run: go install gotest.tools/gotestsum@v1.8.0
-      - run: go mod tidy
 
       - name: go test
         run: ~/go/bin/gotestsum -ftestname -- -race ./...
@@ -70,6 +71,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
+          cache: true
       - uses: golangci/golangci-lint-action@v3.2.0
 
   helm-lint:
@@ -86,6 +88,14 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
+          cache: true
+      - run: go mod download -x
+      - run: go build -debug-actiongraph=compile.json .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build-log
+          path: compile.json
+
       - name: Check generated docs are updated
         run: |
           # if checking a release candidate pull request, unset `internal.Metadata`


### PR DESCRIPTION
Downloading dependencies only takes 5 seconds for me locally (with an empty GOMODCACHE), but it appears to take ~2m30s
for every CI job that runs or builds the project.

This change should give us some idea of why it is so slow in CI.