### PR TITLE
fix: password confirmation field and minor improvements

### DIFF
--- a/ui/pages/login/finish.js
+++ b/ui/pages/login/finish.js
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { useSWRConfig } from 'swr'
+import ErrorMessage from '../../components/error-message'
 
 import Login from '../../components/layouts/login'
 
@@ -8,7 +9,10 @@ export default function Finish() {
   const router = useRouter()
 
   const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState('')
+  const [errors, setErrors] = useState('')
+
   const { mutate } = useSWRConfig()
 
   const { query } = router
@@ -20,6 +24,13 @@ export default function Finish() {
 
   async function finish(e) {
     e.preventDefault()
+
+    if (password !== confirmPassword) {
+      setErrors({
+        confirmPassword: 'the confirm password confirmation does not match.',
+      })
+      return false
+    }
 
     try {
       const res = await fetch(`/api/users/${user}`, {
@@ -33,11 +44,19 @@ export default function Finish() {
 
       await mutate('/api/users/self')
 
-      router.replace('/')
+      await router.replace('/')
     } catch (e) {
-      setError(e.message || 'Invalid password')
+      if (e.fieldErrors) {
+        const errors = {}
+        for (const error of e.fieldErrors) {
+          errors[error.fieldName.toLowerCase()] =
+            error.errors[0] || 'invalid value'
+        }
+        setErrors(errors)
+      } else {
+        setError(e.message || 'Invalid password')
+      }
     }
-
     return false
   }
 
@@ -54,7 +73,7 @@ export default function Finish() {
         onSubmit={finish}
         className='relative flex w-full max-w-sm flex-col'
       >
-        <div className='my-4 w-full'>
+        <div className='my-2 w-full'>
           <label
             htmlFor='password'
             className='text-3xs uppercase text-gray-500'
@@ -68,24 +87,47 @@ export default function Finish() {
             placeholder='enter your new password'
             onChange={e => {
               setPassword(e.target.value)
+              setErrors({})
               setError('')
             }}
-            className={`w-full border-b border-gray-800 bg-transparent px-px py-3 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
-              error ? 'border-pink-500/60' : ''
+            className={`mb-1 w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
+              errors.password ? 'border-pink-500/60' : ''
             }`}
           />
+          {errors.password && <ErrorMessage message={errors.password} />}
+        </div>
+        <div className='my-2 w-full'>
+          <label
+            htmlFor='password'
+            className='text-3xs uppercase text-gray-500'
+          >
+            Confirm New Password
+          </label>
+          <input
+            required
+            name='confirmPassword'
+            type='password'
+            placeholder='confirm your new password'
+            onChange={e => {
+              setConfirmPassword(e.target.value)
+              setErrors({})
+              setError('')
+            }}
+            className={`mb-1 w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
+              errors.confirmPassword ? 'border-pink-500/60' : ''
+            }`}
+          />
+          {errors.confirmPassword && (
+            <ErrorMessage message={errors.confirmPassword} />
+          )}
         </div>
         <button
-          disabled={!password}
+          disabled={!password || !confirmPassword}
           className='my-2 rounded-lg border border-violet-300 px-4 py-3 text-2xs text-violet-100 hover:border-violet-100 disabled:pointer-events-none disabled:opacity-30'
         >
           Finish
         </button>
-        {error && (
-          <p className='absolute -bottom-3.5 mx-auto w-full text-center text-2xs text-pink-400'>
-            {error}
-          </p>
-        )}
+        {error && <ErrorMessage message={error} />}
       </form>
     </>
   )

--- a/ui/pages/login/finish.js
+++ b/ui/pages/login/finish.js
@@ -101,13 +101,13 @@ export default function Finish() {
             htmlFor='password'
             className='text-3xs uppercase text-gray-500'
           >
-            Confirm New Password
+            Confirm Password
           </label>
           <input
             required
             name='confirmPassword'
             type='password'
-            placeholder='confirm your new password'
+            placeholder='confirm your password'
             onChange={e => {
               setConfirmPassword(e.target.value)
               setErrors({})

--- a/ui/pages/login/finish.js
+++ b/ui/pages/login/finish.js
@@ -1,8 +1,8 @@
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { useSWRConfig } from 'swr'
-import ErrorMessage from '../../components/error-message'
 
+import ErrorMessage from '../../components/error-message'
 import Login from '../../components/layouts/login'
 
 export default function Finish() {

--- a/ui/pages/login/finish.js
+++ b/ui/pages/login/finish.js
@@ -27,7 +27,7 @@ export default function Finish() {
 
     if (password !== confirmPassword) {
       setErrors({
-        confirmPassword: 'the confirm password confirmation does not match.',
+        confirmPassword: 'passwords do not match',
       })
       return false
     }

--- a/ui/pages/settings/password-reset.js
+++ b/ui/pages/settings/password-reset.js
@@ -15,16 +15,17 @@ export default function PasswordReset() {
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState('')
+  const [errors, setErrors] = useState({})
 
   async function onSubmit(e) {
     e.preventDefault()
 
     if (password !== confirmPassword) {
-      setError('password does not match')
+      setErrors({
+        confirmPassword: 'the confirm password confirmation does not match.',
+      })
       return false
     }
-
-    setError('')
 
     try {
       const rest = await fetch(`/api/users/${auth?.id}`, {
@@ -41,9 +42,18 @@ export default function PasswordReset() {
         throw data
       }
 
-      router.replace('/settings?resetPassword=success')
+      await router.replace('/settings?resetPassword=success')
     } catch (e) {
-      setError(e.message || 'something went wrong, please try again')
+      if (e.fieldErrors) {
+        const errors = {}
+        for (const error of e.fieldErrors) {
+          errors[error.fieldName.toLowerCase()] =
+            error.errors[0] || 'invalid value'
+        }
+        setErrors(errors)
+      } else {
+        setError(e.message)
+      }
     }
   }
 
@@ -70,12 +80,14 @@ export default function PasswordReset() {
             placeholder='enter your new password'
             onChange={e => {
               setPassword(e.target.value)
+              setErrors({})
               setError('')
             }}
-            className={`w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:border-gray-200 focus:outline-none ${
-              error ? 'border-pink-500/60' : ''
+            className={`mb-1 w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
+              errors.password ? 'border-pink-500/60' : ''
             }`}
           />
+          {errors.password && <ErrorMessage message={errors.password} />}
         </div>
         <div className='my-2 w-full'>
           <label
@@ -91,12 +103,16 @@ export default function PasswordReset() {
             placeholder='confirm your new password'
             onChange={e => {
               setConfirmPassword(e.target.value)
+              setErrors({})
               setError('')
             }}
-            className={`w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
-              error ? 'border-pink-500/60' : ''
+            className={`mb-1 w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
+              errors.confirmPassword ? 'border-pink-500/60' : ''
             }`}
           />
+          {errors.confirmPassword && (
+            <ErrorMessage message={errors.confirmPassword} />
+          )}
         </div>
         <div className='mt-6 flex flex-row items-center justify-end'>
           <Link href='/settings'>

--- a/ui/pages/settings/password-reset.js
+++ b/ui/pages/settings/password-reset.js
@@ -42,7 +42,7 @@ export default function PasswordReset() {
         throw data
       }
 
-      await router.replace('/settings?resetPassword=success')
+      router.replace('/settings?resetPassword=success')
     } catch (e) {
       if (e.fieldErrors) {
         const errors = {}

--- a/ui/pages/settings/password-reset.js
+++ b/ui/pages/settings/password-reset.js
@@ -22,7 +22,7 @@ export default function PasswordReset() {
 
     if (password !== confirmPassword) {
       setErrors({
-        confirmPassword: 'the confirm password confirmation does not match.',
+        confirmPassword: 'passwords do not match',
       })
       return false
     }

--- a/ui/pages/signup/index.js
+++ b/ui/pages/signup/index.js
@@ -57,7 +57,7 @@ export default function Signup() {
       await mutate('/api/signup')
       await mutate('/api/users/self')
 
-      await router.replace('/')
+      router.replace('/')
     } catch (e) {
       if (e.fieldErrors) {
         const errors = {}
@@ -129,13 +129,13 @@ export default function Signup() {
             htmlFor='password'
             className='text-3xs uppercase text-gray-500'
           >
-            Confirm New Password
+            Confirm Password
           </label>
           <input
             required
             name='confirmPassword'
             type='password'
-            placeholder='confirm your new password'
+            placeholder='confirm your password'
             onChange={e => {
               setConfirmPassword(e.target.value)
               setErrors({})

--- a/ui/pages/signup/index.js
+++ b/ui/pages/signup/index.js
@@ -11,14 +11,19 @@ export default function Signup() {
 
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState('')
   const [errors, setErrors] = useState({})
 
   async function onSubmit(e) {
     e.preventDefault()
 
-    setErrors({})
-    setError('')
+    if (password !== confirmPassword) {
+      setErrors({
+        confirmPassword: 'the confirm password confirmation does not match.',
+      })
+      return false
+    }
 
     try {
       // signup
@@ -52,7 +57,7 @@ export default function Signup() {
       await mutate('/api/signup')
       await mutate('/api/users/self')
 
-      router.replace('/')
+      await router.replace('/')
     } catch (e) {
       if (e.fieldErrors) {
         const errors = {}
@@ -78,8 +83,8 @@ export default function Signup() {
         Set up your admin user to get started.
       </h2>
       <form onSubmit={onSubmit} className='flex w-full max-w-sm flex-col'>
-        <div className='my-4 w-full'>
-          <label htmlFor='email' className='text-3xs uppercase text-gray-400'>
+        <div className='my-2 w-full'>
+          <label htmlFor='email' className='text-3xs uppercase text-gray-500'>
             Email
           </label>
           <input
@@ -87,38 +92,70 @@ export default function Signup() {
             name='email'
             type='email'
             placeholder='email@address.com'
-            onChange={e => setEmail(e.target.value)}
-            className={`mt-2 w-full border-b border-gray-800 bg-transparent px-px py-3 text-2xs placeholder:italic focus:border-b focus:border-gray-200 focus:outline-none ${
+            onChange={e => {
+              setEmail(e.target.value)
+              setErrors({})
+              setError('')
+            }}
+            className={`mb-1 w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
               errors.email ? 'border-pink-500/60' : ''
             }`}
           />
           {errors.email && <ErrorMessage message={errors.email} />}
         </div>
-        <div className='my-4 w-full'>
+        <div className='my-2 w-full'>
           <label
             htmlFor='password'
-            className='text-3xs uppercase text-gray-400'
+            className='text-3xs uppercase text-gray-500'
           >
             Password
           </label>
           <input
             type='password'
             placeholder='enter your password'
-            onChange={e => setPassword(e.target.value)}
-            className={`mt-2 w-full border-b border-gray-800 bg-transparent px-px py-3 text-2xs placeholder:italic focus:border-b focus:border-gray-200 focus:outline-none ${
+            onChange={e => {
+              setPassword(e.target.value)
+              setErrors({})
+              setError('')
+            }}
+            className={`mb-1 w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
               errors.password ? 'border-pink-500/60' : ''
             }`}
           />
           {errors.password && <ErrorMessage message={errors.password} />}
         </div>
-
+        <div className='my-2 w-full'>
+          <label
+            htmlFor='password'
+            className='text-3xs uppercase text-gray-500'
+          >
+            Confirm New Password
+          </label>
+          <input
+            required
+            name='confirmPassword'
+            type='password'
+            placeholder='confirm your new password'
+            onChange={e => {
+              setConfirmPassword(e.target.value)
+              setErrors({})
+              setError('')
+            }}
+            className={`mb-1 w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
+              errors.confirmPassword ? 'border-pink-500/60' : ''
+            }`}
+          />
+          {errors.confirmPassword && (
+            <ErrorMessage message={errors.confirmPassword} />
+          )}
+        </div>
         <button
-          disabled={!email || !password}
+          disabled={!email || !password || !confirmPassword}
           className='my-2 rounded-lg border border-violet-300 px-4 py-3 text-2xs text-violet-100 hover:border-violet-100 disabled:pointer-events-none disabled:opacity-30'
         >
           Get Started
-          {error && <ErrorMessage message={error} center />}
         </button>
+        {error && <ErrorMessage message={error} center />}
       </form>
     </>
   )

--- a/ui/pages/signup/index.js
+++ b/ui/pages/signup/index.js
@@ -20,7 +20,7 @@ export default function Signup() {
 
     if (password !== confirmPassword) {
       setErrors({
-        confirmPassword: 'the confirm password confirmation does not match.',
+        confirmPassword: 'passwords do not match',
       })
       return false
     }


### PR DESCRIPTION
## Summary
- added password confirmation field on signup and initial password reset (#2108)
<img width="570" alt="Screen Shot 2022-07-04 at 12 01 51 PM" src="https://user-images.githubusercontent.com/63033505/177193072-47a5d387-bd37-4edc-b84f-68516e9caca1.png">
<img width="529" alt="Screen Shot 2022-07-04 at 11 53 06 AM" src="https://user-images.githubusercontent.com/63033505/177193078-29d99155-c8f9-4bd9-aef9-f4e5da448271.png">

- prevent user to reset password that is invalid (#2373)
<img width="613" alt="Screen Shot 2022-07-04 at 11 37 28 AM" src="https://user-images.githubusercontent.com/63033505/177193174-ff418c93-d6f4-46d9-980d-018f8ceed2b4.png">

- improve confirmation password field error handling
<img width="630" alt="Screen Shot 2022-07-04 at 12 22 34 PM" src="https://user-images.githubusercontent.com/63033505/177193247-a07b3f57-84e2-4fe8-9f86-2ffddc82cc04.png">


## Related Issues
Resolves #2108 
Resolves #2373 