### PR TITLE
helm: refactor to not create a new CA on every connector deploy

### DIFF
--- a/helm/charts/infra/templates/connector/secret.yaml
+++ b/helm/charts/infra/templates/connector/secret.yaml
@@ -1,3 +1,4 @@
+
 {{- if include "connector.enabled" . | eq "true" }}
 {{- $accessKey := default "" .Values.connector.config.accessKey -}}
 {{- if or (not $accessKey) (and (not (hasPrefix "file:" $accessKey)) (not (hasPrefix "env:" $accessKey))) }}
@@ -9,11 +10,10 @@ metadata:
 {{- include "connector.labels" . | nindent 4 }}
 data:
   access-key: {{ include "connector.accessKey" . | b64enc | quote }}
-{{- end }}
+{{- end }}{{/* if not accessKey */}}
 ---
 {{- if and (not .Values.connector.config.caCert) (not .Values.connector.config.caKey) }}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-ca" (include "connector.fullname" .)) -}}
-{{- $ca := genCA "infra-connector" 3650 -}}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,17 +21,21 @@ metadata:
   labels:
 {{- include "connector.labels" . | nindent 4 }}
 data:
+
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-ca" (include "connector.fullname" .)) }}
+{{- if $secret.data }}
   ca.crt: |
-{{- if $secret.data }}
 {{- get $secret.data "ca.crt" | nindent 4 }}
-{{- else }}
-{{- $ca.Cert | b64enc | nindent 4 }}
-{{- end }}
   ca.key: |
-{{- if $secret.data }}
 {{- get $secret.data "ca.key" | nindent 4 }}
+
 {{- else }}
+{{- $ca := genCA "infra-connector" 3650 }}
+  ca.crt: |
+{{- $ca.Cert | b64enc | nindent 4 }}
+  ca.key: |
 {{- $ca.Key | b64enc | nindent 4 }}
-{{- end }}
-{{- end }}
-{{- end }}
+
+{{- end }}{{/* if secret.data */}}
+{{- end }}{{/* if not connector.config */}}
+{{- end }}{{/* if server.enabled */}}


### PR DESCRIPTION
This PR changes the infra-connector-ca secret helm template to only `genCA` if there is not an existing secret. Also adds a few comments to the `{{ end }}` tags to make it easier to follow.

This `secret.yaml` is modeled after the one for infra server, added in #2401.