### PR TITLE
maintain(website): add should-build script for previews

### DIFF
--- a/website/scripts/should-build.sh
+++ b/website/scripts/should-build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ "$VERCEL_GIT_COMMIT_REF" = "release-please--branches--main" ] ; then
+  # Don't build
+  exit 0
+fi
+
+if [ "$VERCEL_ENV" = "production" ] ; then
+  # Proceed with the build
+  exit 1
+else
+  # only build if website or docs files have changes
+  git diff --quiet HEAD^ HEAD ../docs .
+fi


### PR DESCRIPTION
Stops our release branch from building previews (for now – we may want to have this later for better versioning)