### PR TITLE
maintain(docs): replace key name argument w/ flag

### DIFF
--- a/docs/connectors/kubernetes.md
+++ b/docs/connectors/kubernetes.md
@@ -10,7 +10,7 @@ position: 1
 First, generate an access key:
 
 ```
-infra keys add KEY_NAME connector
+infra keys add connector
 ```
 
 Next, use this access key to connect your cluster:

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -422,7 +422,7 @@ infra keys add USER|connector [flags]
 ```
 
 # Create an access key named 'example-key' for a user that expires in 12 hours
-$ infra keys add example-key user@example.com --ttl=12h
+$ infra keys add user@example.com --ttl=12h --name example-key
 
 # Create an access key to add a Kubernetes connection to Infra
 $ infra keys add connector

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -49,7 +49,7 @@ func newKeysAddCmd(cli *CLI) *cobra.Command {
 		Long:  `Create an access key for a user or a connector.`,
 		Example: `
 # Create an access key named 'example-key' for a user that expires in 12 hours
-$ infra keys add example-key user@example.com --ttl=12h
+$ infra keys add user@example.com --ttl=12h --name example-key
 
 # Create an access key to add a Kubernetes connection to Infra
 $ infra keys add connector


### PR DESCRIPTION
Replaced outdated references to required key name when using `infra keys add`