### PR TITLE
tls: generate server TLS cert from CA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test/update:
 	go test ./internal/cmd -test.update-golden
 
 dev:
-	docker build . -t infrahq/infra:dev
+	docker buildx build . -t infrahq/infra:dev
 	kubectl config use-context docker-desktop
 	helm upgrade --install --wait  \
 		--set global.image.pullPolicy=Never \

--- a/helm/charts/infra/templates/server/configmap.yaml
+++ b/helm/charts/infra/templates/server/configmap.yaml
@@ -36,6 +36,12 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if not .Values.server.config.tls }}
+    tls:
+      ca: "/var/run/secrets/infrahq.com/tls-ca/ca.crt"
+      caPrivateKey: "file:/var/run/secrets/infrahq.com/tls-ca/ca.key"
+{{- end }}
+
     providers:
 {{- .Values.server.additionalProviders | default list | concat .Values.server.config.providers | uniq | toYaml | nindent 6 }}
 

--- a/helm/charts/infra/templates/server/deployment.yaml
+++ b/helm/charts/infra/templates/server/deployment.yaml
@@ -48,6 +48,10 @@ spec:
             - name: conf
               mountPath: /etc/infrahq
               readOnly: true
+{{- if (not .Values.server.config.tls) }}
+            - name: tls-ca
+              mountPath: /var/run/secrets/infrahq.com/tls-ca
+{{- end }}
 {{- if .Values.server.persistence.enabled }}
             - name: data
               mountPath: /var/lib/infrahq/server
@@ -89,6 +93,11 @@ spec:
         - name: conf
           configMap:
             name: {{ include "server.fullname" . }}
+{{- if (not .Values.server.config.tls) }}
+        - name: tls-ca
+          secret:
+            secretName: {{ include "server.fullname" . }}-ca
+{{- end }}
 {{- if .Values.server.persistence.enabled }}
         - name: data
           persistentVolumeClaim:

--- a/helm/charts/infra/templates/server/secret.yaml
+++ b/helm/charts/infra/templates/server/secret.yaml
@@ -1,0 +1,29 @@
+
+{{- if include "server.enabled" . | eq "true" }}
+{{- if (not .Values.server.config.tls) }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "server.fullname" . }}-ca
+  labels:
+{{- include "server.labels" . | nindent 4 }}
+data:
+
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-ca" (include "server.fullname" .)) -}}
+{{- if $secret.data }}
+  ca.crt: |
+{{- get $secret.data "ca.crt" | nindent 4 }}
+  ca.key: |
+{{- get $secret.data "ca.key" | nindent 4 }}
+
+{{- else }}
+{{- $ca := genCA "Infra Server" 3650 }}
+  ca.crt: |
+{{- $ca.Cert | b64enc | nindent 4 }}
+  ca.key: |
+{{- $ca.Key | b64enc | nindent 4 }}
+
+{{- end }}{{/* if secret.data */}}
+{{- end }}{{/* if not tls */}}
+{{- end }}{{/* if server.enabled */}}

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -531,6 +531,19 @@ server:
     # - name: dev@example.com
     #   password: file:/var/run/secrets/dev@example.com
 
