### PR TITLE
Add and remove groups

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -221,6 +221,10 @@ func (c Client) CreateGroup(req *CreateGroupRequest) (*Group, error) {
 	return post[CreateGroupRequest, Group](c, "/api/groups", req)
 }
 
+func (c Client) DeleteGroup(id uid.ID) error {
+	return delete(c, fmt.Sprintf("/api/groups/%s", id))
+}
+
 // Deprecated: use ListGrants
 func (c Client) ListGroupGrants(id uid.ID) (*ListResponse[Grant], error) {
 	return get[ListResponse[Grant]](c, fmt.Sprintf("/api/groups/%s/grants", id), Query{})

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -2073,6 +2073,90 @@
       }
     },
     "/api/groups/{id}": {
+      "delete": {
+        "description": "DeleteGroup",
+        "operationId": "DeleteGroup",
+        "parameters": [
+          {
+            "example": "4yJ3n3D8E2",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "4yJ3n3D8E2",
+              "format": "uid",
+              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "DeleteGroup",
+        "tags": [
+          "Groups"
+        ]
+      },
       "get": {
         "description": "GetGroup",
         "operationId": "GetGroup",

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -68,3 +68,16 @@ func GetGroup(c *gin.Context, id uid.ID) (*models.Group, error) {
 
 	return data.GetGroup(db, data.ByID(id))
 }
+
+func DeleteGroup(c *gin.Context, id uid.ID) error {
+	db, err := RequireInfraRole(c, models.InfraAdminRole)
+	if err != nil {
+		return err
+	}
+
+	selectors := []data.SelectorFunc{
+		data.ByID(id),
+	}
+
+	return data.DeleteGroups(db, selectors...)
+}

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -116,7 +116,7 @@ func newGroupsAddCmd(cli *CLI) *cobra.Command {
 		Short: "Create a group",
 		Args:  ExactArgs(1),
 		Example: `# Create a group
-$ infra groups add 'Engineering'`,
+$ infra groups add Engineering`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := defaultAPIClient()
 			if err != nil {
@@ -135,13 +135,15 @@ $ infra groups add 'Engineering'`,
 }
 
 func newGroupsRemoveCmd(cli *CLI) *cobra.Command {
-	return &cobra.Command{
+	var force bool
+
+	cmd := &cobra.Command{
 		Use:     "remove GROUP",
 		Aliases: []string{"rm"},
 		Short:   "Delete a group",
 		Args:    ExactArgs(1),
 		Example: `# Delete a group
-$ infra groups remove 'Engineering'`,
+$ infra groups remove Engineering`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
@@ -155,7 +157,7 @@ $ infra groups remove 'Engineering'`,
 				return err
 			}
 
-			if groups.Count == 0 {
+			if groups.Count == 0 && !force {
 				return fmt.Errorf("unknown group %q", name)
 			}
 
@@ -169,4 +171,8 @@ $ infra groups remove 'Engineering'`,
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Exit successfully even if the group does not exist")
+
+	return cmd
 }

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -51,7 +51,9 @@ func newGroupsCmd(cli *CLI) *cobra.Command {
 		},
 	}
 
+	cmd.AddCommand(newGroupsAddCmd(cli))
 	cmd.AddCommand(newGroupsListCmd(cli))
+	cmd.AddCommand(newGroupsRemoveCmd(cli))
 
 	return cmd
 }
@@ -103,6 +105,67 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 				cli.Output("No groups found")
 			}
 
+			return nil
+		},
+	}
+}
+
+func newGroupsAddCmd(cli *CLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "add GROUP",
+		Short: "Create a group",
+		Args:  ExactArgs(1),
+		Example: `# Create a group
+$ infra groups add 'Engineering'`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := defaultAPIClient()
+			if err != nil {
+				return err
+			}
+
+			_, err = client.CreateGroup(&api.CreateGroupRequest{Name: args[0]})
+			if err != nil {
+				return err
+			}
+			cli.Output("Added group %q", args[0])
+
+			return nil
+		},
+	}
+}
+
+func newGroupsRemoveCmd(cli *CLI) *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove GROUP",
+		Aliases: []string{"rm"},
+		Short:   "Delete a group",
+		Args:    ExactArgs(1),
+		Example: `# Delete a group
+$ infra groups remove 'Engineering'`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			client, err := defaultAPIClient()
+			if err != nil {
+				return err
+			}
+
+			groups, err := client.ListGroups(api.ListGroupsRequest{Name: name})
+			if err != nil {
+				return err
+			}
+
+			if groups.Count == 0 {
+				return fmt.Errorf("unknown group %q", name)
+			}
+
+			for _, group := range groups.Items {
+				if err := client.DeleteGroup(group.ID); err != nil {
+					return err
+				}
+
+				cli.Output("Removed group %q", group.Name)
+			}
 			return nil
 		},
 	}

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -62,7 +62,10 @@ func AssignIdentityToGroups(db *gorm.DB, user *models.Identity, provider *models
 			}
 		}
 		if !found {
-			group := &models.Group{Name: name}
+			group := &models.Group{
+				Name:              name,
+				CreatedByProvider: true,
+			}
 
 			if err = CreateGroup(db, group); err != nil {
 				return fmt.Errorf("create group: %w", err)

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -64,7 +64,7 @@ func AssignIdentityToGroups(db *gorm.DB, user *models.Identity, provider *models
 		if !found {
 			group := &models.Group{
 				Name:              name,
-				CreatedByProvider: true,
+				CreatedByProvider: provider.ID,
 			}
 
 			if err = CreateGroup(db, group); err != nil {

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,60 +9,57 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/uid"
 )
+
+func createIdentities(t *testing.T, db *gorm.DB, identities ...*models.Identity) {
+	t.Helper()
+	for i := range identities {
+		err := data.CreateIdentity(db, identities[i])
+		assert.NilError(t, err, identities[i].Name)
+	}
+}
+
+func createGroups(t *testing.T, db *gorm.DB, groups ...*models.Group) {
+	t.Helper()
+	for i := range groups {
+		err := data.CreateGroup(db, groups[i])
+		assert.NilError(t, err, groups[i].Name)
+	}
+}
 
 func TestAPI_ListGroups(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	createID := func(t *testing.T, name string) uid.ID {
-		t.Helper()
-		var buf bytes.Buffer
-		body := api.CreateUserRequest{Name: name}
-		err := json.NewEncoder(&buf).Encode(body)
-		assert.NilError(t, err)
+	var (
+		humans = models.Group{Name: "humans"}
+		second = models.Group{Name: "second"}
+		others = models.Group{Name: "others"}
+	)
 
-		req, err := http.NewRequest(http.MethodPost, "/v1/identities", &buf)
-		assert.NilError(t, err)
-		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
+	createGroups(t, srv.db, &humans, &second)
 
-		resp := httptest.NewRecorder()
-		routes.ServeHTTP(resp, req)
-		assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
-		respObj := &api.CreateUserResponse{}
-		err = json.Unmarshal(resp.Body.Bytes(), respObj)
-		assert.NilError(t, err)
-		return respObj.ID
-	}
-
-	createGroup := func(t *testing.T, name string, users ...uid.ID) uid.ID {
-		t.Helper()
-		group := &models.Group{Name: name}
-		for _, user := range users {
-			iden := models.Identity{Model: models.Model{ID: user}}
-			group.Identities = append(group.Identities, iden)
+	var (
+		idInGroup = models.Identity{
+			Name:   "inagroup@example.com",
+			Groups: []models.Group{humans, second},
 		}
+		idOther = models.Identity{
+			Name:   "other@example.com",
+			Groups: []models.Group{others},
+		}
+	)
 
-		err := data.CreateGroup(srv.db, group)
-		assert.NilError(t, err)
-		return group.ID
-	}
-
-	idInGroup := createID(t, "inagroup@example.com")
-	idOther := createID(t, "other@example.com")
-
-	humansID := createGroup(t, "humans", idInGroup)
-	secondID := createGroup(t, "second", idInGroup)
-	createGroup(t, "others", idOther)
+	createIdentities(t, srv.db, &idInGroup, &idOther)
 
 	token := &models.AccessKey{
-		IssuedFor:  idInGroup,
+		IssuedFor:  idInGroup.ID,
 		ProviderID: data.InfraProvider(srv.db).ID,
 		ExpiresAt:  time.Now().Add(10 * time.Second),
 	}
@@ -104,7 +100,7 @@ func TestAPI_ListGroups(t *testing.T) {
 			},
 		},
 		"not authorized, wrong identity": {
-			urlPath: "/api/groups?userID=" + idOther.String(),
+			urlPath: "/api/groups?userID=" + idOther.ID.String(),
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusForbidden, resp.Body.String())
 			},
@@ -130,7 +126,7 @@ func TestAPI_ListGroups(t *testing.T) {
 			},
 		},
 		"authorized by group membership": {
-			urlPath: "/api/groups?userID=" + idInGroup.String(),
+			urlPath: "/api/groups?userID=" + idInGroup.ID.String(),
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
 
@@ -158,7 +154,7 @@ func TestAPI_ListGroups(t *testing.T) {
 		"updated": "%[2]v"
 	}
 ]`,
-					humansID.String(),
+					humans.ID.String(),
 					time.Now().UTC().Format(time.RFC3339),
 				))
 				actual := jsonUnmarshal(t, resp.Body.String())
@@ -166,7 +162,7 @@ func TestAPI_ListGroups(t *testing.T) {
 			},
 		},
 		"version 0.13.0 - list user groups": {
-			urlPath: fmt.Sprintf("/api/users/%v/groups", idInGroup),
+			urlPath: fmt.Sprintf("/api/users/%v/groups", idInGroup.ID),
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Add("Infra-Version", "0.13.0")
 			},
@@ -189,8 +185,8 @@ func TestAPI_ListGroups(t *testing.T) {
 		"updated": "%[3]v"
 	}]
 }`,
-					humansID,
-					secondID,
+					humans.ID,
+					second.ID,
 					time.Now().UTC().Format(time.RFC3339),
 				))
 				actual := jsonUnmarshal(t, resp.Body.String())
@@ -215,11 +211,89 @@ func TestAPI_ListGroups(t *testing.T) {
 		"updated": "%[2]v"
 	}]
 }`,
-					humansID.String(),
+					humans.ID.String(),
 					time.Now().UTC().Format(time.RFC3339),
 				))
 				actual := jsonUnmarshal(t, resp.Body.String())
 				assert.DeepEqual(t, actual, expected, cmpAPIGrantJSON)
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestAPI_DeleteGroup(t *testing.T) {
+	srv := setupServer(t, withAdminUser)
+	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+
+	var humans = models.Group{Name: "humans"}
+
+	createGroups(t, srv.db, &humans)
+
+	var (
+		inGroup = models.Identity{
+			Name:   "inagroup@example.com",
+			Groups: []models.Group{humans},
+		}
+	)
+
+	createIdentities(t, srv.db, &inGroup)
+
+	type testCase struct {
+		urlPath  string
+		setup    func(t *testing.T, req *http.Request)
+		expected func(t *testing.T, resp *httptest.ResponseRecorder)
+	}
+
+	token := &models.AccessKey{
+		IssuedFor:  inGroup.ID,
+		ProviderID: data.InfraProvider(srv.db).ID,
+		ExpiresAt:  time.Now().Add(10 * time.Second),
+	}
+
+	accessKey, err := data.CreateAccessKey(srv.db, token)
+	assert.NilError(t, err)
+
+	run := func(t *testing.T, tc testCase) {
+		req, err := http.NewRequest(http.MethodDelete, tc.urlPath, nil)
+		assert.NilError(t, err)
+		req.Header.Set("Authorization", "Bearer "+accessKey)
+		req.Header.Add("Infra-Version", "0.13.0")
+
+		if tc.setup != nil {
+			tc.setup(t, req)
+		}
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+
+		tc.expected(t, resp)
+	}
+
+	testCases := map[string]testCase{
+		"not authenticated": {
+			urlPath: "/api/groups/" + humans.ID.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Del("Authorization")
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusUnauthorized)
+			},
+		},
+		"authorized by grant": {
+			urlPath: "/api/groups/" + humans.ID.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusNoContent, resp.Body.String())
+				actual, err := data.ListGroups(srv.db, data.ByID(humans.ID))
+				assert.NilError(t, err)
+				assert.Equal(t, len(actual), 0)
 			},
 		},
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -165,6 +165,10 @@ func (a *API) CreateGroup(c *gin.Context, r *api.CreateGroupRequest) (*api.Group
 	return group.ToAPI(), nil
 }
 
