### PR TITLE
api: only sample successful GET requests

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -89,6 +89,9 @@ func SetLevel(levelName string) error {
 		return err
 	}
 
+	// logging middleware depends on this level. If we stop using the global level
+	// make sure to adjust the logging middleware to check the level of the
+	// logger instead of the global level.
 	zerolog.SetGlobalLevel(level)
 	return nil
 }

--- a/internal/logging/middleware.go
+++ b/internal/logging/middleware.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -38,8 +39,9 @@ func Middleware() gin.HandlerFunc {
 	})
 
 	return func(c *gin.Context) {
+		method := c.Request.Method
 		log := L.With().
-			Str("method", c.Request.Method).
+			Str("method", method).
 			Str("path", c.Request.URL.Path).
 			Str("host", c.Request.Host).
 			Str("remoteAddr", c.Request.RemoteAddr).
@@ -53,8 +55,8 @@ func Middleware() gin.HandlerFunc {
 
 		status := c.Writer.Status()
 
-		// sample logs if the request was a success and log level is info or above
-		if status < 400 && zerolog.GlobalLevel() >= zerolog.InfoLevel {
+		// sample logs for successful GET request if the log level is INFO or above
+		if status < 400 && method == http.MethodGet && zerolog.GlobalLevel() >= zerolog.InfoLevel {
 			log = log.Sample(sampler.Get(c.Request.Method, c.FullPath()))
 		}
 

--- a/internal/logging/middleware_test.go
+++ b/internal/logging/middleware_test.go
@@ -51,6 +51,7 @@ func TestMiddleware(t *testing.T) {
 			{Method: "GET", Path: "/good/1", StatusCode: 200, Level: "info"},
 			{Method: "GET", Path: "/gooder/", StatusCode: 200, Level: "info"},
 			{Method: "POST", Path: "/good/1", StatusCode: 200, Level: "info"},
+			{Method: "POST", Path: "/good/2", StatusCode: 200, Level: "info"},
 		}
 		assert.DeepEqual(t, actual, expected)
 	})

--- a/internal/logging/middleware_test.go
+++ b/internal/logging/middleware_test.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -19,14 +20,14 @@ func TestMiddleware(t *testing.T) {
 		router := gin.New()
 		router.Use(Middleware())
 
-		router.GET("/good", func(c *gin.Context) {})
-		router.POST("/good", func(c *gin.Context) {})
-		router.GET("/gooder", func(c *gin.Context) {})
-		router.GET("/bad", func(c *gin.Context) {
+		router.GET("/good/:id", func(c *gin.Context) {})
+		router.POST("/good/:id", func(c *gin.Context) {})
+		router.GET("/gooder/", func(c *gin.Context) {})
+		router.GET("/bad/:id", func(c *gin.Context) {
 			c.Status(http.StatusBadRequest)
 		})
 		router.GET("/broken", func(c *gin.Context) {
-			c.Status(http.StatusBadGateway)
+			c.Status(http.StatusInternalServerError)
 		})
 
 		return router
@@ -35,54 +36,67 @@ func TestMiddleware(t *testing.T) {
 	t.Run("identical requests are sampled", func(t *testing.T) {
 		b := &bytes.Buffer{}
 		router := setup(t, b)
-		router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/good", nil))
-		router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/good", nil))
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/good/1", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/good/2", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/good/3", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/good/4", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/gooder/", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/good/5", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("POST", "/good/1", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("POST", "/good/2", nil))
 
-		lines := bytes.Split(bytes.TrimSpace(b.Bytes()), []byte("\n"))
-		assert.Equal(t, len(lines), 1)
-
-		good := map[string]interface{}{}
-		err := json.Unmarshal(lines[0], &good)
-		assert.NilError(t, err)
-		assert.Equal(t, good["path"], "/good")
-	})
-
-	t.Run("good and gooder", func(t *testing.T) {
-		b := &bytes.Buffer{}
-		router := setup(t, b)
-		router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/good", nil))
-		router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/gooder", nil))
-
-		lines := bytes.Split(bytes.TrimSpace(b.Bytes()), []byte("\n"))
-		assert.Equal(t, len(lines), 2)
-
-		good := map[string]interface{}{}
-		err := json.Unmarshal(lines[0], &good)
-		assert.NilError(t, err)
-		assert.Equal(t, good["path"], "/good")
-
-		gooder := map[string]interface{}{}
-		err = json.Unmarshal(lines[1], &gooder)
-		assert.NilError(t, err)
-		assert.Equal(t, gooder["path"], "/gooder")
+		actual := decodeLogs(t, b)
+		expected := []logEntry{
+			{Method: "GET", Path: "/good/1", StatusCode: 200, Level: "info"},
+			{Method: "GET", Path: "/gooder/", StatusCode: 200, Level: "info"},
+			{Method: "POST", Path: "/good/1", StatusCode: 200, Level: "info"},
+		}
+		assert.DeepEqual(t, actual, expected)
 	})
 
 	t.Run("non-200 status responses are never sampled", func(t *testing.T) {
 		b := &bytes.Buffer{}
 		router := setup(t, b)
 		resp := httptest.NewRecorder()
-		router.ServeHTTP(resp, httptest.NewRequest("GET", "/bad", nil))
-		router.ServeHTTP(resp, httptest.NewRequest("GET", "/bad", nil))
-		router.ServeHTTP(resp, httptest.NewRequest("GET", "/bad", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/bad/1", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/bad/1", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/bad/2", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/broken", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/broken", nil))
+		router.ServeHTTP(resp, httptest.NewRequest("GET", "/broken", nil))
 
-		lines := bytes.Split(bytes.TrimSpace(b.Bytes()), []byte("\n"))
-		assert.Equal(t, len(lines), 3)
-
-		for _, line := range lines {
-			bad := map[string]interface{}{}
-			err := json.Unmarshal(line, &bad)
-			assert.NilError(t, err)
-			assert.Equal(t, bad["path"], "/bad")
+		actual := decodeLogs(t, b)
+		expected := []logEntry{
+			{Method: "GET", Path: "/bad/1", StatusCode: 400, Level: "info"},
+			{Method: "GET", Path: "/bad/1", StatusCode: 400, Level: "info"},
+			{Method: "GET", Path: "/bad/2", StatusCode: 400, Level: "info"},
+			{Method: "GET", Path: "/broken", StatusCode: 500, Level: "info"},
+			{Method: "GET", Path: "/broken", StatusCode: 500, Level: "info"},
+			{Method: "GET", Path: "/broken", StatusCode: 500, Level: "info"},
 		}
+		assert.DeepEqual(t, actual, expected)
 	})
+}
+
+func decodeLogs(t *testing.T, input io.Reader) []logEntry {
+	const maxLogs = 15
+	logs := make([]logEntry, maxLogs)
+	dec := json.NewDecoder(input)
+	for i := 0; i < cap(logs); i++ {
+		err := dec.Decode(&logs[i])
+		if errors.Is(err, io.EOF) {
+			return logs[:i]
+		}
+		assert.NilError(t, err)
+	}
+	t.Errorf("more than %d logs, some were not decoded", maxLogs)
+	return logs
+}
+
+type logEntry struct {
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+	StatusCode int    `json:"statusCode"`
+	Level      string `json:"level"`
 }


### PR DESCRIPTION
## Summary

This PR makes a few improvements to our API log sampling, added in #2555.

* never sample requests if the status code is >= 400, errors should always be logged. Previously we were looking at `gin.Context.Errors` to determine this, but we are not populated it yet
* never sample non-GET requests. Any POST, PUT, or DELETE should be logged as they modify data and should not happen as frequently
* turn off sampling if the log level is set to `DEBUG` or `TRACE`. In those cases the user probably does not want sampling. This gives us an easy way to see all requests in development.
* update the tests to be a bit more strict about the expected log output, and include some test cases that use parameters in the URL to show the sampling works correctly with parameters.
* use a `sync.Map` instead of a `sync.Mutex` to avoid locking in the common case. Once each sampler is created we should be able to fetch it without any locking.


## Related Issues

Resolves #2566
