### PR TITLE
maintain: organize the connector code

### DIFF
--- a/internal/connector/authn.go
+++ b/internal/connector/authn.go
@@ -1,0 +1,133 @@
+package connector
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+
+	"github.com/infrahq/infra/internal/claims"
+)
+
+type authenticator struct {
+	mu          sync.Mutex
+	key         *jose.JSONWebKey
+	lastChecked time.Time
+
+	client  httpClient
+	baseURL string
+}
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func newAuthenticator(url string, options Options) *authenticator {
+	// nolint:forcetypeassert // http.DefaultTransport is always http.Transport
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		//nolint:gosec // We may purposely set InsecureSkipVerify via a flag
+		InsecureSkipVerify: options.SkipTLSVerify,
+	}
+
+	return &authenticator{
+		client:  &http.Client{Transport: transport},
+		baseURL: url,
+	}
+}
+
+var JWKCacheRefresh = 5 * time.Minute
+
+func (j *authenticator) Authenticate(req *http.Request) (claims.Custom, error) {
+	c := claims.Custom{}
+	authHeader := req.Header.Get("Authorization")
+
+	raw := strings.TrimPrefix(authHeader, "Bearer ")
+	if raw == "" {
+		return c, fmt.Errorf("no bearer token found")
+	}
+
+	tok, err := jwt.ParseSigned(raw)
+	if err != nil {
+		return c, fmt.Errorf("invalid JWT signature: %w", err)
+	}
+
+	key, err := j.getJWK()
+	if err != nil {
+		return c, fmt.Errorf("get JWK from server: %w", err)
+	}
+
+	var allClaims struct {
+		jwt.Claims
+		claims.Custom
+	}
+	if err := tok.Claims(key, &allClaims); err != nil {
+		return c, fmt.Errorf("invalid token claims: %w", err)
+	}
+
+	err = allClaims.Claims.Validate(jwt.Expected{Time: time.Now().UTC()})
+	switch {
+	case errors.Is(err, jwt.ErrExpired):
+		return c, err
+	case err != nil:
+		return c, fmt.Errorf("invalid JWT %w", err)
+	}
+
+	if allClaims.Custom.Name == "" {
+		return c, fmt.Errorf("no username in JWT claims")
+	}
+
+	return allClaims.Custom, nil
+}
+
+func (j *authenticator) getJWK() (*jose.JSONWebKey, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if !j.lastChecked.IsZero() && time.Now().Before(j.lastChecked.Add(JWKCacheRefresh)) {
+		return j.key, nil
+	}
+
+	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, fmt.Sprintf("%s/.well-known/jwks.json", j.baseURL), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := j.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Keys []jose.JSONWebKey `json:"keys"`
+	}
+
+	err = json.Unmarshal(data, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(response.Keys) < 1 {
+		return nil, errors.New("no jwks provided by infra")
+	}
+
+	j.lastChecked = time.Now().UTC()
+	j.key = &response.Keys[0]
+
+	return &response.Keys[0], nil
+}

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -5,30 +5,23 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/goware/urlx"
 	"github.com/infrahq/secrets"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
-	"github.com/infrahq/infra/internal/certs"
-	"github.com/infrahq/infra/internal/claims"
 	"github.com/infrahq/infra/internal/ginutil"
 	"github.com/infrahq/infra/internal/kubernetes"
 	"github.com/infrahq/infra/internal/logging"