+func (a *API) DeleteGroup(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
+	return nil, access.DeleteGroup(c, r.ID)
+}
+
 // caution: this endpoint is unauthenticated, do not return sensitive info
 func (a *API) ListProviders(c *gin.Context, r *api.ListProvidersRequest) (*api.ListResponse[api.Provider], error) {
 	exclude := []string{models.InternalInfraProviderName}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -157,6 +157,11 @@ func (a *API) CreateGroup(c *gin.Context, r *api.CreateGroupRequest) (*api.Group
 		Name: r.Name,
 	}
 
+	authIdent := access.AuthenticatedIdentity(c)
+	if authIdent != nil {
+		group.CreatedBy = authIdent.ID
+	}
+
 	err := access.CreateGroup(c, group)
 	if err != nil {
 		return nil, err

--- a/internal/server/models/group.go
+++ b/internal/server/models/group.go
@@ -10,7 +10,7 @@ type Group struct {
 
 	Name              string `gorm:"uniqueIndex:idx_groups_name,where:deleted_at is NULL"`
 	CreatedBy         uid.ID
-	CreatedByProvider bool
+	CreatedByProvider uid.ID
 
 	Identities []Identity `gorm:"many2many:identities_groups"`
 }

--- a/internal/server/models/group.go
+++ b/internal/server/models/group.go
@@ -8,8 +8,9 @@ import (
 type Group struct {
 	Model
 
-	Name      string `gorm:"uniqueIndex:idx_groups_name,where:deleted_at is NULL"`
-	CreatedBy uid.ID
+	Name              string `gorm:"uniqueIndex:idx_groups_name,where:deleted_at is NULL"`
+	CreatedBy         uid.ID
+	CreatedByProvider bool
 
 	Identities []Identity `gorm:"many2many:identities_groups"`
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -75,6 +75,7 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	get(a, authn, "/api/groups", a.ListGroups)
 	post(a, authn, "/api/groups", a.CreateGroup)
 	get(a, authn, "/api/groups/:id", a.GetGroup)
+	delete(a, authn, "/api/groups/:id", a.DeleteGroup)
 
 	get(a, authn, "/api/grants", a.ListGrants)
 	get(a, authn, "/api/grants/:id", a.GetGrant)


### PR DESCRIPTION
## Summary

This change allows users to add and remove simple groups from the CLI, and also includes a new delete group endpoint.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades

