### PR TITLE
maintain(docs): fix typos in the cli user docs

### DIFF
--- a/docs/configuration/working-with-users.md
+++ b/docs/configuration/working-with-users.md
@@ -7,7 +7,7 @@ position: 3
 
 ## Listing users
 
-To see all users being managed by Infra, use `infra id list`:
+To see all users being managed by Infra, use `infra users list`:
 
 ```
 infra users list
@@ -25,7 +25,7 @@ michael@infrahq.com          3 days ago
 
 ## Adding a user
 
-To add a user to Infra, use `infra id add`:
+To add a user to Infra, use `infra users add`:
 
 ```
 infra users add example@acme.com


### PR DESCRIPTION
## Summary

Fix up some references in our docs which point to the unused `infra id` command to instead use `infra users`

## Checklist

- [x] Updated associated docs where necessary

