### PR TITLE
fix: build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,6 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist --skip-publish
-        env:
-          GORELEASER_CURRENT_TAG: ${{ inputs.RELEASE_NAME }}
       - uses: actions/upload-artifact@v3
         with:
           name: binaries

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           name: binaries
       - run: |
+          apt update && apt install -y jq
+          RELEASE_ID=$(curl -fs -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ inputs.RELEASE_NAME }} | jq -r .id)
+          for ASSET in infra-checksums.txt *.zip *.deb *.rpm; do
+            curl -fs -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --data-binary @$ASSET https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets?name=$(basename $ASSET)
+          done
           for PACKAGE in *.deb *.rpm; do
             curl -fs -F package=@$PACKAGE https://${{ secrets.GEMFURY_TOKEN }}@push.fury.io/infrahq/
           done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ on:
         required: true
       GEMFURY_TOKEN:
         required: true
-      RELEASE_PLEASE_TOKEN:
+      GORELEASER_GITHUB_TOKEN:
         required: true
       DOCKERHUB_USERNAME:
         required: true
@@ -59,7 +59,7 @@ jobs:
         with:
           repository: infrahq/homebrew-tap
           path: homebrew-tap
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
         if: ${{ inputs.ENVIRONMENT == 'production' }}
       - run: |
           sh update-tap.sh -b https://${{ secrets.RELEASES_BUCKET }}/infra ${{ inputs.RELEASE_NAME }}
@@ -73,7 +73,7 @@ jobs:
         with:
           repository: infrahq/scoop
           path: scoop
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
         if: ${{ inputs.ENVIRONMENT == 'production' }}
       - run: |
           sh update-scoop.sh -b https://${{ secrets.RELEASES_BUCKET }}/infra ${{ inputs.RELEASE_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     secrets: inherit
 
   release-publish:
-    needs: [release-name]
+    needs: [release-name, release-build]
     uses: ./.github/workflows/publish.yml
     with:
       RELEASE_NAME: ${{ needs.release-name.outputs.release_name }}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

- fix job dependency in release workflow
- revert setting GORELEASER_CURRENT_TAG; goreleaser requires this to exist which in the case of the dev build will never exist. Find another way to set the right version.