### PR TITLE
fix(cmd): insert newline between user and group grants

### DIFF
--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -73,6 +73,10 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
+			if numUserGrants != 0 {
+				cli.Output("")
+			}
+
 			numGroupGrants, err := groupGrants(cli, client, grants)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Add a newline between user and group grants if output non-zero number of user grants. This makes the output much more readable

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2374
