### PR TITLE
fix: use the correct TLS certificate

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -64,16 +64,14 @@ func GenerateCertificate(hosts []string, caCert *x509.Certificate, caKey crypto.
 	return PEMEncodeCertificate(certBytes), keyBytes, nil
 }
 
-func SelfSignedOrLetsEncryptCert(manager *autocert.Manager, serverName string) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+func SelfSignedOrLetsEncryptCert(manager *autocert.Manager) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 		cert, err := manager.GetCertificate(hello)
 		if err == nil {
 			return cert, nil
 		}
 
-		if serverName == "" {
-			serverName = hello.ServerName
-		}
+		serverName := hello.ServerName
 
 		if serverName == "" {
 			serverName = hello.Conn.LocalAddr().String()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -297,7 +297,7 @@ func tlsConfigWithCacheDir(tlsCacheDir string) (*tls.Config, error) {
 		Cache:  autocert.DirCache(tlsCacheDir),
 	}
 	tlsConfig := manager.TLSConfig()
-	tlsConfig.GetCertificate = certs.SelfSignedOrLetsEncryptCert(manager, "")
+	tlsConfig.GetCertificate = certs.SelfSignedOrLetsEncryptCert(manager)
 
 	return tlsConfig, nil
 }


### PR DESCRIPTION
## Summary

`SelfSignedOrLetsEncryptCert` is a closure. The closure was called with `serverName=""`, and the inner function also modified `serverName`, so after the first request the `serverName` would never change. It would also be set to the value of the first request.

This resulted in the wrong TLS certificate being returned to clients. The client would error because the hostnames do not match.

I attempted to write a test for this, but `httptest.Server.StartTLS` isn't ware of `tls.Config.GetCertificate`. It only looks at `tls.Config.Certificates`, so it never calls `SelfSignedOrLetsEncryptCert`.  We'd have to use a regular `http.Server`, but even that is a challenge because we throw away the CA used to generate these.

This will all be changing for #2176, so I'll write some more test cases as part of that change.

I tested this manually by adding an extra to `/etc/hosts`, and making requests with both `localhost` and the hostname in `/etc/hosts`. Before this change it was easy to reproduce the error. After this change it no longer errored.