### PR TITLE
maintain: docs/api/openapi3.json no longer exists

### DIFF
--- a/.github/release-please.json
+++ b/.github/release-please.json
@@ -17,12 +17,7 @@
         "Dockerfile",
         "helm/charts/infra/Chart.yaml",
         "internal/version.go",
-        "docs/install/upgrading.md",
-        {
-          "type": "json",
-          "path": "docs/api/openapi3.json",
-          "jsonpath": "$.info.version"
-        }
+        "docs/install/upgrading.md"
       ]
     }
   }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Minor cleanup: `docs/api/openapi3.json` doesn't exist anymore so these configurations are unnecessary