### PR TITLE
fix: db migration from 0.13.3

### DIFF
--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -534,10 +534,8 @@ func addKindToProviders() *gormigrate.Migration {
 			}
 
 			db := tx.Begin()
-			db.Table("providers").Where("kind IS NULL AND name == ?", "infra").
-				Update("kind", models.InfraKind)
-			db.Table("providers").Where("kind IS NULL").
-				Update("kind", models.OktaKind)
+			db.Table("providers").Where("kind IS NULL AND name = ?", "infra").Update("kind", models.InfraKind)
+			db.Table("providers").Where("kind IS NULL").Update("kind", models.OktaKind)
 
 			return db.Commit().Error
 		},


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`==` is a valid sqlite operator but not a valid postgresql operator. change it to `=` which is more portable

```
postgres      | 2022-06-24 01:29:55.564 UTC [34] ERROR:  operator does not exist: text == unknown at character 62
postgres      | 2022-06-24 01:29:55.564 UTC [34] HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
postgres      | 2022-06-24 01:29:55.564 UTC [34] STATEMENT:  UPDATE "providers" SET "kind"=$1 WHERE kind IS NULL AND name == $2
postgres      | 2022-06-24 01:29:55.564 UTC [34] ERROR:  current transaction is aborted, commands ignored until end of transaction block
postgres      | 2022-06-24 01:29:55.564 UTC [34] STATEMENT:  UPDATE "providers" SET "kind"=$1 WHERE kind IS NULL
```

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
