### PR TITLE
Small improvement to InitializeSettings and Telemetry

### DIFF
--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -13,6 +13,11 @@ import (
 )
 
 func InitializeSettings(db *gorm.DB) (*models.Settings, error) {
+	settings, err := GetSettings(db)
+	if settings != nil {
+		return settings, err
+	}
+
 	pubkey, seckey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, err
@@ -39,7 +44,7 @@ func InitializeSettings(db *gorm.DB) (*models.Settings, error) {
 		return nil, err
 	}
 
-	settings := models.Settings{
+	settings = &models.Settings{
 		PrivateJWK: secs,
 		PublicJWK:  pubs,
 	}
@@ -49,7 +54,7 @@ func InitializeSettings(db *gorm.DB) (*models.Settings, error) {
 		return nil, err
 	}
 
-	return &settings, nil
+	return settings, nil
 }
 
 func GetSettings(db *gorm.DB) (*models.Settings, error) {

--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -60,7 +60,3 @@ func GetSettings(db *gorm.DB) (*models.Settings, error) {
 
 	return &settings, nil
 }
-
-func SaveSettings(db *gorm.DB, settings *models.Settings) error {
-	return save(db, settings)
-}

--- a/internal/server/data/settings_test.go
+++ b/internal/server/data/settings_test.go
@@ -1,0 +1,47 @@
+package data
+
+import (
+	"testing"
+	"time"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"gorm.io/gorm"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/opt"
+
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func TestInitializeSettings(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		var settings *models.Settings
+		runStep(t, "first call creates new settings", func(t *testing.T) {
+			var err error
+			settings, err = InitializeSettings(db)
+			assert.NilError(t, err)
+
+			assert.Assert(t, settings.ID != 0)
+			assert.Assert(t, len(settings.PrivateJWK) != 0)
+			assert.Assert(t, len(settings.PublicJWK) != 0)
+		})
+
+		runStep(t, "next call returns existing settings", func(t *testing.T) {
+			nextSettings, err := InitializeSettings(db)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, settings, nextSettings, cmpModel)
+		})
+	})
+}
+
+var cmpModel = gocmp.Options{
+	gocmp.FilterPath(opt.PathField(models.Model{}, "CreatedAt"),
+		opt.TimeWithThreshold(2*time.Second)),
+	gocmp.FilterPath(opt.PathField(models.Model{}, "UpdatedAt"),
+		opt.TimeWithThreshold(2*time.Second)),
+}
+
+func runStep(t *testing.T, name string, fn func(t *testing.T)) {
+	if !t.Run(name, fn) {
+		t.FailNow()
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -138,15 +138,13 @@ func New(options Options) (*Server, error) {
 		return nil, fmt.Errorf("db: %w", err)
 	}
 
-	_, err = data.InitializeSettings(server.db)
+	settings, err := data.InitializeSettings(server.db)
 	if err != nil {
 		return nil, fmt.Errorf("settings: %w", err)
 	}
 
 	if options.EnableTelemetry {
-		if err := configureTelemetry(server); err != nil {
-			return nil, fmt.Errorf("configuring telemetry: %w", err)
-		}
+		server.tel = NewTelemetry(server.db, settings.ID)
 	}
 
 	if err := server.loadConfig(server.options.Config); err != nil {
@@ -179,17 +177,14 @@ func (s *Server) Run(ctx context.Context) error {
 		s.routines[i].stop()
 	}
 
-	return group.Wait()
-}
-
-func configureTelemetry(server *Server) error {
-	tel, err := NewTelemetry(server.db)
-	if err != nil {
-		return err
+	err := group.Wait()
+	if s.tel != nil {
+		s.tel.Close()
 	}
-	server.tel = tel
-
-	return nil
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
 }
 
 //go:embed all:ui/*

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -178,9 +178,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	err := group.Wait()
-	if s.tel != nil {
-		s.tel.Close()
-	}
+	s.tel.Close()
 	if errors.Is(err, context.Canceled) {
 		return nil
 	}

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -13,33 +12,24 @@ import (
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 type Properties = analytics.Properties
 
 type Telemetry struct {
-	client analytics.Client
-	db     *gorm.DB
+	client  analytics.Client
+	db      *gorm.DB
+	infraID uid.ID
 }
 
-func NewTelemetry(db *gorm.DB) (*Telemetry, error) {
-	if db == nil {
-		return nil, errors.New("db cannot be nil")
-	}
-
-	var err error
-	settings, err = data.GetSettings(db)
-	if err != nil {
-		return nil, err
-	}
-
+func NewTelemetry(db *gorm.DB, infraID uid.ID) *Telemetry {
 	return &Telemetry{
-		client: analytics.New(internal.TelemetryWriteKey),
-		db:     db,
-	}, nil
+		client:  analytics.New(internal.TelemetryWriteKey),
+		db:      db,
+		infraID: infraID,
+	}
 }
-
-var settings *models.Settings
 
 func (t *Telemetry) Enqueue(track analytics.Message) error {
 	if internal.TelemetryWriteKey == "" {
@@ -52,14 +42,14 @@ func (t *Telemetry) Enqueue(track analytics.Message) error {
 			track.Properties = analytics.Properties{}
 		}
 
-		track.Properties.Set("infraId", settings.ID)
+		track.Properties.Set("infraId", t.infraID)
 		track.Properties.Set("version", internal.Version)
 	case analytics.Page:
 		if track.Properties == nil {
 			track.Properties = analytics.Properties{}
 		}
 
-		track.Properties.Set("infraId", settings.ID)
+		track.Properties.Set("infraId", t.infraID)
 		track.Properties.Set("version", internal.Version)
 	}
 
@@ -67,9 +57,8 @@ func (t *Telemetry) Enqueue(track analytics.Message) error {
 }
 
 func (t *Telemetry) Close() {
-	if t.client != nil {
-		t.client.Close()
-	}
+	// the only error here is "already closed"
+	_ = t.client.Close()
 }
 
 func (t *Telemetry) EnqueueHeartbeat() {

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -57,6 +57,9 @@ func (t *Telemetry) Enqueue(track analytics.Message) error {
 }
 
 func (t *Telemetry) Close() {
+	if t == nil {
+		return
+	}
 	// the only error here is "already closed"
 	_ = t.client.Close()
 }


### PR DESCRIPTION
## Summary

Primarily this PR changes `InitializeSettings`, so that it only creates a new private key for JWT signing when there are not existing settings. Previously we were generating a private key and throwing it away on every server startup.

While working on that area I also did a bit of cleanup:

* Added tests for `data.InitializeSettings`
* Use the settings returned by `InitializeSettings`, and store it on the `Telemetry` struct instead of a package-level static variable.
* Remove the error return from NewTelemetry, a nil db is a programming error that should panic.
* Remove `configureTelemetry`. Call `NewTelemetry` directly and assign it to the server field directly, making the the code easier to trace.
* Call `Telemetry.Close` to flush telemetry on server shutdown, previously this was not called anywhere.
* Remove unused `data.SaveSettings`.