### PR TITLE
feat: better feedback for connector key

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -11,8 +11,8 @@ type AccessKey struct {
 	IssuedForName     string `json:"issuedForName"`
 	IssuedFor         uid.ID `json:"issuedFor"`
 	ProviderID        uid.ID `json:"providerID"`
-	Expires           Time   `json:"expires,omitempty" note:"key is no longer valid after this time"`
-	ExtensionDeadline Time   `json:"extensionDeadline" note:"key must be renewed after this time"`
+	Expires           Time   `json:"expires" note:"key is no longer valid after this time"`
+	ExtensionDeadline Time   `json:"extensionDeadline" note:"key must be used within this duration to remain valid"`
 }
 
 type ListAccessKeysRequest struct {

--- a/internal/cmd/format.go
+++ b/internal/cmd/format.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 )
 
@@ -56,4 +57,60 @@ func HumanTime(t time.Time, zeroValue string) string {
 		return HumanDuration(-delta) + " from now"
 	}
 	return HumanDuration(delta) + " ago"
+}
+
+// ExcatDuration returns a human readable hours/minutes/seconds or milliseconds format of a duration
+// the most precise level of duration is milliseconds
+func ExactDuration(d time.Duration) string {
+	if d.Seconds() < 1 {
+		if d.Milliseconds() == 1 {
+			return fmt.Sprintf("%d millisecond", d.Milliseconds())
+		}
+		return fmt.Sprintf("%d milliseconds", d.Milliseconds())
+	}
+
+	var readableDur strings.Builder
+
+	dur := d.String()
+
+	// split the default duration string format of 0h0m0s into something nicer to read
+	h := strings.Split(dur, "h")
+	if len(h) > 1 {
+		hours := h[0]
+		if hours == "1" {
+			readableDur.WriteString(fmt.Sprintf("%s hour ", hours))
+		} else {
+			readableDur.WriteString(fmt.Sprintf("%s hours ", hours))
+		}
+		dur = h[1]
+	}
+
+	m := strings.Split(dur, "m")
+	if len(m) > 1 {
+		mins := m[0]
+		switch mins {
+		case "0":
+			// skip
+		case "1":
+			readableDur.WriteString(fmt.Sprintf("%s minute ", mins))
+		default:
+			readableDur.WriteString(fmt.Sprintf("%s minutes ", mins))
+		}
+		dur = m[1]
+	}
+
+	s := strings.Split(dur, "s")
+	if len(s) > 0 {
+		sec := s[0]
+		switch sec {
+		case "0":
+			// skip
+		case "1":
+			readableDur.WriteString(fmt.Sprintf("%s second ", sec))
+		default:
+			readableDur.WriteString(fmt.Sprintf("%s seconds ", sec))
+		}
+	}
+
+	return strings.TrimSpace(readableDur.String())
 }

--- a/internal/cmd/format_test.go
+++ b/internal/cmd/format_test.go
@@ -74,5 +74,21 @@ func TestHumanTime(t *testing.T) {
 		v := now.Add(-48 * time.Hour)
 		assert.Equal(t, HumanTime(v, ""), "2 days ago")
 	})
+}
 
+func TestExactDuration(t *testing.T) {
+	assert.Equal(t, "1 millisecond", ExactDuration(1*time.Millisecond))
+	assert.Equal(t, "10 milliseconds", ExactDuration(10*time.Millisecond))
+	assert.Equal(t, "1 second", ExactDuration(1*time.Second))
+	assert.Equal(t, "10 seconds", ExactDuration(10*time.Second))
+	assert.Equal(t, "1 minute", ExactDuration(1*time.Minute))
+	assert.Equal(t, "10 minutes", ExactDuration(10*time.Minute))
+	assert.Equal(t, "1 hour", ExactDuration(1*time.Hour))
+	assert.Equal(t, "10 hours", ExactDuration(10*time.Hour))
+	assert.Equal(t, "1 hour 1 second", ExactDuration(1*time.Hour+1*time.Second))
+	assert.Equal(t, "1 hour 10 seconds", ExactDuration(1*time.Hour+10*time.Second))
+	assert.Equal(t, "1 hour 1 minute", ExactDuration(1*time.Hour+1*time.Minute))
+	assert.Equal(t, "1 hour 10 minutes", ExactDuration(1*time.Hour+10*time.Minute))
+	assert.Equal(t, "1 hour 1 minute 1 second", ExactDuration(1*time.Hour+1*time.Minute+1*time.Second))
+	assert.Equal(t, "10 hours 10 minutes 10 seconds", ExactDuration(10*time.Hour+10*time.Minute+10*time.Second))
 }

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -11,7 +11,7 @@ import (
 	"github.com/infrahq/infra/internal/logging"
 )
 
