### PR TITLE
fix: offline access for google

### DIFF
--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/race"
 	"github.com/infrahq/infra/internal/server"
+	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -502,4 +503,42 @@ func TestLoginCmd_TLSVerify(t *testing.T) {
 
 		golden.Assert(t, bufs.Stderr.String(), t.Name())
 	})
+}
+
+func TestAuthURLForProvider(t *testing.T) {
+	expectedOktaAuthURL := "https://okta.example.com/oauth2/v1/authorize?redirect_uri=http://localhost:8301&client_id=001&response_type=code&scope=email+openid&state=state"
+	okta := api.Provider{
+		AuthURL:  "https://okta.example.com/oauth2/v1/authorize",
+		ClientID: "001",
+		Kind:     string(models.ProviderKindOkta),
+		Scopes: []string{
+			"email",
+			"openid",
+		},
+	}
+	assert.Equal(t, authURLForProvider(okta, "state"), expectedOktaAuthURL)
+
+	expectedAzureAuthURL := "https://login.microsoftonline.com/0/oauth2/v2.0/authorize?redirect_uri=http://localhost:8301&client_id=001&response_type=code&scope=email+openid&state=state"
+	azure := api.Provider{
+		AuthURL:  "https://login.microsoftonline.com/0/oauth2/v2.0/authorize",
+		ClientID: "001",
+		Kind:     string(models.ProviderKindAzure),
+		Scopes: []string{
+			"email",
+			"openid",
+		},
+	}
+	assert.Equal(t, authURLForProvider(azure, "state"), expectedAzureAuthURL)
+
+	expectedGoogleAuthURL := "https://accounts.google.com/o/oauth2/v2/auth?redirect_uri=http://localhost:8301&prompt=consent&access_type=offline&client_id=001&response_type=code&scope=email+openid&state=state"
+	google := api.Provider{
+		AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
+		ClientID: "001",
+		Kind:     string(models.ProviderKindGoogle),
+		Scopes: []string{
+			"email",
+			"openid",
+		},
+	}
+	assert.Equal(t, authURLForProvider(google, "state"), expectedGoogleAuthURL)
 }

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/race"
 	"github.com/infrahq/infra/internal/server"
-	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -506,11 +505,11 @@ func TestLoginCmd_TLSVerify(t *testing.T) {
 }
 
 func TestAuthURLForProvider(t *testing.T) {
-	expectedOktaAuthURL := "https://okta.example.com/oauth2/v1/authorize?redirect_uri=http://localhost:8301&client_id=001&response_type=code&scope=email+openid&state=state"
+	expectedOktaAuthURL := "https://okta.example.com/oauth2/v1/authorize?client_id=001&redirect_uri=http%3A%2F%2Flocalhost%3A8301&response_type=code&scope=email+openid&state=state"
 	okta := api.Provider{
 		AuthURL:  "https://okta.example.com/oauth2/v1/authorize",
 		ClientID: "001",
-		Kind:     string(models.ProviderKindOkta),
+		Kind:     "okta",
 		Scopes: []string{
 			"email",
 			"openid",
@@ -518,11 +517,11 @@ func TestAuthURLForProvider(t *testing.T) {
 	}
 	assert.Equal(t, authURLForProvider(okta, "state"), expectedOktaAuthURL)
 
-	expectedAzureAuthURL := "https://login.microsoftonline.com/0/oauth2/v2.0/authorize?redirect_uri=http://localhost:8301&client_id=001&response_type=code&scope=email+openid&state=state"
+	expectedAzureAuthURL := "https://login.microsoftonline.com/0/oauth2/v2.0/authorize?client_id=001&redirect_uri=http%3A%2F%2Flocalhost%3A8301&response_type=code&scope=email+openid&state=state"
 	azure := api.Provider{
 		AuthURL:  "https://login.microsoftonline.com/0/oauth2/v2.0/authorize",
 		ClientID: "001",
-		Kind:     string(models.ProviderKindAzure),
+		Kind:     "azure",
 		Scopes: []string{
 			"email",
 			"openid",
@@ -530,11 +529,11 @@ func TestAuthURLForProvider(t *testing.T) {
 	}
 	assert.Equal(t, authURLForProvider(azure, "state"), expectedAzureAuthURL)
 
-	expectedGoogleAuthURL := "https://accounts.google.com/o/oauth2/v2/auth?redirect_uri=http://localhost:8301&prompt=consent&access_type=offline&client_id=001&response_type=code&scope=email+openid&state=state"
+	expectedGoogleAuthURL := "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&client_id=001&prompt=consent&redirect_uri=http%3A%2F%2Flocalhost%3A8301&response_type=code&scope=email+openid&state=state"
 	google := api.Provider{
 		AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
 		ClientID: "001",
-		Kind:     string(models.ProviderKindGoogle),
+		Kind:     "google",
 		Scopes: []string{
 			"email",
 			"openid",


### PR DESCRIPTION
- ensure we always get refresh token from google oidc

## Summary
The Google OIDC login flow requires a special parameter to be specified in order to retrieve a refresh token. This differs from the more standard offline scope we use to get the refresh token. This change ensures we always get a refresh token from Google OIDC so that user sessions are valid longer.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2499
