### PR TITLE
api: allow types to define their own default values for openapi schema

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/infrahq/infra/uid"
 )
 
@@ -29,6 +31,14 @@ func (i *IDOrSelf) UnmarshalText(b []byte) error {
 	var err error
 	i.ID, err = uid.Parse(b)
 	return err
+}
+
+func (i IDOrSelf) DescribeSchema(schema *openapi3.Schema) {
+	schema.Type = "string"
+	schema.Format = "uid|self"
+	schema.Pattern = `[\da-zA-HJ-NP-Z]{1,11}|self`
+	schema.Example = "4yJ3n3D8E2"
+	schema.Description = "a uid or the literal self"
 }
 
 type Time time.Time
@@ -91,6 +101,24 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 
 func (d Duration) String() string {
 	return time.Duration(d).String()
+}
+
+func (t Time) DescribeSchema(schema *openapi3.Schema) {
+	schema.Type = "string"
+	schema.Format = "date-time" // date-time is rfc3339
+	schema.Example = time.Date(2022, 3, 14, 9, 48, 0, 0, time.UTC).Format(time.RFC3339)
+	if len(schema.Description) == 0 {
+		schema.Description = "formatted as an RFC3339 date-time"
+	}
+}
+
+func (d Duration) DescribeSchema(schema *openapi3.Schema) {
+	schema.Type = "string"
+	schema.Format = "duration"
+	schema.Example = "72h3m6.5s"
+	if len(schema.Description) == 0 {
+		schema.Description = "a duration of time supporting (h)ours, (m)inutes, and (s)econds"
+	}
 }
 
 type ListResponse[T any] struct {

--- a/internal/server/apimigrator.go
+++ b/internal/server/apimigrator.go
@@ -102,7 +102,7 @@ func rebuildRequest(c *gin.Context, newReqObj interface{}) {
 	for i := 0; i < r.NumField(); i++ {
 		f := r.Field(i)
 		if fieldName, ok := t.Field(i).Tag.Lookup("form"); ok {
-			if structNameWithPkg(f.Type()) == "uid.ID" {
+			if f.Type() == reflect.TypeOf(uid.ID(0)) {
 				query.Add(fieldName, uid.ID(f.Int()).String())
 				continue
 			}
@@ -114,8 +114,8 @@ func rebuildRequest(c *gin.Context, newReqObj interface{}) {
 				query.Add(fieldName, f.String())
 			case reflect.Slice:
 				// only type that does this is []uid.ID
-				switch structNameWithPkg(f.Type()) {
-				case "uid.ID":
+				switch f.Type() {
+				case reflect.TypeOf(uid.ID(0)):
 					for j := 0; j < f.Len(); j++ {
 						query.Add(fieldName, uid.ID(f.Index(j).Int()).String())
 					}

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -165,7 +165,7 @@ func buildProperty(f reflect.StructField, t, parent reflect.Type, parentSchema *
 	}
 
 	s := &openapi3.Schema{}
-	setTagInfo(f, t, parent, s, parentSchema)
+	setTagInfo(f, parent, s, parentSchema)
 	setTypeInfo(t, s)
 
 	if s.Type == "array" {
@@ -216,11 +216,7 @@ func WriteOpenAPIDocToFile(openAPIDoc openapi3.T, version string, filename strin
 	return nil
 }
 
-func setTagInfo(f reflect.StructField, t, parent reflect.Type, schema, parentSchema *openapi3.Schema) {
-	if ex := getDefaultExampleForType(t); len(ex) > 0 {
-		schema.Example = ex
-	}
-
+func setTagInfo(f reflect.StructField, parent reflect.Type, schema, parentSchema *openapi3.Schema) {
 	if example, ok := f.Tag.Lookup("example"); ok {
 		schema.Example = example
 	}
@@ -229,6 +225,7 @@ func setTagInfo(f reflect.StructField, t, parent reflect.Type, schema, parentSch
 		schema.Description = note
 	}
 
+	// TODO: remove with pgValidate
 	if validate, ok := f.Tag.Lookup("validate"); ok {
 		for _, val := range strings.Split(validate, ",") {
 			if val == "required" && parentSchema != nil {
@@ -250,58 +247,33 @@ func setTagInfo(f reflect.StructField, t, parent reflect.Type, schema, parentSch
 	}
 }
 
-var exampleTime = time.Date(2022, 3, 14, 9, 48, 0, 0, time.UTC).Format(time.RFC3339)
+type describeSchema interface {
+	DescribeSchema(schema *openapi3.Schema)
+}
 
 // `type` can be one of the following only: "object", "array", "string", "number", "integer", "boolean", "null".
 // `format` has a few defined types, but can be anything. https://swagger.io/docs/specification/data-models/data-types/
 func setTypeInfo(t reflect.Type, schema *openapi3.Schema) {
-	switch structNameWithPkg(t) {
-	case "api.Time", "time.Time":
-		schema.Type = "string"
-		schema.Format = "date-time" // date-time is rfc3339
-		schema.Example = exampleTime
-		if len(schema.Description) == 0 {
-			schema.Description = "formatted as an RFC3339 date-time"
-		}
+	// TODO: convert to value earlier?
+	value := reflect.New(t).Interface()
+	if ds, ok := value.(describeSchema); ok {
+		ds.DescribeSchema(schema)
 		return
+	}
 
-	case "api.Duration", "time.Duration":
-		schema.Type = "string"
-		schema.Format = "duration"
-		schema.Example = "72h3m6.5s"
-		if len(schema.Description) == 0 {
-			schema.Description = "a duration of time supporting (h)ours, (m)inutes, and (s)econds"
-		}
-		return
+	switch value.(type) {
+	case time.Time:
+		panic("field must use api.Time")
+	case time.Duration:
+		panic("field must use api.Duration")
+	}
 
-	case "uid.ID":
-		schema.Type = "string"
-		schema.Format = "uid"
-		schema.Pattern = `[\da-zA-HJ-NP-Z]{1,11}`
-		schema.Example = "4yJ3n3D8E2"
-		return
-
-	case "api.IDOrSelf":
-		schema.Type = "string"
-		schema.Format = "uid|self"
-		schema.Pattern = `[\da-zA-HJ-NP-Z]{1,11}|self`
-		schema.Example = "4yJ3n3D8E2"
-		schema.Description = "a uid or the literal self"
-		return
-
-	case "uid.PolymorphicID":
-		schema.Type = "string"
-		schema.Format = "poly-uid"
-		schema.Pattern = `\w:[\da-zA-HJ-NP-Z]{1,11}`
-		schema.Example = "i:4yJ3n3D8E3"
-
-		return
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
 	}
 
 	//nolint:exhaustive
 	switch t.Kind() {
-	case reflect.Pointer:
-		setTypeInfo(t.Elem(), schema)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		schema.Type = "integer"
 		schema.Format = t.Kind().String()
@@ -479,10 +451,7 @@ func buildRequest(r reflect.Type, op *openapi3.Operation) {
 			panic(fmt.Sprintf("field %q of struct %q must have a tag (json, form, or uri) with a name or '-'", f.Name, r.Name()))
 		}
 
-		if ex := getDefaultExampleForType(f.Type); len(ex) > 0 {
-			p.Example = ex
-		}
-
+		// TODO: share this with setTagInfo
 		if example, ok := f.Tag.Lookup("example"); ok {
 			p.Example = example
 		}
@@ -491,6 +460,7 @@ func buildRequest(r reflect.Type, op *openapi3.Operation) {
 			p.Description = note
 		}
 
+		// TODO: remove with pgValidate
 		if validate, ok := f.Tag.Lookup("validate"); ok {
 			for _, val := range strings.Split(validate, ",") {
 				if val == "required" {
@@ -529,35 +499,6 @@ func buildRequest(r reflect.Type, op *openapi3.Operation) {
 	}
 }
 
-func getDefaultExampleForType(t reflect.Type) string {
-	if t.Kind() == reflect.Pointer {
-		return getDefaultExampleForType(t.Elem())
-	}
-
-	name := structNameWithPkg(t)
-	switch name {
-	case "uid.ID":
-		return "4yJ3n3D8E2"
-	case "uid.PolymorphicID":
-		return "i:4yJ3n3D8E3"
-	case "time.Time":
-		return exampleTime
-	default:
-		return ""
-	}
-}
-
-func structNameWithPkg(t reflect.Type) string {
-	path := strings.Split(t.PkgPath(), "/")
-	p := path[len(path)-1]
-
-	if len(p) > 0 {
-		return p + "." + t.Name()
-	}
-
-	return t.Name()
-}
-
 func getFieldName(f reflect.StructField, parent reflect.Type) string {
 	if name, ok := f.Tag.Lookup("json"); ok {
 		if name != "-" {
@@ -576,6 +517,7 @@ func getFieldName(f reflect.StructField, parent reflect.Type) string {
 	panic(fmt.Sprintf("field %q of struct %q must have a tag (json, form, or uri) with a name or '-'", f.Name, parent.Name()))
 }
 
+// TODO: remove with pgValidate
 func parseMinLength(tag string) uint64 {
 	minLength := strings.Split(tag, "min=")
 	if len(minLength) != 2 {
@@ -590,6 +532,7 @@ func parseMinLength(tag string) uint64 {
 	return len
 }
 
+// TODO: remove with pgValidate
 func parseOneOf(tag string) []interface{} {
 	oneof := strings.Split(tag, "oneof=")
 	if len(oneof) != 2 {

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -865,7 +865,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "query",
             "name": "user_id",
             "schema": {
@@ -1111,7 +1110,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -1454,7 +1452,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -1549,7 +1546,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -1644,7 +1640,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -1789,7 +1784,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "query",
             "name": "user",
             "schema": {
@@ -1800,7 +1794,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "query",
             "name": "group",
             "schema": {
@@ -2059,7 +2052,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -2154,7 +2146,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -2258,7 +2249,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "query",
             "name": "userID",
             "schema": {
@@ -2470,7 +2460,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -2565,7 +2554,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -2662,7 +2650,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -3248,7 +3235,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -3343,7 +3329,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -3438,7 +3423,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -3863,7 +3847,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "query",
             "name": "group",
             "schema": {
@@ -4089,7 +4072,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,
@@ -4279,7 +4261,6 @@
             }
           },
           {
-            "example": "4yJ3n3D8E2",
             "in": "path",
             "name": "id",
             "required": true,

--- a/uid/polymorphic.go
+++ b/uid/polymorphic.go
@@ -3,6 +3,8 @@ package uid
 import (
 	"fmt"
 	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // PolymorphicID is a reference of the format "i:<idstr>" for identities and "g:<idstr>" for groups
@@ -17,6 +19,13 @@ func (p PolymorphicID) ID() (ID, error) {
 		return ID(0), fmt.Errorf("invalid polymorphic ID encountered: %v", p)
 	}
 	return Parse([]byte(string(p)[2:]))
+}
+
+func (p PolymorphicID) DescribeSchema(schema *openapi3.Schema) {
+	schema.Type = "string"
+	schema.Format = "poly-uid"
+	schema.Pattern = `\w:[\da-zA-HJ-NP-Z]{1,11}`
+	schema.Example = "i:4yJ3n3D8E3"
 }
 
 func (p PolymorphicID) IsIdentity() bool {

--- a/uid/snowid.go
+++ b/uid/snowid.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 var (
@@ -188,4 +190,11 @@ func (id *ID) UnmarshalText(b []byte) error {
 	var err error
 	*id, err = Parse(b)
 	return err
+}
+
+func (id ID) DescribeSchema(schema *openapi3.Schema) {
+	schema.Type = "string"
+	schema.Format = "uid"
+	schema.Pattern = `[\da-zA-HJ-NP-Z]{1,11}`
+	schema.Example = "4yJ3n3D8E2"
 }


### PR DESCRIPTION
## Summary

This commit moves schema descriptions for api types from being hard-coded in the openapi doc generation, to being methods on the types being described. This `DescribeSchema` method is the same interface we use in `internal/validate` to allow validation rules to describe themselves.

By using an interface it makes it easy for us to support new api types without modifying the openapi doc generation.