### PR TITLE
feat: create and mount db encryption key

### DIFF
--- a/helm/charts/infra/templates/server/configmap.yaml
+++ b/helm/charts/infra/templates/server/configmap.yaml
@@ -35,10 +35,10 @@ data:
 {{- if not (hasKey .Values.server.config "dbFile") }}
     dbFile: /var/lib/infrahq/server/sqlite3.db
 {{- end }}
-
-{{- if not (hasKey .Values.server.config "dbEncryptionKey") }}
-    dbEncryptionKey: /var/lib/infrahq/server/sqlite3.db.key
 {{- end }}
+
+{{- if not .Values.server.config.dbEncryptionKey }}
+    dbEncryptionKey: /var/run/secrets/infrahq.com/encryption-key/key
 {{- end }}
 
 {{- if not .Values.server.config.tls }}

--- a/helm/charts/infra/templates/server/deployment.yaml
+++ b/helm/charts/infra/templates/server/deployment.yaml
@@ -51,10 +51,16 @@ spec:
 {{- if (not .Values.server.config.tls) }}
             - name: tls-ca
               mountPath: /var/run/secrets/infrahq.com/tls-ca
+              readOnly: true
 {{- end }}
 {{- if .Values.server.persistence.enabled }}
             - name: data
               mountPath: /var/lib/infrahq/server
+{{- end }}
+{{- if not .Values.server.config.dbEncryptionKey }}
+            - name: encryption-key
+              mountPath: /var/run/secrets/infrahq.com/encryption-key
+              readOnly: true
 {{- end }}
 {{- if .Values.server.volumeMounts }}
 {{- toYaml .Values.server.volumeMounts | nindent 12 }}
@@ -118,6 +124,11 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "server.fullname" . }}
+{{- end }}
+{{- if not .Values.server.config.dbEncryptionKey }}
+        - name: encryption-key
+          secret:
+            secretName: {{ include "server.fullname" . }}-encryption-key
 {{- end }}
 {{- if .Values.server.volumes }}
 {{- toYaml .Values.server.volumes | nindent 8 }}

--- a/helm/charts/infra/templates/server/secret.yaml
+++ b/helm/charts/infra/templates/server/secret.yaml
@@ -27,3 +27,21 @@ data:
 {{- end }}{{/* if secret.data */}}
 {{- end }}{{/* if not tls */}}
 {{- end }}{{/* if server.enabled */}}
+---
+{{- if include "server.enabled" . | eq "true" }}
+{{- if not .Values.server.config.dbEncryptionKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "server.fullname" . }}-encryption-key
+  labels:
+{{- include "server.labels" . | nindent 4 }}
+data:
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-encryption-key" (include "server.fullname" .)) -}}
+{{- if $secret.data }}
+  key: {{ $secret.data.key }}
+{{- else }}
+  key: {{ randAlphaNum 32 | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

When creating a server deployment, if a DB encryption key isn't supplied, create one as a kubernetes secret and mount it into the server pod. This is nicer than the existing default which is to create an encryption key in the pod itself which is only persisted if the key is in the path of a PVC.

It removes a dependency on PVCs. Once this is merged, the only remaining dependency is the database.

Note: This is a _breaking change_ since it discards the previous encryption. Manual steps are required to ensure the continued viability of the data.

## TODO

- [x] add migration steps

Before attempting an upgrade from <=0.14.x, follow the steps below to migrate the encryption key if using Helm release name `infra` and namespaces `infrahq`:

```
$ ENCRYPTION_KEY=$(mktemp)
$ kubectl -n infrahq exec -i deployment/infra-server -- cat /var/lib/infrahq/server/sqlite3.db.key >$ENCRYPTION_KEY
$ kubectl -n infrahq create secret generic infra-server-encryption-key --from-file=key=$ENCRYPTION_KEY
$ kubectl -n infrahq annotate secret infra-server-encryption-key meta.helm.sh/release-name=infra meta.helm.sh/release-namespace=infrahq
$ kubectl -n infrahq label secret infra-server-encryption-key app.kubernetes.io/managed-by=Helm
# upgrade as usual and verify the upgrade. once the upgrade is complete, remove $ENCRYPTION_KEY
```
