### PR TITLE
fix: unrecognized lint nolint directive

### DIFF
--- a/internal/server/providers/oidc_test.go
+++ b/internal/server/providers/oidc_test.go
@@ -190,7 +190,7 @@ func setupOIDCTest(t *testing.T, userInfoResp string) (testOIDCServer, context.C
 	}
 
 	// setup a an HTTP client that skips TLS verify for test purposes
-	//nolint:forcedtypeassert
+	//nolint:forcetypeassert
 	testTransport, ok := http.DefaultTransport.(*http.Transport)
 	assert.Assert(t, ok)
 	testTransport = testTransport.Clone()


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

```
WARN [runner/nolint] Found unknown linters in //nolint directives: forcedtypeassert
```

Should be `forcetypeassert`