### PR TITLE
fix: use SNI in the CLI

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -113,6 +113,7 @@ func httpTransportForHostConfig(config *ClientHostConfig) *http.Transport {
 			//nolint:gosec // We may purposely set insecureskipverify via a flag
 			InsecureSkipVerify: config.SkipTLSVerify,
 			RootCAs:            pool,
+			ServerName:         config.Host,
 		},
 	}
 }

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -455,6 +455,7 @@ func newLoginClient(cli *CLI, options loginCmdOptions) (loginClient, error) {
 				// set min version to the same as default to make gosec linter happy
 				MinVersion: tls.VersionTLS12,
 				RootCAs:    pool,
+				ServerName: options.Server,
 			},
 		}
 		c.APIClient = apiClient(options.Server, "", transport)
@@ -517,7 +518,11 @@ func attemptTLSRequest(options loginCmdOptions) error {
 	httpClient = http.Client{
 		Timeout: 60 * time.Second,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+			TLSClientConfig: &tls.Config{
+				RootCAs:    pool,
+				MinVersion: tls.VersionTLS12,
+				ServerName: options.Server,
+			},
 		},
 	}
 	res, err = httpClient.Do(req)


### PR DESCRIPTION
We attempt to generate a certificate for the request based on the SNI
name or the local address. The local address lookup doesn't work when
the server is behind a load balancer.

This commit has the CLI use an SNI name so that the server can generate
a certificate with the correct IP or hostname.

TODO:
* [ ] fix test failures caused by `httptest.Server` not understanding how to serve requests for the SNI IP
* [ ] fix the login test failures, that seems to be a different problem
* [ ] should we strip the port from the name before setting it as `ServerName` ?