@@ -43,286 +36,6 @@ type Options struct {
 	CACert        string
 	CAKey         string
 	SkipTLSVerify bool
-}
-
-type authenticator struct {
-	mu          sync.Mutex
-	key         *jose.JSONWebKey
-	lastChecked time.Time
-
-	client  httpClient
-	baseURL string
-}
-
-type httpClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
-func (j *authenticator) getJWK() (*jose.JSONWebKey, error) {
-	j.mu.Lock()
-	defer j.mu.Unlock()
-
-	if !j.lastChecked.IsZero() && time.Now().Before(j.lastChecked.Add(JWKCacheRefresh)) {
-		return j.key, nil
-	}
-
-	req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, fmt.Sprintf("%s/.well-known/jwks.json", j.baseURL), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := j.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	data, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var response struct {
-		Keys []jose.JSONWebKey `json:"keys"`
-	}
-
-	err = json.Unmarshal(data, &response)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(response.Keys) < 1 {
-		return nil, errors.New("no jwks provided by infra")
-	}
-
-	j.lastChecked = time.Now().UTC()
-	j.key = &response.Keys[0]
-
-	return &response.Keys[0], nil
-}
-
-func newAuthenticator(url string, options Options) *authenticator {
-	// nolint:forcetypeassert // http.DefaultTransport is always http.Transport
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{
-		//nolint:gosec // We may purposely set InsecureSkipVerify via a flag
-		InsecureSkipVerify: options.SkipTLSVerify,
-	}
-
-	return &authenticator{
-		client:  &http.Client{Transport: transport},
-		baseURL: url,
-	}
-}
-
-var JWKCacheRefresh = 5 * time.Minute
-
-func (j *authenticator) Authenticate(req *http.Request) (claims.Custom, error) {
-	c := claims.Custom{}
-	authHeader := req.Header.Get("Authorization")
-
-	raw := strings.TrimPrefix(authHeader, "Bearer ")
-	if raw == "" {
-		return c, fmt.Errorf("no bearer token found")
-	}
-
-	tok, err := jwt.ParseSigned(raw)
-	if err != nil {
-		return c, fmt.Errorf("invalid JWT signature: %w", err)
-	}
-
-	key, err := j.getJWK()
-	if err != nil {
-		return c, fmt.Errorf("get JWK from server: %w", err)
-	}
-
-	var allClaims struct {
-		jwt.Claims
-		claims.Custom
-	}
-	if err := tok.Claims(key, &allClaims); err != nil {
-		return c, fmt.Errorf("invalid token claims: %w", err)
-	}
-
-	err = allClaims.Claims.Validate(jwt.Expected{Time: time.Now().UTC()})
-	switch {
-	case errors.Is(err, jwt.ErrExpired):
-		return c, err
-	case err != nil:
-		return c, fmt.Errorf("invalid JWT %w", err)
-	}
-
-	if allClaims.Custom.Name == "" {
-		return c, fmt.Errorf("no username in JWT claims")
-	}
-
-	return allClaims.Custom, nil
-}
-
-func proxyMiddleware(
-	proxy *httputil.ReverseProxy,
-	authn *authenticator,
-	bearerToken string,
-) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		claim, err := authn.Authenticate(c.Request)
-		if err != nil {
-			logging.L.Info().Err(err).Msgf("failed to authenticate request")
-			c.AbortWithStatus(http.StatusUnauthorized)
-			return
-		}
-
-		c.Request.Header.Set("Impersonate-User", claim.Name)
-		for _, g := range claim.Groups {
-			c.Request.Header.Add("Impersonate-Group", g)
-		}
-
-		c.Request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
-		proxy.ServeHTTP(c.Writer, c.Request)
-	}
-}
-
-// UpdateRoles converts infra grants to role-bindings in the current cluster
-func updateRoles(c *api.Client, k *kubernetes.Kubernetes, grants []api.Grant) error {
-	logging.Debugf("syncing local grants from infra configuration")
-
-	crSubjects := make(map[string][]rbacv1.Subject)                           // cluster-role: subject
-	crnSubjects := make(map[kubernetes.ClusterRoleNamespace][]rbacv1.Subject) // cluster-role+namespace: subject
-
-	for _, g := range grants {
-		var name, kind string
-
-		if g.Privilege == "connect" {
-			continue
-		}
-
-		switch {
-		case g.Group != 0:
-			group, err := c.GetGroup(g.Group)
-			if err != nil {
-				return err
-			}
-
-			name = group.Name
-			kind = rbacv1.GroupKind
-		case g.User != 0:
-			user, err := c.GetUser(g.User)
-			if err != nil {
-				return err
-			}
-
-			name = user.Name
-			kind = rbacv1.UserKind
-		}
-
-		subj := rbacv1.Subject{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     kind,
-			Name:     name,
-		}
-
-		parts := strings.Split(g.Resource, ".")
-
-		var crn kubernetes.ClusterRoleNamespace
-
-		switch len(parts) {
-		// <cluster>
-		case 1:
-			crn.ClusterRole = g.Privilege
-			crSubjects[g.Privilege] = append(crSubjects[g.Privilege], subj)
-
-		// <cluster>.<namespace>
-		case 2:
-			crn.ClusterRole = g.Privilege
-			crn.Namespace = parts[1]
-			crnSubjects[crn] = append(crnSubjects[crn], subj)
-
-		default:
-			logging.Warnf("invalid grant resource: %s", g.Resource)
-			continue
-		}
-	}
-
-	if err := k.UpdateClusterRoleBindings(crSubjects); err != nil {
-		return fmt.Errorf("update cluster role bindings: %w", err)
-	}
-
-	if err := k.UpdateRoleBindings(crnSubjects); err != nil {
-		return fmt.Errorf("update cluster role bindings: %w", err)
-	}
-
-	return nil
-}
-
-type CertCache struct {
-	mu     sync.Mutex
-	caCert []byte
-	caKey  []byte
-	hosts  []string
-	cert   *tls.Certificate
-}
-
-func (c *CertCache) AddHost(host string) (*tls.Certificate, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	for _, h := range c.hosts {
-		if h == host {
-			return c.cert, nil
-		}
-	}
-
-	c.hosts = append(c.hosts, host)
-
-	logging.Debugf("generating certificate for: %v", c.hosts)
-
-	ca, err := tls.X509KeyPair(c.caCert, c.caKey)
-	if err != nil {
-		return nil, err
-	}
-
-	caCert, err := x509.ParseCertificate(ca.Certificate[0])
-	if err != nil {
-		return nil, err
-	}
-
-	certPEM, keyPEM, err := certs.GenerateCertificate(c.hosts, caCert, ca.PrivateKey)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		return nil, err
-	}
-
-	c.cert = &tlsCert
-
-	return c.cert, nil
-}
-
-// readCertificate is a threadsafe way to read the certificate
-func (c *CertCache) readCertificate() *tls.Certificate {
-	c.mu.Lock()
-	cert := c.cert
-	c.mu.Unlock()
-	return cert
-}
-
-// Certificate returns a TLS certificate for the connector, if one does not exist it is generated for the empty host
-func (c *CertCache) Certificate() (*tls.Certificate, error) {
-	cert := c.readCertificate()
-	if cert == nil {
-		// the host is not available externally, or this would have been set
-		// set to an empty host for the liveness check to resolve from the same host
-		return c.AddHost("")
-	}
-
-	return cert, nil
-}
-
-func NewCertCache(caCertPEM []byte, caKeyPem []byte) *CertCache {
-	return &CertCache{caCert: caCertPEM, caKey: caKeyPem}
 }
 
 func Run(ctx context.Context, options Options) error {
@@ -585,6 +298,78 @@ func syncWithServer(k8s *kubernetes.Kubernetes, client *api.Client, destination 
 			return
 		}
 	}
