### PR TITLE
improve: add fingerprint lookup to quickstart

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -32,6 +32,13 @@ infra login localhost
 ```
 
 {% callout type="info" %}
+You may be prompted to verify the fingerprint of the server's TLS certificate. The
+fingerprint can be found in the server logs:
+
+```
+kubectl logs -l 'app.kubernetes.io/name=infra-server' | grep fingerprint
+```
+
 If you're not using Docker Desktop, you'll be need to specify a different endpoint than `localhost`. This endpoint can be found via the following `kubectl` command:
 
 ```


### PR DESCRIPTION
Related to #296

Give users a `kubectl` command in the quickstart to look up the fingerprint of the server's TLS certificate.