-const ThirtyDays = 30 * (24 * time.Hour)
+const thirtyDays = 30 * (24 * time.Hour)
 
 func newKeysCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
@@ -97,15 +97,26 @@ $ infra keys add connector
 				return err
 			}
 
+			var expMsg strings.Builder
+			expMsg.WriteString("This key will expire in ")
+			expMsg.WriteString(ExactDuration(options.TTL))
+			if !resp.Expires.Equal(resp.ExtensionDeadline) {
+				expMsg.WriteString(", and must be used every ")
+				expMsg.WriteString(ExactDuration(options.ExtensionDeadline))
+				expMsg.WriteString(" to remain valid")
+			}
 			cli.Output("Issued access key %q for %q", resp.Name, userName)
+			cli.Output(expMsg.String())
+			cli.Output("")
+
 			cli.Output("Key: %s", resp.AccessKey)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&options.Name, "name", "", "The name of the access key")
-	cmd.Flags().DurationVar(&options.TTL, "ttl", ThirtyDays, "The total time that the access key will be valid for")
-	cmd.Flags().DurationVar(&options.ExtensionDeadline, "extension-deadline", ThirtyDays, "A specified deadline that the access key must be used within to remain valid")
+	cmd.Flags().DurationVar(&options.TTL, "ttl", thirtyDays, "The total time that the access key will be valid for")
+	cmd.Flags().DurationVar(&options.ExtensionDeadline, "extension-deadline", thirtyDays, "A specified deadline that the access key must be used within to remain valid")
 
 	return cmd
 }

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -35,6 +35,7 @@ func TestServerCmd_LoadOptions(t *testing.T) {
 		patchNewServer(t, &actual)
 
 		cmd := newServerCmd()
+		cmd.SetArgs([]string{}) // prevent reading of os.Args
 		if tc.setup != nil {
 			tc.setup(t, cmd)
 		}

--- a/internal/server/authn/key_exchange_test.go
+++ b/internal/server/authn/key_exchange_test.go
@@ -50,7 +50,7 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 				return NewKeyExchangeAuthentication(bearer, time.Now().Add(5*time.Minute))
 			},
 			"verify": func(t *testing.T, identity *models.Identity, provider *models.Provider, err error) {
-				assert.ErrorContains(t, err, "token expired")
+				assert.ErrorContains(t, err, data.ErrAccessKeyExpired.Error())
 			},
 		},
 		"AccessKeyCannotBeExchangedForLongerLived": {

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -120,12 +120,12 @@ func ValidateAccessKey(db *gorm.DB, authnKey string) (*models.AccessKey, error) 
 	}
 
 	if time.Now().UTC().After(t.ExpiresAt) {
-		return nil, fmt.Errorf("token expired")
+		return nil, ErrAccessKeyExpired
 	}
 
 	if !t.ExtensionDeadline.IsZero() {
 		if time.Now().UTC().After(t.ExtensionDeadline) {
-			return nil, fmt.Errorf("token extension deadline exceeded")
+			return nil, ErrAccessKeyDeadlineExceeded
 		}
 
 		t.ExtensionDeadline = time.Now().UTC().Add(t.Extension)

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -15,6 +15,11 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+var (
+	ErrAccessKeyExpired          = fmt.Errorf("access key expired")
+	ErrAccessKeyDeadlineExceeded = fmt.Errorf("%w: extension deadline exceeded", ErrAccessKeyExpired)
+)
+
 func secretChecksum(secret string) []byte {
 	chksm := sha256.Sum256([]byte(secret))
 	return chksm[:]

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -140,7 +140,7 @@ func TestCheckAccessKeyExpired(t *testing.T) {
 		body, _ := createTestAccessKey(t, db, -1*time.Hour)
 
 		_, err := ValidateAccessKey(db, body)
-		assert.Error(t, err, "token expired")
+		assert.ErrorIs(t, err, ErrAccessKeyExpired)
 	})
 }
 
@@ -149,7 +149,7 @@ func TestCheckAccessKeyPastExtensionDeadline(t *testing.T) {
 		body, _ := createAccessKeyWithExtensionDeadline(t, db, 1*time.Hour, -1*time.Hour)
 
 		_, err := ValidateAccessKey(db, body)
-		assert.Error(t, err, "token extension deadline exceeded")
+		assert.ErrorIs(t, err, ErrAccessKeyDeadlineExceeded)
 	})
 }
 

--- a/internal/server/data/errors.go
+++ b/internal/server/data/errors.go
@@ -1,0 +1,8 @@
+package data
+
+import "fmt"
+
+var (
+	ErrAccessKeyExpired          = fmt.Errorf("access key expired")
+	ErrAccessKeyDeadlineExceeded = fmt.Errorf("%w: extension deadline exceeded", ErrAccessKeyExpired)
+)

