### PR TITLE
fix: find server endpoint for localhost

### DIFF
--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -529,18 +529,13 @@ func CA() ([]byte, error) {
 }
 
 // Find the first suitable Service, filtering on infrahq.com/component
-func (k *Kubernetes) Service(component string) (*corev1.Service, error) {
+func (k *Kubernetes) Service(component string, labels ...string) (*corev1.Service, error) {
 	clientset, err := kubernetes.NewForConfig(k.Config)
 	if err != nil {
 		return nil, err
 	}
 
 	namespace, err := Namespace()
-	if err != nil {
-		return nil, err
-	}
-
-	labels, err := PodLabels()
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +567,11 @@ func (k *Kubernetes) Service(component string) (*corev1.Service, error) {
 
 // Find a suitable Endpoint to use by inspecting Service objects
 func (k *Kubernetes) Endpoint() (string, int, error) {
-	service, err := k.Service("connector")
+	labels, err := PodLabels()
+	if err != nil {
+		return "", -1, err
+	}
+	service, err := k.Service("connector", labels...)
 	if err != nil {
 		return "", -1, err
 	}
@@ -608,7 +607,11 @@ func (k *Kubernetes) Endpoint() (string, int, error) {
 }
 
 func (k *Kubernetes) IsServiceTypeClusterIP() (bool, error) {
-	service, err := k.Service("connector")
+	labels, err := PodLabels()
+	if err != nil {
+		return false, err
+	}
+	service, err := k.Service("connector", labels...)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
- make service labels variadic

## Summary
When looking up "localhost" as the server name in the connector (as seen in the docs) the request was failing to find the infra server in the local pod. This was due to the labels being applied to the look-up, this change makes the labels optional and applies them where needed so that the local server look-up succeeds.

No tests at the moment because using a mock Kubernetes clientset will require some refactoring in our Kubernetes code.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2452 
