### PR TITLE
improve: eof errors are more user friendly

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -113,7 +113,8 @@ func request[Req, Res any](client Client, method string, path string, query Quer
 
 	resp, err := client.HTTP.Do(req)
 	if err != nil {
-		if connError := HandleConnError(err); connError != nil {
+		connError := HandleConnError(err)
+		if connError != nil {
 			return nil, connError
 		}
 		return nil, fmt.Errorf("%s %q: %w", method, path, err)
@@ -326,9 +327,6 @@ func partialText(body []byte, limit int) string {
 	return string(body[:limit]) + "..."
 }
 
-// HandleConnError translates common connection errors into more informative human
-// readable errors. Returns `nil` if the error was not handled, so it is the callers responsibility to
-// return the original error if `HandleConnError` returns nil.
 func HandleConnError(err error) error {
 	urlErr := &url.Error{}
 	if errors.As(err, &urlErr) {

--- a/api/client.go
+++ b/api/client.go
@@ -113,8 +113,7 @@ func request[Req, Res any](client Client, method string, path string, query Quer
 
 	resp, err := client.HTTP.Do(req)
 	if err != nil {
-		connError := HandleConnError(err)
-		if connError != nil {
+		if connError := HandleConnError(err); connError != nil {
 			return nil, connError
 		}
 		return nil, fmt.Errorf("%s %q: %w", method, path, err)
@@ -327,6 +326,9 @@ func partialText(body []byte, limit int) string {
 	return string(body[:limit]) + "..."
 }
 
+// HandleConnError translates common connection errors into more informative human
+// readable errors. Returns `nil` if the error was not handled, so it is the callers responsibility to
+// return the original error if `HandleConnError` returns nil.
 func HandleConnError(err error) error {
 	urlErr := &url.Error{}
 	if errors.As(err, &urlErr) {

--- a/api/client.go
+++ b/api/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ssoroka/slice"
 
+	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -112,11 +113,9 @@ func request[Req, Res any](client Client, method string, path string, query Quer
 
 	resp, err := client.HTTP.Do(req)
 	if err != nil {
-		urlErr := &url.Error{}
-		if errors.As(err, &urlErr) {
-			if urlErr.Timeout() {
-				return nil, fmt.Errorf("%w: %s", ErrTimeout, err)
-			}
+		connError := HandleConnError(err)
+		if connError != nil {
+			return nil, connError
 		}
 		return nil, fmt.Errorf("%s %q: %w", method, path, err)
 	}
@@ -326,4 +325,20 @@ func partialText(body []byte, limit int) string {
 	}
 
 	return string(body[:limit]) + "..."
+}
+
+func HandleConnError(err error) error {
+	urlErr := &url.Error{}
+	if errors.As(err, &urlErr) {
+		if urlErr.Timeout() {
+			return fmt.Errorf("%w: %s", ErrTimeout, err)
+		}
+	}
+
+	if errors.Is(err, io.EOF) {
+		logging.Debugf("request error: %v", err)
+		return fmt.Errorf("could not reach infra server, please wait a moment and try again")
+	}
+
+	return nil
 }

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -497,9 +497,7 @@ func attemptTLSRequest(options loginCmdOptions) error {
 		return nil
 	}
 
-	connError := api.HandleConnError(err)
-
-	if connError != nil {
+	if connError := api.HandleConnError(err); connError != nil {
 		return connError
 	}
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/mail"
+	"net/url"
 	"os"
 	"strings"
 	"time"

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -491,12 +491,15 @@ func attemptTLSRequest(options loginCmdOptions) error {
 	}
 
 	res, err = httpClient.Do(req)
+
 	if err == nil {
 		res.Body.Close()
 		return nil
 	}
 
-	if connError := api.HandleConnError(err); connError != nil {
+	connError := api.HandleConnError(err)
+
+	if connError != nil {
 		return connError
 	}
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -491,15 +491,12 @@ func attemptTLSRequest(options loginCmdOptions) error {
 	}
 
 	res, err = httpClient.Do(req)
-
 	if err == nil {
 		res.Body.Close()
 		return nil
 	}
 
-	connError := api.HandleConnError(err)
-
-	if connError != nil {
+	if connError := api.HandleConnError(err); connError != nil {
 		return connError
 	}
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/mail"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -490,17 +489,20 @@ func attemptTLSRequest(options loginCmdOptions) error {
 			TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
 		},
 	}
+
 	res, err = httpClient.Do(req)
-	urlErr := &url.Error{}
-	switch {
-	case err == nil:
+
+	if err == nil {
 		res.Body.Close()
 		return nil
-	case errors.As(err, &urlErr):
-		if urlErr.Timeout() {
-			return fmt.Errorf("%w: %s", api.ErrTimeout, err)
-		}
 	}
+
+	connError := api.HandleConnError(err)
+
+	if connError != nil {
+		return connError
+	}
+
 	return err
 }
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 
@@ -17,9 +16,6 @@ func main() {
 	if err := cmd.Run(context.Background(), os.Args[1:]...); err != nil {
 		var userErr cmd.Error
 		switch {
-		case strings.HasSuffix(err.Error(), ": EOF"):
-			logging.Debugf("%v\n", err)
-			fmt.Fprintln(os.Stderr, "Could not reach infra server, please wait a moment and try again.")
 		case errors.Is(err, terminal.InterruptErr):
 			logging.Debugf("user interrupted the process")
 		case errors.As(err, &userErr):

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 
@@ -16,6 +17,9 @@ func main() {
 	if err := cmd.Run(context.Background(), os.Args[1:]...); err != nil {
 		var userErr cmd.Error
 		switch {
+		case strings.HasSuffix(err.Error(), ": EOF"):
+			logging.Debugf("%v\n", err)
+			fmt.Fprintln(os.Stderr, "Could not reach infra server, please wait a moment and try again.")
 		case errors.Is(err, terminal.InterruptErr):
 			logging.Debugf("user interrupted the process")
 		case errors.As(err, &userErr):


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->
Earlier, the CLI would show EOF when the server wasn't ready/unable to connect to and the user tried to login (or use a different command upon update).

It now shows:
`Could not reach infra server, please wait a moment and try again.`

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2307 