+    # TLS configuration for the API server. Defaults to generating a self-signed CA and
+    # generating certificates from that CA.
+    tls: {}
+
+    # Configure a CA and private key using files
+    # ca: /path/to/ca.crt
+    # caPrivateKey: file:/path/to/ca.key
+
+    # Configure a TLS certificate and private key using files
+    # certificate: /path/to/server.crt
+    # privateKey: file:/path/to/server.key
+
+
 ## Default connector configurations
 connector:
 

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -14,10 +13,6 @@ import (
 	"net"
 	"strings"
 	"time"
-
-	"golang.org/x/crypto/acme/autocert"
-
-	"github.com/infrahq/infra/internal/logging"
 )
 
 func GenerateCertificate(hosts []string, caCert *x509.Certificate, caKey crypto.PrivateKey) (certPEM []byte, keyPEM []byte, err error) {
@@ -62,68 +57,6 @@ func GenerateCertificate(hosts []string, caCert *x509.Certificate, caKey crypto.
 	return PEMEncodeCertificate(certBytes), keyBytes, nil
 }
 
-func SelfSignedOrLetsEncryptCert(manager *autocert.Manager) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-		ctx := hello.Context()
-		cert, err := manager.GetCertificate(hello)
-		if err == nil {
-			return cert, nil
-		}
-
-		serverName := hello.ServerName
-
-		if serverName == "" {
-			serverName, _, err = net.SplitHostPort(hello.Conn.LocalAddr().String())
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		certBytes, err := manager.Cache.Get(ctx, serverName+".crt")
-		if err != nil {
-			logging.Warnf("cert: %s", err)
-		}
-
-		keyBytes, err := manager.Cache.Get(ctx, serverName+".key")
-		if err != nil {
-			logging.Warnf("key: %s", err)
-		}
-
-		// if either cert or key is missing, create it
-		if certBytes == nil || keyBytes == nil {
-			ca, caPrivKey, err := newCA()
-			if err != nil {
-				return nil, err
-			}
-
-			certBytes, keyBytes, err = GenerateCertificate([]string{serverName}, ca, caPrivKey)
-			if err != nil {
-				return nil, err
-			}
-
-			if err := manager.Cache.Put(ctx, serverName+".crt", certBytes); err != nil {
-				return nil, err
-			}
-
-			if err := manager.Cache.Put(ctx, serverName+".key", keyBytes); err != nil {
-				return nil, err
-			}
-
-			logging.L.Info().
-				Str("serverName", serverName).
-				Str("fingerprint", Fingerprint(pemDecode(certBytes))).
-				Msg("new server certificate")
-		}
-
-		keypair, err := tls.X509KeyPair(certBytes, keyBytes)
-		if err != nil {
-			return nil, err
-		}
-
-		return &keypair, nil
-	}
-}
-
 // Fingerprint returns a sha256 checksum of the certificate formatted as
 // hex pairs separated by colons. This is a common format used by browsers.
 // The bytes must be the ASN.1 DER form of the x509.Certificate.
@@ -131,11 +64,6 @@ func Fingerprint(raw []byte) string {
 	checksum := sha256.Sum256(raw)
 	s := strings.ReplaceAll(fmt.Sprintf("% x", checksum), " ", ":")
 	return strings.ToUpper(s)
-}
-
-func pemDecode(raw []byte) []byte {
-	block, _ := pem.Decode(raw)
-	return block.Bytes
 }
 
 // PEMEncodeCertificate accepts the bytes of a x509 certificate in ASN.1 DER form
@@ -148,40 +76,4 @@ func PEMEncodeCertificate(raw []byte) []byte {
 // PEM encoded representation of that private key.
 func pemEncodePrivateKey(raw []byte) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: raw})
-}
-
-func newCA() (*x509.Certificate, *rsa.PrivateKey, error) {
-	// Generate a CA to sign self-signed certificates
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ca := &x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-			Organization: []string{"Infra"},
-		},
-		NotBefore:             time.Now().Add(-5 * time.Minute).UTC(),
-		NotAfter:              time.Now().AddDate(0, 0, 365).UTC(),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-	}
-
-	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// TODO: is there really no other way to get the Raw field populated?
-	ca, _ = x509.ParseCertificate(caBytes)
-
-	return ca, caPrivKey, nil
 }

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -34,14 +34,13 @@ func TestListCmd(t *testing.T) {
 			{User: "manygrants@example.com", Resource: "moon", Role: "inhabitant"},
 		},
 	}