+}
+
+// UpdateRoles converts infra grants to role-bindings in the current cluster
+func updateRoles(c *api.Client, k *kubernetes.Kubernetes, grants []api.Grant) error {
+	logging.Debugf("syncing local grants from infra configuration")
+
+	crSubjects := make(map[string][]rbacv1.Subject)                           // cluster-role: subject
+	crnSubjects := make(map[kubernetes.ClusterRoleNamespace][]rbacv1.Subject) // cluster-role+namespace: subject
+
+	for _, g := range grants {
+		var name, kind string
+
+		if g.Privilege == "connect" {
+			continue
+		}
+
+		switch {
+		case g.Group != 0:
+			group, err := c.GetGroup(g.Group)
+			if err != nil {
+				return err
+			}
+
+			name = group.Name
+			kind = rbacv1.GroupKind
+		case g.User != 0:
+			user, err := c.GetUser(g.User)
+			if err != nil {
+				return err
+			}
+
+			name = user.Name
+			kind = rbacv1.UserKind
+		}
+
+		subj := rbacv1.Subject{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     kind,
+			Name:     name,
+		}
+
+		parts := strings.Split(g.Resource, ".")
+
+		var crn kubernetes.ClusterRoleNamespace
+
+		switch len(parts) {
+		// <cluster>
+		case 1:
+			crn.ClusterRole = g.Privilege
+			crSubjects[g.Privilege] = append(crSubjects[g.Privilege], subj)
+
+		// <cluster>.<namespace>
+		case 2:
+			crn.ClusterRole = g.Privilege
+			crn.Namespace = parts[1]
+			crnSubjects[crn] = append(crnSubjects[crn], subj)
+
+		default:
+			logging.Warnf("invalid grant resource: %s", g.Resource)
+			continue
+		}
+	}
+
+	if err := k.UpdateClusterRoleBindings(crSubjects); err != nil {
+		return fmt.Errorf("update cluster role bindings: %w", err)
+	}
+
+	if err := k.UpdateRoleBindings(crnSubjects); err != nil {
+		return fmt.Errorf("update cluster role bindings: %w", err)
+	}
+
+	return nil
 }
 
 // createOrUpdateDestination creates a destination in the infra server if it does not exist and updates it if it does

