### PR TITLE
improve: include the server TLS CA in the chain

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -592,13 +592,17 @@ func promptVerifyTLSCert(cli *CLI, cert *x509.Certificate) error {
 	formatTime := func(t time.Time) string {
 		return fmt.Sprintf("%v (%v)", HumanTime(t, "none"), t.Format(time.RFC1123))
 	}
+	title := "Certificate"
+	if cert.IsCA {
+		title = "Certificate Authority"
+	}
 
 	// TODO: improve this message
 	// TODO: use color/bold to highlight important parts
 	fmt.Fprintf(cli.Stderr, `
 The certificate presented by the server is not trusted by your operating system.
 
-Certificate
+%[6]v
 
 Subject: %[1]s
 Issuer: %[2]s
@@ -608,7 +612,7 @@ Validity
   Not After:  %[4]v
 
 SHA256 Fingerprint
-  %[5]s
+  %[5]v
 
 Compare the SHA256 fingerprint to the one provided by your administrator to
 manually verify the certificate can be trusted.
@@ -619,6 +623,7 @@ manually verify the certificate can be trusted.
 		formatTime(cert.NotBefore),
 		formatTime(cert.NotAfter),
 		certs.Fingerprint(cert.Raw),
+		title,
 	)
 	confirmPrompt := &survey.Select{
 		Message: "Options:",

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -323,8 +323,8 @@ func TestServerCmd_WithSecretsConfig(t *testing.T) {
         metrics: "127.0.0.1:0"
 
       tls:
-        ca: some-ca
-        caPrivateKey: some-key
+        ca: testdata/pki/localhost.crt
+        caPrivateKey: file:testdata/pki/localhost.key
 
       secrets:
         - kind: env


### PR DESCRIPTION
## Summary

Branched from #2401

This ended up being easier than I thought. By adding the CA cert to the chain returned by the server the client side error already has the right cert.  Also log the CA fingerprint in the server on startup so that it is visible in logs.


Resolves #2362
