### PR TITLE
connector: verify the server TLS

### DIFF
--- a/helm/charts/infra/templates/connector/configmap.yaml
+++ b/helm/charts/infra/templates/connector/configmap.yaml
@@ -7,35 +7,34 @@ metadata:
 {{- include "connector.labels" . | nindent 4 }}
 data:
   infra.yaml: |
-{{- range $key, $val := omit .Values.connector.config "accessKey" }}
-{{- if kindIs "invalid" $val }}
-    # skipping invalid value: {{ $val }} ({{ kindOf $val }})
-{{- else if kindIs "map" $val }}
-    {{ $key }}:
-{{- $val | toYaml | nindent 6 }}
-{{- else if kindIs "slice" $val }}
-    {{ $key }}:
-{{- $val | toYaml | nindent 6 }}
-{{- else if kindIs "string" $val }}
-    {{ $key }}: {{ tpl $val $ }}
-{{- else }}
-    {{ $key }}: {{ $val }}
-{{- end }}
+
+{{- with .Values.connector.config.name }}
+    name: {{ . }}
 {{- end }}
 
+    server:
 {{- $accessKey := default "" .Values.connector.config.accessKey }}
 {{- if and $accessKey (or (hasPrefix "file:" $accessKey) (hasPrefix "env:" $accessKey)) }}
-    accessKey: {{ $accessKey }}
+      accessKey: {{ $accessKey }}
 {{- else }}
-    accessKey: file:/var/run/secrets/infrahq.com/access-key/access-key
+      accessKey: file:/var/run/secrets/infrahq.com/access-key/access-key
+{{- end }}
+
+{{- with .Values.connector.config.serverTrustedCertificate }}
+      trustedCertificate: |
+{{ indent 8 . }}
+{{- end }}
+
+{{- with .Values.connector.config.server }}
+      url: {{ . }}
 {{- end }}
 
 {{- if include "server.enabled" . | eq "true" }}
-    server: {{ .Release.Name }}-server.{{ .Release.Namespace }}
+      url: {{ .Release.Name }}-server.{{ .Release.Namespace }}
 
 {{- if (not (hasKey .Values.connector.config "skipTLSVerify")) }}
-    # skip tls verify if we're connecting to an in-cluster server
-    skipTLSVerify: true
+      # skip tls verify if we're connecting to an in-cluster server
+      skipTLSVerify: true
 {{- end }}
 {{- end }}
 

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -816,5 +816,5 @@ connector:
   ## Destination name
   #   name: ""
 
-  ## Skip verify server TLS certificate
-  #   skipTLSVerify: true
+  ## PEM encoded CA certificate of the server
+  #   serverTrustedCertificate:

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -220,12 +220,12 @@ func newConnectorCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&configFilename, "config-file", "f", "", "Connector config file")
-	cmd.Flags().StringP("server", "s", "", "Infra server hostname")
-	cmd.Flags().StringP("access-key", "a", "", "Infra access key (use file:// to load from a file)")
+	cmd.Flags().StringP("server-url", "s", "", "Infra server hostname")
+	cmd.Flags().StringP("server-access-key", "a", "", "Infra access key (use file:// to load from a file)")
 	cmd.Flags().StringP("name", "n", "", "Destination name")
 	cmd.Flags().String("ca-cert", "", "Path to CA certificate file")
 	cmd.Flags().String("ca-key", "", "Path to CA key file")
-	cmd.Flags().Bool("skip-tls-verify", false, "Skip verifying server TLS certificates")
+	cmd.Flags().Bool("server-skip-tls-verify", false, "Skip verifying server TLS certificates")
 
 	return cmd
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -291,12 +291,14 @@ func TestConnectorCmd(t *testing.T) {
 	})
 
 	content := `
-server: the-server
+server:
+  url: the-server
+  accessKey: /var/run/secrets/key
+  skipTLSVerify: true
+  trustedCertificate: ca.pem
 name: the-name
-accessKey: /var/run/secrets/key
 caCert: /path/to/cert
 caKey: /path/to/key
-skipTLSVerify: true
 `
 
 	dir := fs.NewDir(t, t.Name(), fs.WithFile("config.yaml", content))
@@ -306,12 +308,15 @@ skipTLSVerify: true
 	assert.NilError(t, err)
 
 	expected := connector.Options{
-		Name:          "the-name",
-		Server:        "the-server",
-		AccessKey:     "/var/run/secrets/key",
-		CACert:        "/path/to/cert",
-		CAKey:         "/path/to/key",
-		SkipTLSVerify: true,
+		Name: "the-name",
+		Server: connector.ServerOptions{
+			URL:                "the-server",
+			AccessKey:          "/var/run/secrets/key",
+			SkipTLSVerify:      true,
+			TrustedCertificate: "ca.pem",
+		},
+		CACert: "/path/to/cert",
+		CAKey:  "/path/to/key",
 	}
 	assert.DeepEqual(t, actual, expected)
 }

--- a/internal/connector/authn.go
+++ b/internal/connector/authn.go
@@ -2,7 +2,6 @@ package connector
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,13 +31,7 @@ type httpClient interface {
 }
 
 func newAuthenticator(url string, options Options) *authenticator {
-	// nolint:forcetypeassert // http.DefaultTransport is always http.Transport
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{
-		//nolint:gosec // We may purposely set InsecureSkipVerify via a flag
-		InsecureSkipVerify: options.SkipTLSVerify,
-	}
-
+	transport := httpTransportFromOptions(options.Server)
 	return &authenticator{
 		client:  &http.Client{Transport: transport},
 		baseURL: url,

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -41,7 +41,8 @@ func TestAuthenticator_Authenticate(t *testing.T) {
 			tc.setup(t, req)
 		}
 
-		authn := newAuthenticator("https://127.0.0.1:12345", Options{SkipTLSVerify: true})
+		opts := Options{Server: ServerOptions{SkipTLSVerify: true}}
+		authn := newAuthenticator("https://127.0.0.1:12345", opts)
 		authn.client = tc.fakeClient
 
 		actual, err := authn.Authenticate(req)

--- a/internal/server/tls.go
+++ b/internal/server/tls.go
@@ -42,7 +42,7 @@ func tlsConfigFromOptions(
 
 	roots, err := x509.SystemCertPool()
 	if err != nil {
-		logging.Warnf("failed to load TLS roots from system: %v", err)
+		logging.L.Err(err).Msgf("failed to load TLS roots from system")
 		roots = x509.NewCertPool()
 	}
 


### PR DESCRIPTION
## Summary

Branched from #2401

This PR adds support to the connector to trust the TLS CA or certificate of the server.

With this change, someone deploying a connector can set the trusted certificate instead of `skipTLSVerify`:

```
helm upgrade --install infra-connector ... --set connector.config.serverTrustedCertificate="$(cat server.ca)"
```

I think we can improve this by fetching the CA for them, if they've already trusted it in the CLI. We might also want to fetch it out of a previous config map to remove the need to set it every time. I think those could be follow up PRs.