### PR TITLE
improve: added links to pagination response

### DIFF
--- a/api/pagination.go
+++ b/api/pagination.go
@@ -9,5 +9,8 @@ type PaginationResponse struct {
 	Page  int `json:"page,omitempty"`
 	Limit int `json:"limit,omitempty"`
 
+	Next    string `json:"next,omitempty"`
+	Current string `json:"current,omitempty"`
+	Prev    string `json:"previous,omitempty"`
 	//TODO: add some indication of number of records/pages or if a next page exists
 }

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -9,8 +9,8 @@ type PaginationResponse struct {
 	Page  int `json:"page,omitempty"`
 	Limit int `json:"limit,omitempty"`
 
-	Next    string `json:"next,omitempty"`
-	Current string `json:"current,omitempty"`
-	Prev    string `json:"previous,omitempty"`
+	Next string `json:"next,omitempty"`
+	Self string `json:"self,omitempty"`
+	Prev string `json:"prev,omitempty"`
 	//TODO: add some indication of number of records/pages or if a next page exists
 }

--- a/api/types.go
+++ b/api/types.go
@@ -94,7 +94,7 @@ func (d Duration) String() string {
 }
 
 type ListResponse[T any] struct {
-	PaginationInfo PaginationResponse `json:"pagination_info"`
+	PaginationInfo PaginationResponse `json:"_page_links"`
 	Items          []T                `json:"items"`
 	Count          int                `json:"count"`
 }

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -248,6 +248,28 @@
       },
       "ListResponse_AccessKey": {
         "properties": {
+          "_page_links": {
+            "properties": {
+              "current": {
+                "type": "string"
+              },
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "next": {
+                "type": "string"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              },
+              "previous": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "count": {
             "format": "int",
             "type": "integer"
@@ -301,24 +323,33 @@
               "type": "object"
             },
             "type": "array"
-          },
-          "pagination_info": {
-            "properties": {
-              "limit": {
-                "format": "int",
-                "type": "integer"
-              },
-              "page": {
-                "format": "int",
-                "type": "integer"
-              }
-            },
-            "type": "object"
           }
         }
       },
       "ListResponse_Destination": {
         "properties": {
+          "_page_links": {
+            "properties": {
+              "current": {
+                "type": "string"
+              },
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "next": {
+                "type": "string"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              },
+              "previous": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "count": {
             "format": "int",
             "type": "integer"
@@ -383,24 +414,33 @@
               "type": "object"
             },
             "type": "array"
-          },
-          "pagination_info": {
-            "properties": {
-              "limit": {
-                "format": "int",
-                "type": "integer"
-              },
-              "page": {
-                "format": "int",
-                "type": "integer"
-              }
-            },
-            "type": "object"
           }
         }
       },
       "ListResponse_Grant": {
         "properties": {
+          "_page_links": {
+            "properties": {
+              "current": {
+                "type": "string"
+              },
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "next": {
+                "type": "string"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              },
+              "previous": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "count": {
             "format": "int",
             "type": "integer"
@@ -457,24 +497,33 @@
               "type": "object"
             },
             "type": "array"
-          },
-          "pagination_info": {
-            "properties": {
-              "limit": {
-                "format": "int",
-                "type": "integer"
-              },
-              "page": {
-                "format": "int",
-                "type": "integer"
-              }
-            },
-            "type": "object"
           }
         }
       },
       "ListResponse_Group": {
         "properties": {
+          "_page_links": {
+            "properties": {
+              "current": {
+                "type": "string"
+              },
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "next": {
+                "type": "string"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              },
+              "previous": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "count": {
             "format": "int",
             "type": "integer"
@@ -507,24 +556,33 @@
               "type": "object"
             },
             "type": "array"
-          },
-          "pagination_info": {
-            "properties": {
-              "limit": {
-                "format": "int",
-                "type": "integer"
-              },
-              "page": {
-                "format": "int",
-                "type": "integer"
-              }
-            },
-            "type": "object"
           }
         }
       },
       "ListResponse_Provider": {
         "properties": {
+          "_page_links": {
+            "properties": {
+              "current": {
+                "type": "string"
+              },
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "next": {
+                "type": "string"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              },
+              "previous": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "count": {
             "format": "int",
             "type": "integer"
@@ -574,24 +632,33 @@
               "type": "object"
             },
             "type": "array"
-          },
-          "pagination_info": {
-            "properties": {
-              "limit": {
-                "format": "int",
-                "type": "integer"
-              },
-              "page": {
-                "format": "int",
-                "type": "integer"
-              }
-            },
-            "type": "object"
           }
         }
       },
       "ListResponse_User": {
         "properties": {
+          "_page_links": {
+            "properties": {
+              "current": {
+                "type": "string"
+              },
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "next": {
+                "type": "string"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              },
+              "previous": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "count": {
             "format": "int",
             "type": "integer"
@@ -639,19 +706,6 @@
               "type": "object"
             },
             "type": "array"
-          },
-          "pagination_info": {
-            "properties": {
-              "limit": {
-                "format": "int",
-                "type": "integer"
-              },
-              "page": {
-                "format": "int",
-                "type": "integer"
-              }
-            },
-            "type": "object"
           }
         }
       },

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -250,9 +250,6 @@
         "properties": {
           "_page_links": {
             "properties": {
-              "current": {
-                "type": "string"
-              },
               "limit": {
                 "format": "int",
                 "type": "integer"
@@ -264,7 +261,10 @@
                 "format": "int",
                 "type": "integer"
               },
-              "previous": {
+              "prev": {
+                "type": "string"
+              },
+              "self": {
                 "type": "string"
               }
             },
@@ -330,9 +330,6 @@
         "properties": {
           "_page_links": {
             "properties": {
-              "current": {
-                "type": "string"
-              },
               "limit": {
                 "format": "int",
                 "type": "integer"
@@ -344,7 +341,10 @@
                 "format": "int",
                 "type": "integer"
               },
-              "previous": {
+              "prev": {
+                "type": "string"
+              },
+              "self": {
                 "type": "string"
               }
             },
@@ -421,9 +421,6 @@
         "properties": {
           "_page_links": {
             "properties": {
-              "current": {
-                "type": "string"
-              },
               "limit": {
                 "format": "int",
                 "type": "integer"
@@ -435,7 +432,10 @@
                 "format": "int",
                 "type": "integer"
               },
-              "previous": {
+              "prev": {
+                "type": "string"
+              },
+              "self": {
                 "type": "string"
               }
             },
@@ -504,9 +504,6 @@
         "properties": {
           "_page_links": {
             "properties": {
-              "current": {
-                "type": "string"
-              },
               "limit": {
                 "format": "int",
                 "type": "integer"
@@ -518,7 +515,10 @@
                 "format": "int",
                 "type": "integer"
               },
-              "previous": {
+              "prev": {
+                "type": "string"
+              },
+              "self": {
                 "type": "string"
               }
             },
@@ -563,9 +563,6 @@
         "properties": {
           "_page_links": {
             "properties": {
-              "current": {
-                "type": "string"
-              },
               "limit": {
                 "format": "int",
                 "type": "integer"
@@ -577,7 +574,10 @@
                 "format": "int",
                 "type": "integer"
               },
-              "previous": {
+              "prev": {
+                "type": "string"
+              },
+              "self": {
                 "type": "string"
               }
             },
@@ -639,9 +639,6 @@
         "properties": {
           "_page_links": {
             "properties": {
-              "current": {
-                "type": "string"
-              },
               "limit": {
                 "format": "int",
                 "type": "integer"
@@ -653,7 +650,10 @@
                 "format": "int",
                 "type": "integer"
               },
-              "previous": {
+              "prev": {
+                "type": "string"
+              },
+              "self": {
                 "type": "string"
               }
             },

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -253,7 +253,9 @@ func TestAPI_ListGrants(t *testing.T) {
 					},
 				}
 				assert.DeepEqual(t, grants.Items, expected, cmpAPIGrantShallow)
-				assert.Assert(t, grants.PaginationInfo == api.PaginationResponse{Limit: 2, Page: 2})
+				assert.Assert(t, grants.PaginationInfo == api.PaginationResponse{Limit: 2, Page: 2,
+					Current: "http:///api/grants?page=2&limit=2", Next: "http:///api/grants?page=3&limit=2", Prev: "http:///api/grants?page=1&limit=2"})
+				// hostname is missing while testing
 			},
 		},
 		"filter by resource": {
@@ -311,7 +313,7 @@ func TestAPI_ListGrants(t *testing.T) {
 
 				expected := jsonUnmarshal(t, fmt.Sprintf(`
 {
-	"pagination_info":{},
+	"_page_links":{},
 	"count": 1,
 	"items": [{
 		"id": "<any-valid-uid>",

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -253,8 +254,14 @@ func TestAPI_ListGrants(t *testing.T) {
 					},
 				}
 				assert.DeepEqual(t, grants.Items, expected, cmpAPIGrantShallow)
-				assert.Assert(t, grants.PaginationInfo == api.PaginationResponse{Limit: 2, Page: 2,
-					Current: "http:///api/grants?page=2&limit=2", Next: "http:///api/grants?page=3&limit=2", Prev: "http:///api/grants?page=1&limit=2"})
+				assert.Assert(t, grants.PaginationInfo.Limit == 2 && grants.PaginationInfo.Page == 2)
+
+				self, _ := url.Parse("http:///api/grants?page=2&limit=2")
+				next, _ := url.Parse("http:///api/grants?page=3&limit=2")
+				prev, _ := url.Parse("http:///api/grants?page=1&limit=2")
+				assert.Assert(t, self.Query().Get("limit") == "2" && self.Query().Get("page") == "2")
+				assert.Assert(t, next.Query().Get("limit") == "2" && next.Query().Get("page") == "3")
+				assert.Assert(t, prev.Query().Get("limit") == "2" && prev.Query().Get("page") == "1")
 				// hostname is missing while testing
 			},
 		},

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -138,11 +138,11 @@ func TestAPI_ListGroups(t *testing.T) {
 				assert.NilError(t, err)
 				assert.Equal(t, len(actual.Items), 1)
 				assert.Equal(t, api.PaginationResponse{
-					Page:    2,
-					Limit:   2,
-					Current: "http:///api/groups?page=2&limit=2",
-					Prev:    "http:///api/groups?page=1&limit=2",
-					Next:    "http:///api/groups?page=3&limit=2"}, actual.PaginationInfo)
+					Page:  2,
+					Limit: 2,
+					Self:  "http:///api/groups?page=2&limit=2",
+					Prev:  "http:///api/groups?page=1&limit=2",
+					Next:  "http:///api/groups?page=3&limit=2"}, actual.PaginationInfo)
 			},
 		},
 		"authorized by group membership": {

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -137,7 +137,12 @@ func TestAPI_ListGroups(t *testing.T) {
 				err := json.NewDecoder(resp.Body).Decode(&actual)
 				assert.NilError(t, err)
 				assert.Equal(t, len(actual.Items), 1)
-				assert.Equal(t, api.PaginationResponse{Page: 2, Limit: 2}, actual.PaginationInfo)
+				assert.Equal(t, api.PaginationResponse{
+					Page:    2,
+					Limit:   2,
+					Current: "http:///api/groups?page=2&limit=2",
+					Prev:    "http:///api/groups?page=1&limit=2",
+					Next:    "http:///api/groups?page=3&limit=2"}, actual.PaginationInfo)
 			},
 		},
 		"authorized by group membership": {
@@ -186,7 +191,7 @@ func TestAPI_ListGroups(t *testing.T) {
 
 				expected := jsonUnmarshal(t, fmt.Sprintf(`
 {
-	"pagination_info": {},
+	"_page_links": {},
 	"count": 2,
 	"items": [{
 		"id": "%[1]v",
@@ -219,7 +224,7 @@ func TestAPI_ListGroups(t *testing.T) {
 
 				expected := jsonUnmarshal(t, fmt.Sprintf(`
 {
-	"pagination_info":{},
+	"_page_links":{},
 	"count": 1,
 	"items": [{
 		"id": "%[1]v",

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -34,7 +34,7 @@ func (a *API) ListUsers(c *gin.Context, r *api.ListUsersRequest) (*api.ListRespo
 		return nil, err
 	}
 
-	result := api.NewListResponse(users, models.PaginationToResponse(pg), func(identity models.Identity) api.User {
+	result := api.NewListResponse(users, models.PaginationToResponse(c, pg), func(identity models.Identity) api.User {
 		return *identity.ToAPI()
 	})
 
@@ -138,7 +138,7 @@ func (a *API) ListGroups(c *gin.Context, r *api.ListGroupsRequest) (*api.ListRes
 		return nil, err
 	}
 
-	result := api.NewListResponse(groups, models.PaginationToResponse(pg), func(group models.Group) api.Group {
+	result := api.NewListResponse(groups, models.PaginationToResponse(c, pg), func(group models.Group) api.Group {
 		return *group.ToAPI()
 	})
 
@@ -185,7 +185,7 @@ func (a *API) ListProviders(c *gin.Context, r *api.ListProvidersRequest) (*api.L
 		return nil, err
 	}
 
-	result := api.NewListResponse(providers, models.PaginationToResponse(pg), func(provider models.Provider) api.Provider {
+	result := api.NewListResponse(providers, models.PaginationToResponse(c, pg), func(provider models.Provider) api.Provider {
 		return *provider.ToAPI()
 	})
 
@@ -279,7 +279,7 @@ func (a *API) ListDestinations(c *gin.Context, r *api.ListDestinationsRequest) (
 		return nil, err
 	}
 
-	result := api.NewListResponse(destinations, models.PaginationToResponse(pg), func(destination models.Destination) api.Destination {
+	result := api.NewListResponse(destinations, models.PaginationToResponse(c, pg), func(destination models.Destination) api.Destination {
 		return *destination.ToAPI()
 	})
 
@@ -362,7 +362,7 @@ func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api
 		return nil, err
 	}
 
-	result := api.NewListResponse(accessKeys, models.PaginationToResponse(pg), func(accessKey models.AccessKey) api.AccessKey {
+	result := api.NewListResponse(accessKeys, models.PaginationToResponse(c, pg), func(accessKey models.AccessKey) api.AccessKey {
 		return *accessKey.ToAPI()
 	})
 
@@ -414,7 +414,7 @@ func (a *API) ListGrants(c *gin.Context, r *api.ListGrantsRequest) (*api.ListRes
 		return nil, err
 	}
 
-	result := api.NewListResponse(grants, models.PaginationToResponse(pg), func(grant models.Grant) api.Grant {
+	result := api.NewListResponse(grants, models.PaginationToResponse(c, pg), func(grant models.Grant) api.Grant {
 		return *grant.ToAPI()
 	})
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -90,7 +90,7 @@ func TestAPI_ListUsers(t *testing.T) {
 			urlPath: "/api/users?name=doesnotmatch",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK)
-				assert.Equal(t, resp.Body.String(), `{"pagination_info":{},"items":[],"count":0}`)
+				assert.Equal(t, resp.Body.String(), `{"_page_links":{},"items":[],"count":0}`)
 			},
 		},
 		"name match": {
@@ -178,8 +178,11 @@ func TestAPI_ListUsers(t *testing.T) {
 						{Name: "me@example.com"},
 					},
 					PaginationInfo: api.PaginationResponse{
-						Page:  2,
-						Limit: 2,
+						Page:    2,
+						Limit:   2,
+						Current: "http:///api/users?limit=2&page=2",
+						Next:    "http:///api/users?limit=2&page=3",
+						Prev:    "http:///api/users?limit=2&page=1",
 					},
 				}
 				assert.DeepEqual(t, actual, expected, cmpAPIUserShallow)

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -178,11 +178,11 @@ func TestAPI_ListUsers(t *testing.T) {
 						{Name: "me@example.com"},
 					},
 					PaginationInfo: api.PaginationResponse{
-						Page:    2,
-						Limit:   2,
-						Current: "http:///api/users?limit=2&page=2",
-						Next:    "http:///api/users?limit=2&page=3",
-						Prev:    "http:///api/users?limit=2&page=1",
+						Page:  2,
+						Limit: 2,
+						Self:  "http:///api/users?limit=2&page=2",
+						Next:  "http:///api/users?limit=2&page=3",
+						Prev:  "http:///api/users?limit=2&page=1",
 					},
 				}
 				assert.DeepEqual(t, actual, expected, cmpAPIUserShallow)

--- a/internal/server/models/pagination.go
+++ b/internal/server/models/pagination.go
@@ -44,7 +44,11 @@ func PaginationToResponse(c *gin.Context, p Pagination) api.PaginationResponse {
 
 	uri := *c.Request.URL
 	uri.Host = c.Request.Host
-	uri.Scheme = "https" // TODO: get proper scheme
+
+	uri.Scheme = "https"
+	if c.Request.TLS == nil {
+		uri.Scheme = "http"
+	}
 
 	pr := api.PaginationResponse{
 		Page:    p.Page,

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -184,7 +184,7 @@ func add[Req, Res any](a *API, r *gin.RouterGroup, route route[Req, Res]) {
 			a.t.RouteEvent(c, route.path, Properties{"method": strings.ToLower(route.method)})
 		}
 
-		c.JSON(defaultResponseCodeForMethod(route.method), resp)
+		c.PureJSON(defaultResponseCodeForMethod(route.method), resp)
 	}
 
 	bindRoute(a, r, route.method, route.path, wrappedHandler)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Pagination responses now have three (or less) links returned: Self, Next, and Prev. These are the proper links for the corresponding API to get the current, next, or previous page.

Previous gets hidden if there is no previous link, Next will be hidden in a future update.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->
