### PR TITLE
cleanup checking IDs while updating group membership

### DIFF
--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -89,15 +89,6 @@ func DeleteGroup(c *gin.Context, id uid.ID) error {
 }
 
 func checkIdentitiesInList(db *gorm.DB, ids []uid.ID) ([]uid.ID, error) {
-	contains := func(ids []models.Identity, id uid.ID) bool {
-		for _, i := range ids {
-			if i.ID == id {
-				return true
-			}
-		}
-		return false
-	}
-
 	identities, err := data.ListIdentities(db, data.ByIDs(ids))
 	if err != nil {
 		return nil, err
@@ -108,9 +99,15 @@ func checkIdentitiesInList(db *gorm.DB, ids []uid.ID) ([]uid.ID, error) {
 		return ids, nil
 	}
 
+	uidMap := make(map[uid.ID]bool)
+	for _, ident := range identities {
+		uidMap[ident.ID] = true
+	}
+
 	var uidStrList []string
 	for _, id := range ids {
-		if !contains(identities, id) {
+		_, ok := uidMap[id]
+		if !ok {
 			uidStrList = append(uidStrList, id.String())
 		}
 	}

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -2,9 +2,13 @@ package access
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -84,6 +88,36 @@ func DeleteGroup(c *gin.Context, id uid.ID) error {
 	return data.DeleteGroups(db, selectors...)
 }
 
+func checkIdentitiesInList(db *gorm.DB, ids []uid.ID) ([]uid.ID, error) {
+	contains := func(ids []models.Identity, id uid.ID) bool {
+		for _, i := range ids {
+			if i.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	identities, err := data.ListIdentities(db, data.ByIDs(ids))
+	if err != nil {
+		return nil, err
+	}
+
+	// return the original list if we found all of the IDs
+	if len(identities) == len(ids) {
+		return ids, nil
+	}
+
+	var uidStrList []string
+	for _, id := range ids {
+		if !contains(identities, id) {
+			uidStrList = append(uidStrList, id.String())
+		}
+	}
+
+	return nil, fmt.Errorf("%w: %s", internal.ErrBadRequest, "Couldn't find UIDs: "+strings.Join(uidStrList, ","))
+}
+
 func UpdateUsersInGroup(c *gin.Context, groupID uid.ID, uidsToAdd []uid.ID, uidsToRemove []uid.ID) error {
 	db, err := RequireInfraRole(c, models.InfraAdminRole)
 	if err != nil {
@@ -95,23 +129,19 @@ func UpdateUsersInGroup(c *gin.Context, groupID uid.ID, uidsToAdd []uid.ID, uids
 		return err
 	}
 
-	for _, userID := range uidsToAdd {
-		_, err := data.GetIdentity(db, data.ByID(userID))
-		if err != nil {
-			return err
-		}
-	}
-
-	for _, userID := range uidsToRemove {
-		_, err := data.GetIdentity(db, data.ByID(userID))
-		if err != nil {
-			return err
-		}
-	}
-
-	err = data.AddUsersToGroup(db, groupID, uidsToAdd)
+	addIDList, err := checkIdentitiesInList(db, uidsToAdd)
 	if err != nil {
 		return err
 	}
-	return data.RemoveUsersFromGroup(db, groupID, uidsToRemove)
+
+	rmIDList, err := checkIdentitiesInList(db, uidsToRemove)
+	if err != nil {
+		return err
+	}
+
+	err = data.AddUsersToGroup(db, groupID, addIDList)
+	if err != nil {
+		return err
+	}
+	return data.RemoveUsersFromGroup(db, groupID, rmIDList)
 }

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -62,7 +62,9 @@ func DeleteGroups(db *gorm.DB, selectors ...SelectorFunc) error {
 
 func AddUsersToGroup(db *gorm.DB, groupID uid.ID, idsToAdd []uid.ID) error {
 	for _, id := range idsToAdd {
-		err := db.Exec("INSERT INTO identities_groups (group_id, identity_id) select ?, ? WHERE NOT EXISTS (SELECT 1 FROM identities_groups WHERE group_id = ? AND identity_id = ?)", groupID, id, groupID, id).Error
+		// This is effectively an "INSERT OR IGNORE" or "INSERT ... ON CONFLICT ... DO NOTHING" statement which
+		// works across both sqlite and postgres
+		err := db.Exec("INSERT INTO identities_groups (group_id, identity_id) SELECT ?, ? WHERE NOT EXISTS (SELECT 1 FROM identities_groups WHERE group_id = ? AND identity_id = ?)", groupID, id, groupID, id).Error
 		if err != nil {
 			return err
 		}

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -481,6 +481,30 @@ func TestAPI_UpdateUsersInGroup(t *testing.T) {
 				UserIDsToRemove: []uid.ID{first.ID, second.ID},
 			},
 		},
+		"add unknown user": {
+			urlPath: fmt.Sprintf("/api/groups/%s/users", humans.ID.String()),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusBadRequest, resp.Body.String())
+			},
+			body: api.UpdateUsersInGroupRequest{
+				UserIDsToAdd: []uid.ID{first.ID, 1337, second.ID},
+			},
+		},
+		"remove unknown user": {
+			urlPath: fmt.Sprintf("/api/groups/%s/users", humans.ID.String()),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusBadRequest, resp.Body.String())
+			},
+			body: api.UpdateUsersInGroupRequest{
+				UserIDsToRemove: []uid.ID{1337},
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

The way we were looking up user IDs when adding or removing them from groups was fairly costly. This change uses the `ListIdentities()` call with the `ByIDs()` selector to verify that an ID exists. It also adds a couple of unit tests, and cleans up the `INSERT OR IGNORE` statement.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

