### PR TITLE
fix: create a separate session for each db query

### DIFF
--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -19,23 +19,22 @@ func SignupEnabled(c *gin.Context) (bool, error) {
 	// no authorization is setup yet
 	db := getDB(c)
 
-	// use Unscoped because deleting identities, providers or grants should not re-enable signup
-	identities, err := data.Count[models.Identity](db.Unscoped(), data.NotName(models.InternalInfraConnectorIdentityName))
+	identities, err := data.Count[models.Identity](db, data.IncludeSoftDeleted, data.NotName(models.InternalInfraConnectorIdentityName))
 	if err != nil {
 		return false, err
 	}
 
-	providers, err := data.Count[models.Provider](db.Unscoped(), data.NotProviderKind(models.ProviderKindInfra))
+	providers, err := data.Count[models.Provider](db, data.IncludeSoftDeleted, data.NotProviderKind(models.ProviderKindInfra))
 	if err != nil {
 		return false, err
 	}
 
-	grants, err := data.Count[models.Grant](db.Unscoped(), data.NotPrivilege(models.InfraConnectorRole))
+	grants, err := data.Count[models.Grant](db, data.IncludeSoftDeleted, data.NotPrivilege(models.InfraConnectorRole))
 	if err != nil {
 		return false, err
 	}
 
-	accessKeys, err := data.Count[models.AccessKey](db.Unscoped())
+	accessKeys, err := data.Count[models.AccessKey](db, data.IncludeSoftDeleted)
 	if err != nil {
 		return false, err
 	}

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -105,6 +105,7 @@ func getDefaultSortFromType(t interface{}) string {
 }
 
 func get[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) (*T, error) {
+	db = db.Session(&gorm.Session{})
 	for _, selector := range selectors {
 		db = selector(db)
 	}
@@ -122,6 +123,7 @@ func get[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) (*T, error)
 }
 
 func list[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) ([]T, error) {
+	db = db.Session(&gorm.Session{NewDB: true})
 	db = db.Order(getDefaultSortFromType((*T)(nil)))
 	for _, selector := range selectors {
 		db = selector(db)
@@ -141,6 +143,7 @@ func save[T models.Modelable](db *gorm.DB, model *T) error {
 		return err
 	}
 
+	db = db.Session(&gorm.Session{NewDB: true})
 	err := db.Save(model).Error
 	return handleError(err)
 }
@@ -151,6 +154,7 @@ func add[T models.Modelable](db *gorm.DB, model *T) error {
 		return err
 	}
 
+	db = db.Session(&gorm.Session{NewDB: true})
 	err := db.Create(model).Error
 	return handleError(err)
 }
@@ -229,10 +233,12 @@ func handleError(err error) error {
 }
 
 func delete[T models.Modelable](db *gorm.DB, id uid.ID) error {
+	db = db.Session(&gorm.Session{NewDB: true})
 	return db.Delete(new(T), id).Error
 }
 
 func deleteAll[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) error {
+	db = db.Session(&gorm.Session{NewDB: true})
 	for _, selector := range selectors {
 		db = selector(db)
 	}
@@ -241,6 +247,7 @@ func deleteAll[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) error
 }
 
 func Count[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) (int64, error) {
+	db = db.Session(&gorm.Session{NewDB: true})
 	for _, selector := range selectors {
 		db = selector(db)
 	}

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -210,3 +210,7 @@ func ByOptionalIdentityGroupID(groupID uid.ID) SelectorFunc {
 			Where("identities_groups.group_id = ?", groupID)
 	}
 }
+
+func IncludeSoftDeleted(db *gorm.DB) *gorm.DB {
+	return db.Unscoped()
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -336,7 +336,7 @@ func TestListKeys(t *testing.T) {
 	resp, err := handlers.ListAccessKeys(c, &api.ListAccessKeysRequest{})
 	assert.NilError(t, err)
 
-	assert.Assert(t, len(resp.Items) > 0)
+	assert.Equal(t, len(resp.Items), 1)
 	assert.Equal(t, resp.Count, len(resp.Items))
 	assert.Equal(t, resp.Items[0].IssuedForName, user.Name)
 


### PR DESCRIPTION
## Background

After reading https://gorm.io/docs/method_chaining.html I think I finally understand how gorm queries are supposed to work.  The important bit is this:

>  After a Chain method [or] Finisher Method, GORM returns an initialized `*gorm.DB` instance, which is NOT safe to reuse anymore, or new generated SQL might be polluted by the previous conditions.

It sounds like a "gorm session" is how we are supposed to be building queries. A session is created with `db.Session`, or `db.WithContext` (which is a thin wrapper around `db.Session`).

Today we create a new session in `DatabaseMiddleware` with `WithContext` . The first chain method called on an empty session will create a new clone, so in most cases we did not run into problems because of that session.

Previous to  #1871 we had this extra `db2` variable, but that did not actually create a new session, so that wasn't addressing the problem either.  The tests I added in that PR used `WithContext` (like our middleware) to create a new session, which is why it all looks good in that test. 

## Summary

This PR adds a call to `db.Session` before making any modifications to `gorm.DB`, which should prevent one query from interfering with others.