### PR TITLE
Replace go-prettytime

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/andanhm/go-prettytime"
-
 	"github.com/infrahq/infra/uid"
 )
 
@@ -71,17 +69,8 @@ func (t Time) Equal(other Time) bool {
 	return time.Time(t).Equal(time.Time(other))
 }
 
-func (t Time) Relative(zeroName ...string) string {
-	time := time.Time(t)
-
-	if time.IsZero() {
-		if len(zeroName) == 0 {
-			return "none"
-		}
-		return zeroName[0]
-	}
-
-	return prettytime.Format(time)
+func (t Time) Time() time.Time {
+	return time.Time(t)
 }
 
 type Duration time.Duration

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
-	github.com/andanhm/go-prettytime v1.1.0
 	github.com/coreos/go-oidc/v3 v3.2.0
 	github.com/creack/pty v1.1.18
 	github.com/getkin/kin-openapi v0.97.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/andanhm/go-prettytime v1.1.0 h1:7Zr0ZiYUhV+aG7fFaVx+z/8di961R6btNyidMo9Gptw=
-github.com/andanhm/go-prettytime v1.1.0/go.mod h1:uizwLzwLZu1FTvSz8DSGkqm8Vc4edGa2VIMu16aoiZg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-metrics v0.3.9/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-metrics v0.3.10 h1:FR+drcQStOe+32sYyJYyZ7FIdgoGGBnwLl+flodp8Uo=

--- a/internal/cmd/format.go
+++ b/internal/cmd/format.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// HumanDuration returns a human-readable approximation of a duration
+// (eg. "About a minute", "4 hours ago", etc.).
+// Modified version of github.com/docker/go-units.HumanDuration
+func HumanDuration(d time.Duration) string {
+	seconds := int(d.Seconds())
+
+	switch {
+	case seconds < 1:
+		return "Less than a second"
+	case seconds == 1:
+		return "1 second"
+	case seconds < 60:
+		return fmt.Sprintf("%d seconds", seconds)
+	}
+
+	minutes := int(d.Minutes())
+	switch {
+	case minutes == 1:
+		return "About a minute"
+	case minutes < 60:
+		return fmt.Sprintf("%d minutes", minutes)
+	}
+
+	hours := int(math.Round(d.Hours()))
+	switch {
+	case hours == 1:
+		return "About an hour"
+	case hours < 48:
+		return fmt.Sprintf("%d hours", hours)
+	case hours < 24*7*2:
+		return fmt.Sprintf("%d days", hours/24)
+	case hours < 24*30*2:
+		return fmt.Sprintf("%d weeks", hours/24/7)
+	case hours < 24*365*2:
+		return fmt.Sprintf("%d months", hours/24/30)
+	}
+
+	return fmt.Sprintf("%d years", int(d.Hours())/24/365)
+}
+
+func HumanTime(t time.Time, zeroValue string) string {
+	if t.IsZero() {
+		return zeroValue
+	}
+
+	delta := time.Since(t)
+	if delta < 0 {
+		return HumanDuration(-delta) + " from now"
+	}
+	return HumanDuration(delta) + " ago"
+}

--- a/internal/cmd/format_test.go
+++ b/internal/cmd/format_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHumanDuration(t *testing.T) {
+	day := 24 * time.Hour
+	week := 7 * day
+	month := 30 * day
+	year := 365 * day
+
+	assert.Equal(t, "Less than a second", HumanDuration(450*time.Millisecond))
+	assert.Equal(t, "1 second", HumanDuration(1*time.Second))
+	assert.Equal(t, "45 seconds", HumanDuration(45*time.Second))
+	assert.Equal(t, "46 seconds", HumanDuration(46*time.Second))
+	assert.Equal(t, "59 seconds", HumanDuration(59*time.Second))
+	assert.Equal(t, "About a minute", HumanDuration(60*time.Second))
+	assert.Equal(t, "About a minute", HumanDuration(1*time.Minute))
+	assert.Equal(t, "3 minutes", HumanDuration(3*time.Minute))
+	assert.Equal(t, "35 minutes", HumanDuration(35*time.Minute))
+	assert.Equal(t, "35 minutes", HumanDuration(35*time.Minute+40*time.Second))
+	assert.Equal(t, "45 minutes", HumanDuration(45*time.Minute))
+	assert.Equal(t, "45 minutes", HumanDuration(45*time.Minute+40*time.Second))
+	assert.Equal(t, "46 minutes", HumanDuration(46*time.Minute))
+	assert.Equal(t, "59 minutes", HumanDuration(59*time.Minute))
+	assert.Equal(t, "About an hour", HumanDuration(1*time.Hour))
+	assert.Equal(t, "About an hour", HumanDuration(1*time.Hour+29*time.Minute))
+	assert.Equal(t, "2 hours", HumanDuration(1*time.Hour+31*time.Minute))
+	assert.Equal(t, "2 hours", HumanDuration(1*time.Hour+59*time.Minute))
+	assert.Equal(t, "3 hours", HumanDuration(3*time.Hour))
+	assert.Equal(t, "3 hours", HumanDuration(3*time.Hour+29*time.Minute))
+	assert.Equal(t, "4 hours", HumanDuration(3*time.Hour+31*time.Minute))
+	assert.Equal(t, "4 hours", HumanDuration(3*time.Hour+59*time.Minute))
+	assert.Equal(t, "4 hours", HumanDuration(3*time.Hour+60*time.Minute))
+	assert.Equal(t, "24 hours", HumanDuration(24*time.Hour))
+	assert.Equal(t, "36 hours", HumanDuration(1*day+12*time.Hour))
+	assert.Equal(t, "2 days", HumanDuration(2*day))
+	assert.Equal(t, "7 days", HumanDuration(7*day))
+	assert.Equal(t, "13 days", HumanDuration(13*day+5*time.Hour))
+	assert.Equal(t, "2 weeks", HumanDuration(2*week))
+	assert.Equal(t, "2 weeks", HumanDuration(2*week+4*day))
+	assert.Equal(t, "3 weeks", HumanDuration(3*week))
+	assert.Equal(t, "4 weeks", HumanDuration(4*week))
+	assert.Equal(t, "4 weeks", HumanDuration(4*week+3*day))
+	assert.Equal(t, "4 weeks", HumanDuration(1*month))
+	assert.Equal(t, "6 weeks", HumanDuration(1*month+2*week))
+	assert.Equal(t, "2 months", HumanDuration(2*month))
+	assert.Equal(t, "2 months", HumanDuration(2*month+2*week))
+	assert.Equal(t, "3 months", HumanDuration(3*month))
+	assert.Equal(t, "3 months", HumanDuration(3*month+1*week))
+	assert.Equal(t, "5 months", HumanDuration(5*month+2*week))
+	assert.Equal(t, "13 months", HumanDuration(13*month))
+	assert.Equal(t, "23 months", HumanDuration(23*month))
+	assert.Equal(t, "24 months", HumanDuration(24*month))
+	assert.Equal(t, "2 years", HumanDuration(24*month+2*week))
+	assert.Equal(t, "3 years", HumanDuration(3*year+2*month))
+}
+
+func TestHumanTime(t *testing.T) {
+	now := time.Now()
+
+	t.Run("zero value", func(t *testing.T) {
+		assert.Equal(t, HumanTime(time.Time{}, "never"), "never")
+	})
+	t.Run("time in the future", func(t *testing.T) {
+		v := now.Add(48 * time.Hour)
+		assert.Equal(t, HumanTime(v, ""), "2 days from now")
+	})
+	t.Run("time in the past", func(t *testing.T) {
+		v := now.Add(-48 * time.Hour)
+		assert.Equal(t, HumanTime(v, ""), "2 days ago")
+	})
+
+}

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -204,9 +204,9 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 				rows = append(rows, row{
 					Name:              k.Name,
 					IssuedFor:         name,
-					Created:           k.Created.Relative("never"),
-					Expires:           k.Expires.Relative("never"),
-					ExtensionDeadline: k.ExtensionDeadline.Relative("never"),
+					Created:           HumanTime(k.Created.Time(), "never"),
+					Expires:           HumanTime(k.Expires.Time(), "never"),
+					ExtensionDeadline: HumanTime(k.ExtensionDeadline.Time(), "never"),
 				})
 			}
 

--- a/internal/cmd/testdata/TestKeysListCmd/list_all
+++ b/internal/cmd/testdata/TestKeysListCmd/list_all
@@ -1,4 +1,4 @@
   NAME        ISSUED FOR  CREATED       EXPIRES           EXTENSION DEADLINE  
   front-door  admin       24 hours ago  never             never               
-  side-door   admin       24 hours ago  6 hours from now  tomorrow            
+  side-door   admin       24 hours ago  6 hours from now  26 hours from now   
   storage     clerk       20 hours ago  6 hours from now  never               

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -137,7 +137,7 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 				for _, user := range users.Items {
 					rows = append(rows, row{
 						Name:       user.Name,
-						LastSeenAt: user.LastSeenAt.Relative("never"),
+						LastSeenAt: HumanTime(user.LastSeenAt.Time(), "never"),
 					})
 				}
 


### PR DESCRIPTION
go-prettytime uses the wrong suffix when the value is between 1.5 and 2. Replace the library with a modified version of go-units formatting. The go-units implementation is much easier to follow and does not have that bug.

This PR also removes the `api.Time.Relative` method, and moves the implementation to the `cmd` package where it is used. Formatting values is the responsibility of the CLI.