--- a/internal/connector/proxy.go
+++ b/internal/connector/proxy.go
@@ -1,0 +1,109 @@
+package connector
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/infrahq/infra/internal/certs"
+	"github.com/infrahq/infra/internal/logging"
+)
+
+func proxyMiddleware(
+	proxy *httputil.ReverseProxy,
+	authn *authenticator,
+	bearerToken string,
+) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		claim, err := authn.Authenticate(c.Request)
+		if err != nil {
+			logging.L.Info().Err(err).Msgf("failed to authenticate request")
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+
+		c.Request.Header.Set("Impersonate-User", claim.Name)
+		for _, g := range claim.Groups {
+			c.Request.Header.Add("Impersonate-Group", g)
+		}
+
+		c.Request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
+		proxy.ServeHTTP(c.Writer, c.Request)
+	}
+}
+
+type CertCache struct {
+	mu     sync.Mutex
+	caCert []byte
+	caKey  []byte
+	hosts  []string
+	cert   *tls.Certificate
+}
+
+func (c *CertCache) AddHost(host string) (*tls.Certificate, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, h := range c.hosts {
+		if h == host {
+			return c.cert, nil
+		}
+	}
+
+	c.hosts = append(c.hosts, host)
+
+	logging.Debugf("generating certificate for: %v", c.hosts)
+
+	ca, err := tls.X509KeyPair(c.caCert, c.caKey)
+	if err != nil {
+		return nil, err
+	}
+
+	caCert, err := x509.ParseCertificate(ca.Certificate[0])
+	if err != nil {
+		return nil, err
+	}
+
+	certPEM, keyPEM, err := certs.GenerateCertificate(c.hosts, caCert, ca.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cert = &tlsCert
+
+	return c.cert, nil
+}
+
+// readCertificate is a threadsafe way to read the certificate
+func (c *CertCache) readCertificate() *tls.Certificate {
+	c.mu.Lock()
+	cert := c.cert
+	c.mu.Unlock()
+	return cert
+}
+
+// Certificate returns a TLS certificate for the connector, if one does not exist it is generated for the empty host
+func (c *CertCache) Certificate() (*tls.Certificate, error) {
+	cert := c.readCertificate()
+	if cert == nil {
+		// the host is not available externally, or this would have been set
+		// set to an empty host for the liveness check to resolve from the same host
+		return c.AddHost("")
+	}
+
+	return cert, nil
+}
+
+func NewCertCache(caCertPEM []byte, caKeyPem []byte) *CertCache {
+	return &CertCache{caCert: caCertPEM, caKey: caKeyPem}
+}


### PR DESCRIPTION
This PR moves some of the connector code around. Doing it separate from any other refactors or code changes so that it's easier to review. 

* Move everything related to authenticating requests into authn.go
* Move the rest of the proxy code into proxy.go
* Move updateRoles to the bottom of connector.go so that the Run function is at the top

There are a few things that can be extracted out of `Run` and moved into the proxy file, but I want to do that separately so it's easier to see the changes.

In the future maybe we'll move the reconcile logic into a separate file as well, and `connector.go` can be just the generic parts.