### PR TITLE
feat: add connector build_info

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -21,7 +21,6 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/goware/urlx"
 	"github.com/infrahq/secrets"
-	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -509,7 +508,7 @@ func Run(ctx context.Context, options Options) error {
 	proxy := httputil.NewSingleHostReverseProxy(proxyHost)
 	proxy.Transport = proxyTransport
 
-	promRegistry := prometheus.NewRegistry()
+	promRegistry := setupMetrics()
 	metricsServer := &http.Server{
 		Addr:     ":9090",
 		Handler:  metrics.NewHandler(promRegistry),

--- a/internal/connector/metrics.go
+++ b/internal/connector/metrics.go
@@ -1,0 +1,26 @@
+package connector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/infrahq/infra/internal"
+)
+
+func setupMetrics() *prometheus.Registry {
+	registry := prometheus.NewRegistry()
+	factory := promauto.With(registry)
+
+	factory.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "build",
+		Name:      "info",
+		Help:      "Build information about Infra Connector.",
+	}, []string{"branch", "version", "commit", "date"}).With(prometheus.Labels{
+		"branch":  internal.Branch,
+		"version": internal.FullVersion(),
+		"commit":  internal.Commit,
+		"date":    internal.Date,
+	}).Set(1)
+
+	return registry
+}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -11,7 +11,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func SetupMetrics(db *gorm.DB) *prometheus.Registry {
+func setupMetrics(db *gorm.DB) *prometheus.Registry {
 	reg := prometheus.NewRegistry()
 	factory := promauto.With(reg)
 
@@ -21,7 +21,7 @@ func SetupMetrics(db *gorm.DB) *prometheus.Registry {
 		Help:      "Build information about Infra Server.",
 	}, []string{"branch", "version", "commit", "date"}).With(prometheus.Labels{
 		"branch":  internal.Branch,
-		"version": internal.Version,
+		"version": internal.FullVersion(),
 		"commit":  internal.Commit,
 		"date":    internal.Date,
 	}).Set(1)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -225,7 +225,7 @@ func registerUIRoutes(router *gin.Engine, opts UIOptions) {
 
 func (s *Server) listen() error {
 	ginutil.SetMode()
-	promRegistry := SetupMetrics(s.db)
+	promRegistry := setupMetrics(s.db)
 	router := s.GenerateRoutes(promRegistry)
 
 	metricsServer := &http.Server{


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Add prometheus metric for connector version and other build information

Also use `internal.FullVersion` instead of just `internal.version`

Raw metric looks something like this:

```
# HELP build_info Build information about Infra Connector.
# TYPE build_info gauge
build_info{branch="main",commit="",date="",version="0.13.5"} 1
```

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2429 