### PR TITLE
Support nested structs in request validation

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -24,6 +24,8 @@ type ListAccessKeysRequest struct {
 }
 
 func (r ListAccessKeysRequest) ValidationRules() []validate.ValidationRule {
+	// no-op ValidationRules implementation so that the rules from the
+	// embedded PaginationRequest struct are not applied twice.
 	return nil
 }
 

--- a/api/access_key.go
+++ b/api/access_key.go
@@ -24,7 +24,7 @@ type ListAccessKeysRequest struct {
 }
 
 func (r ListAccessKeysRequest) ValidationRules() []validate.ValidationRule {
-	return r.PaginationRequest.ValidationRules()
+	return nil
 }
 
 type CreateAccessKeyRequest struct {

--- a/api/destination.go
+++ b/api/destination.go
@@ -23,8 +23,14 @@ type Destination struct {
 }
 
 type DestinationConnection struct {
-	URL string `json:"url" validate:"required" example:"aa60eexample.us-west-2.elb.amazonaws.com"`
+	URL string `json:"url" example:"aa60eexample.us-west-2.elb.amazonaws.com"`
 	CA  PEM    `json:"ca" example:"-----BEGIN CERTIFICATE-----\nMIIDNTCCAh2gAwIBAgIRALRetnpcTo9O3V2fAK3ix+c\n-----END CERTIFICATE-----\n"`
+}
+
+func (r DestinationConnection) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.Required("url", r.URL),
+	}
 }
 
 type ListDestinationsRequest struct {
@@ -34,28 +40,43 @@ type ListDestinationsRequest struct {
 }
 
 func (r ListDestinationsRequest) ValidationRules() []validate.ValidationRule {
-	return r.PaginationRequest.ValidationRules()
+	return nil
 }
 
 type CreateDestinationRequest struct {
-	UniqueID string `json:"uniqueID" validate:"required"`
-	Name     string `json:"name" validate:"required"`
-	Version  string `json:"version"`
-
+	UniqueID   string                `json:"uniqueID"`
+	Name       string                `json:"name"`
+	Version    string                `json:"version"`
 	Connection DestinationConnection `json:"connection"`
 
 	Resources []string `json:"resources"`
 	Roles     []string `json:"roles"`
 }
 
-type UpdateDestinationRequest struct {
-	ID       uid.ID `uri:"id" json:"-" validate:"required"`
-	UniqueID string `json:"uniqueID" validate:"required"`
-	Name     string `json:"name" validate:"required"`
-	Version  string `json:"version"`
+func (r CreateDestinationRequest) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		ValidateName(r.Name),
+		validate.Required("name", r.Name),
+		validate.Required("uniqueID", r.UniqueID),
+	}
+}
 
+type UpdateDestinationRequest struct {
+	ID         uid.ID                `uri:"id" json:"-"`
+	Name       string                `json:"name"`
+	UniqueID   string                `json:"uniqueID"`
+	Version    string                `json:"version"`
 	Connection DestinationConnection `json:"connection"`
 
 	Resources []string `json:"resources"`
 	Roles     []string `json:"roles"`
+}
+
+func (r UpdateDestinationRequest) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		ValidateName(r.Name),
+		validate.Required("name", r.Name),
+		validate.Required("id", r.ID),
+		validate.Required("uniqueID", r.UniqueID),
+	}
 }

--- a/api/destination.go
+++ b/api/destination.go
@@ -40,6 +40,8 @@ type ListDestinationsRequest struct {
 }
 
 func (r ListDestinationsRequest) ValidationRules() []validate.ValidationRule {
+	// no-op ValidationRules implementation so that the rules from the
+	// embedded PaginationRequest struct are not applied twice.
 	return nil
 }
 

--- a/api/destination.go
+++ b/api/destination.go
@@ -55,9 +55,9 @@ type CreateDestinationRequest struct {
 
 func (r CreateDestinationRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
+		validate.Required("uniqueID", r.UniqueID),
 		ValidateName(r.Name),
 		validate.Required("name", r.Name),
-		validate.Required("uniqueID", r.UniqueID),
 	}
 }
 
