### PR TITLE
fix: url running over when clicking on cluster in ui

### DIFF
--- a/ui/pages/destinations/index.js
+++ b/ui/pages/destinations/index.js
@@ -27,7 +27,7 @@ function SidebarContent ({ destination, admin, setSelectedDestination }) {
         <section>
           <h3 className='py-4 text-3xs text-gray-400 border-b border-gray-800 uppercase'>Connect</h3>
           <p className='text-2xs my-4'>Connect to this cluster via the <a target='_blank' href='https://infrahq.com/docs/install/install-infra-cli' className='underline text-violet-200 font-medium' rel='noreferrer'>Infra CLI</a></p>
-          <pre className='px-4 py-3 rounded-md text-gray-300 bg-gray-900 text-2xs leading-normal'>
+          <pre className='px-4 py-3 rounded-md text-gray-300 bg-gray-900 text-2xs leading-normal overflow-auto'>
             infra login {window.location.host}<br />
             infra use {destination.name}<br />
             kubectl get pods


### PR DESCRIPTION
## Summary

Extremely simple fix to url running over (overflow scroll)
<img width="451" alt="Screen Shot 2022-06-15 at 3 34 23 PM" src="https://user-images.githubusercontent.com/25213198/173945161-bf75339d-3432-472b-bcc1-892ae4beb2ba.png">

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2173 
