### PR TITLE
fix: connector service query

### DIFF
--- a/helm/charts/infra/templates/connector/deployment.yaml
+++ b/helm/charts/infra/templates/connector/deployment.yaml
@@ -45,6 +45,9 @@ spec:
           envFrom:
 {{- include "connector.envFrom" . | nindent 12 }}
           volumeMounts:
+            - name: podinfo
+              mountPath: /etc/podinfo
+              readOnly: true
             - name: conf
               mountPath: /etc/infrahq
               readOnly: true
@@ -87,6 +90,15 @@ spec:
           resources:
 {{- toYaml .Values.connector.resources | nindent 12 }}
       volumes:
+        - name: podinfo
+          downwardAPI:
+            items:
+              - path: "labels"
+                fieldRef:
+                  fieldPath: metadata.labels
+              - path: "annotations"
+                fieldRef:
+                  fieldPath: metadata.annotations
         - name: conf
           configMap:
             name: {{ include "connector.fullname" . }}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

When more than one deployment of infra exists, the service query will possibly return the incorrect service endpoint since the selector it uses is common to all deployments. Instead mount and add the instance label to the selector as well. The instance selector, when deployed with Helm, is the name of the deployment and will be unique between deployments. This will allow the connector to find the right service.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2365
