### PR TITLE
fix: possible panic on server restart

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -95,7 +95,12 @@ func AuthenticationMiddleware() gin.HandlerFunc {
 
 // RequireAccessKey checks the bearer token is present and valid
 func RequireAccessKey(c *gin.Context) error {
-	db, ok := c.MustGet("db").(*gorm.DB)
+	val, ok := c.Get("db")
+	if !ok {
+		return errors.New("could not find db in context")
+	}
+
+	db, ok := val.(*gorm.DB)
 	if !ok {
 		return errors.New("unknown db type in context")
 	}


### PR DESCRIPTION
When server restart, it's possible the database object is no longer
valid which causes a panic. Partial stack trace:

2022/07/11 20:24:45 [Recovery] 2022/07/11 - 20:24:45 panic recovered:
Key "db" does not exist
/go/pkg/mod/github.com/infrahq/gin@v1.7.2-0.20220120203023-0eaa562f3a8a/context.go:268 (0x1aec1e3)
/go/src/github.com/infrahq/infra/internal/server/middleware.go:98 (0x1aebba8)