### PR TITLE
Use request context for oidc calls

### DIFF
--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -147,6 +147,7 @@ func GetContextProviderIdentity(c *gin.Context) (*models.Provider, string, error
 
 // UpdateIdentityInfoFromProvider calls the identity provider used to authenticate this user session to update their current information
 func UpdateIdentityInfoFromProvider(c *gin.Context, oidc authn.OIDC) error {
+	ctx := c.Request.Context()
 	// added by the authentication middleware
 	identity := AuthenticatedIdentity(c)
 	if identity == nil {
@@ -173,7 +174,7 @@ func UpdateIdentityInfoFromProvider(c *gin.Context, oidc authn.OIDC) error {
 	}
 
 	// check if the access token needs to be refreshed
-	newAccessToken, newExpiry, err := oidc.RefreshAccessToken(providerUser)
+	newAccessToken, newExpiry, err := oidc.RefreshAccessToken(ctx, providerUser)
 	if err != nil {
 		return fmt.Errorf("refresh provider access: %w", err)
 	}
@@ -190,7 +191,7 @@ func UpdateIdentityInfoFromProvider(c *gin.Context, oidc authn.OIDC) error {
 	}
 
 	// get current identity provider groups
-	info, err := oidc.GetUserInfo(providerUser)
+	info, err := oidc.GetUserInfo(ctx, providerUser)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return fmt.Errorf("%w: %s", internal.ErrBadGateway, err.Error())

--- a/internal/access/login.go
+++ b/internal/access/login.go
@@ -12,7 +12,7 @@ import (
 // Login uses a login method to authenticate a user
 func Login(c *gin.Context, loginMethod authn.LoginMethod, keyExpiresAt time.Time, keyExtension time.Duration) (*models.AccessKey, string, bool, error) {
 	db := getDB(c)
-	key, bearer, err := authn.Login(db, loginMethod, keyExpiresAt, keyExtension)
+	key, bearer, err := authn.Login(c.Request.Context(), db, loginMethod, keyExpiresAt, keyExtension)
 	if err != nil {
 		return nil, "", false, err
 	}

--- a/internal/access/signup_test.go
+++ b/internal/access/signup_test.go
@@ -1,6 +1,8 @@
 package access
 
 import (
+	"context"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -18,6 +20,7 @@ func TestSignupEnabled(t *testing.T) {
 	setup := func(t *testing.T) (*gin.Context, *gorm.DB) {
 		db := setupDB(t)
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = (&http.Request{}).WithContext(context.Background())
 		c.Set("db", db)
 		_, err := data.InitializeSettings(db)
 		assert.NilError(t, err)

--- a/internal/server/authn/authn_method.go
+++ b/internal/server/authn/authn_method.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -11,14 +12,14 @@ import (
 )
 
 type LoginMethod interface {
-	Authenticate(db *gorm.DB) (*models.Identity, *models.Provider, error)
+	Authenticate(ctx context.Context, db *gorm.DB) (*models.Identity, *models.Provider, error)
 	Name() string                             // Name returns the name of the authentication method used
 	RequiresUpdate(db *gorm.DB) (bool, error) // Temporary way to check for one time password re-use, remove with #1441
 }
 
-func Login(db *gorm.DB, loginMethod LoginMethod, keyExpiresAt time.Time, keyExtension time.Duration) (*models.AccessKey, string, error) {
+func Login(ctx context.Context, db *gorm.DB, loginMethod LoginMethod, keyExpiresAt time.Time, keyExtension time.Duration) (*models.AccessKey, string, error) {
 	// challenge the user to authenticate
-	identity, provider, err := loginMethod.Authenticate(db)
+	identity, provider, err := loginMethod.Authenticate(ctx, db)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to login: %w", err)
 	}

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ func setupDB(t *testing.T) *gorm.DB {
 }
 
 func TestLogin(t *testing.T) {
+	ctx := context.Background()
 	db := setupDB(t)
 	// setup with user/pass login
 	// authentication method should not matter for this test
@@ -52,7 +54,7 @@ func TestLogin(t *testing.T) {
 
 	t.Run("failed login does not create access key", func(t *testing.T) {
 		authn := NewPasswordCredentialAuthentication(username, "invalid password")
-		_, bearer, err := Login(db, authn, time.Now().Add(1*time.Minute), time.Minute)
+		_, bearer, err := Login(ctx, db, authn, time.Now().Add(1*time.Minute), time.Minute)
 
 		assert.ErrorContains(t, err, "failed to login")
 		assert.Equal(t, bearer, "")
@@ -62,7 +64,7 @@ func TestLogin(t *testing.T) {
 		authn := NewPasswordCredentialAuthentication("gohan@example.com", password)
 		exp := time.Now().Add(1 * time.Minute)
 		ext := 1 * time.Minute
-		key, bearer, err := Login(db, authn, exp, ext)
+		key, bearer, err := Login(ctx, db, authn, exp, ext)
 
 		assert.NilError(t, err)
 		assert.Assert(t, bearer != "")

--- a/internal/server/authn/key_exchange.go
+++ b/internal/server/authn/key_exchange.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -24,7 +25,7 @@ func NewKeyExchangeAuthentication(requestingAccessKey string, requestedExpiry ti
 	}
 }
 
-func (a *keyExchangeAuthn) Authenticate(db *gorm.DB) (*models.Identity, *models.Provider, error) {
+func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *gorm.DB) (*models.Identity, *models.Provider, error) {
 	validatedRequestKey, err := data.ValidateAccessKey(db, a.RequestingAccessKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid access key in exchange: %w", err)

--- a/internal/server/authn/key_exchange_test.go
+++ b/internal/server/authn/key_exchange_test.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -124,7 +125,7 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 			assert.Assert(t, ok)
 			keyExchangeLogin := setupFunc(t, db)
 
-			identity, provider, err := keyExchangeLogin.Authenticate(db)
+			identity, provider, err := keyExchangeLogin.Authenticate(context.Background(), db)
 
 			verifyFunc, ok := v["verify"].(func(*testing.T, *models.Identity, *models.Provider, error))
 			assert.Assert(t, ok)

--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -56,14 +56,14 @@ func TestOIDCAuthenticate(t *testing.T) {
 
 	t.Run("invalid provider", func(t *testing.T) {
 		unknownProviderOIDCAuthn := NewOIDCAuthentication(uid.New(), "localhost:8031", "1234", oidc)
-		_, _, err := unknownProviderOIDCAuthn.Authenticate(db)
+		_, _, err := unknownProviderOIDCAuthn.Authenticate(context.Background(), db)
 
 		assert.ErrorIs(t, err, internal.ErrNotFound)
 	})
 
 	t.Run("successful authentication", func(t *testing.T) {
 		oidcAuthn := NewOIDCAuthentication(mocktaProvider.ID, "localhost:8031", "1234", oidc)
-		identity, provider, err := oidcAuthn.Authenticate(db)
+		identity, provider, err := oidcAuthn.Authenticate(context.Background(), db)
 
 		assert.NilError(t, err)
 		// user should be created
@@ -256,7 +256,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 
 			loginMethod := NewOIDCAuthentication(provider.ID, "mockOIDC.example.com/redirect", "AAA", mockOIDC)
 
-			u, _, err := loginMethod.Authenticate(db)
+			u, _, err := loginMethod.Authenticate(context.Background(), db)
 
 			verifyFunc, ok := v["verify"].(func(*testing.T, *models.Identity, error))
 			assert.Assert(t, ok)

--- a/internal/server/authn/password_credentials.go
+++ b/internal/server/authn/password_credentials.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"context"
 	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
@@ -23,7 +24,7 @@ func NewPasswordCredentialAuthentication(username, password string) LoginMethod 
 	}
 }
 
-func (a *passwordCredentialAuthn) Authenticate(db *gorm.DB) (*models.Identity, *models.Provider, error) {
+func (a *passwordCredentialAuthn) Authenticate(_ context.Context, db *gorm.DB) (*models.Identity, *models.Provider, error) {
 	identity, err := data.GetIdentity(db, data.ByName(a.Username))
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get identity for username: %w", err)

--- a/internal/server/authn/password_credentials_test.go
+++ b/internal/server/authn/password_credentials_test.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"context"
 	"testing"
 
 	"golang.org/x/crypto/bcrypt"
@@ -123,7 +124,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 
 				userPassLogin := NewPasswordCredentialAuthentication(username, password)
 
-				_, _, err = userPassLogin.Authenticate(db)
+				_, _, err = userPassLogin.Authenticate(context.Background(), db)
 				assert.NilError(t, err)
 
 				return userPassLogin
@@ -217,7 +218,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			assert.Assert(t, ok)
 			credentialLogin := setupFunc(t, db)
 
-			identity, provider, err := credentialLogin.Authenticate(db)
+			identity, provider, err := credentialLogin.Authenticate(context.Background(), db)
 
 			verifyFunc, ok := v["verify"].(func(*testing.T, *models.Identity, *models.Provider, error))
 			assert.Assert(t, ok)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -621,7 +621,7 @@ func (a *API) validateProvider(c *gin.Context, provider *models.Provider) error 
 		return fmt.Errorf("%w: %s", internal.ErrBadRequest, err)
 	}
 
-	return oidc.Validate()
+	return oidc.Validate(c.Request.Context())
 }
 
 func (a *API) providerClient(c *gin.Context, provider *models.Provider, redirectURL string) (authn.OIDC, error) {


### PR DESCRIPTION
By passing the context along from the API request

1. The `odic` and `oauth2` libraries can make use of an `http.Client` stored in the context values. We can set the `http.Client` in some API middelware. This allows us to log all the request, and possibly do something like #1793
2. if the client disconnects we can also cancel the request to the provider, so that the request can exit instead of continue to block waiting on the provider.

Using a logging transport I noticed we were requesting the `.well-known/openid-configuration` 3 times from the oidc provider as part of a single API login request. The last commit removes one of these calls by refactoring `tokenSource` a bit. I think to remove the second call we would need to create the `oidc.Provider` in `NewOIDC`, instead of doing it in each of the methods.