### PR TITLE
Make tests easier to debug by hiding unrelated output

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -26,11 +26,12 @@ func init() {
 		short := filepath.Join(filepath.Base(filepath.Dir(file)), filepath.Base(file))
 		return fmt.Sprintf("%s:%d", short, line)
 	}
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 }
 
 func NewLogger(writer io.Writer) *logger {
 	return &logger{
-		zerolog.New(writer).With().Timestamp().Caller().Logger(),
+		Logger: zerolog.New(writer).With().Timestamp().Caller().Logger(),
 	}
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -21,10 +22,17 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/generate"
+	"github.com/infrahq/infra/internal/ginutil"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
+
+func TestMain(m *testing.M) {
+	// set mode so that test failure output is not filled by gin debug output by default
+	ginutil.SetMode()
+	os.Exit(m.Run())
+}
 
 func adminAccessKey(s *Server) string {
 	for _, id := range s.options.Users {


### PR DESCRIPTION


## Summary

With our recent logging changes the default log level changed from info to trace. This
caused most test failures to include tons of trace-level DB query logs. This logs make
the actual failure message harder to find.

Similarly, the gin default mode is debug. Calling SetMode sets it to release mode, while
still allowing for the GIN_MODE= environment variable to set it back to debug.