### PR TITLE
maintain: add unit test for listing users in a given group

### DIFF
--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -110,11 +110,8 @@ func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID, p
 	selectors := []data.SelectorFunc{
 		data.ByOptionalName(name),
 		data.ByOptionalIDs(ids),
+		data.ByOptionalIdentityGroupID(groupID),
 		data.ByPagination(pg),
-	}
-
-	if groupID != 0 {
-		return data.ListIdentitiesByGroup(db.Preload("Providers"), groupID, selectors...)
 	}
 
 	return data.ListIdentities(db.Preload("Providers"), selectors...)

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -105,23 +105,6 @@ func ListIdentities(db *gorm.DB, selectors ...SelectorFunc) ([]models.Identity, 
 	return list[models.Identity](db, selectors...)
 }
 
-func ListIdentitiesByGroup(db *gorm.DB, groupID uid.ID, selectors ...SelectorFunc) ([]models.Identity, error) {
-	group, err := GetGroup(db.Preload("Identities", func(db *gorm.DB) *gorm.DB {
-		for _, selector := range selectors {
-			db = selector(db)
-		}
-		return db.Order("identities.name ASC")
-	}), ByID(groupID))
-	if err != nil {
-		return nil, err
-	}
-
-	var identities []models.Identity
-	identities = append(identities, group.Identities...)
-
-	return identities, nil
-}
-
 func DeleteIdentity(db *gorm.DB, id uid.ID) error {
 	return delete[models.Identity](db, id)
 }

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -110,21 +110,21 @@ func TestListIdentities(t *testing.T) {
 		})
 
 		t.Run("filter identities by group", func(t *testing.T) {
-			actual, err := ListIdentitiesByGroup(db, everyone.ID)
+			actual, err := ListIdentities(db, ByOptionalIdentityGroupID(everyone.ID))
 			assert.NilError(t, err)
 			expected := []models.Identity{bauer, bond, bourne}
 			assert.DeepEqual(t, actual, expected, cmpModelsIdentityShallow)
 		})
 
 		t.Run("filter identities by different group", func(t *testing.T) {
-			actual, err := ListIdentitiesByGroup(db, engineers.ID)
+			actual, err := ListIdentities(db, ByOptionalIdentityGroupID(engineers.ID))
 			assert.NilError(t, err)
 			expected := []models.Identity{bond}
 			assert.DeepEqual(t, actual, expected, cmpModelsIdentityShallow)
 		})
 
 		t.Run("filter identities by group and name", func(t *testing.T) {
-			actual, err := ListIdentitiesByGroup(db, everyone.ID, ByName(bauer.Name))
+			actual, err := ListIdentities(db, ByOptionalIdentityGroupID(everyone.ID), ByName(bauer.Name))
 			assert.NilError(t, err)
 			expected := []models.Identity{bauer}
 			assert.DeepEqual(t, actual, expected, cmpModelsIdentityShallow)

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -188,3 +188,14 @@ func NotPrivilege(privilege string) SelectorFunc {
 		return db.Not("privilege = ?", privilege)
 	}
 }
+
+func ByOptionalIdentityGroupID(groupID uid.ID) SelectorFunc {
+	return func(db *gorm.DB) *gorm.DB {
+		if groupID == 0 {
+			return db
+		}
+		return db.
+			Joins("join identities_groups on identities_groups.identity_id = id").
+			Where("identities_groups.group_id = ?", groupID)
+	}
+}


### PR DESCRIPTION
## Summary

Add a unit test to list users in a group. There are already unit tests for the data layer, however not currently one which accesses the actual http routes/handlers. 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
