### PR TITLE
maintain: no need to install jq

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,7 @@ jobs:
           git push origin @:refs/heads/main
         working-directory: homebrew-tap
         if: ${{ inputs.ENVIRONMENT == 'production' }}
+        continue-on-error: true
       - uses: actions/checkout@v3
         with:
           repository: infrahq/scoop
@@ -90,6 +91,7 @@ jobs:
           git push origin @:refs/heads/main
         working-directory: scoop
         if: ${{ inputs.ENVIRONMENT == 'production' }}
+        continue-on-error: true
 
   publish-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,9 @@ jobs:
           for ASSET in infra-checksums.txt *.zip *.deb *.rpm; do
             curl -fs -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --data-binary @$ASSET https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets?name=$(basename $ASSET)
           done
+        if: ${{ inputs.ENVIRONMENT == 'production' }}
+        continue-on-error: true
+      - run: |
           for PACKAGE in *.deb *.rpm; do
             curl -fs -F package=@$PACKAGE https://${{ secrets.GEMFURY_TOKEN }}@push.fury.io/infrahq/
           done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           name: binaries
       - run: |
-          sudo apt-get update && sudo apt-get install -y jq
           RELEASE_ID=$(curl -fs -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ inputs.RELEASE_NAME }} | jq -r .id)
           for ASSET in infra-checksums.txt *.zip *.deb *.rpm; do
             curl -fs -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" --data-binary @$ASSET https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets?name=$(basename $ASSET)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Container image already has it installed and `apt-get` exits with error