### PR TITLE
feat: add destination status and last seen to CLI and UI

### DIFF
--- a/api/destination.go
+++ b/api/destination.go
@@ -15,7 +15,8 @@ type Destination struct {
 	Resources []string `json:"resources"`
 	Roles     []string `json:"roles"`
 
-	LastSeen Time `json:"lastSeen"`
+	LastSeen  Time `json:"lastSeen"`
+	Connected bool `json:"connected"`
 }
 
 type DestinationConnection struct {

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -10,6 +10,11 @@ import (
 	"github.com/infrahq/infra/internal/logging"
 )
 
+const (
+	DestinationStatusConnected    = "Connected"
+	DestinationStatusDisconnected = "Disconnected"
+)
+
 func newDestinationsCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "destinations",
@@ -58,15 +63,24 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 				cli.Output(string(jsonOutput))
 			default:
 				type row struct {
-					Name string `header:"NAME"`
-					URL  string `header:"URL"`
+					Name     string `header:"NAME"`
+					URL      string `header:"URL"`
+					Status   string `header:"STATUS"`
+					LastSeen string `header:"LAST SEEN"`
 				}
 
 				var rows []row
 				for _, d := range destinations.Items {
+					status := DestinationStatusDisconnected
+					if d.Connected {
+						status = DestinationStatusConnected
+					}
+
 					rows = append(rows, row{
-						Name: d.Name,
-						URL:  d.Connection.URL,
+						Name:     d.Name,
+						URL:      d.Connection.URL,
+						Status:   status,
+						LastSeen: HumanTime(d.LastSeen.Time(), "never"),
 					})
 				}
 				if len(rows) > 0 {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1401,6 +1401,7 @@ func TestAPI_CreateDestination(t *testing.T) {
 		"url": "cluster.production.example",
 		"ca": "-----BEGIN CERTIFICATE-----\nok\n-----END CERTIFICATE-----\n"
 	},
+	"connected": false,
 	"lastSeen": null,
 	"resources": ["res1", "res2"],
 	"roles": ["role1", "role2"],

--- a/internal/server/models/destination.go
+++ b/internal/server/models/destination.go
@@ -21,6 +21,13 @@ type Destination struct {
 }
 
 func (d *Destination) ToAPI() *api.Destination {
+	connected := false
+	// TODO: this should be configurable
+	// https://github.com/infrahq/infra/issues/2505
+	if time.Since(d.LastSeenAt) < 5*time.Minute {
+		connected = true
+	}
+
 	return &api.Destination{
 		ID:       d.ID,
 		Created:  api.Time(d.CreatedAt),
@@ -34,5 +41,6 @@ func (d *Destination) ToAPI() *api.Destination {
 		Resources: d.Resources,
 		Roles:     d.Roles,
 		LastSeen:  api.Time(d.LastSeenAt),
+		Connected: connected,
 	}
 }

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -82,6 +82,9 @@
       },
       "Destination": {
         "properties": {
+          "connected": {
+            "type": "boolean"
+          },
           "connection": {
             "properties": {
               "ca": {
@@ -332,6 +335,9 @@
           "items": {
             "items": {
               "properties": {
+                "connected": {
+                  "type": "boolean"
+                },
                 "connection": {
                   "properties": {
                     "ca": {

--- a/ui/pages/destinations/index.js
+++ b/ui/pages/destinations/index.js
@@ -262,7 +262,7 @@ const columns = [
   {
     Header: 'Name',
     accessor: 'name',
-    width: '67%',
+    width: '70%',
     Cell: ({ row, value }) => {
       return (
         <div className='flex items-center py-2'>
@@ -305,11 +305,32 @@ const columns = [
   {
     Header: 'Kind',
     accessor: v => v,
-    width: '33%',
+    width: '15%',
     Cell: ({ value }) => (
       <span className='rounded bg-gray-800 px-2 py-0.5 text-gray-400'>
         {value.kind}
       </span>
+    ),
+  },
+  {
+    Header: 'Status',
+    accessor: v => v,
+    width: '15%',
+    Cell: ({ value }) => (
+      <div className='flex items-center py-2'>
+        {value.kind === 'cluster' && (
+          <>
+            <div
+              className={`h-2 w-2 rounded-full ${
+                value.connected ? 'bg-green-400' : 'bg-gray-400'
+              }`}
+            />
+            <span className='px-2 text-gray-400'>
+              {value.connected ? 'Connected' : 'Disconnected'}
+            </span>
+          </>
+        )}
+      </div>
     ),
   },
 ]


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

- Add Destination `Status` API field
- Add columns for Status and Last Seen to CLI and UI list outputs

```
$ infra destinations list
  NAME            URL                 STATUS        LAST SEEN
  docker-desktop  localhost:123       Disconnected  never
  docker-desktop  localhost:123       Disconnected  never
  docker-desktop  10.98.125.93:10443  Connected     1 second ago
```
![image](https://user-images.githubusercontent.com/2372640/177619030-f0985938-ec4b-46b4-b85a-cf8f58265076.png)

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2151