### PR TITLE
Fix a couple problems with login tests

### DIFF
--- a/internal/race/norace.go
+++ b/internal/race/norace.go
@@ -1,0 +1,6 @@
+//go:build !race
+// +build !race
+
+package race
+
+const Enabled = false

--- a/internal/race/race.go
+++ b/internal/race/race.go
@@ -1,0 +1,6 @@
+//go:build race
+// +build race
+
+package race
+
+const Enabled = true


### PR DESCRIPTION
**Stop http servers on shutdown**

This shouldn't impact production at all, but when running a server for tests we were not
releasing the ports until the process exited. When running with `-count=`100 this could
consume all ports.

With this change the server is closed before the test ends, which closes the listener
and releases the ports.

**Reduce the chance of a timeout**

When the login test times out the t.Cleanup function could attempt to
close the pty at the same time as the login command running in a
separate goroutine is attempting to read from it.

We can't fix the data race because the survey library does not provide
any way to cancel the prompt. So instead we have to try and prevent
the timeout.

This PR increases the timeout used with expect when the race detector is
enabled.