### PR TITLE
fix(ui): fix minor issues in destinations dashboard

### DIFF
--- a/ui/components/layouts/dashboard.js
+++ b/ui/components/layouts/dashboard.js
@@ -56,7 +56,7 @@ function Layout({ children }) {
 
   return (
     <div className='flex h-full min-w-[800px]'>
-      <nav className='flex w-40 flex-none flex-col lg:w-48 xl:w-56'>
+      <nav className='flex w-48 flex-none flex-col xl:w-56'>
         <div className='lg:my-18 mt-6 mb-10 flex flex-shrink-0 select-none items-center px-5'>
           <Link href='/'>
             <a>
@@ -127,7 +127,7 @@ function Layout({ children }) {
                 Sign Out
               </button>
               <div className='mt-2 text-3xs leading-none text-violet-50/40'>
-                Infra version{' '}
+                version{' '}
                 <span className='select-text font-mono'>
                   {version?.version}
                 </span>

--- a/ui/components/sidebar.js
+++ b/ui/components/sidebar.js
@@ -16,7 +16,7 @@ export default function Sidebar({
   return (
     <aside
       ref={ref}
-      className='my-0 flex h-full w-full min-w-[18em] max-w-sm flex-col overflow-x-visible overflow-y-scroll pl-8 pr-6 lg:max-w-md lg:pl-12 xl:max-w-lg xl:pl-16'
+      className='my-0 flex h-full w-full min-w-[24em] max-w-sm flex-col overflow-x-visible overflow-y-scroll pl-8 pr-6 lg:max-w-md lg:pl-12 xl:max-w-lg xl:pl-16'
     >
       <header className='flex-start sticky top-0 z-10 flex items-center justify-between bg-black py-3'>
         <div className='mr-3 flex-none'>

--- a/ui/pages/destinations/index.js
+++ b/ui/pages/destinations/index.js
@@ -262,10 +262,10 @@ const columns = [
   {
     Header: 'Name',
     accessor: 'name',
-    width: '70%',
+    width: '55%',
     Cell: ({ row, value }) => {
       return (
-        <div className='flex items-center py-2'>
+        <div className='flex truncate py-2'>
           {row.canExpand && (
             <span
               {...row.getToggleRowExpandedProps({
@@ -291,12 +291,12 @@ const columns = [
             </span>
           )}
           <span
-            {...row.getToggleRowExpandedProps()}
-            className={`flex items-center ${row.depth === 0 ? 'h-6' : ''} ${
-              row.canExpand ? '' : 'pl-9'
-            }`}
+            title={value}
+            className={`flex flex-1 items-center truncate ${
+              row.depth === 0 ? 'h-6' : ''
+            } ${row.canExpand ? '' : 'pl-9'}`}
           >
-            {value}
+            <span className='truncate'>{value}</span>
           </span>
         </div>
       )
@@ -305,7 +305,7 @@ const columns = [
   {
     Header: 'Kind',
     accessor: v => v,
-    width: '15%',
+    width: '20%',
     Cell: ({ value }) => (
       <span className='rounded bg-gray-800 px-2 py-0.5 text-gray-400'>
         {value.kind}
@@ -315,17 +315,17 @@ const columns = [
   {
     Header: 'Status',
     accessor: v => v,
-    width: '15%',
+    width: '25%',
     Cell: ({ value }) => (
       <div className='flex items-center py-2'>
         {value.kind === 'cluster' && (
           <>
             <div
-              className={`h-2 w-2 rounded-full ${
-                value.connected ? 'bg-green-400' : 'bg-gray-400'
+              className={`h-2 w-2 flex-none rounded-full ${
+                value.connected ? 'bg-green-400' : 'bg-gray-600'
               }`}
             />
-            <span className='px-2 text-gray-400'>
+            <span className='flex-none px-2 text-gray-400'>
               {value.connected ? 'Connected' : 'Disconnected'}
             </span>
           </>
@@ -370,7 +370,7 @@ export default function Destinations() {
       </Head>
       {!loading && (
         <div className='flex h-full flex-1'>
-          <div className='flex min-w-[20em] flex-1 flex-col space-y-4'>
+          <div className='flex min-w-[32em] flex-1 flex-col space-y-4'>
             <PageHeader
               header='Clusters'
               buttonHref={admin && '/destinations/add'}
@@ -386,10 +386,7 @@ export default function Destinations() {
                   columns={columns}
                   data={data}
                   getRowProps={row => ({
-                    onClick: () => {
-                      setSelected(row.original)
-                      row.toggleRowExpanded(true)
-                    },
+                    onClick: () => setSelected(row.original),
                     className:
                       selected?.resource === row.original.resource
                         ? 'bg-gray-900/50'


### PR DESCRIPTION
Fixes  #2514:

<img width="180" alt="Screen Shot 2022-07-07 at 2 46 39 PM" src="https://user-images.githubusercontent.com/251292/177847535-81cb7b1c-7d84-4130-8a69-1c4866b71bf3.png">

Also fixes #2515 and an issue where clicking a destination row would expand it