### PR TITLE
fix: do not update provider user groups in sync

### DIFF
--- a/internal/server/providers/oidc.go
+++ b/internal/server/providers/oidc.go
@@ -217,11 +217,6 @@ func (o *oidcImplementation) SyncProviderUser(ctx context.Context, db *gorm.DB, 
 
 	logging.S.Debugf("user synchronized with %q groups from provider (ID: %v)", info.Groups, providerUser.ProviderID)
 
-	providerUser.Groups = info.Groups
-	if err := data.UpdateProviderUser(db, providerUser); err != nil {
-		return fmt.Errorf("update provider user: %w", err)
-	}
-
 	if err := data.AssignIdentityToGroups(db, user, provider, info.Groups); err != nil {
 		return fmt.Errorf("assign identity to groups: %w", err)
 	}


### PR DESCRIPTION
- provider user groups are updated in the data package when an identity is assigned to groups

## Summary
This is an error from the Azure groups update which causes Okta groups to not be updated on a user. When a user's groups are updated from a provider the provider-user relation was being updated before the groups were assigned, this meant that the provider's groups were not seen as "new groups" in the data package when the user relation was updated.

Associated test is in the separate OIDC testing PR:
https://github.com/infrahq/infra/pull/2394/commits/c342c92ce42f9142ae6aabccb59941790178e1b8
## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2412 
