### PR TITLE
fix: add provider buttons should not check name against kind

### DIFF
--- a/ui/pages/providers/add/details.js
+++ b/ui/pages/providers/add/details.js
@@ -4,8 +4,6 @@ import Head from 'next/head'
 import Link from 'next/link'
 import { useSWRConfig } from 'swr'
 
-import { providers } from '../../../lib/providers'
-
 import Fullscreen from '../../../components/layouts/fullscreen'
 import ErrorMessage from '../../../components/error-message'
 
@@ -22,11 +20,12 @@ export default function ProvidersAddDetails() {
   const [errors, setErrors] = useState({})
   const [name, setName] = useState(kind)
 
-  const provider = providers.find(p => p.name.toLowerCase() === kind)
+  function docLink() {
+    if (kind == 'azure') {
+      return 'https://infrahq.com/docs/identity-providers/azure-ad'
+    }
 
-  if (!provider) {
-    router.replace('/providers/add')
-    return null
+    return 'https://infrahq.com/docs/identity-providers/' + kind
   }
 
   async function onSubmit(e) {
@@ -115,7 +114,7 @@ export default function ProvidersAddDetails() {
           <a
             className='text-violet-100 underline'
             target='_blank'
-            href='https://infrahq.com/docs/identity-providers/okta'
+            href={docLink()}
             rel='noreferrer'
           >
             learn more


### PR DESCRIPTION
## Summary
Adding non-Okta providers through the UI that didn't have the same 'name' as their 'kind' would re-direct the user back to the provider screen when attempting to add. This fixes the behavior by removing this check and updates the relevant doc link also.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Related to #2353