--- a/internal/server/data/errors.go
+++ b/internal/server/data/errors.go
@@ -1,8 +1,0 @@
-package data
-
-import "fmt"
-
-var (
-	ErrAccessKeyExpired          = fmt.Errorf("access key expired")
-	ErrAccessKeyDeadlineExceeded = fmt.Errorf("%w: extension deadline exceeded", ErrAccessKeyExpired)
-)

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -163,6 +163,7 @@ func TestMigration_AddKindToProvider(t *testing.T) {
 	}
 }
 
+// this test does an external call to example.okta.com, if it fails check your network connection
 func TestMigration_AddAuthURLAndScopesToProvider(t *testing.T) {
 	for _, driver := range dbDrivers(t) {
 		t.Run(driver.Name(), func(t *testing.T) {

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -41,6 +41,11 @@ func sendAPIError(c *gin.Context, err error) {
 		// log the error at info because it is not in the response
 		log = logging.L.Info()
 
+	case errors.Is(err, data.ErrAccessKeyExpired):
+		resp.Code = http.StatusUnauthorized
+		// this means the key was once valid, so include some extra details
+		resp.Message = fmt.Sprintf("%s: %s", internal.ErrUnauthorized, err)
+
 	case errors.As(err, &authzError):
 		resp.Code = http.StatusForbidden
 		resp.Message = authzError.Error()

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -42,6 +42,18 @@ func TestSendAPIError(t *testing.T) {
 			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized"},
 		},
 		{
+			err:    data.ErrAccessKeyExpired,
+			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized: " + data.ErrAccessKeyExpired.Error()},
+		},
+		{
+			err:    data.ErrAccessKeyDeadlineExceeded,
+			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized: " + data.ErrAccessKeyDeadlineExceeded.Error()},
+		},
+		{
+			err:    fmt.Errorf("hide this: %w", internal.ErrUnauthorized),
+			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized"},
+		},
+		{
 			err: access.AuthorizationError{
 				Resource:      "provider",
 				Operation:     "create",

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -50,10 +50,6 @@ func TestSendAPIError(t *testing.T) {
 			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized: " + data.ErrAccessKeyDeadlineExceeded.Error()},
 		},
 		{
-			err:    fmt.Errorf("hide this: %w", internal.ErrUnauthorized),
-			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized"},
-		},
-		{
 			err: access.AuthorizationError{
 				Resource:      "provider",
 				Operation:     "create",

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -91,6 +91,9 @@ func RequireAccessKey(c *gin.Context) error {
 
 	accessKey, err := data.ValidateAccessKey(db, bearer)
 	if err != nil {
+		if errors.Is(err, data.ErrAccessKeyExpired) {
+			return err
+		}
 		return fmt.Errorf("%w: invalid token: %s", internal.ErrUnauthorized, err)
 	}
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -131,7 +131,7 @@ func TestRequireAuthentication(t *testing.T) {
 				c.Request = r
 			},
 			"verifyFunc": func(t *testing.T, c *gin.Context, err error) {
-				assert.ErrorContains(t, err, data.ErrAccessKeyExpired.Error())
+				assert.ErrorIs(t, err, data.ErrAccessKeyExpired)
 			},
 		},
 		"AccessKeyInvalidKey": {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -131,7 +131,7 @@ func TestRequireAuthentication(t *testing.T) {
 				c.Request = r
 			},
 			"verifyFunc": func(t *testing.T, c *gin.Context, err error) {
-				assert.ErrorContains(t, err, "token expired")
+				assert.ErrorContains(t, err, data.ErrAccessKeyExpired.Error())
 			},
 		},
 		"AccessKeyInvalidKey": {

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -268,7 +268,7 @@
                   "type": "string"
                 },
                 "extensionDeadline": {
-                  "description": "key must be renewed after this time",
+                  "description": "key must be used within this duration to remain valid",
                   "example": "2022-03-14T09:48:00Z",
                   "format": "date-time",
                   "type": "string"


### PR DESCRIPTION
- output lifetime and extension deadline from keys add command
- specify when an access key was valid but is now expired

## Summary
The connector key expired after 30 days by default. This was not clear in our workflow or docs and caused an unexpected failure for connectors after the 30 day period ends. This change alleviates the problem by specifying the access key lifetime on creation and giving info in the error response for expired keys that detail the actual problem.

The connector log will look something like this when the access key expires:
```
{"level":"error","time":1657026989645,"caller":"logging/logger.go:58","message":"initializing destination: error listing destinations: unauthorized: access key expired: extension deadline exceeded"}
```
## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2293
