### PR TITLE
feat: sample api request logs based on fields

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -26,7 +26,6 @@ type logger struct {
 }
 
 func init() {
-	zerolog.DisableSampling(true)
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
 	zerolog.CallerMarshalFunc = func(file string, line int) string {
 		short := filepath.Join(filepath.Base(filepath.Dir(file)), filepath.Base(file))

--- a/internal/logging/middleware.go
+++ b/internal/logging/middleware.go
@@ -1,16 +1,51 @@
 package logging
 
 import (
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 )
 
+type Sampler struct {
+	fn       func() zerolog.Sampler
+	samplers map[string]zerolog.Sampler
+	mu       sync.Mutex
+}
+
+func NewSampler(fn func() zerolog.Sampler) *Sampler {
+	return &Sampler{
+		fn:       fn,
+		samplers: make(map[string]zerolog.Sampler),
+	}
+}
+
+func (c *Sampler) Get(fields ...string) zerolog.Sampler {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := strings.Join(fields, "-")
+	sampler, ok := c.samplers[key]
+	if !ok {
+		sampler = c.fn()
+		c.samplers[key] = sampler
+	}
+
+	return sampler
+}
+
 func Middleware() gin.HandlerFunc {
+	sampler := NewSampler(func() zerolog.Sampler {
+		return &zerolog.BurstSampler{
+			Burst:  1,
+			Period: 7 * time.Second,
+		}
+	})
+
 	return func(c *gin.Context) {
-		log := L.Sample(zerolog.Often).
-			With().
+		log := L.With().
 			Str("method", c.Request.Method).
 			Str("path", c.Request.URL.Path).
 			Str("host", c.Request.Host).
@@ -23,9 +58,9 @@ func Middleware() gin.HandlerFunc {
 
 		c.Next()
 
-		levelName := zerolog.InfoLevel
+		level := zerolog.InfoLevel
 		if len(c.Errors) > 0 {
-			levelName = zerolog.ErrorLevel
+			level = zerolog.ErrorLevel
 		}
 
 		errs := make([]error, 0, len(c.Errors))
@@ -33,7 +68,12 @@ func Middleware() gin.HandlerFunc {
 			errs = append(errs, err.Err)
 		}
 
-		log.WithLevel(levelName).
+		// attach log sampler. should not sample logs if level >= Warn
+		if level <= zerolog.InfoLevel {
+			log = log.Sample(sampler.Get(c.Request.Method, c.FullPath()))
+		}
+
+		log.WithLevel(level).
 			Errs("errors", errs).
 			Dur("elapsed", time.Since(begin)).
 			Int("statusCode", c.Writer.Status()).


### PR DESCRIPTION
## Summary

Built-in zerolog samplers are not aware of the data they're sampling so
enabling it for even something as specific as api request logs may drop
useful information. Instead, create a simpler something that can sample
based on specified fields.

For API requests, group by request method (GET, POST, etc.) and request
path. The path is the template path known to gin, not the real path seen
my the request. e.g. /api/users/:id instead of /api/users/amNmdZKwwU

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2368