### PR TITLE
fix: delete access keys and users when providers are removed

### DIFF
--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -56,6 +56,7 @@ func InfraConnectorIdentity(c *gin.Context) *models.Identity {
 	return data.InfraConnectorIdentity(getDB(c))
 }
 
+// TODO remove provider user, not user.
 func DeleteIdentity(c *gin.Context, id uid.ID) error {
 	self, err := isIdentitySelf(c, id)
 	if err != nil {
@@ -113,10 +114,10 @@ func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID, p
 	}
 
 	if groupID != 0 {
-		return data.ListIdentitiesByGroup(db, groupID, selectors...)
+		return data.ListIdentitiesByGroup(db.Preload("Providers"), groupID, selectors...)
 	}
 
-	return data.ListIdentities(db, selectors...)
+	return data.ListIdentities(db.Preload("Providers"), selectors...)
 }
 
 func GetContextProviderIdentity(c *gin.Context) (*models.Provider, string, error) {

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -56,7 +56,7 @@ func InfraConnectorIdentity(c *gin.Context) *models.Identity {
 	return data.InfraConnectorIdentity(getDB(c))
 }
 
-// TODO remove provider user, not user.
+// TODO (https://github.com/infrahq/infra/issues/2318) remove provider user, not user.
 func DeleteIdentity(c *gin.Context, id uid.ID) error {
 	self, err := isIdentitySelf(c, id)
 	if err != nil {

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/mail"
+	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
@@ -116,6 +117,7 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 			type row struct {
 				Name       string `header:"Name"`
 				LastSeenAt string `header:"Last Seen"`
+				Providers  string `header:"Provided By"`
 			}
 
 			var rows []row
@@ -138,6 +140,7 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 					rows = append(rows, row{
 						Name:       user.Name,
 						LastSeenAt: HumanTime(user.LastSeenAt.Time(), "never"),
+						Providers:  strings.Join(user.ProviderNames, ", "),
 					})
 				}
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -575,7 +575,8 @@ func (s Server) loadConfig(config Config) error {
 }
 
 func (s Server) loadProviders(db *gorm.DB, providers []Provider) error {
-	keep := make([]uid.ID, 0, len(providers))
+	infraProvider := data.InfraProvider(db)
+	keep := []uid.ID{infraProvider.ID}
 
 	for _, p := range providers {
 		provider, err := s.loadProvider(db, p)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -575,8 +575,7 @@ func (s Server) loadConfig(config Config) error {
 }
 
 func (s Server) loadProviders(db *gorm.DB, providers []Provider) error {
-	infraProvider := data.InfraProvider(db)
-	keep := []uid.ID{infraProvider.ID}
+	keep := []uid.ID{}
 
 	for _, p := range providers {
 		provider, err := s.loadProvider(db, p)

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ssoroka/slice"
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
-	"github.com/ssoroka/slice"
 )
 
 func secretChecksum(secret string) []byte {

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -12,6 +12,7 @@ import (
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
+	"github.com/ssoroka/slice"
 )
 
 func secretChecksum(secret string) []byte {
@@ -94,10 +95,9 @@ func DeleteAccessKeys(db *gorm.DB, selectors ...SelectorFunc) error {
 		return err
 	}
 
-	ids := make([]uid.ID, 0)
-	for _, k := range toDelete {
-		ids = append(ids, k.ID)
-	}
+	ids := slice.Map[models.AccessKey, uid.ID](toDelete, func(k models.AccessKey) uid.ID {
+		return k.ID
+	})
 
 	return deleteAll[models.AccessKey](db, ByIDs(ids))
 }

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -238,6 +238,13 @@ func InfraProvider(db *gorm.DB) *models.Provider {
 	if infraProviderCache == nil {
 		infra, err := get[models.Provider](db, ByName(models.InternalInfraProviderName))
 		if err != nil {
+			if errors.Is(err, internal.ErrNotFound) {
+				p := &models.Provider{Name: models.InternalInfraProviderName}
+				if err := add(db, p); err != nil {
+					logging.S.Panic(err)
+				}
+				return p
+			}
 			logging.S.Panic(err)
 			return nil
 		}

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -1,8 +1,12 @@
 package data
 
 import (
+	"errors"
+	"fmt"
+
 	"gorm.io/gorm"
 
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -26,7 +30,7 @@ func SaveProvider(db *gorm.DB, provider *models.Provider) error {
 func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
 	toDelete, err := ListProviders(db, selectors...)
 	if err != nil {
-		return err
+		return fmt.Errorf("listing providers: %w", err)
 	}
 
 	ids := make([]uid.ID, 0)
@@ -35,7 +39,7 @@ func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
 
 		providerUsers, err := ListProviderUsers(db, ByProviderID(p.ID))
 		if err != nil {
-			return err
+			return fmt.Errorf("listing provider users: %w", err)
 		}
 
 		// if a user has no other providers, we need to remove the user.
@@ -43,7 +47,10 @@ func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
 		for _, providerUser := range providerUsers {
 			user, err := GetIdentity(db.Preload("Providers"), ByID(providerUser.IdentityID))
 			if err != nil {
-				return err
+				if errors.Is(err, internal.ErrNotFound) {
+					continue
+				}
+				return fmt.Errorf("get user: %w", err)
 			}
 
 			if len(user.Providers) == 1 && user.Providers[0].ID == p.ID {
@@ -53,16 +60,16 @@ func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
 
 		if len(userIDsToDelete) > 0 {
 			if err := DeleteIdentities(db, ByIDs(userIDsToDelete)); err != nil {
-				return err
+				return fmt.Errorf("delete users: %w", err)
 			}
 		}
 
 		if err := DeleteProviderUsers(db, ByProviderID(p.ID)); err != nil {
-			return err
+			return fmt.Errorf("delete provider users: %w", err)
 		}
 
 		if err := DeleteAccessKeys(db, ByProviderID(p.ID)); err != nil {
-			return err
+			return fmt.Errorf("delete access keys: %w", err)
 		}
 	}
 

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -33,8 +33,35 @@ func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
 	for _, p := range toDelete {
 		ids = append(ids, p.ID)
 
-		err := DeleteProviderUsers(db, ByProviderID(p.ID))
+		providerUsers, err := ListProviderUsers(db, ByProviderID(p.ID))
 		if err != nil {
+			return err
+		}
+
+		// if a user has no other providers, we need to remove the user.
+		userIDsToDelete := []uid.ID{}
+		for _, providerUser := range providerUsers {
+			user, err := GetIdentity(db.Preload("Providers"), ByID(providerUser.IdentityID))
+			if err != nil {
+				return err
+			}
+
+			if len(user.Providers) == 1 && user.Providers[0].ID == p.ID {
+				userIDsToDelete = append(userIDsToDelete, user.ID)
+			}
+		}
+
+		if len(userIDsToDelete) > 0 {
+			if err := DeleteIdentities(db, ByIDs(userIDsToDelete)); err != nil {
+				return err
+			}
+		}
+
+		if err := DeleteProviderUsers(db, ByProviderID(p.ID)); err != nil {
+			return err
+		}
+
+		if err := DeleteAccessKeys(db, ByProviderID(p.ID)); err != nil {
 			return err
 		}
 	}

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"gorm.io/gorm"
@@ -87,21 +88,65 @@ func TestListProviders(t *testing.T) {
 func TestDeleteProviders(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
 		var (
-			providerDevelop    = models.Provider{Name: "okta-development", URL: "dev.okta.com"}
-			providerProduction = models.Provider{Name: "okta-production", URL: "prod.okta.com"}
+			providerDevelop    = models.Provider{}
+			providerProduction = models.Provider{}
+			pu                 = &models.ProviderUser{}
+			user               = &models.Identity{}
+			i                  = 0
 		)
+		setup := func() {
+			providerDevelop = models.Provider{Name: fmt.Sprintf("okta-development-%d", i), URL: "dev.okta.com"}
+			providerProduction = models.Provider{Name: fmt.Sprintf("okta-production-%d", i+1), URL: "prod.okta.com"}
+			i += 2
 
-		createProviders(t, db, providerDevelop, providerProduction)
+			err := CreateProvider(db, &providerDevelop)
+			assert.NilError(t, err)
+			err = CreateProvider(db, &providerProduction)
+			assert.NilError(t, err)
 
-		providers, err := ListProviders(db, NotName(models.InternalInfraProviderName))
-		assert.NilError(t, err)
-		assert.Equal(t, 2, len(providers))
+			providers, err := ListProviders(db, NotName(models.InternalInfraProviderName))
+			assert.NilError(t, err)
+			assert.Assert(t, len(providers) >= 2)
 
-		err = DeleteProviders(db, ByOptionalName("okta-development"))
-		assert.NilError(t, err)
+			user = &models.Identity{Name: "joe@example.com"}
+			err = CreateIdentity(db, user)
+			assert.NilError(t, err)
+			pu, err = CreateProviderUser(db, &providerDevelop, user)
+			assert.NilError(t, err)
+		}
 
-		_, err = GetProvider(db, ByOptionalName("okta-development"))
-		assert.Error(t, err, "record not found")
+		t.Run("Deletes work", func(t *testing.T) {
+			setup()
+			err := DeleteProviders(db, ByOptionalName(providerDevelop.Name))
+			assert.NilError(t, err)
+
+			_, err = GetProvider(db, ByOptionalName(providerDevelop.Name))
+			assert.Error(t, err, "record not found")
+
+			t.Run("provider users are removed", func(t *testing.T) {
+				_, err = GetProviderUser(db, pu.ProviderID, pu.IdentityID)
+				assert.Error(t, err, "record not found")
+			})
+
+			t.Run("user is removed when last providerUser is removed", func(t *testing.T) {
+				_, err = GetIdentity(db, ByID(pu.IdentityID))
+				assert.Error(t, err, "record not found")
+			})
+		})
+
+		t.Run("user is not removed if there are other providerUsers", func(t *testing.T) {
+			setup()
+
+			pu, err := CreateProviderUser(db, &providerProduction, user)
+			assert.NilError(t, err)
+
+			err = DeleteProviders(db, ByOptionalName(providerDevelop.Name))
+			assert.NilError(t, err)
+
+			_, err = GetIdentity(db, ByID(pu.IdentityID))
+			assert.NilError(t, err)
+		})
+
 	})
 }
 

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -38,6 +38,10 @@ func UpdateProviderUser(db *gorm.DB, providerUser *models.ProviderUser) error {
 	return save(db, providerUser)
 }
 
+func ListProviderUsers(db *gorm.DB, selectors ...SelectorFunc) ([]models.ProviderUser, error) {
+	return list[models.ProviderUser](db, selectors...)
+}
+
 func DeleteProviderUsers(db *gorm.DB, selector SelectorFunc) error {
 	return deleteAll[models.ProviderUser](db, selector)
 }


### PR DESCRIPTION
## Summary

- remove access keys when a provider is removed
- remove provider_users when a provider is removed
- remove users if they have no more provider_users


## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2260 