@@ -74,9 +74,9 @@ type UpdateDestinationRequest struct {
 
 func (r UpdateDestinationRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		ValidateName(r.Name),
-		validate.Required("name", r.Name),
-		validate.Required("id", r.ID),
 		validate.Required("uniqueID", r.UniqueID),
+		validate.Required("id", r.ID),
+		validate.Required("name", r.Name),
+		ValidateName(r.Name),
 	}
 }

--- a/api/group.go
+++ b/api/group.go
@@ -21,7 +21,7 @@ type ListGroupsRequest struct {
 }
 
 func (r ListGroupsRequest) ValidationRules() []validate.ValidationRule {
-	return r.PaginationRequest.ValidationRules()
+	return nil
 }
 
 type CreateGroupRequest struct {

--- a/api/group.go
+++ b/api/group.go
@@ -21,6 +21,8 @@ type ListGroupsRequest struct {
 }
 
 func (r ListGroupsRequest) ValidationRules() []validate.ValidationRule {
+	// no-op ValidationRules implementation so that the rules from the
+	// embedded PaginationRequest struct are not applied twice.
 	return nil
 }
 

--- a/api/provider.go
+++ b/api/provider.go
@@ -40,5 +40,5 @@ type ListProvidersRequest struct {
 }
 
 func (r ListProvidersRequest) ValidationRules() []validate.ValidationRule {
-	return r.PaginationRequest.ValidationRules()
+	return nil
 }

--- a/api/provider.go
+++ b/api/provider.go
@@ -40,5 +40,7 @@ type ListProvidersRequest struct {
 }
 
 func (r ListProvidersRequest) ValidationRules() []validate.ValidationRule {
+	// no-op ValidationRules implementation so that the rules from the
+	// embedded PaginationRequest struct are not applied twice.
 	return nil
 }

--- a/api/user.go
+++ b/api/user.go
@@ -26,7 +26,7 @@ type ListUsersRequest struct {
 }
 
 func (r ListUsersRequest) ValidationRules() []validate.ValidationRule {
-	return r.PaginationRequest.ValidationRules()
+	return nil
 }
 
 // CreateUserRequest is only for creating users with the Infra provider

--- a/api/user.go
+++ b/api/user.go
@@ -26,6 +26,8 @@ type ListUsersRequest struct {
 }
 
 func (r ListUsersRequest) ValidationRules() []validate.ValidationRule {
+	// no-op ValidationRules implementation so that the rules from the
+	// embedded PaginationRequest struct are not applied twice.
 	return nil
 }
 

--- a/internal/server/destination_test.go
+++ b/internal/server/destination_test.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+)
+
+func TestAPI_CreateDestination(t *testing.T) {
+	srv := setupServer(t, withAdminUser)
+	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+
+	type testCase struct {
+		name     string
+		setup    func(t *testing.T) api.CreateDestinationRequest
+		expected func(t *testing.T, resp *httptest.ResponseRecorder)
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		createReq := tc.setup(t)
+		body := jsonBody(t, &createReq)
+		req := httptest.NewRequest(http.MethodPost, "/api/destinations", body)
+		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+
+		tc.expected(t, resp)
+	}
+
+	testCases := []testCase{
+		{
+			name: "does not trim trailing newline from CA",
+			setup: func(t *testing.T) api.CreateDestinationRequest {
+				return api.CreateDestinationRequest{
+					Name:     "final",
+					UniqueID: "unique-id",
+					Connection: api.DestinationConnection{
+						URL: "cluster.production.example",
+						CA:  "-----BEGIN CERTIFICATE-----\nok\n-----END CERTIFICATE-----\n",
+					},
+					Resources: []string{"res1", "res2"},
+					Roles:     []string{"role1", "role2"},
+				}
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
+
+				expected := jsonUnmarshal(t, fmt.Sprintf(`
+{
+	"id": "<any-valid-uid>",
+	"name": "final",
+	"uniqueID": "unique-id",
+	"version": "",
+	"connection": {
+		"url": "cluster.production.example",
+		"ca": "-----BEGIN CERTIFICATE-----\nok\n-----END CERTIFICATE-----\n"
+	},
+	"connected": false,
+	"lastSeen": null,
+	"resources": ["res1", "res2"],
+	"roles": ["role1", "role2"],
+	"created": "%[1]v",
+	"updated": "%[1]v"
+}
+`,
+					time.Now().UTC().Format(time.RFC3339)))
+
+				actual := jsonUnmarshal(t, resp.Body.String())
+				assert.DeepEqual(t, actual, expected, cmpAPIDestinationJSON)
+			},
+		},
+		{
+			name: "missing required fields",
+			setup: func(t *testing.T) api.CreateDestinationRequest {
+				return api.CreateDestinationRequest{}
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusBadRequest, resp.Body.String())
+
+				respBody := &api.Error{}
+				err := json.Unmarshal(resp.Body.Bytes(), respBody)
+				assert.NilError(t, err)
+
+				expected := []api.FieldError{
+					{FieldName: "connection.url", Errors: []string{"is required"}},
+					{FieldName: "name", Errors: []string{"is required"}},
+					{FieldName: "uniqueID", Errors: []string{"is required"}},
+				}
+				assert.DeepEqual(t, respBody.FieldErrors, expected)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+var cmpAPIDestinationJSON = gocmp.Options{
+	gocmp.FilterPath(pathMapKey(`created`, `updated`), cmpApproximateTime),
+	gocmp.FilterPath(pathMapKey(`id`), cmpAnyValidUID),
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -232,13 +232,31 @@ func TestAPI_ListUsers(t *testing.T) {
 		"invalid limit": {
 			urlPath: "/api/users?limit=1001",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.Equal(t, resp.Code, http.StatusBadRequest)
+				assert.Equal(t, resp.Code, http.StatusBadRequest, resp.Body.String())
+
+				respBody := &api.Error{}
+				err := json.Unmarshal(resp.Body.Bytes(), respBody)
+				assert.NilError(t, err)
+
+				expected := []api.FieldError{
+					{FieldName: "limit", Errors: []string{"value (1001) must be at most 1000"}},
+				}
+				assert.DeepEqual(t, respBody.FieldErrors, expected)
 			},
 		},
 		"invalid page": {
 			urlPath: "/api/users?page=-1",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.Equal(t, resp.Code, http.StatusBadRequest)
+				assert.Equal(t, resp.Code, http.StatusBadRequest, resp.Body.String())
+
+				respBody := &api.Error{}
+				err := json.Unmarshal(resp.Body.Bytes(), respBody)
+				assert.NilError(t, err)
+
+				expected := []api.FieldError{
+					{FieldName: "page", Errors: []string{"value (-1) must be at least 0"}},
+				}
+				assert.DeepEqual(t, respBody.FieldErrors, expected)
 			},
 		},
 		// TODO: assert full JSON response

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -189,6 +189,12 @@ func buildProperty(f reflect.StructField, t, parent reflect.Type, parentSchema *
 			f2 := t.Field(i)
 			s.Properties[getFieldName(f2, t)] = buildProperty(f2, f2.Type, t, s)
 		}
+
+		if req, ok := reflect.New(t).Interface().(validate.Request); ok {
+			for _, rule := range req.ValidationRules() {
+				rule.DescribeSchema(s)
+			}
+		}
 	}
 
 	return &openapi3.SchemaRef{Value: s}

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -1408,6 +1408,9 @@
                     "type": "object"
                   },
                   "name": {
+                    "format": "[a-zA-Z0-9\\-_.]",
+                    "maxLength": 256,
+                    "minLength": 3,
                     "type": "string"
                   },
                   "resources": {
@@ -1744,6 +1747,9 @@
                     "type": "object"
                   },
                   "name": {
+                    "format": "[a-zA-Z0-9\\-_.]",
+                    "maxLength": 256,
+                    "minLength": 3,
                     "type": "string"
                   },
                   "resources": {

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -40,6 +40,7 @@ func validateStruct(v reflect.Value) Error {
 		for i := 0; i < v.NumField(); i++ {
 			f := v.Field(i)
 			if v.Type().Field(i).Anonymous {
+				// validate the embedded struct
 				for k, v := range validateStruct(f) {
 					err[k] = append(err[k], v...)
 				}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -11,19 +11,51 @@ import (
 // Validate that the values in the Request struct are valid according to the
 // validation rules defined on the struct.
 // If validation fails the error will be of type Error.
+//
+// Validate automatically traverses the fields on the struct. If any of the
+// fields are of a type that implement Request, the validation rules of that
+// field will be used as well.
 func Validate(req Request) error {
-	err := make(Error)
-
-	for _, rule := range req.ValidationRules() {
-		if failure := rule.Validate(); failure != nil {
-			err[failure.Name] = append(err[failure.Name], failure.Problems...)
-		}
-	}
-
+	reqV := reflect.Indirect(reflect.ValueOf(req))
+	err := validateStruct(reqV)
 	if len(err) > 0 {
 		return err
 	}
 	return nil
+}
+
+func validateStruct(v reflect.Value) Error {
+	err := make(Error)
+
+	req, ok := v.Interface().(Request)
+	if ok {
+		for _, rule := range req.ValidationRules() {
+			if failure := rule.Validate(); failure != nil {
+				err[failure.Name] = append(err[failure.Name], failure.Problems...)
+			}
+		}
+	}
+
+	if v.Kind() == reflect.Struct {
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			if v.Type().Field(i).Anonymous {
+				for k, v := range validateStruct(f) {
+					err[k] = append(err[k], v...)
+				}
+				continue
+			}
+			name := fieldName(v.Type().Field(i))
+			for k, v := range validateStruct(f) {
+				n := name
+				if k != "" {
+					n = name + "." + k
+				}
+				err[n] = append(err[n], v...)
+			}
+		}
+	}
+	return err
 }
 
 // ValidationRule performs validation on one or more struct fields and can
@@ -172,4 +204,26 @@ func schemaForProperty(parent *openapi3.Schema, prop string) *openapi3.Schema {
 		parent.Properties[prop] = &openapi3.SchemaRef{Value: &openapi3.Schema{}}
 	}
 	return parent.Properties[prop].Value
+}
+
+func fieldName(f reflect.StructField) string {
+	if name, ok := f.Tag.Lookup("form"); ok {
+		return name
+	}
+
+	if name, ok := f.Tag.Lookup("uri"); ok {
+		return name
+	}
+
+	// lookup json tag last, as a field may have a uri or form name, but a
+	// json name of "-".
+	if name, ok := f.Tag.Lookup("json"); ok {
+		name = strings.Split(name, ",")[0]
+		if name == "-" {
+			return ""
+		}
+		return name
+	}
+
+	return ""
 }


### PR DESCRIPTION
Branched from #2527

This PR adds validation rules to `CreateDestinationRequest` and `UpdateDestinationRequest`.
These are the first two structs that have nested validation, so most of the PR is adding support for nested rules.

The challenge with nested structs is that openapi doc generation uses reflection (don't see any way around that), but `Validate` does not. The `ValidationRules` on a struct can't return the rules for nested or embedded structs, since we'd see them described the wrong way in openapi doc generation.  

So `Validate` ends up needing to use reflection as well, to match `DescribeSchema`.

In the current state:
* openapi doc generation calls `DescribeSchema` on the nested fields
* `Validate` will call `ValidationRules` on the top level struct, and use reflection to traverse the fields and call it on any nested or embedded structs.

Embedded structs are a challenge, because a `ValidationRules` method on an embedded struct could satisfy the interface for the parent struct. We'd end up calling it twice. So I updated all the list requests to return `nil` for validation rules.