-	opts.Addr = server.ListenerOptions{HTTPS: "127.0.0.1:0", HTTP: "127.0.0.1:0"}
+	setupServerTLSOptions(t, &opts)
 	srv, err := server.New(opts)
 	assert.NilError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	setupCertManager(t, opts.TLSCache, srv.Addrs.HTTPS.String())
 	go func() {
 		assert.Check(t, srv.Run(ctx))
 	}()

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -321,6 +321,11 @@ func TestServerCmd_WithSecretsConfig(t *testing.T) {
         http: "127.0.0.1:0"
         https: "127.0.0.1:0"
         metrics: "127.0.0.1:0"
+
+      tls:
+        ca: some-ca
+        caPrivateKey: some-key
+
       secrets:
         - kind: env
           name: base64env

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -142,6 +142,7 @@ tls:
   caPrivateKey: file:ca.key
   certificate: testdata/server.crt
   privateKey: file:server.key
+  ACME: true
 
 keys:
   - kind: vault
@@ -223,6 +224,7 @@ users:
 						CAPrivateKey: "file:ca.key",
 						Certificate:  "-----BEGIN CERTIFICATE-----\nnot a real server certificate\n-----END CERTIFICATE-----\n",
 						PrivateKey:   "file:server.key",
+						ACME:         true,
 					},
 
 					Keys: []server.KeyProvider{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,7 +80,7 @@ type TLSOptions struct {
 	Certificate  types.StringOrFile
 	PrivateKey   string
 
-	// ACME enables automated certificate manangement. When set to true a TLS
+	// ACME enables automated certificate management. When set to true a TLS
 	// certificate will be requested from Let's Encrypt, which will be cached
 	// in the TLSCache.
 	ACME bool

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -79,6 +79,11 @@ type TLSOptions struct {
 	CAPrivateKey string
 	Certificate  types.StringOrFile
 	PrivateKey   string
+
+	// ACME enables automated certificate manangement. When set to true a TLS
+	// certificate will be requested from Let's Encrypt, which will be cached
+	// in the TLSCache.
+	ACME bool
 }
 
 type Server struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -20,10 +19,8 @@ import (
 	"github.com/rs/zerolog"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/golden"
 
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 )
@@ -487,42 +484,3 @@ func TestServer_PersistSignupUser(t *testing.T) {
 	// retry the authenticated endpoint
 	checkAuthenticated()
 }
-
-func TestTLSConfigFromOptions(t *testing.T) {
-	storage := map[string]secrets.SecretStorage{
-		"plaintext": &secrets.PlainSecretProvider{},
-		"file":      &secrets.FileSecretProvider{},
-	}
-
-	ca := golden.Get(t, "pki/ca.crt")
-	t.Run("user provided certificate", func(t *testing.T) {
-		opts := TLSOptions{
-			CA:          types.StringOrFile(ca),
-			Certificate: types.StringOrFile(golden.Get(t, "pki/localhost.crt")),
-			PrivateKey:  "file:testdata/pki/localhost.key",
-		}
-		config, err := tlsConfigFromOptions(storage, t.TempDir(), opts)
-		assert.NilError(t, err)
-
-		srv := httptest.NewUnstartedServer(noopHandler)
-		srv.TLS = config
-		srv.StartTLS()
-		t.Cleanup(srv.Close)
-
-		roots := x509.NewCertPool()
-		roots.AppendCertsFromPEM(ca)
-		client := &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12},
-			},
-		}
-
-		resp, err := client.Get(srv.URL)
-		assert.NilError(t, err)
-		assert.Equal(t, resp.StatusCode, http.StatusOK)
-	})
-}
-
-var noopHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-	w.WriteHeader(http.StatusOK)
-})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -19,8 +19,10 @@ import (
 	"github.com/rs/zerolog"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/golden"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 )
@@ -119,7 +121,12 @@ func TestServer_Run(t *testing.T) {
 		DBEncryptionKey:         filepath.Join(dir, "sqlite3.db.key"),
 		TLSCache:                filepath.Join(dir, "tlscache"),
 		DBFile:                  filepath.Join(dir, "sqlite3.db"),
+		TLS: TLSOptions{
+			CA:           types.StringOrFile(golden.Get(t, "pki/ca.crt")),
+			CAPrivateKey: string(golden.Get(t, "pki/ca.key")),
+		},
 	}
+
 	srv, err := New(opts)
 	assert.NilError(t, err)
 
@@ -199,6 +206,10 @@ func TestServer_Run_UIProxy(t *testing.T) {
 		DBFile:                  filepath.Join(dir, "sqlite3.db"),
 		UI:                      UIOptions{Enabled: true},
 		EnableSignup:            true,
+		TLS: TLSOptions{
+			CA:           types.StringOrFile(golden.Get(t, "pki/ca.crt")),
+			CAPrivateKey: string(golden.Get(t, "pki/ca.key")),
+		},
 	}
 	assert.NilError(t, opts.UI.ProxyURL.Set(uiSrv.URL))
 

--- a/internal/server/tls.go
+++ b/internal/server/tls.go
@@ -1,0 +1,182 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"time"
+
+	"github.com/infrahq/secrets"
+	"golang.org/x/crypto/acme/autocert"
+
+	"github.com/infrahq/infra/internal/certs"
+	"github.com/infrahq/infra/internal/logging"
+)
+
+func tlsConfigFromOptions(
+	storage map[string]secrets.SecretStorage,
+	tlsCacheDir string,
+	opts TLSOptions,
+) (*tls.Config, error) {
+	// TODO: print CA fingerprint when the client can trust that fingerprint
+
+	if opts.Certificate != "" && opts.PrivateKey != "" {
+		roots, err := x509.SystemCertPool()
+		if err != nil {
+			logging.Warnf("failed to load TLS roots from system: %v", err)
+			roots = x509.NewCertPool()
+		}
+
+		if opts.CA != "" {
+			if !roots.AppendCertsFromPEM([]byte(opts.CA)) {
+				logging.Warnf("failed to load TLS CA, invalid PEM")
+			}
+		}
+
+		key, err := secrets.GetSecret(opts.PrivateKey, storage)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load TLS private key: %w", err)
+		}
+
+		cert, err := tls.X509KeyPair([]byte(opts.Certificate), []byte(key))
+		if err != nil {
+			return nil, fmt.Errorf("failed to load TLS key pair: %w", err)
+		}
+
+		return &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			// enable HTTP/2
+			NextProtos:   []string{"h2", "http/1.1"},
+			Certificates: []tls.Certificate{cert},
+			// enabled optional mTLS
+			ClientAuth: tls.VerifyClientCertIfGiven,
+			ClientCAs:  roots,
+		}, nil
+	}
+
+	if err := os.MkdirAll(tlsCacheDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create tls cache: %w", err)
+	}
+
+	manager := &autocert.Manager{
+		Prompt: autocert.AcceptTOS,
+		Cache:  autocert.DirCache(tlsCacheDir),
+	}
+	tlsConfig := manager.TLSConfig()
+	tlsConfig.MinVersion = tls.VersionTLS12
+	// TODO: enabled optional mTLS when opts.CA is set
+	tlsConfig.GetCertificate = SelfSignedOrLetsEncryptCert(manager)
+
+	return tlsConfig, nil
+}
+
+func SelfSignedOrLetsEncryptCert(manager *autocert.Manager) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		ctx := hello.Context()
+		cert, err := manager.GetCertificate(hello)
+		if err == nil {
+			return cert, nil
+		}
+
+		serverName := hello.ServerName
+
+		if serverName == "" {
+			serverName, _, err = net.SplitHostPort(hello.Conn.LocalAddr().String())
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		certBytes, err := manager.Cache.Get(ctx, serverName+".crt")
+		if err != nil {
+			logging.Warnf("cert: %s", err)
+		}
+
+		keyBytes, err := manager.Cache.Get(ctx, serverName+".key")
+		if err != nil {
+			logging.Warnf("key: %s", err)
+		}
+
+		// if either cert or key is missing, create it
+		if certBytes == nil || keyBytes == nil {
+			ca, caPrivKey, err := newCA()
+			if err != nil {
+				return nil, err
+			}
+
+			certBytes, keyBytes, err = certs.GenerateCertificate([]string{serverName}, ca, caPrivKey)
+			if err != nil {
+				return nil, err
+			}
+
+			if err := manager.Cache.Put(ctx, serverName+".crt", certBytes); err != nil {
+				return nil, err
+			}
+
+			if err := manager.Cache.Put(ctx, serverName+".key", keyBytes); err != nil {
+				return nil, err
+			}
+
+			logging.L.Info().
+				Str("Server name", serverName).
+				Str("SHA256 fingerprint", certs.Fingerprint(pemDecode(certBytes))).
+				Msg("new server certificate")
+		}
+
+		keypair, err := tls.X509KeyPair(certBytes, keyBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		return &keypair, nil
+	}
+}
+
+func pemDecode(raw []byte) []byte {
+	block, _ := pem.Decode(raw)
+	return block.Bytes
+}
+
+// TODO: remove
+func newCA() (*x509.Certificate, *rsa.PrivateKey, error) {
+	// Generate a CA to sign self-signed certificates
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ca := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Infra"},
+		},
+		NotBefore:             time.Now().Add(-5 * time.Minute).UTC(),
+		NotAfter:              time.Now().AddDate(0, 0, 365).UTC(),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: is there really no other way to get the Raw field populated?
+	ca, _ = x509.ParseCertificate(caBytes)
+
+	return ca, caPrivKey, nil
+}

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/infrahq/secrets"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
+
+	"github.com/infrahq/infra/internal/cmd/types"
+)
+
+func TestTLSConfigFromOptions(t *testing.T) {
+	storage := map[string]secrets.SecretStorage{
+		"plaintext": &secrets.PlainSecretProvider{},
+		"file":      &secrets.FileSecretProvider{},
+	}
+
+	ca := golden.Get(t, "pki/ca.crt")
+	t.Run("user provided certificate", func(t *testing.T) {
+		opts := TLSOptions{
+			CA:          types.StringOrFile(ca),
+			Certificate: types.StringOrFile(golden.Get(t, "pki/localhost.crt")),
+			PrivateKey:  "file:testdata/pki/localhost.key",
+		}
+		config, err := tlsConfigFromOptions(storage, t.TempDir(), opts)
+		assert.NilError(t, err)
+
+		srv := httptest.NewUnstartedServer(noopHandler)
+		srv.TLS = config
+		srv.StartTLS()
+		t.Cleanup(srv.Close)
+
+		roots := x509.NewCertPool()
+		roots.AppendCertsFromPEM(ca)
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12},
+			},
+		}
+
+		resp, err := client.Get(srv.URL)
+		assert.NilError(t, err)
+		assert.Equal(t, resp.StatusCode, http.StatusOK)
+	})
+}
+
+var noopHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -64,6 +64,7 @@ func TestTLSConfigFromOptions(t *testing.T) {
 		srv := http.Server{Handler: noopHandler}
 
 		go func() {
+			// nolint:errorlint
 			if err := srv.Serve(l); err != http.ErrServerClosed {
 				t.Log(err)
 			}


### PR DESCRIPTION
## Summary

The first commit moves some functions to `tls.go`, so best viewed by individual commit.

With the changes in this PR, a user has 3 options for configuring TLS:

1. set `tls.ACME=true`, to use ACME to create a publicly trusted certificate
2. set `tls.ca` and `tls.caPrivateKey`, which will be used to generate a TLS ceritifcate for any hostname the client requests.
3. set `tls.certificate` and `tls.privateKey` to use that certificate for TLS

We plan on setting a CA as part of the helm deploy, so the default for any user that uses our helm charts will be to specify nothing and use option 2.

ACME is no longer the default option. It has to be explicitly enabled, which is probably better because currently every single TLS request could make an ACME API request, even when it should never be used.

Resolves #2067
And addresses parts 1 and 2 of #2362


TODO:
* [x] fix some CLI tests that are failing due to missing CA option
* [x] add test case for generating certs from a CA
* [x] update helm to generate the CA as part of deploy