### PR TITLE
maintain: move openapi3 spec to testdata

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -122,7 +122,6 @@ jobs:
           if [[ "$GITHUB_HEAD_REF" =~ ^release-please-.*$ ]]; then LDFLAGS='-X github.com/infrahq/infra/internal.Metadata='; fi
           # fake a terminal to get the right defaults for non-interactive
           script -e -q -c "go run ${LDFLAGS:+-ldflags \"$LDFLAGS\"} ./internal/docgen"
-          go run ${LDFLAGS:+-ldflags "$LDFLAGS"} ./internal/openapigen docs/api/openapi3.json
           git diff --exit-code
       - name: Check go mod is tidy
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 # infra binary
 dist
+docs/api/openapi3.json

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,6 +18,7 @@
 /internal/server/openapi.go @ssoroka
 /internal/server/routes.go @ssoroka
 /internal/server/validator.go @ssoroka
+/internal/server/testdata/openapi3.json @ssoroka @hoyyeva @dnephin @jmorganca @pdevine
 
 pki/ @ssoroka @dnephin
 ui/ @FSHA @hoyyeva @jmorganca
@@ -25,7 +26,6 @@ uid/ @ssoroka @dnephin
 
 docs/ @FSHA @technovangelist @dnephin @jmorganca @pdevine @mchiang0610
 /docs/reference/helm-chart.md @mxyng @FSHA @technovangelist @dnephin @jmorganca @pdevine @mchiang0610
-/docs/api/openapi3.json @ssoroka @hoyyeva @dnephin @jmorganca @pdevine
 
 grants.go @ssoroka
 grant.go @ssoroka

--- a/internal/openapigen/main.go
+++ b/internal/openapigen/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server"
 )
 
@@ -25,5 +26,5 @@ func run(args []string) error {
 	s := server.Server{}
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
-	return server.WriteOpenAPIDocToFile(routes.OpenAPIDocument, filename)
+	return server.WriteOpenAPIDocToFile(routes.OpenAPIDocument, internal.FullVersion(), filename)
 }

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -16,7 +16,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/internal"
 )
 
 var (
@@ -212,11 +211,11 @@ func buildProperty(f reflect.StructField, t, parent reflect.Type, parentSchema *
 	}
 }
 
-func writeOpenAPISpec(spec openapi3.T, out io.Writer) error {
+func writeOpenAPISpec(spec openapi3.T, version string, out io.Writer) error {
 	spec.OpenAPI = "3.0.0"
 	spec.Info = &openapi3.Info{
 		Title:       "Infra API",
-		Version:     internal.FullVersion(),
+		Version:     version,
 		Description: "Infra API",
 		License:     &openapi3.License{Name: "Elastic License v2.0", URL: "https://www.elastic.co/licensing/elastic-license"},
 	}
@@ -232,13 +231,13 @@ func writeOpenAPISpec(spec openapi3.T, out io.Writer) error {
 	return nil
 }
 
-func WriteOpenAPIDocToFile(openAPIDoc openapi3.T, filename string) error {
+func WriteOpenAPIDocToFile(openAPIDoc openapi3.T, version string, filename string) error {
 	fh, err := os.Create(filename)
 	if err != nil {
 		return err
 	}
 	defer fh.Close()
-	if err := writeOpenAPISpec(openAPIDoc, fh); err != nil {
+	if err := writeOpenAPISpec(openAPIDoc, version, fh); err != nil {
 		return err
 	}
 	return nil

--- a/internal/server/openapi_test.go
+++ b/internal/server/openapi_test.go
@@ -1,19 +1,29 @@
 package server
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
 )
 
-// TestWriteOpenAPISpec is not really a test. It's a way of ensuring the openapi
-// spec is updated when routes change.
-func TestWriteOpenAPISpec(t *testing.T) {
+// TestWriteOpenAPIDocToFile runs the OpenAPI document generation to preview the changes.
+// This test is used to catch any potential problems with the step in the PR
+// that introduces them. Without this test we wouldn't notice until release time.
+// To update the expected value, run:
+//     go test ./internal/server -update
+func TestWriteOpenAPIDocToFile(t *testing.T) {
 	s := Server{}
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
-	filename := "../../docs/api/openapi3.json"
-	err := WriteOpenAPIDocToFile(routes.OpenAPIDocument, filename)
+	filename := filepath.Join(t.TempDir(), "openapi3.json")
+	err := WriteOpenAPIDocToFile(routes.OpenAPIDocument, "0.0.0", filename)
 	assert.NilError(t, err)
+
+	actual, err := ioutil.ReadFile(filename)
+	assert.NilError(t, err)
+	golden.Assert(t, string(actual), "openapi3.json")
 }

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -785,7 +785,7 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     },
     "title": "Infra API",
-    "version": "0.13.6+dev"
+    "version": "0.0.0"
   },
   "paths": {
     "/api/access-keys": {


### PR DESCRIPTION
## Summary 

Previously we were writing the openapi3 doc to the path that would be used forpublic docs.
This caused us problems because after a release we had to update the doc to the new version.

This commit moves the openspi3.json doc testdata. This allows us to preview any API changes, and catch any problems with doc generation in any PR that makes changes, without the problem of having to update the version.

As part of releasing the website we will generate this doc again, so the version will be correct on the website.
