### PR TITLE
improve: log authn errors

### DIFF
--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -87,6 +88,11 @@ func TestSendAPIError(t *testing.T) {
 		t.Run(test.err.Error(), func(t *testing.T) {
 			resp := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(resp)
+			c.Request = &http.Request{
+				Method:     http.MethodPost,
+				URL:        &url.URL{Path: "/api/path"},
+				RemoteAddr: "10.10.10.10:34124",
+			}
 
 			sendAPIError(c, test.err)
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -46,7 +46,7 @@ func (a *API) GetUser(c *gin.Context, r *api.GetUserRequest) (*api.User, error) 
 	if r.ID.IsSelf {
 		iden := access.AuthenticatedIdentity(c)
 		if iden == nil {
-			return nil, internal.ErrUnauthorized
+			return nil, fmt.Errorf("%w: no user is logged in", internal.ErrUnauthorized)
 		}
 		r.ID.ID = iden.ID
 	}
@@ -355,7 +355,7 @@ func (a *API) CreateToken(c *gin.Context, r *api.EmptyRequest) (*api.CreateToken
 		return &api.CreateTokenResponse{Token: token.Token, Expires: api.Time(token.Expires)}, nil
 	}
 
-	return nil, fmt.Errorf("no identity found in access key: %w", internal.ErrUnauthorized)
+	return nil, fmt.Errorf("%w: no identity found in access key", internal.ErrUnauthorized)
 }
 
 func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api.ListResponse[api.AccessKey], error) {
@@ -569,9 +569,8 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 			// this means an external request failed, probably to an IDP
 			return nil, err
 		}
-		logging.S.Debug(err)
 		// all other failures from login should result in an unauthorized response
-		return nil, internal.ErrUnauthorized
+		return nil, fmt.Errorf("%w: login failed: %v", internal.ErrUnauthorized, err)
 	}
 
 	setAuthCookie(c, bearer, expires)


### PR DESCRIPTION
## Summary

First I audited all the places we use `internal.ErrUnauthorized` to make sure all of them provide additional context. I fixed one error that did not have additional context, and one place where we hid the error (and only logged it with `Debug`).

Then I changed `sendAPIError` to make sure that we log the full error at `Warn` level, along with relevant request details.

Testing this with an automated test is difficult until we do #1609. I tested manually that these messages are at the warn level and contain the relevant context.