### PR TITLE
maintain: add a newline to test output

### DIFF
--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -197,6 +197,9 @@ func newConsole(t *testing.T) *expect.Console {
 		expect.WithCloser(pseudoTY, tty))
 	assert.NilError(t, err)
 	t.Cleanup(func() {
+		// make sure stdout has newlines to prevent test2json parse failures,
+		// and leaking control sequences to stdout.
+		t.Log("\n")
 		console.Close()
 	})
 	return console


### PR DESCRIPTION
## Summary

Without this the console output may not contain a newline, which causes problems with `test2json` (ex: https://github.com/infrahq/infra/runs/6906405805?check_suite_focus=true#step:7:646) and can leave control sequences on the terminal after tests end:

```
^[[79;158R^[[79;10R^[[79;158R^[[79;13R^[[79;158R^[[79;21R^[[79;158R^[[79;10R^[[79;158R^[[79
```

A single newline seems to fix the problem.