### PR TITLE
api: integrate validation library

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/infrahq/infra/internal/validate"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -23,10 +24,19 @@ type ListAccessKeysRequest struct {
 }
 
 type CreateAccessKeyRequest struct {
-	UserID            uid.ID   `json:"userID" validate:"required"`
-	Name              string   `json:"name" validate:"excludes= "`
-	TTL               Duration `json:"ttl" validate:"required" note:"maximum time valid"`
-	ExtensionDeadline Duration `json:"extensionDeadline,omitempty" validate:"required" note:"How long the key is active for before it needs to be renewed. The access key must be used within this amount of time to renew validity"`
+	UserID            uid.ID   `json:"userID"`
+	Name              string   `json:"name"`
+	TTL               Duration `json:"ttl" note:"maximum time valid"`
+	ExtensionDeadline Duration `json:"extensionDeadline,omitempty" note:"How long the key is active for before it needs to be renewed. The access key must be used within this amount of time to renew validity"`
+}
+
+func (r *CreateAccessKeyRequest) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		ValidateName(r.Name),
+		validate.Required("userID", r.UserID),
+		validate.Required("ttl", r.TTL),
+		validate.Required("extensionDeadline", r.ExtensionDeadline),
+	}
 }
 
 type CreateAccessKeyResponse struct {
@@ -38,4 +48,21 @@ type CreateAccessKeyResponse struct {
 	Expires           Time   `json:"expires" note:"after this deadline the key is no longer valid"`
 	ExtensionDeadline Time   `json:"extensionDeadline" note:"the key must be used by this time to remain valid"`
 	AccessKey         string `json:"accessKey"`
+}
+
+// ValidateName returns a standard validation rule for all name fields. The
+// field name must always be "name".
+func ValidateName(value string) validate.ValidationRule {
+	return validate.StringRule{
+		Value:     value,
+		Name:      "name",
+		MinLength: 3,
+		MaxLength: 256,
+		CharacterRanges: []validate.CharRange{
+			validate.AlphabetLower,
+			validate.AlphabetUpper,
+			validate.Numbers,
+			validate.Dash, validate.Underscore, validate.Dot,
+		},
+	}
 }

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -69,6 +70,9 @@ func sendAPIError(c *gin.Context, err error) {
 				Errors:    problems,
 			})
 		}
+		sort.Slice(resp.FieldErrors, func(i, j int) bool {
+			return resp.FieldErrors[i].FieldName < resp.FieldErrors[j].FieldName
+		})
 
 	case errors.As(err, pgValidationErrors):
 		resp.Code = http.StatusBadRequest

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/validate"
 )
 
 func TestSendAPIError(t *testing.T) {
@@ -36,6 +37,16 @@ func TestSendAPIError(t *testing.T) {
 		{
 			err:    internal.ErrUnauthorized,
 			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized"},
+		},
+		{
+			err: validate.Error{"fieldname": []string{"is required"}},
+			result: api.Error{
+				Code:    http.StatusBadRequest,
+				Message: "validation failed: fieldname: is required",
+				FieldErrors: []api.FieldError{
+					{FieldName: "fieldname", Errors: []string{"is required"}},
+				},
+			},
 		},
 		{
 			err:    fmt.Errorf("hide this: %w", internal.ErrUnauthorized),

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/validate"
 )
 
 var pathIDReplacer = regexp.MustCompile(`:\w+`)
@@ -439,6 +440,12 @@ func buildRequest(r reflect.Type, op *openapi3.Operation) {
 					op.AddParameter(param.Value)
 				}
 			}
+
+			if req, ok := reflect.New(f.Type).Interface().(validate.Request); ok {
+				for _, rule := range req.ValidationRules() {
+					rule.DescribeSchema(schema)
+				}
+			}
 			continue
 		}
 
@@ -512,6 +519,12 @@ func buildRequest(r reflect.Type, op *openapi3.Operation) {
 		}
 
 		op.AddParameter(p)
+	}
+
+	if req, ok := reflect.New(r).Interface().(validate.Request); ok {
+		for _, rule := range req.ValidationRules() {
+			rule.DescribeSchema(schema)
+		}
 	}
 
 	if len(schema.Properties) > 0 {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -18,6 +18,7 @@ import (
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/validate"
 	"github.com/infrahq/infra/metrics"
 )
 
@@ -261,6 +262,13 @@ func bind(c *gin.Context, req interface{}) error {
 		}
 	}
 
+	if r, ok := req.(validate.Request); ok {
+		if err := validate.Validate(r); err != nil {
+			return err
+		}
+	}
+
+	// TODO: remove once all requests use internal/validate
 	if err := pgValidate.Struct(req); err != nil {
 		return err
 	}

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -1001,6 +1001,9 @@
                     "type": "string"
                   },
                   "name": {
+                    "format": "[a-zA-Z0-9\\-_.]",
+                    "maxLength": 256,
+                    "minLength": 3,
                     "type": "string"
                   },
                   "ttl": {

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -50,6 +50,9 @@ func TestTLSConfigFromOptions(t *testing.T) {
 	})
 
 	t.Run("generate TLS cert from CA", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("too slow for short run")
+		}
 		opts := TLSOptions{
 			CA:           types.StringOrFile(ca),
 			CAPrivateKey: "file:testdata/pki/ca.key",


### PR DESCRIPTION
Branched from #2158

This PR adds validation rules to `CreateAccessKeyRequest`. Also updates the test for `CreateAccessKey` and adds a test case for failed validation.

It also integrates the `internal/validate` library with both the `routes.go` framework, and openapi doc generation.

* Handle the validation error in sendAPIError.
* Call Validate from the handler wrapper.
* Call DescribeSchema from openapi doc generation.
* Change the text of the required validation rule failure.

Related to #1763