### PR TITLE
fix: use correct version for dev builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist --skip-publish
+        env:
+          GORELEASER_CURRENT_TAG: ${{ inputs.RELEASE_NAME }}
       - uses: actions/upload-artifact@v3
         with:
           name: binaries


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Dev builds are special as they need special handling when building with goreleaser. Goreleaser uses the git tag to determine the version string. Since dev builds are untagged but set a future release, this needs to be overwritten in Goreleaser.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2522
