### PR TITLE
fix: resolve the provider url when not provided

### DIFF
--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -515,7 +515,9 @@ func TestAuthURLForProvider(t *testing.T) {
 			"openid",
 		},
 	}
-	assert.Equal(t, authURLForProvider(okta, "state"), expectedOktaAuthURL)
+	url, err := authURLForProvider(okta, "state")
+	assert.NilError(t, err)
+	assert.Equal(t, url, expectedOktaAuthURL)
 
 	expectedAzureAuthURL := "https://login.microsoftonline.com/0/oauth2/v2.0/authorize?client_id=001&redirect_uri=http%3A%2F%2Flocalhost%3A8301&response_type=code&scope=email+openid&state=state"
 	azure := api.Provider{
@@ -527,7 +529,9 @@ func TestAuthURLForProvider(t *testing.T) {
 			"openid",
 		},
 	}
-	assert.Equal(t, authURLForProvider(azure, "state"), expectedAzureAuthURL)
+	url, err = authURLForProvider(azure, "state")
+	assert.NilError(t, err)
+	assert.Equal(t, url, expectedAzureAuthURL)
 
 	expectedGoogleAuthURL := "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&client_id=001&prompt=consent&redirect_uri=http%3A%2F%2Flocalhost%3A8301&response_type=code&scope=email+openid&state=state"
 	google := api.Provider{
@@ -539,5 +543,24 @@ func TestAuthURLForProvider(t *testing.T) {
 			"openid",
 		},
 	}
-	assert.Equal(t, authURLForProvider(google, "state"), expectedGoogleAuthURL)
+	url, err = authURLForProvider(google, "state")
+	assert.NilError(t, err)
+	assert.Equal(t, url, expectedGoogleAuthURL)
+
+	// test that the client resolve the auth URL when the server does not send it
+	// this test does an external call to example.okta.com, if it fails check your network connection
+	expectedResolvedAuthURL := "https://example.okta.com/oauth2/v1/authorize?client_id=001&redirect_uri=http%3A%2F%2Flocalhost%3A8301&response_type=code&scope=openid+email+offline_access+groups&state=state"
+	oldProvider := api.Provider{
+		// no AuthURL set
+		URL:      "example.okta.com",
+		ClientID: "001",
+		Kind:     "okta",
+		Scopes: []string{
+			"email",
+			"openid",
+		},
+	}
+	url, err = authURLForProvider(oldProvider, "state")
+	assert.NilError(t, err)
+	assert.Equal(t, url, expectedResolvedAuthURL)
 }


### PR DESCRIPTION
## Summary
In the most recent CLI version the auth URL is sent from the server, but old versions of the server do not send this value. For backwards compatibility, the CLI is now able to resolve the auth URL it needs from a provider in the case its not present. If we don't do this the CLI attempts to redirect the user to a local directory. 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2553
