### PR TITLE
feat: azure groups

### DIFF
--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -146,6 +146,8 @@ func GetContextProviderIdentity(c *gin.Context) (*models.Provider, string, error
 
 // UpdateIdentityInfoFromProvider calls the identity provider used to authenticate this user session to update their current information
 func UpdateIdentityInfoFromProvider(c *gin.Context, oidc providers.OIDC) error {
+	ctx := c.Request.Context()
+
 	// added by the authentication middleware
 	identity := AuthenticatedIdentity(c)
 	if identity == nil {
@@ -163,7 +165,7 @@ func UpdateIdentityInfoFromProvider(c *gin.Context, oidc providers.OIDC) error {
 	}
 
 	// get current identity provider groups
-	err = oidc.SyncProviderUser(db, identity, provider)
+	err = oidc.SyncProviderUser(ctx, db, identity, provider)
 	if err != nil {
 		if errors.Is(err, internal.ErrBadGateway) {
 			return err

--- a/internal/server/authn/oidc.go
+++ b/internal/server/authn/oidc.go
@@ -30,7 +30,7 @@ func NewOIDCAuthentication(providerID uid.ID, redirectURL string, code string, o
 	}
 }
 
-func (a *oidcAuthn) Authenticate(db *gorm.DB) (*models.Identity, *models.Provider, error) {
+func (a *oidcAuthn) Authenticate(ctx context.Context, db *gorm.DB) (*models.Identity, *models.Provider, error) {
 	provider, err := data.GetProvider(db, data.ByID(a.ProviderID))
 	if err != nil {
 		return nil, nil, err
@@ -74,7 +74,7 @@ func (a *oidcAuthn) Authenticate(db *gorm.DB) (*models.Identity, *models.Provide
 	}
 
 	// update users attributes (such as groups) from the IDP
-	err = a.OIDCProviderClient.SyncProviderUser(db, identity, provider)
+	err = a.OIDCProviderClient.SyncProviderUser(ctx, db, identity, provider)
 	if err != nil {
 		return nil, nil, fmt.Errorf("sync user on login: %w", err)
 	}

--- a/internal/server/authn/oidc.go
+++ b/internal/server/authn/oidc.go
@@ -4,37 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
-	"time"
 
-	"github.com/coreos/go-oidc/v3/oidc"
-	"golang.org/x/oauth2"
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
-	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/server/providers"
 	"github.com/infrahq/infra/uid"
 )
-
-const oidcProviderRequestTimeout = time.Second * 10
-
-// InfoClaims captures the claims fields from a user-info response that we care about
-type InfoClaims struct {
-	Email  string   `json:"email"` // returned by default for Okta user info
-	Groups []string `json:"groups"`
-	Name   string   `json:"name"` // returned by default for Azure user info
-}
 
 type oidcAuthn struct {
 	ProviderID         uid.ID
 	RedirectURL        string
 	Code               string
-	OIDCProviderClient OIDC
+	OIDCProviderClient providers.OIDC
 }
 
-func NewOIDCAuthentication(providerID uid.ID, redirectURL string, code string, oidcProviderClient OIDC) LoginMethod {
+func NewOIDCAuthentication(providerID uid.ID, redirectURL string, code string, oidcProviderClient providers.OIDC) LoginMethod {
 	return &oidcAuthn{
 		ProviderID:         providerID,
 		RedirectURL:        redirectURL,
@@ -43,30 +30,7 @@ func NewOIDCAuthentication(providerID uid.ID, redirectURL string, code string, o
 	}
 }
 
-type OIDC interface {
-	Validate(context.Context) error
-	ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (accessToken, refreshToken string, accessTokenExpiry time.Time, email string, err error)
-	RefreshAccessToken(ctx context.Context, providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error)
-	GetUserInfo(ctx context.Context, providerUser *models.ProviderUser) (*InfoClaims, error)
-}
-
-type oidcImplementation struct {
-	Domain       string
-	ClientID     string
-	ClientSecret string
-	RedirectURL  string
-}
-
-func NewOIDC(domain, clientID, clientSecret, redirectURL string) OIDC {
-	return &oidcImplementation{
-		Domain:       domain,
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		RedirectURL:  redirectURL,
-	}
-}
-
-func (a *oidcAuthn) Authenticate(ctx context.Context, db *gorm.DB) (*models.Identity, *models.Provider, error) {
+func (a *oidcAuthn) Authenticate(db *gorm.DB) (*models.Identity, *models.Provider, error) {
 	provider, err := data.GetProvider(db, data.ByID(a.ProviderID))
 	if err != nil {
 		return nil, nil, err
@@ -109,19 +73,10 @@ func (a *oidcAuthn) Authenticate(ctx context.Context, db *gorm.DB) (*models.Iden
 		return nil, nil, fmt.Errorf("UpdateProviderUser: %w", err)
 	}
 
-	// get current identity provider groups
-	info, err := a.OIDCProviderClient.GetUserInfo(ctx, providerUser)
+	// update users attributes (such as groups) from the IDP
+	err = a.OIDCProviderClient.SyncProviderUser(db, identity, provider)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return nil, nil, fmt.Errorf("%w: %s", internal.ErrBadGateway, err.Error())
-		}
-
-		return nil, nil, fmt.Errorf("login user info: %w", err)
-	}
-
-	err = UpdateUserInfoFromProvider(db, info, identity, provider)
-	if err != nil {
-		return nil, nil, fmt.Errorf("update info on login: %w", err)
+		return nil, nil, fmt.Errorf("sync user on login: %w", err)
 	}
 
 	return identity, provider, nil
@@ -133,189 +88,4 @@ func (a *oidcAuthn) Name() string {
 
 func (a *oidcAuthn) RequiresUpdate(db *gorm.DB) (bool, error) {
 	return false, nil // not applicable to oidc
-}
-
-// Validate tests if an identity provider has valid attributes to support user login
-func (o *oidcImplementation) Validate(ctx context.Context) error {
-	conf, _, err := o.clientConfig(ctx)
-	if err != nil {
-		logging.S.Debugf("error validating oidc provider: %s", err)
-		return ErrInvalidProviderURL
-	}
-
-	_, err = conf.Exchange(ctx, "test-code") // 'test-code' is a placeholder for a valid authorization code, it will always fail
-	if err != nil {
-		var errRetrieve *oauth2.RetrieveError
-		if errors.As(err, &errRetrieve) {
-			if strings.Contains(string(errRetrieve.Body), "client_id") || strings.Contains(string(errRetrieve.Body), "client id") {
-				logging.S.Debugf("error validating oidc provider client: %s", err)
-				return ErrInvalidProviderClientID
-			}
-
-			if strings.Contains(string(errRetrieve.Body), "secret") {
-				logging.S.Debugf("error validating oidc provider client: %s", err)
-				return ErrInvalidProviderClientSecret
-			}
-		}
-		logging.S.Debug(err)
-	}
-
-	return nil
-}
-
-// clientConfig returns the OAuth client configuration needed to interact with an identity provider
-func (o *oidcImplementation) clientConfig(ctx context.Context) (*oauth2.Config, *oidc.Provider, error) {
-	provider, err := oidc.NewProvider(ctx, fmt.Sprintf("https://%s", o.Domain))
-	if err != nil {
-		return nil, nil, fmt.Errorf("get provider openid info: %w", err)
-	}
-
-	conf := &oauth2.Config{
-		ClientID:     o.ClientID,
-		ClientSecret: o.ClientSecret,
-		RedirectURL:  o.RedirectURL,
-		Scopes:       []string{oidc.ScopeOpenID, "email", "groups", oidc.ScopeOfflineAccess},
-		Endpoint:     provider.Endpoint(),
-	}
-
-	return conf, provider, nil
-}
-
-// tokenSource is used to call an identity provider with the specified provider tokens
-func (o *oidcImplementation) tokenSource(ctx context.Context, conf *oauth2.Config, providerTokens *models.ProviderUser) (oauth2.TokenSource, error) {
-	userToken := &oauth2.Token{
-		AccessToken:  string(providerTokens.AccessToken),
-		RefreshToken: string(providerTokens.RefreshToken),
-		Expiry:       providerTokens.ExpiresAt,
-	}
-
-	return conf.TokenSource(ctx, userToken), nil
-}
-
-func (o *oidcImplementation) ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (rawAccessToken, rawRefreshToken string, accessTokenExpiry time.Time, email string, err error) {
-	ctx, cancel := context.WithTimeout(ctx, oidcProviderRequestTimeout)
-	defer cancel()
-
-	conf, provider, err := o.clientConfig(ctx)
-	if err != nil {
-		return "", "", time.Time{}, "", fmt.Errorf("client exchange code: %w", err)
-	}
-
-	exchanged, err := conf.Exchange(ctx, code)
-	if err != nil {
-		return "", "", time.Time{}, "", fmt.Errorf("code exchange: %w", err)
-	}
-
-	rawAccessToken, ok := exchanged.Extra("access_token").(string)
-	if !ok {
-		return "", "", time.Time{}, "", errors.New("could not extract access token from oauth2")
-	}
-
-	rawRefreshToken, ok = exchanged.Extra("refresh_token").(string)
-	if !ok {
-		// this probably means that the client does not have refresh tokens enabled
-		logging.S.Warnf("no refresh token returned from oidc client for %q, session lifetime will be reduced", o.Domain)
-	}
-
-	rawIDToken, ok := exchanged.Extra("id_token").(string)
-	if !ok {
-		return "", "", time.Time{}, "", errors.New("could not extract id_token from oauth2 token")
-	}
-
-	// we get sensitive claims from the ID token, must validate them
-	verifier := provider.Verifier(&oidc.Config{ClientID: o.ClientID})
-
-	idToken, err := verifier.Verify(ctx, rawIDToken)
-	if err != nil {
-		return "", "", time.Time{}, "", fmt.Errorf("validate id token: %w", err)
-	}
-
-	var claims struct {
-		Email string `json:"email" validate:"required"`
-	}
-
-	if err := idToken.Claims(&claims); err != nil {
-		return "", "", time.Time{}, "", fmt.Errorf("id token claims: %w", err)
-	}
-
-	return rawAccessToken, rawRefreshToken, exchanged.Expiry, claims.Email, nil
-}
-
-// RefreshAccessToken uses the refresh token to get a new access token if it is expired
-func (o *oidcImplementation) RefreshAccessToken(ctx context.Context, providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error) {
-	ctx, cancel := context.WithTimeout(ctx, oidcProviderRequestTimeout)
-	defer cancel()
-
-	conf, _, err := o.clientConfig(ctx)
-	if err != nil {
-		return "", nil, fmt.Errorf("call idp with tokens: %w", err)
-	}
-
-	tokenSource, err := o.tokenSource(ctx, conf, providerUser)
-	if err != nil {
-		return "", nil, fmt.Errorf("ref token source: %w", err)
-	}
-
-	newToken, err := tokenSource.Token() // this refreshes token if needed
-	if err != nil {
-		return "", nil, fmt.Errorf("refresh user token: %w", err)
-	}
-
-	return newToken.AccessToken, &newToken.Expiry, nil
-}
-
-// GetUserInfo uses a provider token to get the current information about a user,
-// make sure an access token is valid (not expired) before using this
-func (o *oidcImplementation) GetUserInfo(ctx context.Context, providerUser *models.ProviderUser) (*InfoClaims, error) {
-	ctx, cancel := context.WithTimeout(ctx, oidcProviderRequestTimeout)
-	defer cancel()
-
-	conf, provider, err := o.clientConfig(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("user info client: %w", err)
-	}
-
-	tokenSource, err := o.tokenSource(ctx, conf, providerUser)
-	if err != nil {
-		return nil, fmt.Errorf("info token source: %w", err)
-	}
-
-	info, err := provider.UserInfo(ctx, tokenSource)
-	if err != nil {
-		return nil, fmt.Errorf("get user info: %w", err)
-	}
-
-	claims := &InfoClaims{}
-	if err := info.Claims(claims); err != nil {
-		return nil, fmt.Errorf("user info claims: %w", err)
-	}
-
-	// in the case of azure a deleted user's info will still resolve
-	// guard against this by validating the info in the response is what we expect
-	if err := claims.validate(); err != nil {
-		return nil, err
-	}
-
-	return claims, nil
-}
-
-// validate checks if the user info response claims have the information we expect
-func (ic *InfoClaims) validate() error {
-	// if these fields aren't present, this user may have been deleted in the up-stream provider
-	if ic.Email == "" && ic.Name == "" {
-		return fmt.Errorf("required user info not received, name or email are required, the user may have been deleted")
-	}
-
-	return nil
-}
-
-// UpdateUserInfoFromProvider calls the user info endpoint of an external identity provider to see a user's current attributes
-func UpdateUserInfoFromProvider(db *gorm.DB, info *InfoClaims, user *models.Identity, provider *models.Provider) error {
-	logging.S.Debugf("%s user authenticated with %q groups", provider.Name, info.Groups)
-
-	if err := data.AssignIdentityToGroups(db, user, provider, info.Groups); err != nil {
-		return fmt.Errorf("assign identity to groups: %w", err)
-	}
-
-	return nil
 }

--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -25,7 +25,7 @@ type mockOIDCImplementation struct {
 	UserGroupsResp []string
 }
 
-func (m *mockOIDCImplementation) Validate(context.Context) error {
+func (m *mockOIDCImplementation) Validate(_ context.Context) error {
 	return nil
 }
 
@@ -38,11 +38,11 @@ func (m *mockOIDCImplementation) RefreshAccessToken(_ context.Context, providerU
 	return string(providerUser.AccessToken), &providerUser.ExpiresAt, nil
 }
 
-func (m *mockOIDCImplementation) GetUserInfo(providerUser *models.ProviderUser) (*providers.InfoClaims, error) {
+func (m *mockOIDCImplementation) GetUserInfo(_ context.Context, providerUser *models.ProviderUser) (*providers.InfoClaims, error) {
 	return &providers.InfoClaims{Email: m.UserEmailResp, Groups: m.UserGroupsResp}, nil
 }
 
-func (m *mockOIDCImplementation) SyncProviderUser(db *gorm.DB, user *models.Identity, provider *models.Provider) error {
+func (m *mockOIDCImplementation) SyncProviderUser(_ context.Context, db *gorm.DB, user *models.Identity, provider *models.Provider) error {
 	if err := data.AssignIdentityToGroups(db, user, provider, m.UserGroupsResp); err != nil {
 		return err
 	}

--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/server/providers"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -37,8 +38,16 @@ func (m *mockOIDCImplementation) RefreshAccessToken(_ context.Context, providerU
 	return string(providerUser.AccessToken), &providerUser.ExpiresAt, nil
 }
 
-func (m *mockOIDCImplementation) GetUserInfo(_ context.Context, _ *models.ProviderUser) (*InfoClaims, error) {
-	return &InfoClaims{Email: m.UserEmailResp, Groups: m.UserGroupsResp}, nil
+func (m *mockOIDCImplementation) GetUserInfo(providerUser *models.ProviderUser) (*providers.InfoClaims, error) {
+	return &providers.InfoClaims{Email: m.UserEmailResp, Groups: m.UserGroupsResp}, nil
+}
+
+func (m *mockOIDCImplementation) SyncProviderUser(db *gorm.DB, user *models.Identity, provider *models.Provider) error {
+	if err := data.AssignIdentityToGroups(db, user, provider, m.UserGroupsResp); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func TestOIDCAuthenticate(t *testing.T) {
@@ -81,17 +90,10 @@ func TestOIDCAuthenticate(t *testing.T) {
 	})
 }
 
-func TestValidateInvalidURL(t *testing.T) {
-	oidc := NewOIDC("invalid.example.com", "some_client_id", "some_client_secret", "http://localhost:8301")
-
-	err := oidc.Validate(context.Background())
-	assert.ErrorIs(t, err, ErrInvalidProviderURL)
-}
-
 func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 	cases := map[string]map[string]interface{}{
 		"NewUserNewGroups": {
-			"setup": func(t *testing.T, db *gorm.DB) OIDC {
+			"setup": func(t *testing.T, db *gorm.DB) providers.OIDC {
 				return &mockOIDCImplementation{
 					UserEmailResp:  "newusernewgroups@example.com",
 					UserGroupsResp: []string{"Everyone", "developers"},
@@ -103,7 +105,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 			},
 		},
 		"NewUserExistingGroups": {
-			"setup": func(t *testing.T, db *gorm.DB) OIDC {
+			"setup": func(t *testing.T, db *gorm.DB) providers.OIDC {
 				existingGroup1 := &models.Group{Name: "existing1"}
 				existingGroup2 := &models.Group{Name: "existing2"}
 
@@ -133,7 +135,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 			},
 		},
 		"ExistingUserNewGroups": {
-			"setup": func(t *testing.T, db *gorm.DB) OIDC {
+			"setup": func(t *testing.T, db *gorm.DB) providers.OIDC {
 				err := data.CreateIdentity(db, &models.Identity{Name: "existingusernewgroups@example.com"})
 				assert.NilError(t, err)
 
@@ -157,7 +159,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 			},
 		},
 		"ExistingUserExistingGroups": {
-			"setup": func(t *testing.T, db *gorm.DB) OIDC {
+			"setup": func(t *testing.T, db *gorm.DB) providers.OIDC {
 				err := data.CreateIdentity(db, &models.Identity{Name: "existinguserexistinggroups@example.com"})
 				assert.NilError(t, err)
 
@@ -187,7 +189,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 			},
 		},
 		"ExistingUserGroupsWithNewGroups": {
-			"setup": func(t *testing.T, db *gorm.DB) OIDC {
+			"setup": func(t *testing.T, db *gorm.DB) providers.OIDC {
 				user := &models.Identity{Name: "eugwnw@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
@@ -250,7 +252,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 		assert.NilError(t, err)
 
 		t.Run(k, func(t *testing.T) {
-			setupFunc, ok := v["setup"].(func(*testing.T, *gorm.DB) OIDC)
+			setupFunc, ok := v["setup"].(func(*testing.T, *gorm.DB) providers.OIDC)
 			assert.Assert(t, ok)
 			mockOIDC := setupFunc(t, db)
 
@@ -272,17 +274,4 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestUserInfo(t *testing.T) {
-	t.Run("no email and no name fails validation", func(t *testing.T) {
-		claims := &InfoClaims{}
-		err := claims.validate()
-		assert.ErrorContains(t, err, "name or email are required")
-	})
-	t.Run("groups are not required", func(t *testing.T) {
-		claims := &InfoClaims{Email: "hello@example.com"}
-		err := claims.validate()
-		assert.NilError(t, err)
-	})
 }

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -29,7 +29,7 @@ func CreateProviderUser(db *gorm.DB, provider *models.Provider, ident *models.Id
 		}
 	}
 
-	// If there were other attributes to udpate, I guess they should be updated here.
+	// If there were other attributes to update, I guess they should be updated here.
 
 	return pu, nil
 }

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -142,7 +142,6 @@ func ByNotExpiredOrExtended() SelectorFunc {
 
 func ByPagination(pg models.Pagination) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
-
 		if pg.Page == 0 && pg.Limit == 0 {
 			return db
 		}

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -14,8 +14,8 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
-	"github.com/infrahq/infra/internal/server/authn"
 	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/providers"
 )
 
 // sendAPIError translates err into the appropriate HTTP status code, builds a
@@ -56,7 +56,7 @@ func sendAPIError(c *gin.Context, err error) {
 		resp.Message = err.Error()
 		parseFieldErrors(resp, validationErrors)
 
-	case errors.Is(err, internal.ErrBadRequest), errors.Is(err, authn.ErrValidation):
+	case errors.Is(err, internal.ErrBadRequest), errors.Is(err, providers.ErrValidation):
 		resp.Code = http.StatusBadRequest
 		resp.Message = err.Error()
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/authn"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/server/providers"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -621,10 +622,10 @@ func (a *API) validateProvider(c *gin.Context, provider *models.Provider) error 
 	return oidc.Validate(c.Request.Context())
 }
 
-func (a *API) providerClient(c *gin.Context, provider *models.Provider, redirectURL string) (authn.OIDC, error) {
+func (a *API) providerClient(c *gin.Context, provider *models.Provider, redirectURL string) (providers.OIDC, error) {
 	if val, ok := c.Get("oidc"); ok {
 		// oidc is added to the context during unit tests
-		oidc, _ := val.(authn.OIDC)
+		oidc, _ := val.(providers.OIDC)
 		return oidc, nil
 	}
 
@@ -634,5 +635,5 @@ func (a *API) providerClient(c *gin.Context, provider *models.Provider, redirect
 		return nil, fmt.Errorf("client secret not found")
 	}
 
-	return authn.NewOIDC(provider.URL, provider.ClientID, clientSecret, redirectURL), nil
+	return providers.NewOIDC(*provider, clientSecret, redirectURL), nil
 }

--- a/internal/server/providers/azure.go
+++ b/internal/server/providers/azure.go
@@ -36,34 +36,34 @@ type azure struct {
 	OIDC OIDC
 }
 
-func (a *azure) Validate() error {
-	return a.OIDC.Validate()
+func (a *azure) Validate(ctx context.Context) error {
+	return a.OIDC.Validate(ctx)
 }
 
-func (a *azure) ExchangeAuthCodeForProviderTokens(code string) (rawAccessToken, rawRefreshToken string, accessTokenExpiry time.Time, email string, err error) {
-	return a.OIDC.ExchangeAuthCodeForProviderTokens(code)
+func (a *azure) ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (rawAccessToken, rawRefreshToken string, accessTokenExpiry time.Time, email string, err error) {
+	return a.OIDC.ExchangeAuthCodeForProviderTokens(ctx, code)
 }
 
-func (a *azure) RefreshAccessToken(providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error) {
-	return a.OIDC.RefreshAccessToken(providerUser)
+func (a *azure) RefreshAccessToken(ctx context.Context, providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error) {
+	return a.OIDC.RefreshAccessToken(ctx, providerUser)
 }
 
-func (a *azure) GetUserInfo(providerUser *models.ProviderUser) (*InfoClaims, error) {
-	return a.OIDC.GetUserInfo(providerUser)
+func (a *azure) GetUserInfo(ctx context.Context, providerUser *models.ProviderUser) (*InfoClaims, error) {
+	return a.OIDC.GetUserInfo(ctx, providerUser)
 }
 
-func (a *azure) SyncProviderUser(db *gorm.DB, user *models.Identity, provider *models.Provider) error {
+func (a *azure) SyncProviderUser(ctx context.Context, db *gorm.DB, user *models.Identity, provider *models.Provider) error {
 	providerUser, err := data.GetProviderUser(db, provider.ID, user.ID)
 	if err != nil {
 		return err
 	}
 
-	if err := checkRefreshAccessToken(db, providerUser, a); err != nil {
+	if err := checkRefreshAccessToken(ctx, db, providerUser, a); err != nil {
 		return fmt.Errorf("oidc sync failed to check users access token: %w", err)
 	}
 
 	// this checks if the user still exists
-	_, err = a.OIDC.GetUserInfo(providerUser)
+	_, err = a.OIDC.GetUserInfo(ctx, providerUser)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return fmt.Errorf("%w: %s", internal.ErrBadGateway, err.Error())

--- a/internal/server/providers/azure.go
+++ b/internal/server/providers/azure.go
@@ -1,0 +1,143 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+const (
+	graphGroupMemberEndpoint = "https://graph.microsoft.com/v1.0/me/memberOf"
+	graphGroupDataType       = "#microsoft.graph.group"
+)
+
+type graphObject struct {
+	Type        string `json:"@odata.type"`
+	DisplayName string `json:"displayName"`
+}
+
+type graphResponse struct {
+	Context string        `json:"@odata.context"`
+	Value   []graphObject `json:"value"`
+}
+
+type azure struct {
+	OIDC OIDC
+}
+
+func (a *azure) Validate() error {
+	return a.OIDC.Validate()
+}
+
+func (a *azure) ExchangeAuthCodeForProviderTokens(code string) (rawAccessToken, rawRefreshToken string, accessTokenExpiry time.Time, email string, err error) {
+	return a.OIDC.ExchangeAuthCodeForProviderTokens(code)
+}
+
+func (a *azure) RefreshAccessToken(providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error) {
+	return a.OIDC.RefreshAccessToken(providerUser)
+}
+
+func (a *azure) GetUserInfo(providerUser *models.ProviderUser) (*InfoClaims, error) {
+	return a.OIDC.GetUserInfo(providerUser)
+}
+
+func (a *azure) SyncProviderUser(db *gorm.DB, user *models.Identity, provider *models.Provider) error {
+	providerUser, err := data.GetProviderUser(db, provider.ID, user.ID)
+	if err != nil {
+		return err
+	}
+
+	if err := checkRefreshAccessToken(db, providerUser, a); err != nil {
+		return fmt.Errorf("oidc sync failed to check users access token: %w", err)
+	}
+
+	// this checks if the user still exists
+	_, err = a.OIDC.GetUserInfo(providerUser)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("%w: %s", internal.ErrBadGateway, err.Error())
+		}
+		return fmt.Errorf("could not get user info from provider: %w", err)
+	}
+
+	newGroups, err := checkMemberOfGraphGroups(string(providerUser.AccessToken))
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("%w: %s", internal.ErrBadGateway, err.Error())
+		} else if errors.Is(err, ErrUnauthorized) {
+			newGroups = &[]string{} // set the groups empty to clear them
+			logging.S.Warnf("Unable to get groups from the Azure API for %q provider. Make sure the application client has the required permissions.", provider.Name)
+		} else {
+			return fmt.Errorf("could not check azure user groups: %w", err)
+		}
+	}
+
+	logging.S.Debugf("user synchronized with %q groups from provider %q", *newGroups, provider.Name)
+
+	if err := data.AssignIdentityToGroups(db, user, provider, *newGroups); err != nil {
+		return fmt.Errorf("assign identity to groups: %w", err)
+	}
+
+	return nil
+}
+
+// checkMemberOfGraphGroups calls the Microsoft Graph API to find out what groups a user belongs to
+func checkMemberOfGraphGroups(accessToken string) (*[]string, error) {
+	bearer := "Bearer " + accessToken
+
+	req, err := http.NewRequest(http.MethodGet, graphGroupMemberEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create azure groups request: %w", err)
+	}
+
+	req.Header.Add("Authorization", bearer)
+
+	ctx, cancel := context.WithTimeout(context.Background(), oidcProviderRequestTimeout)
+	defer cancel()
+
+	client := http.DefaultClient
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("%w: %s", internal.ErrBadGateway, err.Error())
+		}
+		return nil, fmt.Errorf("failed to query azure for groups: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, ErrUnauthorized
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read azure groups response: %w", err)
+	}
+
+	graphResp := graphResponse{}
+	err = json.Unmarshal(body, &graphResp)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse azure groups response: %w", err)
+	}
+
+	groups := []string{}
+	for _, object := range graphResp.Value {
+		if object.Type == graphGroupDataType {
+			groups = append(groups, object.DisplayName)
+		}
+	}
+
+	return &groups, nil
+}

--- a/internal/server/providers/azure.go
+++ b/internal/server/providers/azure.go
@@ -81,13 +81,13 @@ func (a *azure) SyncProviderUser(ctx context.Context, db *gorm.DB, user *models.
 			return fmt.Errorf("could not check azure user groups: %w", err)
 		}
 
-		newGroups = &[]string{} // set the groups empty to clear them
+		newGroups = []string{} // set the groups empty to clear them
 		logging.S.Warnf("Unable to get groups from the Azure API for %q provider. Make sure the application client has the required permissions.", provider.Name)
 	}
 
-	logging.S.Debugf("user synchronized with %q groups from provider %q", *newGroups, provider.Name)
+	logging.S.Debugf("user synchronized with %q groups from provider %q", &newGroups, provider.Name)
 
-	if err := data.AssignIdentityToGroups(db, user, provider, *newGroups); err != nil {
+	if err := data.AssignIdentityToGroups(db, user, provider, newGroups); err != nil {
 		return fmt.Errorf("assign identity to groups: %w", err)
 	}
 
@@ -95,7 +95,7 @@ func (a *azure) SyncProviderUser(ctx context.Context, db *gorm.DB, user *models.
 }
 
 // checkMemberOfGraphGroups calls the Microsoft Graph API to find out what groups a user belongs to
-func checkMemberOfGraphGroups(accessToken string) (*[]string, error) {
+func checkMemberOfGraphGroups(accessToken string) ([]string, error) {
 	bearer := "Bearer " + accessToken
 
 	req, err := http.NewRequest(http.MethodGet, graphGroupMemberEndpoint, nil)
@@ -141,5 +141,5 @@ func checkMemberOfGraphGroups(accessToken string) (*[]string, error) {
 		}
 	}
 
-	return &groups, nil
+	return groups, nil
 }

--- a/internal/server/providers/azure.go
+++ b/internal/server/providers/azure.go
@@ -75,12 +75,14 @@ func (a *azure) SyncProviderUser(db *gorm.DB, user *models.Identity, provider *m
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return fmt.Errorf("%w: %s", internal.ErrBadGateway, err.Error())
-		} else if errors.Is(err, ErrUnauthorized) {
-			newGroups = &[]string{} // set the groups empty to clear them
-			logging.S.Warnf("Unable to get groups from the Azure API for %q provider. Make sure the application client has the required permissions.", provider.Name)
-		} else {
+		}
+
+		if !errors.Is(err, ErrUnauthorized) {
 			return fmt.Errorf("could not check azure user groups: %w", err)
 		}
+
+		newGroups = &[]string{} // set the groups empty to clear them
+		logging.S.Warnf("Unable to get groups from the Azure API for %q provider. Make sure the application client has the required permissions.", provider.Name)
 	}
 
 	logging.S.Debugf("user synchronized with %q groups from provider %q", *newGroups, provider.Name)

--- a/internal/server/providers/errors.go
+++ b/internal/server/providers/errors.go
@@ -1,4 +1,4 @@
-package authn
+package providers
 
 import (
 	"fmt"
@@ -9,4 +9,5 @@ var (
 	ErrInvalidProviderURL          = fmt.Errorf("%w: invalid provider url", ErrValidation)
 	ErrInvalidProviderClientID     = fmt.Errorf("%w: invalid provider client id", ErrValidation)
 	ErrInvalidProviderClientSecret = fmt.Errorf("%w: invalid provider client secret", ErrValidation)
+	ErrUnauthorized                = fmt.Errorf("unauthorized")
 )

--- a/internal/server/providers/oidc.go
+++ b/internal/server/providers/oidc.go
@@ -23,9 +23,9 @@ const oidcProviderRequestTimeout = time.Second * 10
 
 // InfoClaims captures the claims fields from a user-info response that we care about
 type InfoClaims struct {
-	Email  string   `json:"email"` // returned by default for Okta user info
+	Email  string   `json:"email" validate:"required_without=Name"` // returned by default for Okta user info
 	Groups []string `json:"groups"`
-	Name   string   `json:"name"` // returned by default for Azure user info
+	Name   string   `json:"name" validate:"required_without=Email"` // returned by default for Azure user info
 }
 
 type OIDC interface {
@@ -127,7 +127,7 @@ func (o *oidcImplementation) tokenSource(providerTokens *models.ProviderUser) (o
 	return conf.TokenSource(ctx, userToken), nil
 }
 
-// ExchangeAuthCodeForProviderTokens exchanges the authorization code a user recieved on login for valid identity provider tokens
+// ExchangeAuthCodeForProviderTokens exchanges the authorization code a user received on login for valid identity provider tokens
 func (o *oidcImplementation) ExchangeAuthCodeForProviderTokens(code string) (rawAccessToken, rawRefreshToken string, accessTokenExpiry time.Time, email string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), oidcProviderRequestTimeout)
 	defer cancel()
@@ -260,7 +260,7 @@ func (o *oidcImplementation) GetUserInfo(providerUser *models.ProviderUser) (*In
 
 	// in the case of azure a deleted user's info will still resolve
 	// guard against this by validating the info in the response is what we expect
-	if err := claims.validate(); err != nil {
+	if err := validator.New().Struct(claims); err != nil {
 		return nil, err
 	}
 

--- a/internal/server/providers/oidc.go
+++ b/internal/server/providers/oidc.go
@@ -1,0 +1,301 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-playground/validator/v10"
+	"golang.org/x/oauth2"
+	"gorm.io/gorm"
+
+	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+const oidcProviderRequestTimeout = time.Second * 10
+
+// InfoClaims captures the claims fields from a user-info response that we care about
+type InfoClaims struct {
+	Email  string   `json:"email"` // returned by default for Okta user info
+	Groups []string `json:"groups"`
+	Name   string   `json:"name"` // returned by default for Azure user info
+}
+
+type OIDC interface {
+	Validate() error
+	ExchangeAuthCodeForProviderTokens(code string) (accessToken, refreshToken string, accessTokenExpiry time.Time, email string, err error)
+	RefreshAccessToken(providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error)
+	GetUserInfo(providerUser *models.ProviderUser) (*InfoClaims, error)
+	SyncProviderUser(db *gorm.DB, user *models.Identity, provider *models.Provider) error
+}
+
+type oidcImplementation struct {
+	ProviderID   uid.ID
+	Domain       string
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+}
+
+func NewOIDC(provider models.Provider, clientSecret, redirectURL string) OIDC {
+	oidc := &oidcImplementation{
+		ProviderID:   provider.ID,
+		Domain:       provider.URL,
+		ClientID:     provider.ClientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+	}
+
+	// nolint:exhaustive
+	switch provider.Kind {
+	case models.AzureKind:
+		return &azure{OIDC: oidc}
+	default:
+		return oidc
+	}
+}
+
+// Validate tests if an identity provider has valid attributes to support user login
+func (o *oidcImplementation) Validate() error {
+	ctx := context.Background()
+	conf, _, err := o.clientConfig(ctx)
+	if err != nil {
+		logging.S.Debugf("error validating oidc provider: %s", err)
+		return ErrInvalidProviderURL
+	}
+
+	_, err = conf.Exchange(ctx, "test-code") // 'test-code' is a placeholder for a valid authorization code, it will always fail
+	if err != nil {
+		var errRetrieve *oauth2.RetrieveError
+		if errors.As(err, &errRetrieve) {
+			if strings.Contains(string(errRetrieve.Body), "client_id") || strings.Contains(string(errRetrieve.Body), "client id") {
+				logging.S.Debugf("error validating oidc provider client: %s", err)
+				return ErrInvalidProviderClientID
+			}
+
+			if strings.Contains(string(errRetrieve.Body), "secret") {
+				logging.S.Debugf("error validating oidc provider client: %s", err)
+				return ErrInvalidProviderClientSecret
+			}
+		}
+		logging.S.Debug(err)
+	}
+
+	return nil
+}
+
+// clientConfig returns the OAuth client configuration needed to interact with an identity provider
+func (o *oidcImplementation) clientConfig(ctx context.Context) (*oauth2.Config, *oidc.Provider, error) {
+	provider, err := oidc.NewProvider(ctx, fmt.Sprintf("https://%s", o.Domain))
+	if err != nil {
+		return nil, nil, fmt.Errorf("get provider openid info: %w", err)
+	}
+
+	conf := &oauth2.Config{
+		ClientID:     o.ClientID,
+		ClientSecret: o.ClientSecret,
+		RedirectURL:  o.RedirectURL,
+		Scopes:       []string{oidc.ScopeOpenID, "email", "groups", oidc.ScopeOfflineAccess},
+		Endpoint:     provider.Endpoint(),
+	}
+
+	return conf, provider, nil
+}
+
+// tokenSource is used to call an identity provider with the specified provider tokens
+func (o *oidcImplementation) tokenSource(providerTokens *models.ProviderUser) (oauth2.TokenSource, error) {
+	ctx := context.Background()
+
+	conf, _, err := o.clientConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("call idp with tokens: %w", err)
+	}
+
+	userToken := &oauth2.Token{
+		AccessToken:  string(providerTokens.AccessToken),
+		RefreshToken: string(providerTokens.RefreshToken),
+		Expiry:       providerTokens.ExpiresAt,
+	}
+
+	return conf.TokenSource(ctx, userToken), nil
+}
+
+// ExchangeAuthCodeForProviderTokens exchanges the authorization code a user recieved on login for valid identity provider tokens
+func (o *oidcImplementation) ExchangeAuthCodeForProviderTokens(code string) (rawAccessToken, rawRefreshToken string, accessTokenExpiry time.Time, email string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), oidcProviderRequestTimeout)
+	defer cancel()
+
+	conf, provider, err := o.clientConfig(ctx)
+	if err != nil {
+		return "", "", time.Time{}, "", fmt.Errorf("client exchange code: %w", err)
+	}
+
+	exchanged, err := conf.Exchange(ctx, code)
+	if err != nil {
+		return "", "", time.Time{}, "", fmt.Errorf("code exchange: %w", err)
+	}
+
+	rawAccessToken, ok := exchanged.Extra("access_token").(string)
+	if !ok {
+		return "", "", time.Time{}, "", errors.New("could not extract access token from oauth2")
+	}
+
+	rawRefreshToken, ok = exchanged.Extra("refresh_token").(string)
+	if !ok {
+		// this probably means that the client does not have refresh tokens enabled
+		logging.S.Warnf("no refresh token returned from oidc client for %q, session lifetime will be reduced", o.Domain)
+	}
+
+	rawIDToken, ok := exchanged.Extra("id_token").(string)
+	if !ok {
+		return "", "", time.Time{}, "", errors.New("could not extract id_token from oauth2 token")
+	}
+
+	// we get sensitive claims from the ID token, must validate them
+	verifier := provider.Verifier(&oidc.Config{ClientID: o.ClientID})
+
+	idToken, err := verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return "", "", time.Time{}, "", fmt.Errorf("validate id token: %w", err)
+	}
+
+	var claims struct {
+		Email string `json:"email" validate:"required"`
+	}
+
+	if err := idToken.Claims(&claims); err != nil {
+		return "", "", time.Time{}, "", fmt.Errorf("id token claims: %w", err)
+	}
+
+	if err := validator.New().Struct(claims); err != nil {
+		logging.S.Errorf("%s provider incorrectly configured, no email found in ID token authenticated user, this claim is required", o.Domain)
+		return "", "", time.Time{}, "", fmt.Errorf("failed to validate ID token claims: %w", err)
+	}
+
+	return rawAccessToken, rawRefreshToken, exchanged.Expiry, claims.Email, nil
+}
+
+// RefreshAccessToken uses the refresh token to get a new access token if it is expired
+func (o *oidcImplementation) RefreshAccessToken(providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error) {
+	tokenSource, err := o.tokenSource(providerUser)
+	if err != nil {
+		return "", nil, fmt.Errorf("ref token source: %w", err)
+	}
+
+	newToken, err := tokenSource.Token() // this refreshes token if needed
+	if err != nil {
+		return "", nil, fmt.Errorf("refresh user token: %w", err)
+	}
+
+	return newToken.AccessToken, &newToken.Expiry, nil
+}
+
+func (o *oidcImplementation) SyncProviderUser(db *gorm.DB, user *models.Identity, provider *models.Provider) error {
+	providerUser, err := data.GetProviderUser(db, provider.ID, user.ID)
+	if err != nil {
+		return err
+	}
+
+	if err := checkRefreshAccessToken(db, providerUser, o); err != nil {
+		return fmt.Errorf("oidc sync failed to check users access token: %w", err)
+	}
+
+	info, err := o.GetUserInfo(providerUser)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("%w: %s", internal.ErrBadGateway, err.Error())
+		}
+		return fmt.Errorf("could not get user info from provider: %w", err)
+	}
+
+	logging.S.Debugf("user synchronized with %q groups from provider (ID: %v)", info.Groups, providerUser.ProviderID)
+
+	providerUser.Groups = info.Groups
+	if err := data.UpdateProviderUser(db, providerUser); err != nil {
+		return fmt.Errorf("update provider user: %w", err)
+	}
+
+	if err := data.AssignIdentityToGroups(db, user, provider, info.Groups); err != nil {
+		return fmt.Errorf("assign identity to groups: %w", err)
+	}
+
+	return nil
+}
+
+// GetUserInfo uses a provider token to call the OpenID Connect UserInfo endpoint,
+// make sure an access token is valid (not expired) before using this
+func (o *oidcImplementation) GetUserInfo(providerUser *models.ProviderUser) (*InfoClaims, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), oidcProviderRequestTimeout)
+	defer cancel()
+
+	tokenSource, err := o.tokenSource(providerUser)
+	if err != nil {
+		return nil, fmt.Errorf("info token source: %w", err)
+	}
+
+	_, provider, err := o.clientConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("user info client: %w", err)
+	}
+
+	info, err := provider.UserInfo(ctx, tokenSource)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("get user info: %w", err)
+	}
+
+	claims := &InfoClaims{}
+	if err := info.Claims(claims); err != nil {
+		return nil, fmt.Errorf("user info claims: %w", err)
+	}
+
+	// in the case of azure a deleted user's info will still resolve
+	// guard against this by validating the info in the response is what we expect
+	if err := claims.validate(); err != nil {
+		return nil, err
+	}
+
+	return claims, nil
+}
+
+// validate checks if the user info response claims have the information we expect
+func (ic *InfoClaims) validate() error {
+	// if these fields aren't present, this user may have been deleted in the up-stream provider
+	if ic.Email == "" && ic.Name == "" {
+		return fmt.Errorf("required user info not received, name or email are required, the user may have been deleted")
+	}
+
+	return nil
+}
+
+// checkRefreshAccessToken checks if an access token is expired, and gets a new one if needed and possible
+func checkRefreshAccessToken(db *gorm.DB, providerUser *models.ProviderUser, oidc OIDC) error {
+	accessToken, expiry, err := oidc.RefreshAccessToken(providerUser)
+	if err != nil {
+		return fmt.Errorf("refresh provider access: %w", err)
+	}
+
+	// update the stored access token if it was refreshed
+	if accessToken != string(providerUser.AccessToken) {
+		logging.S.Debugf("access token for user at provider %s was refreshed", providerUser.ProviderID)
+
+		providerUser.AccessToken = models.EncryptedAtRest(accessToken)
+		providerUser.ExpiresAt = *expiry
+
+		err = data.UpdateProviderUser(db, providerUser)
+		if err != nil {
+			return fmt.Errorf("update provider user on sync: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/server/providers/oidc.go
+++ b/internal/server/providers/oidc.go
@@ -267,16 +267,6 @@ func (o *oidcImplementation) GetUserInfo(providerUser *models.ProviderUser) (*In
 	return claims, nil
 }
 
-// validate checks if the user info response claims have the information we expect
-func (ic *InfoClaims) validate() error {
-	// if these fields aren't present, this user may have been deleted in the up-stream provider
-	if ic.Email == "" && ic.Name == "" {
-		return fmt.Errorf("required user info not received, name or email are required, the user may have been deleted")
-	}
-
-	return nil
-}
-
 // checkRefreshAccessToken checks if an access token is expired, and gets a new one if needed and possible
 func checkRefreshAccessToken(db *gorm.DB, providerUser *models.ProviderUser, oidc OIDC) error {
 	accessToken, expiry, err := oidc.RefreshAccessToken(providerUser)

--- a/internal/server/providers/oidc_test.go
+++ b/internal/server/providers/oidc_test.go
@@ -14,16 +14,3 @@ func TestValidateInvalidURL(t *testing.T) {
 	err := oidc.Validate()
 	assert.ErrorIs(t, err, ErrInvalidProviderURL)
 }
-
-func TestUserInfo(t *testing.T) {
-	t.Run("no email and no name fails validation", func(t *testing.T) {
-		claims := &InfoClaims{}
-		err := claims.validate()
-		assert.ErrorContains(t, err, "name or email are required")
-	})
-	t.Run("groups are not required", func(t *testing.T) {
-		claims := &InfoClaims{Email: "hello@example.com"}
-		err := claims.validate()
-		assert.NilError(t, err)
-	})
-}

--- a/internal/server/providers/oidc_test.go
+++ b/internal/server/providers/oidc_test.go
@@ -1,0 +1,29 @@
+package providers
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func TestValidateInvalidURL(t *testing.T) {
+	oidc := NewOIDC(models.Provider{Name: "example-oidc", Kind: models.OIDCKind, URL: "example.com"}, "some_client_secret", "http://localhost:8301")
+
+	err := oidc.Validate()
+	assert.ErrorIs(t, err, ErrInvalidProviderURL)
+}
+
+func TestUserInfo(t *testing.T) {
+	t.Run("no email and no name fails validation", func(t *testing.T) {
+		claims := &InfoClaims{}
+		err := claims.validate()
+		assert.ErrorContains(t, err, "name or email are required")
+	})
+	t.Run("groups are not required", func(t *testing.T) {
+		claims := &InfoClaims{Email: "hello@example.com"}
+		err := claims.validate()
+		assert.NilError(t, err)
+	})
+}

--- a/internal/server/providers/oidc_test.go
+++ b/internal/server/providers/oidc_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -11,6 +12,6 @@ import (
 func TestValidateInvalidURL(t *testing.T) {
 	oidc := NewOIDC(models.Provider{Name: "example-oidc", Kind: models.OIDCKind, URL: "example.com"}, "some_client_secret", "http://localhost:8301")
 
-	err := oidc.Validate()
+	err := oidc.Validate(context.Background())
 	assert.ErrorIs(t, err, ErrInvalidProviderURL)
 }

--- a/internal/server/providers/okta.go
+++ b/internal/server/providers/okta.go
@@ -1,0 +1,1 @@
+package providers

--- a/internal/server/providers/okta.go
+++ b/internal/server/providers/okta.go
@@ -1,1 +1,0 @@
-package providers


### PR DESCRIPTION
- move provider logic to its own package
- move user info check into a general user sync function
- move token check to user sync

## Summary
This change enables calling the Microsoft graph API to synchronize groups in the case of using Azure as an identity provider. It moves the provider logic into its own `provider` package and out of the `authn` package.

This change is notably lacking in tests because the provider code-paths rely so heavily on external APIs. I've opened #2354 for getting better test coverage here, and I'll work on that next. Testing these is probably going to require standing up a local server that responds to the requests as expected.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
