### PR TITLE
Add Organization object

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -31,6 +31,7 @@ type CreateAccessKeyRequest struct {
 
 type CreateAccessKeyResponse struct {
 	ID                uid.ID `json:"id"`
+	OrganizationID    uid.ID `json:"organizationID"`
 	Created           Time   `json:"created"`
 	Name              string `json:"name"`
 	IssuedFor         uid.ID `json:"issuedFor"`

--- a/api/client.go
+++ b/api/client.go
@@ -239,8 +239,8 @@ func (c Client) DeleteOrganization(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/api/organizations/%s", id))
 }
 
-func (c Client) ListProviders(name string) (*ListResponse[Provider], error) {
-	return get[ListResponse[Provider]](c, "/api/providers", Query{"name": {name}})
+func (c Client) ListProviders(name string, orgID uid.ID) (*ListResponse[Provider], error) {
+	return get[ListResponse[Provider]](c, "/api/providers", Query{"name": {name}, "org": {orgID.String()}})
 }
 
 func (c Client) GetProvider(id uid.ID) (*Provider, error) {

--- a/api/client.go
+++ b/api/client.go
@@ -221,6 +221,24 @@ func (c Client) ListGroupGrants(id uid.ID) (*ListResponse[Grant], error) {
 	return get[ListResponse[Grant]](c, fmt.Sprintf("/api/groups/%s/grants", id), Query{})
 }
 
+func (c Client) ListOrganizations(req ListOrganizationsRequest) (*ListResponse[Organization], error) {
+	return get[ListResponse[Organization]](c, "/api/organizations", Query{
+		"name": {req.Name},
+	})
+}
+
+func (c Client) GetOrganization(id uid.ID) (*Organization, error) {
+	return get[Organization](c, fmt.Sprintf("/api/organizations/%s", id), Query{})
+}
+
+func (c Client) CreateOrganization(req *CreateOrganizationRequest) (*Organization, error) {
+	return post[CreateOrganizationRequest, Organization](c, "/api/organizations", req)
+}
+
+func (c Client) DeleteOrganization(id uid.ID) error {
+	return delete(c, fmt.Sprintf("/api/organizations/%s", id))
+}
+
 func (c Client) ListProviders(name string) (*ListResponse[Provider], error) {
 	return get[ListResponse[Provider]](c, "/api/providers", Query{"name": {name}})
 }

--- a/api/login.go
+++ b/api/login.go
@@ -9,9 +9,10 @@ type LoginRequestOIDC struct {
 }
 
 type LoginRequestPasswordCredentials struct {
-	Name     string `json:"name" validate:"required_without=Email"`
-	Email    string `json:"email" validate:"required_without=Name"` // #1825: remove, this is for migration
-	Password string `json:"password" validate:"required"`
+	OrganizationID uid.ID `json:"org" validate:"required"`
+	Name           string `json:"name" validate:"required_without=Email"`
+	Email          string `json:"email" validate:"required_without=Name"` // #1825: remove, this is for migration
+	Password       string `json:"password" validate:"required"`
 }
 
 type LoginRequest struct {

--- a/api/organization.go
+++ b/api/organization.go
@@ -11,6 +11,11 @@ type Organization struct {
 	Updated Time   `json:"updated"`
 }
 
+type ListOrganizationsRequest struct {
+	Name string `form:"name"`
+	PaginationRequest
+}
+
 type CreateOrganizationRequest struct {
 	Name string `json:"name" validate:"required"`
 }

--- a/api/organization.go
+++ b/api/organization.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"github.com/infrahq/infra/uid"
+)
+
+type Organization struct {
+	ID      uid.ID `json:"id"`
+	Name    string `json:"name"`
+	Created Time   `json:"created"`
+	Updated Time   `json:"updated"`
+}
+
+type CreateOrganizationRequest struct {
+	Name string `json:"name" validate:"required"`
+}

--- a/api/provider.go
+++ b/api/provider.go
@@ -34,6 +34,7 @@ type UpdateProviderRequest struct {
 }
 
 type ListProvidersRequest struct {
-	Name string `form:"name" example:"okta"`
+	Name           string `form:"name" example:"okta"`
+	OrganizationID uid.ID `form:"org"`
 	PaginationRequest
 }

--- a/api/signup.go
+++ b/api/signup.go
@@ -5,6 +5,7 @@ type SignupEnabledResponse struct {
 }
 
 type SignupRequest struct {
+	OrgName  string `json:"orgName" validate:"required"`
 	Name     string `json:"name" validate:"omitempty,email,required_without=Email"`
 	Email    string `json:"email" validate:"omitempty,email,required_without=Name"` // #1825: remove, this is for migration
 	Password string `json:"password" validate:"required"`

--- a/api/user.go
+++ b/api/user.go
@@ -9,12 +9,13 @@ type GetUserRequest struct {
 }
 
 type User struct {
-	ID            uid.ID   `json:"id"`
-	Created       Time     `json:"created"`
-	Updated       Time     `json:"updated"`
-	LastSeenAt    Time     `json:"lastSeenAt"`
-	Name          string   `json:"name" validate:"required"`
-	ProviderNames []string `json:"providerNames,omitempty"`
+	ID             uid.ID   `json:"id"`
+	OrganizationID uid.ID   `json:"organizationID"`
+	Created        Time     `json:"created"`
+	Updated        Time     `json:"updated"`
+	LastSeenAt     Time     `json:"lastSeenAt"`
+	Name           string   `json:"name" validate:"required"`
+	ProviderNames  []string `json:"providerNames,omitempty"`
 }
 
 type ListUsersRequest struct {

--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -19,6 +20,21 @@ func getDB(c *gin.Context) *gorm.DB {
 	}
 
 	return db
+}
+
+func GetCurrentOrgID(c *gin.Context) (uid.ID, error) {
+	if org, ok := c.Get("organization"); ok {
+		return org.(*models.Organization).ID, nil
+	}
+	return 0, fmt.Errorf("couldn't find org for current user")
+}
+
+func GetCurrentOrgSelector(c *gin.Context) (data.SelectorFunc, error) {
+	id, err := GetCurrentOrgID(c)
+	if err != nil {
+		return nil, err
+	}
+	return data.ByOrg(id), nil
 }
 
 // hasAuthorization checks if a caller is the owner of a resource before checking if they have an approprite role to access it

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -45,6 +45,12 @@ func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey) (body string, 
 		return "", HandleAuthErr(err, "access key", "create", models.InfraAdminRole)
 	}
 
+	orgID, err := GetCurrentOrgID(c)
+	if err != nil {
+		return "", err
+	}
+	accessKey.OrganizationID = orgID
+
 	body, err = data.CreateAccessKey(db, accessKey)
 	if err != nil {
 		return "", fmt.Errorf("create token: %w", err)

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -26,7 +26,12 @@ func ListAccessKeys(c *gin.Context, identityID uid.ID, name string, showExpired 
 		return nil, HandleAuthErr(err, "access keys", "list", roles...)
 	}
 
-	s := []data.SelectorFunc{data.ByOptionalIssuedFor(identityID), data.ByOptionalName(name), data.ByPagination(pg)}
+	orgSelector, err := GetCurrentOrgSelector(c)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get org for user")
+	}
+
+	s := []data.SelectorFunc{orgSelector, data.ByOptionalIssuedFor(identityID), data.ByOptionalName(name), data.ByPagination(pg)}
 	if !showExpired {
 		s = append(s, data.ByNotExpiredOrExtended())
 	}

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -63,9 +63,8 @@ func CreateIdentity(c *gin.Context, identity *models.Identity) error {
 	return data.CreateIdentity(db, identity)
 }
 
-func InfraConnectorIdentity(c *gin.Context) *models.Identity {
-	// XXX - should this be per org?
-	return data.InfraConnectorIdentity(getDB(c))
+func InfraConnectorIdentity(c *gin.Context, orgID uid.ID) *models.Identity {
+	return data.InfraConnectorIdentity(getDB(c), orgID)
 }
 
 // TODO (https://github.com/infrahq/infra/issues/2318) remove provider user, not user.
@@ -79,7 +78,12 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 		return fmt.Errorf("cannot delete self: %w", internal.ErrBadRequest)
 	}
 
-	if InfraConnectorIdentity(c).ID == id {
+	orgID, err := GetCurrentOrgID(c)
+	if err != nil {
+		return err
+	}
+
+	if InfraConnectorIdentity(c, orgID).ID == id {
 		return fmt.Errorf("%w: the connector user can not be deleted", internal.ErrBadRequest)
 	}
 

--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -14,7 +14,7 @@ func ListOrganizations(c *gin.Context, name string, pg models.Pagination) ([]mod
 		selectors = append(selectors, data.ByName(name))
 	}
 
-	roles := []string{models.InfraAdminRole}
+	roles := []string{models.InfraSupportAdminRole}
 	db, err := RequireInfraRole(c, roles...)
 	if err == nil {
 		return data.ListOrganizations(db, selectors...)
@@ -28,7 +28,7 @@ func ListOrganizations(c *gin.Context, name string, pg models.Pagination) ([]mod
 }
 
 func GetOrganization(c *gin.Context, id uid.ID) (*models.Organization, error) {
-	roles := []string{models.InfraAdminRole}
+	roles := []string{models.InfraSupportAdminRole}
 	db, err := RequireInfraRole(c, roles...)
 	if err != nil {
 		return nil, HandleAuthErr(err, "organizations", "get", roles...)
@@ -38,7 +38,7 @@ func GetOrganization(c *gin.Context, id uid.ID) (*models.Organization, error) {
 }
 
 func CreateOrganization(c *gin.Context, org *models.Organization) error {
-	roles := []string{models.InfraAdminRole}
+	roles := []string{models.InfraSupportAdminRole}
 	db, err := RequireInfraRole(c, roles...)
 	if err != nil {
 		return HandleAuthErr(err, "organizations", "create", roles...)
@@ -48,7 +48,7 @@ func CreateOrganization(c *gin.Context, org *models.Organization) error {
 }
 
 func DeleteOrganization(c *gin.Context, id uid.ID) error {
-	roles := []string{models.InfraAdminRole}
+	roles := []string{models.InfraSupportAdminRole}
 	db, err := RequireInfraRole(c, roles...)
 	if err != nil {
 		return HandleAuthErr(err, "organizations", "delete", roles...)

--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -1,0 +1,62 @@
+package access
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+func ListOrganizations(c *gin.Context, name string, pg models.Pagination) ([]models.Organization, error) {
+	var selectors = []data.SelectorFunc{data.ByPagination(pg)}
+	if name != "" {
+		selectors = append(selectors, data.ByName(name))
+	}
+
+	roles := []string{models.InfraAdminRole}
+	db, err := RequireInfraRole(c, roles...)
+	if err == nil {
+		return data.ListOrganizations(db, selectors...)
+	}
+	err = HandleAuthErr(err, "organizations", "list", roles...)
+
+	// TODO:
+	//    * Consider allowing a user to list their own organization
+
+	return nil, err
+}
+
+func GetOrganization(c *gin.Context, id uid.ID) (*models.Organization, error) {
+	roles := []string{models.InfraAdminRole}
+	db, err := RequireInfraRole(c, roles...)
+	if err != nil {
+		return nil, HandleAuthErr(err, "organizations", "get", roles...)
+	}
+
+	return data.GetOrganization(db, data.ByID(id))
+}
+
+func CreateOrganization(c *gin.Context, org *models.Organization) error {
+	roles := []string{models.InfraAdminRole}
+	db, err := RequireInfraRole(c, roles...)
+	if err != nil {
+		return HandleAuthErr(err, "organizations", "create", roles...)
+	}
+
+	return data.CreateOrganization(db, org)
+}
+
+func DeleteOrganization(c *gin.Context, id uid.ID) error {
+	roles := []string{models.InfraAdminRole}
+	db, err := RequireInfraRole(c, roles...)
+	if err != nil {
+		return HandleAuthErr(err, "organizations", "delete", roles...)
+	}
+
+	selectors := []data.SelectorFunc{
+		data.ByID(id),
+	}
+
+	return data.DeleteOrganizations(db, selectors...)
+}

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -23,13 +24,31 @@ func CreateProvider(c *gin.Context, provider *models.Provider) error {
 func GetProvider(c *gin.Context, id uid.ID) (*models.Provider, error) {
 	db := getDB(c)
 
-	return data.GetProvider(db, data.ByID(id))
+	orgSelector, err := GetCurrentOrgSelector(c)
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't get org for user")
+	}
+
+	return data.GetProvider(db, orgSelector, data.ByID(id))
 }
 
-func ListProviders(c *gin.Context, name string, excludeByKind []models.ProviderKind, pg models.Pagination) ([]models.Provider, error) {
+func ListProviders(c *gin.Context, name string, orgID uid.ID, excludeByKind []models.ProviderKind, pg models.Pagination) ([]models.Provider, error) {
 	db := getDB(c)
 
+	var orgSelector data.SelectorFunc
+	var err error
+
+	if orgID == 0 {
+		orgSelector, err = GetCurrentOrgSelector(c)
+		if err != nil {
+			return nil, fmt.Errorf("Couldn't get org for user")
+		}
+	} else {
+		orgSelector = data.ByOrg(orgID)
+	}
+
 	selectors := []data.SelectorFunc{
+		orgSelector,
 		data.ByOptionalName(name),
 		data.ByPagination(pg),
 	}
@@ -50,6 +69,12 @@ func SaveProvider(c *gin.Context, provider *models.Provider) error {
 		return fmt.Errorf("%w: the infra provider can not be modified", internal.ErrBadRequest)
 	}
 
+	orgID, err := GetCurrentOrgID(c)
+	if err != nil {
+		return err
+	}
+	provider.OrganizationID = orgID
+
 	return data.SaveProvider(db, provider)
 }
 
@@ -62,11 +87,26 @@ func DeleteProvider(c *gin.Context, id uid.ID) error {
 		return fmt.Errorf("%w: the infra provider can not be deleted", internal.ErrBadRequest)
 	}
 
-	return data.DeleteProviders(db, data.ByID(id))
+	orgSelector, err := GetCurrentOrgSelector(c)
+	if err != nil {
+		return fmt.Errorf("Couldn't get org for user")
+	}
+
+	return data.DeleteProviders(db, orgSelector, data.ByID(id))
 }
 
 func InfraProvider(c *gin.Context) *models.Provider {
+	logging.Infof("!!! INFRA PROVIDER")
 	db := getDB(c)
 
-	return data.InfraProvider(db)
+	logging.Infof("got db")
+	orgID, err := GetCurrentOrgID(c)
+	if err != nil {
+		logging.Infof("Couldn't get org ID")
+		return nil
+	}
+
+	logging.Infof("org ID = %s", orgID)
+
+	return data.InfraProvider(db, orgID)
 }

--- a/internal/access/provideruser.go
+++ b/internal/access/provideruser.go
@@ -11,6 +11,14 @@ func CreateProviderUser(c *gin.Context, provider *models.Provider, ident *models
 	// does not need authorization check, this function should only be called internally
 	db := getDB(c)
 
+	if ident.OrganizationID == 0 {
+		orgID, err := GetCurrentOrgID(c)
+		if err != nil {
+			return nil, err
+		}
+		ident.OrganizationID = orgID
+	}
+
 	return data.CreateProviderUser(db, provider, ident)
 }
 
@@ -18,6 +26,12 @@ func CreateProviderUser(c *gin.Context, provider *models.Provider, ident *models
 func UpdateProviderUser(c *gin.Context, providerToken *models.ProviderUser) error {
 	// does not need authorization check, this function should only be called internally
 	db := getDB(c)
+
+	orgID, err := GetCurrentOrgID(c)
+	if err != nil {
+		return err
+	}
+	providerToken.OrganizationID = orgID
 
 	return data.UpdateProviderUser(db, providerToken)
 }

--- a/internal/access/publicjwk.go
+++ b/internal/access/publicjwk.go
@@ -11,7 +11,13 @@ import (
 
 func GetPublicJWK(c *gin.Context) ([]jose.JSONWebKey, error) {
 	db := getDB(c)
-	settings, err := data.GetSettings(db)
+
+	orgID, err := GetCurrentOrgID(c)
+	if err != nil {
+		return nil, err
+	}
+
+	settings, err := data.GetSettings(db, orgID)
 	if err != nil {
 		return nil, fmt.Errorf("could not get JWKs: %w", err)
 	}

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -45,9 +45,14 @@ func SignupEnabled(c *gin.Context) (bool, error) {
 
 // Signup creates a user identity using the supplied name and password and
 // grants the identity "admin" access to Infra.
-func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
+func Signup(c *gin.Context, orgName, name, password string) (*models.Identity, error) {
 	// no authorization is setup yet
 	db := getDB(c)
+
+	organization := &models.Organization{Name: orgName}
+	if err := data.CreateOrganization(db, organization); err != nil {
+		return nil, err
+	}
 
 	identity := &models.Identity{Name: name}
 

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -86,6 +86,7 @@ func Signup(c *gin.Context, orgName, name, password string) (*models.Identity, e
 		Resource:  "infra",
 		CreatedBy: identity.ID,
 	}
+	grant.OrganizationID = organization.ID
 
 	if err := data.CreateGrant(db, grant); err != nil {
 		return nil, err

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -55,6 +55,7 @@ func Signup(c *gin.Context, orgName, name, password string) (*models.Identity, e
 	}
 
 	identity := &models.Identity{Name: name}
+	identity.OrganizationID = organization.ID
 
 	if err := data.CreateIdentity(db, identity); err != nil {
 		return nil, err

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -53,6 +54,8 @@ func Signup(c *gin.Context, orgName, name, password string) (*models.Identity, e
 	if err := data.CreateOrganization(db, organization); err != nil {
 		return nil, err
 	}
+	c.Set("organization", organization)
+	logging.Infof("Org ID -> %s", organization.ID)
 
 	identity := &models.Identity{Name: name}
 	identity.OrganizationID = organization.ID
@@ -75,6 +78,7 @@ func Signup(c *gin.Context, orgName, name, password string) (*models.Identity, e
 		IdentityID:   identity.ID,
 		PasswordHash: hash,
 	}
+	credential.OrganizationID = organization.ID
 
 	if err := data.CreateCredential(db, credential); err != nil {
 		return nil, err

--- a/internal/access/token.go
+++ b/internal/access/token.go
@@ -18,5 +18,10 @@ func CreateToken(c *gin.Context) (token *models.Token, err error) {
 	// does not need authorization check, limited to calling identity
 	db := getDB(c)
 
-	return data.CreateIdentityToken(db, identity.ID)
+	orgID, err := GetCurrentOrgID(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.CreateIdentityToken(db, orgID, identity.ID)
 }

--- a/internal/claims/claims.go
+++ b/internal/claims/claims.go
@@ -1,7 +1,12 @@
 package claims
 
+import (
+	"github.com/infrahq/infra/uid"
+)
+
 type Custom struct {
-	Name   string   `json:"name"`
-	Groups []string `json:"groups"`
-	Nonce  string   `json:"nonce"`
+	Name           string   `json:"name"`
+	Groups         []string `json:"groups"`
+	Nonce          string   `json:"nonce"`
+	OrganizationID uid.ID   `json:"org"`
 }

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -346,7 +346,12 @@ func loginToProvider(provider *api.Provider) (*api.LoginRequestOIDC, error) {
 }
 
 func runSignupForLogin(cli *CLI, client *api.Client) (*api.LoginRequestPasswordCredentials, error) {
-	fmt.Fprintln(cli.Stderr, "  Welcome to Infra. Set up your admin user:")
+	fmt.Fprintln(cli.Stderr, "  Welcome to Infra. Set up your default organization and admin user:")
+
+	orgName, err := promptSetOrgName(cli)
+	if err != nil {
+		return nil, err
+	}
 
 	email, err := promptSetEmail(cli)
 	if err != nil {
@@ -359,7 +364,7 @@ func runSignupForLogin(cli *CLI, client *api.Client) (*api.LoginRequestPasswordC
 	}
 
 	logging.Debugf("call server: signup for user %q", email)
-	_, err = client.Signup(&api.SignupRequest{Name: email, Password: password})
+	_, err = client.Signup(&api.SignupRequest{OrgName: orgName, Name: email, Password: password})
 	if err != nil {
 		return nil, err
 	}
@@ -723,4 +728,19 @@ PROMPT:
 	}
 
 	return email, nil
+}
+
+func promptSetOrgName(cli *CLI) (string, error) {
+	var orgName string
+
+	if err := survey.AskOne(
+		&survey.Input{Message: "Organization Name:"},
+		&orgName,
+		cli.surveyIO,
+		survey.WithValidator(survey.Required),
+	); err != nil {
+		return "", err
+	}
+
+	return orgName, nil
 }

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -364,14 +364,17 @@ func runSignupForLogin(cli *CLI, client *api.Client) (*api.LoginRequestPasswordC
 	}
 
 	logging.Debugf("call server: signup for user %q", email)
-	_, err = client.Signup(&api.SignupRequest{OrgName: orgName, Name: email, Password: password})
+	signupResp, err := client.Signup(&api.SignupRequest{OrgName: orgName, Name: email, Password: password})
 	if err != nil {
 		return nil, err
 	}
 
+	fmt.Fprintf(cli.Stderr, " OrgID = %s\n", signupResp.OrganizationID)
+
 	return &api.LoginRequestPasswordCredentials{
-		Name:     email,
-		Password: password,
+		OrganizationID: signupResp.OrganizationID,
+		Name:           email,
+		Password:       password,
 	}, nil
 }
 

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -47,7 +47,7 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list providers")
-			providers, err := client.ListProviders("")
+			providers, err := client.ListProviders("", 0)
 			if err != nil {
 				return err
 			}
@@ -180,7 +180,7 @@ func newProvidersRemoveCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list providers named %q", args[0])
-			providers, err := client.ListProviders(args[0])
+			providers, err := client.ListProviders(args[0], 0)
 			if err != nil {
 				return err
 			}
@@ -216,7 +216,7 @@ func newProvidersRemoveCmd(cli *CLI) *cobra.Command {
 
 func GetProviderByName(client *api.Client, name string) (*api.Provider, error) {
 	logging.Debugf("call server: list providers named %q", name)
-	providers, err := client.ListProviders(name)
+	providers, err := client.ListProviders(name, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/authn/key_exchange.go
+++ b/internal/server/authn/key_exchange.go
@@ -25,22 +25,27 @@ func NewKeyExchangeAuthentication(requestingAccessKey string, requestedExpiry ti
 	}
 }
 
-func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *gorm.DB) (*models.Identity, *models.Provider, AuthScope, error) {
+func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *gorm.DB) (*models.Organization, *models.Identity, *models.Provider, AuthScope, error) {
 	validatedRequestKey, err := data.ValidateAccessKey(db, a.RequestingAccessKey)
 	if err != nil {
-		return nil, nil, AuthScope{}, fmt.Errorf("invalid access key in exchange: %w", err)
+		return nil, nil, nil, AuthScope{}, fmt.Errorf("invalid access key in exchange: %w", err)
 	}
 
 	if a.RequestedExpiry.After(validatedRequestKey.ExpiresAt) {
-		return nil, nil, AuthScope{}, fmt.Errorf("%w: cannot exchange an access key for another access key with a longer lifetime", internal.ErrBadRequest)
+		return nil, nil, nil, AuthScope{}, fmt.Errorf("%w: cannot exchange an access key for another access key with a longer lifetime", internal.ErrBadRequest)
+	}
+
+	org, err := data.GetOrganization(db, data.ByID(validatedRequestKey.OrganizationID))
+	if err != nil {
+		return nil, nil, nil, AuthScope{}, fmt.Errorf("org is not valid: %w", err)
 	}
 
 	identity, err := data.GetIdentity(db, data.ByID(validatedRequestKey.IssuedFor))
 	if err != nil {
-		return nil, nil, AuthScope{}, fmt.Errorf("user is not valid: %w", err) // the user was probably deleted
+		return nil, nil, nil, AuthScope{}, fmt.Errorf("user is not valid: %w", err) // the user was probably deleted
 	}
 
-	return identity, data.InfraProvider(db), AuthScope{}, nil
+	return org, identity, data.InfraProvider(db), AuthScope{}, nil
 }
 
 func (a *keyExchangeAuthn) Name() string {

--- a/internal/server/authn/key_exchange.go
+++ b/internal/server/authn/key_exchange.go
@@ -40,12 +40,12 @@ func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *gorm.DB) (*models
 		return nil, nil, nil, AuthScope{}, fmt.Errorf("org is not valid: %w", err)
 	}
 
-	identity, err := data.GetIdentity(db, data.ByID(validatedRequestKey.IssuedFor))
+	identity, err := data.GetIdentity(db, data.ByOrg(org.ID), data.ByID(validatedRequestKey.IssuedFor))
 	if err != nil {
 		return nil, nil, nil, AuthScope{}, fmt.Errorf("user is not valid: %w", err) // the user was probably deleted
 	}
 
-	return org, identity, data.InfraProvider(db), AuthScope{}, nil
+	return org, identity, data.InfraProvider(db, org.ID), AuthScope{}, nil
 }
 
 func (a *keyExchangeAuthn) Name() string {

--- a/internal/server/authn/password_credentials.go
+++ b/internal/server/authn/password_credentials.go
@@ -35,7 +35,7 @@ func (a *passwordCredentialAuthn) Authenticate(_ context.Context, db *gorm.DB) (
 		return nil, nil, nil, scope, fmt.Errorf("could not get org: '%s' %w", a.OrganizationID, err)
 	}
 
-	identity, err := data.GetIdentity(db, data.ByName(a.Username))
+	identity, err := data.GetIdentity(db, data.ByOrg(org.ID), data.ByName(a.Username))
 	if err != nil {
 		return nil, nil, nil, scope, fmt.Errorf("could not get identity for username: %w", err)
 	}
@@ -59,7 +59,7 @@ func (a *passwordCredentialAuthn) Authenticate(_ context.Context, db *gorm.DB) (
 	}
 
 	// authentication was a success
-	return org, identity, data.InfraProvider(db), scope, nil // password login is always for infra users
+	return org, identity, data.InfraProvider(db, org.ID), scope, nil // password login is always for infra users
 }
 
 func (a *passwordCredentialAuthn) Name() string {

--- a/internal/server/authn/password_credentials.go
+++ b/internal/server/authn/password_credentials.go
@@ -9,39 +9,48 @@ import (
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 // passwordCredentialAuthn allows presenting username/password credentials in exchange for an access key
 type passwordCredentialAuthn struct {
-	Username string
-	Password string
+	OrganizationID uid.ID
+	Username       string
+	Password       string
 }
 
-func NewPasswordCredentialAuthentication(username, password string) LoginMethod {
+func NewPasswordCredentialAuthentication(orgID uid.ID, username, password string) LoginMethod {
 	return &passwordCredentialAuthn{
-		Username: username,
-		Password: password,
+		OrganizationID: orgID,
+		Username:       username,
+		Password:       password,
 	}
 }
 
-func (a *passwordCredentialAuthn) Authenticate(_ context.Context, db *gorm.DB) (*models.Identity, *models.Provider, AuthScope, error) {
+func (a *passwordCredentialAuthn) Authenticate(_ context.Context, db *gorm.DB) (*models.Organization, *models.Identity, *models.Provider, AuthScope, error) {
 	scope := AuthScope{}
+
+	org, err := data.GetOrganization(db, data.ByID(a.OrganizationID))
+	if err != nil {
+		return nil, nil, nil, scope, fmt.Errorf("could not get org: '%s' %w", a.OrganizationID, err)
+	}
+
 	identity, err := data.GetIdentity(db, data.ByName(a.Username))
 	if err != nil {
-		return nil, nil, scope, fmt.Errorf("could not get identity for username: %w", err)
+		return nil, nil, nil, scope, fmt.Errorf("could not get identity for username: %w", err)
 	}
 
 	// Infra users can have only one username/password combo, look it up
 	userCredential, err := data.GetCredential(db, data.ByIdentityID(identity.ID))
 	if err != nil {
-		return nil, nil, scope, fmt.Errorf("validate creds get user: %w", err)
+		return nil, nil, nil, scope, fmt.Errorf("validate creds get user: %w", err)
 	}
 
 	// compare the stored hash of the user's password and the hash of the presented password
 	err = bcrypt.CompareHashAndPassword(userCredential.PasswordHash, []byte(a.Password))
 	if err != nil {
 		// this probably means the password was wrong
-		return nil, nil, scope, fmt.Errorf("could not verify password: %w", err)
+		return nil, nil, nil, scope, fmt.Errorf("could not verify password: %w", err)
 	}
 
 	if userCredential.OneTimePassword {
@@ -50,7 +59,7 @@ func (a *passwordCredentialAuthn) Authenticate(_ context.Context, db *gorm.DB) (
 	}
 
 	// authentication was a success
-	return identity, data.InfraProvider(db), scope, nil // password login is always for infra users
+	return org, identity, data.InfraProvider(db), scope, nil // password login is always for infra users
 }
 
 func (a *passwordCredentialAuthn) Name() string {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -853,7 +853,7 @@ func (s Server) loadCredential(db *gorm.DB, identity *models.Identity, password 
 			return err
 		}
 
-		if _, err := data.CreateProviderUser(db, data.InfraProvider(db), identity); err != nil {
+		if _, err := data.CreateProviderUser(db, data.InfraProvider(db, identity.OrganizationID), identity); err != nil {
 			return err
 		}
 
@@ -895,14 +895,14 @@ func (s Server) loadAccessKey(db *gorm.DB, identity *models.Identity, key string
 			ExpiresAt:  time.Now().AddDate(10, 0, 0),
 			KeyID:      keyID,
 			Secret:     secret,
-			ProviderID: data.InfraProvider(db).ID,
+			ProviderID: data.InfraProvider(db, identity.OrganizationID).ID,
 		}
 
 		if _, err := data.CreateAccessKey(db, accessKey); err != nil {
 			return err
 		}
 
-		if _, err := data.CreateProviderUser(db, data.InfraProvider(db), identity); err != nil {
+		if _, err := data.CreateProviderUser(db, data.InfraProvider(db, identity.OrganizationID), identity); err != nil {
 			return err
 		}
 

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -286,9 +286,9 @@ var infraConnectorCache *models.Identity
 // InfraConnectorIdentity is a lazy-loaded reference to the connector identity.
 // The cache lasts for the entire lifetime of the process, so any test or test
 // helper that calls InfraConnectorIdentity must call InvalidateCache to clean up.
-func InfraConnectorIdentity(db *gorm.DB) *models.Identity {
+func InfraConnectorIdentity(db *gorm.DB, orgID uid.ID) *models.Identity {
 	if infraConnectorCache == nil {
-		connector, err := GetIdentity(db, ByName(models.InternalInfraConnectorIdentityName))
+		connector, err := GetIdentity(db, ByOrg(orgID), ByName(models.InternalInfraConnectorIdentityName))
 		if err != nil {
 			logging.L.Panic().Err(err).Msg("failed to retrieve connector identity")
 			return nil // unreachable, the line above panics

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -258,12 +258,14 @@ var infraProviderCache *models.Provider
 // InfraProvider is a lazy-loaded cached reference to the infra provider. The
 // cache lasts for the entire lifetime of the process, so any test or test
 // helper that calls InfraProvider must call InvalidateCache to clean up.
-func InfraProvider(db *gorm.DB) *models.Provider {
+func InfraProvider(db *gorm.DB, orgID uid.ID) *models.Provider {
+	// XXX - this will need to work per org
 	if infraProviderCache == nil {
-		infra, err := get[models.Provider](db, ByProviderKind(models.ProviderKindInfra))
+		infra, err := get[models.Provider](db, ByOrg(orgID), ByProviderKind(models.ProviderKindInfra))
 		if err != nil {
 			if errors.Is(err, internal.ErrNotFound) {
 				p := &models.Provider{Name: models.InternalInfraProviderName, Kind: models.ProviderKindInfra}
+				p.OrganizationID = orgID
 				if err := add(db, p); err != nil {
 					logging.L.Panic().Err(err).Msg("failed to create infra provider")
 				}

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -28,8 +28,8 @@ func ListDestinations(db *gorm.DB, selectors ...SelectorFunc) ([]models.Destinat
 	return list[models.Destination](db, selectors...)
 }
 
-func DeleteDestinations(db *gorm.DB, selector SelectorFunc) error {
-	toDelete, err := ListDestinations(db, selector)
+func DeleteDestinations(db *gorm.DB, selectors ...SelectorFunc) error {
+	toDelete, err := ListDestinations(db, selectors...)
 	if err != nil {
 		return err
 	}

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -512,6 +512,7 @@ func initializeSchema(db *gorm.DB) error {
 		&models.EncryptionKey{},
 		&models.Credential{},
 		&models.ProviderUser{},
+		&models.Organization{},
 	}
 
 	for _, table := range tables {

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -316,9 +316,15 @@ func migrate(db *gorm.DB) error {
 			Migrate: func(tx *gorm.DB) error {
 				logging.Infof("running migration 202204111503")
 
-				type Identity struct {
-					models.Model
+				type Model struct {
+					ID        uid.ID
+					CreatedAt time.Time `gorm:"<-:create"`
+					UpdatedAt time.Time
+					DeletedAt gorm.DeletedAt
+				}
 
+				type Identity struct {
+					Model
 					ProviderID uid.ID
 					Name       string `gorm:"uniqueIndex:idx_identities_name_provider_id,where:deleted_at is NULL"`
 				}
@@ -419,8 +425,15 @@ func migrate(db *gorm.DB) error {
 		{
 			ID: "202204211705",
 			Migrate: func(tx *gorm.DB) error {
+				type Model struct {
+					ID        uid.ID
+					CreatedAt time.Time `gorm:"<-:create"`
+					UpdatedAt time.Time
+					DeletedAt gorm.DeletedAt
+				}
+
 				type Settings struct {
-					models.Model
+					Model
 					PrivateJWK models.EncryptedAtRestBytes
 				}
 
@@ -642,7 +655,6 @@ func addOrganizations() *gormigrate.Migration {
 				&models.Grant{},
 				&models.Group{},
 				&models.Identity{},
-				&models.Organization{},
 				&models.Provider{},
 				&models.ProviderUser{},
 				&models.Settings{},
@@ -658,6 +670,5 @@ func addOrganizations() *gormigrate.Migration {
 
 			return nil
 		},
-
 	}
 }

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -4,7 +4,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/models"
-	//"github.com/infrahq/infra/uid"
 )
 
 func CreateOrganization(db *gorm.DB, org *models.Organization) error {

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -19,7 +19,7 @@ func ListOrganizations(db *gorm.DB, selectors ...SelectorFunc) ([]models.Organiz
 	return list[models.Organization](db, selectors...)
 }
 
-func DeleteOrganization(db *gorm.DB, selectors ...SelectorFunc) error {
+func DeleteOrganizations(db *gorm.DB, selectors ...SelectorFunc) error {
 	toDelete, err := GetOrganization(db, selectors...)
 	if err != nil {
 		return err

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -1,0 +1,34 @@
+package data
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/infrahq/infra/internal/server/models"
+	//"github.com/infrahq/infra/uid"
+)
+
+func CreateOrganization(db *gorm.DB, org *models.Organization) error {
+	return add(db, org)
+}
+
+func GetOrganization(db *gorm.DB, selectors ...SelectorFunc) (*models.Organization, error) {
+	return get[models.Organization](db, selectors...)
+}
+
+func ListOrganizations(db *gorm.DB, selectors ...SelectorFunc) ([]models.Organization, error) {
+	return list[models.Organization](db, selectors...)
+}
+
+func DeleteOrganization(db *gorm.DB, selectors ...SelectorFunc) error {
+	toDelete, err := GetOrganization(db, selectors...)
+	if err != nil {
+		return err
+	}
+
+	// TODO:
+	//   * Delete grants
+	//   * Delete groups
+	//   * Delete users
+
+	return delete[models.Organization](db, toDelete.ID)
+}

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -16,7 +16,7 @@ import (
 )
 
 func CreateProviderUser(db *gorm.DB, provider *models.Provider, ident *models.Identity) (*models.ProviderUser, error) {
-	pu, err := get[models.ProviderUser](db, ByIdentityID(ident.ID), ByProviderID(provider.ID))
+	pu, err := get[models.ProviderUser](db, ByOrg(ident.OrganizationID), ByIdentityID(ident.ID), ByProviderID(provider.ID))
 	if err != nil && !errors.Is(err, internal.ErrNotFound) {
 		return nil, err
 	}
@@ -28,6 +28,7 @@ func CreateProviderUser(db *gorm.DB, provider *models.Provider, ident *models.Id
 			Email:      ident.Name,
 			LastUpdate: time.Now().UTC(),
 		}
+		pu.OrganizationID = ident.OrganizationID
 		if err := add(db, pu); err != nil {
 			return nil, err
 		}

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -12,6 +12,12 @@ import (
 
 type SelectorFunc func(db *gorm.DB) *gorm.DB
 
+func ByOrg(id uid.ID) SelectorFunc {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where("organization_id = ?", id)
+	}
+}
+
 func ByID(id uid.ID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("id = ?", id)

--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -10,6 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func InitializeSettings(db *gorm.DB) (*models.Settings, error) {
@@ -52,7 +53,8 @@ func InitializeSettings(db *gorm.DB) (*models.Settings, error) {
 	return &settings, nil
 }
 
-func GetSettings(db *gorm.DB) (*models.Settings, error) {
+func GetSettings(db *gorm.DB, orgID uid.ID) (*models.Settings, error) {
+	// XXX - this needs to work per org
 	var settings models.Settings
 	if err := db.First(&settings).Error; err != nil {
 		return nil, err

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -50,9 +50,10 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 	}
 
 	custom := claims.Custom{
-		Name:   identity.Name,
-		Groups: groups,
-		Nonce:  generate.MathRandom(10, generate.CharsetAlphaNumeric),
+		Name:           identity.Name,
+		Groups:         groups,
+		Nonce:          generate.MathRandom(10, generate.CharsetAlphaNumeric),
+		OrganizationID: identity.OrganizationID,
 	}
 
 	raw, err := jwt.Signed(signer).Claims(claim).Claims(custom).CompactSerialize()

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -18,8 +18,8 @@ var signatureAlgorithmFromKeyAlgorithm = map[string]string{
 	"ED25519": "EdDSA", // elliptic curve 25519
 }
 
-func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires time.Time) (string, error) {
-	settings, err := GetSettings(db)
+func createJWT(db *gorm.DB, orgID uid.ID, identity *models.Identity, groups []string, expires time.Time) (string, error) {
+	settings, err := GetSettings(db, orgID)
 	if err != nil {
 		return "", err
 	}
@@ -64,13 +64,13 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 	return raw, nil
 }
 
-func CreateIdentityToken(db *gorm.DB, identityID uid.ID) (token *models.Token, err error) {
-	identity, err := GetIdentity(db, ByID(identityID))
+func CreateIdentityToken(db *gorm.DB, orgID, identityID uid.ID) (token *models.Token, err error) {
+	identity, err := GetIdentity(db, ByOrg(orgID), ByID(identityID))
 	if err != nil {
 		return nil, err
 	}
 
-	identityGroups, err := ListGroups(db, ByGroupMember(identityID))
+	identityGroups, err := ListGroups(db, ByOrg(orgID), ByGroupMember(identityID))
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func CreateIdentityToken(db *gorm.DB, identityID uid.ID) (token *models.Token, e
 
 	expires := time.Now().Add(time.Minute * 5).UTC()
 
-	jwt, err := createJWT(db, identity, groups, expires)
+	jwt, err := createJWT(db, orgID, identity, groups, expires)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -589,7 +589,10 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 			// #1825: remove, this is for migration
 			r.PasswordCredentials.Name = r.PasswordCredentials.Email
 		}
-		loginMethod = authn.NewPasswordCredentialAuthentication(r.PasswordCredentials.Name, r.PasswordCredentials.Password)
+		loginMethod = authn.NewPasswordCredentialAuthentication(
+			r.PasswordCredentials.OrganizationID,
+			r.PasswordCredentials.Name,
+			r.PasswordCredentials.Password)
 	case r.OIDC != nil:
 		provider, err := access.GetProvider(c, r.OIDC.ProviderID)
 		if err != nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -228,7 +228,7 @@ func (a *API) UpdateUsersInGroup(c *gin.Context, r *api.UpdateUsersInGroupReques
 func (a *API) ListProviders(c *gin.Context, r *api.ListProvidersRequest) (*api.ListResponse[api.Provider], error) {
 	exclude := []models.ProviderKind{models.ProviderKindInfra}
 	pg := models.RequestToPagination(r.PaginationRequest)
-	providers, err := access.ListProviders(c, r.Name, exclude, pg)
+	providers, err := access.ListProviders(c, r.Name, r.OrganizationID, exclude, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -547,18 +547,20 @@ func (a *API) SignupEnabled(c *gin.Context, _ *api.EmptyRequest) (*api.SignupEna
 }
 
 func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.User, error) {
-	if !a.server.options.EnableSignup {
-		return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)
-	}
+	/*
+		if !a.server.options.EnableSignup {
+			return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)
+		}
 
-	signupEnabled, err := access.SignupEnabled(c)
-	if err != nil {
-		return nil, err
-	}
+		signupEnabled, err := access.SignupEnabled(c)
+		if err != nil {
+			return nil, err
+		}
 
-	if !signupEnabled {
-		return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)
-	}
+		if !signupEnabled {
+			return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)
+		}
+	*/
 
 	if r.Name == "" {
 		// #1825: remove, this is for migration

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -565,7 +565,7 @@ func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.User, error) {
 		r.Name = r.Email
 	}
 
-	identity, err := access.Signup(c, r.Name, r.Password)
+	identity, err := access.Signup(c, r.OrgName, r.Name, r.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -122,6 +122,7 @@ func RequireAccessKey(c *gin.Context) error {
 		return fmt.Errorf("%w: skipped validating empty token", internal.ErrUnauthorized)
 	}
 
+	logging.Infof("validating access key")
 	accessKey, err := data.ValidateAccessKey(db, bearer)
 	if err != nil {
 		return fmt.Errorf("%w: invalid token: %s", internal.ErrUnauthorized, err)
@@ -136,13 +137,15 @@ func RequireAccessKey(c *gin.Context) error {
 
 	c.Set("key", accessKey)
 
-	logging.Debugf("getting org %s", accessKey.OrganizationID)
+	logging.Infof("getting org %s", accessKey.OrganizationID)
 	org, err := data.GetOrganization(db, data.ByID(accessKey.OrganizationID))
 	if err != nil {
 		return fmt.Errorf("organization for token: %w", err)
 	}
 	c.Set("organization", org)
 
+	logging.Infof("Org is %s", org.ID)
+	logging.Infof("Issued for %s", accessKey.IssuedFor)
 	identity, err := data.GetIdentity(db, data.ByOrg(org.ID), data.ByID(accessKey.IssuedFor))
 	if err != nil {
 		return fmt.Errorf("identity for token: %w", err)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -136,7 +136,14 @@ func RequireAccessKey(c *gin.Context) error {
 
 	c.Set("key", accessKey)
 
-	identity, err := data.GetIdentity(db, data.ByID(accessKey.IssuedFor))
+	logging.Debugf("getting org %s", accessKey.OrganizationID)
+	org, err := data.GetOrganization(db, data.ByID(accessKey.OrganizationID))
+	if err != nil {
+		return fmt.Errorf("organization for token: %w", err)
+	}
+	c.Set("organization", org)
+
+	identity, err := data.GetIdentity(db, data.ByOrg(org.ID), data.ByID(accessKey.IssuedFor))
 	if err != nil {
 		return fmt.Errorf("identity for token: %w", err)
 	}

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	InfraAdminRole     = "admin"
-	InfraViewRole      = "view"
-	InfraConnectorRole = "connector"
+	InfraSupportAdminRole = "support-admin"
+	InfraAdminRole        = "admin"
+	InfraViewRole         = "view"
+	InfraConnectorRole    = "connector"
 )
 
 // BasePermissionConnect is the first-principle permission that all other permissions are defined from.

--- a/internal/server/models/identity.go
+++ b/internal/server/models/identity.go
@@ -16,7 +16,8 @@ const (
 type Identity struct {
 	Model
 
-	Name       string    `gorm:"uniqueIndex:idx_identities_name,where:deleted_at is NULL"`
+	//Name       string    `gorm:"uniqueIndex:idx_identities_name,where:deleted_at is NULL"`
+	Name       string
 	LastSeenAt time.Time // updated on when an identity uses a session token
 	CreatedBy  uid.ID
 

--- a/internal/server/models/identity.go
+++ b/internal/server/models/identity.go
@@ -27,11 +27,12 @@ type Identity struct {
 
 func (i *Identity) ToAPI() *api.User {
 	return &api.User{
-		ID:         i.ID,
-		Created:    api.Time(i.CreatedAt),
-		Updated:    api.Time(i.UpdatedAt),
-		LastSeenAt: api.Time(i.LastSeenAt),
-		Name:       i.Name,
+		ID:             i.ID,
+		OrganizationID: i.OrganizationID,
+		Created:        api.Time(i.CreatedAt),
+		Updated:        api.Time(i.UpdatedAt),
+		LastSeenAt:     api.Time(i.LastSeenAt),
+		Name:           i.Name,
 		ProviderNames: slice.Map[Provider, string](i.Providers, func(p Provider) string {
 			return p.Name
 		}),

--- a/internal/server/models/model.go
+++ b/internal/server/models/model.go
@@ -17,7 +17,8 @@ type Modelable interface {
 const CreatedBySystem = 1
 
 type Model struct {
-	ID uid.ID
+	ID             uid.ID
+	OrganizationID uid.ID
 	// CreatedAt is set by GORM to time.Now when a record is first created.
 	// See https://gorm.io/docs/conventions.html#Timestamp-Tracking
 	// gorm:"<-:create" allows read and create, but not updating

--- a/internal/server/models/organization.go
+++ b/internal/server/models/organization.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/uid"
+)
+
+type Organization struct {
+	Model
+
+	Name      string `gorm:"uniqueIndex:idx_organizations_name,where:deleted_at is NULL"`
+	CreatedBy uid.ID
+
+	Identities []Identity `gorm:"many2many:identities_organizations"`
+}
+
+func (o *Organization) ToAPI() *api.Organization {
+	return &api.Organization{
+		ID:      o.ID,
+		Created: api.Time(o.CreatedAt),
+		Updated: api.Time(o.UpdatedAt),
+		Name:    o.Name,
+	}
+}
+
+func (o *Organization) PolyID() uid.PolymorphicID {
+	return uid.NewOrganizationPolymorphicID(o.ID)
+}

--- a/internal/server/models/provider.go
+++ b/internal/server/models/provider.go
@@ -45,7 +45,8 @@ func ParseProviderKind(kind string) (ProviderKind, error) {
 type Provider struct {
 	Model
 
-	Name         string       `gorm:"uniqueIndex:idx_providers_name,where:deleted_at is NULL" validate:"required"`
+	//Name         string       `gorm:"uniqueIndex:idx_providers_name,where:deleted_at is NULL" validate:"required"`
+	Name         string       `validate:"required"`
 	Kind         ProviderKind `validate:"required"`
 	URL          string
 	ClientID     string

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -81,6 +81,11 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	delete(a, authn, "/api/groups/:id", a.DeleteGroup)
 	patch(a, authn, "/api/groups/:id/users", a.UpdateUsersInGroup)
 
+	get(a, authn, "/api/organizations", a.ListOrganizations)
+	post(a, authn, "/api/organizations", a.CreateOrganization)
+	get(a, authn, "/api/organizations/:id", a.GetOrganization)
+	delete(a, authn, "/api/organizations/:id", a.DeleteOrganization)
+
 	get(a, authn, "/api/grants", a.ListGrants)
 	get(a, authn, "/api/grants/:id", a.GetGrant)
 	post(a, authn, "/api/grants", a.CreateGrant)

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -27,11 +27,15 @@ func NewTelemetry(db *gorm.DB) (*Telemetry, error) {
 		return nil, errors.New("db cannot be nil")
 	}
 
+	/*
 	var err error
 	settings, err = data.GetSettings(db)
 	if err != nil {
 		return nil, err
 	}
+	*/
+
+	// XXX - This needs to be for the entire infra server, not just a specific Org
 
 	return &Telemetry{
 		client: analytics.New(internal.TelemetryWriteKey),

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -535,6 +535,56 @@
           }
         }
       },
+      "ListResponse_Organization": {
+        "properties": {
+          "count": {
+            "format": "int",
+            "type": "integer"
+          },
+          "items": {
+            "items": {
+              "properties": {
+                "created": {
+                  "description": "formatted as an RFC3339 date-time",
+                  "example": "2022-03-14T09:48:00Z",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "id": {
+                  "example": "4yJ3n3D8E2",
+                  "format": "uid",
+                  "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "updated": {
+                  "description": "formatted as an RFC3339 date-time",
+                  "example": "2022-03-14T09:48:00Z",
+                  "format": "date-time",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "pagination_info": {
+            "properties": {
+              "limit": {
+                "format": "int",
+                "type": "integer"
+              },
+              "page": {
+                "format": "int",
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          }
+        }
+      },
       "ListResponse_Provider": {
         "properties": {
           "count": {
@@ -700,6 +750,31 @@
             "example": "4yJ3n3D8E2",
             "format": "uid",
             "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+            "type": "string"
+          }
+        }
+      },
+      "Organization": {
+        "properties": {
+          "created": {
+            "description": "formatted as an RFC3339 date-time",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "example": "4yJ3n3D8E2",
+            "format": "uid",
+            "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "updated": {
+            "description": "formatted as an RFC3339 date-time",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
             "type": "string"
           }
         }
@@ -2738,6 +2813,360 @@
         "summary": "Logout",
         "tags": [
           "Authentication"
+        ]
+      }
+    },
+    "/api/organizations": {
+      "get": {
+        "description": "ListOrganizations",
+        "operationId": "ListOrganizations",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_Organization"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "ListOrganizations",
+        "tags": [
+          "Misc"
+        ]
+      },
+      "post": {
+        "description": "CreateOrganization",
+        "operationId": "CreateOrganization",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "CreateOrganization",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/organizations/{id}": {
+      "delete": {
+        "description": "DeleteOrganization",
+        "operationId": "DeleteOrganization",
+        "parameters": [
+          {
+            "example": "4yJ3n3D8E2",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "4yJ3n3D8E2",
+              "format": "uid",
+              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "DeleteOrganization",
+        "tags": [
+          "Misc"
+        ]
+      },
+      "get": {
+        "description": "GetOrganization",
+        "operationId": "GetOrganization",
+        "parameters": [
+          {
+            "example": "4yJ3n3D8E2",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "4yJ3n3D8E2",
+              "format": "uid",
+              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "GetOrganization",
+        "tags": [
+          "Misc"
         ]
       }
     },

--- a/uid/polymorphic.go
+++ b/uid/polymorphic.go
@@ -35,6 +35,10 @@ func NewGroupPolymorphicID(id ID) PolymorphicID {
 	return newPolymorphicID("g", id)
 }
 
+func NewOrganizationPolymorphicID(id ID) PolymorphicID {
+	return newPolymorphicID("o", id)
+}
+
 func newPolymorphicID(prefix string, id ID) PolymorphicID {
 	return PolymorphicID(fmt.Sprintf("%s:%s", prefix, id))
 }


### PR DESCRIPTION
## Summary

First cut for adding the orgs base object. This includes the CRUD operations which a support admin would use to work on orgs.

There's still a lot to do here, including:
  * adding unit tests
  * getting the sign-in flow working
  * changing the other base objects (i.e. users, groups, access keys, destinations, providers, etc.) to use the org
  

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


