### PR TITLE
feat: pagination in cli

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -73,10 +73,6 @@ func ValidateName(value string) validate.ValidationRule {
 	}
 }
 
-func (req ListAccessKeysRequest) GetPaginationRequest() PaginationRequest {
-	return req.PaginationRequest
-}
-
 func (req ListAccessKeysRequest) SetPage(page int) Paginatable {
 	req.PaginationRequest.Page = page
 

--- a/api/access_key.go
+++ b/api/access_key.go
@@ -72,3 +72,13 @@ func ValidateName(value string) validate.ValidationRule {
 		},
 	}
 }
+
+func (req ListAccessKeysRequest) GetPaginationRequest() PaginationRequest {
+	return req.PaginationRequest
+}
+
+func (req ListAccessKeysRequest) SetPage(page int) Paginatable {
+	req.PaginationRequest.Page = page
+
+	return req
+}

--- a/api/client.go
+++ b/api/client.go
@@ -167,8 +167,9 @@ func (c Client) ListUsers(req ListUsersRequest) (*ListResponse[User], error) {
 	ids := slice.Map[uid.ID, string](req.IDs, func(id uid.ID) string {
 		return id.String()
 	})
-	return get[ListResponse[User]](c, "/api/users", Query{"name": {req.Name}, "group": {req.Group.String()},
-		"ids": ids, "page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)}})
+	return get[ListResponse[User]](c, "/api/users",
+		Query{"name": {req.Name}, "group": {req.Group.String()}, "ids": ids,
+			"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)}})
 }
 
 func (c Client) GetUser(id uid.ID) (*User, error) {
@@ -194,8 +195,8 @@ func (c Client) ListUserGrants(id uid.ID) (*ListResponse[Grant], error) {
 
 func (c Client) ListGroups(req ListGroupsRequest) (*ListResponse[Group], error) {
 	return get[ListResponse[Group]](c, "/api/groups", Query{
-		"name":   {req.Name},
-		"userID": {req.UserID.String()},
+		"name": {req.Name}, "userID": {req.UserID.String()},
+		"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
 	})
 }
 
@@ -221,8 +222,10 @@ func (c Client) ListGroupGrants(id uid.ID) (*ListResponse[Grant], error) {
 	return get[ListResponse[Grant]](c, fmt.Sprintf("/api/groups/%s/grants", id), Query{})
 }
 
-func (c Client) ListProviders(name string) (*ListResponse[Provider], error) {
-	return get[ListResponse[Provider]](c, "/api/providers", Query{"name": {name}})
+func (c Client) ListProviders(req ListProvidersRequest) (*ListResponse[Provider], error) {
+	return get[ListResponse[Provider]](c, "/api/providers",
+		Query{"name": {req.Name},
+			"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)}})
 }
 
 func (c Client) GetProvider(id uid.ID) (*Provider, error) {
@@ -248,6 +251,7 @@ func (c Client) ListGrants(req ListGrantsRequest) (*ListResponse[Grant], error) 
 		"resource":      {req.Resource},
 		"privilege":     {req.Privilege},
 		"showInherited": {strconv.FormatBool(req.ShowInherited)},
+		"page":          {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
 	})
 }
 
@@ -263,6 +267,7 @@ func (c Client) ListDestinations(req ListDestinationsRequest) (*ListResponse[Des
 	return get[ListResponse[Destination]](c, "/api/destinations", Query{
 		"name":      {req.Name},
 		"unique_id": {req.UniqueID},
+		"page":      {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
 	})
 }
 
@@ -283,6 +288,7 @@ func (c Client) ListAccessKeys(req ListAccessKeysRequest) (*ListResponse[AccessK
 		"user_id":      {req.UserID.String()},
 		"name":         {req.Name},
 		"show_expired": {fmt.Sprint(req.ShowExpired)},
+		"page":         {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
 	})
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -167,7 +167,8 @@ func (c Client) ListUsers(req ListUsersRequest) (*ListResponse[User], error) {
 	ids := slice.Map[uid.ID, string](req.IDs, func(id uid.ID) string {
 		return id.String()
 	})
-	return get[ListResponse[User]](c, "/api/users", Query{"name": {req.Name}, "group": {req.Group.String()}, "ids": ids})
+	return get[ListResponse[User]](c, "/api/users", Query{"name": {req.Name}, "group": {req.Group.String()},
+		"ids": ids, "page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)}})
 }
 
 func (c Client) GetUser(id uid.ID) (*User, error) {

--- a/api/destination.go
+++ b/api/destination.go
@@ -83,10 +83,6 @@ func (r UpdateDestinationRequest) ValidationRules() []validate.ValidationRule {
 	}
 }
 
-func (req ListDestinationsRequest) GetPaginationRequest() PaginationRequest {
-	return req.PaginationRequest
-}
-
 func (req ListDestinationsRequest) SetPage(page int) Paginatable {
 	req.PaginationRequest.Page = page
 

--- a/api/destination.go
+++ b/api/destination.go
@@ -82,3 +82,13 @@ func (r UpdateDestinationRequest) ValidationRules() []validate.ValidationRule {
 		ValidateName(r.Name),
 	}
 }
+
+func (req ListDestinationsRequest) GetPaginationRequest() PaginationRequest {
+	return req.PaginationRequest
+}
+
+func (req ListDestinationsRequest) SetPage(page int) Paginatable {
+	req.PaginationRequest.Page = page
+
+	return req
+}

--- a/api/grant.go
+++ b/api/grant.go
@@ -67,3 +67,13 @@ func (r CreateGrantRequest) ValidationRules() []validate.ValidationRule {
 		validate.Required("resource", r.Resource),
 	}
 }
+
+func (req ListGrantsRequest) GetPaginationRequest() PaginationRequest {
+	return req.PaginationRequest
+}
+
+func (req ListGrantsRequest) SetPage(page int) Paginatable {
+	req.PaginationRequest.Page = page
+
+	return req
+}

--- a/api/grant.go
+++ b/api/grant.go
@@ -68,10 +68,6 @@ func (r CreateGrantRequest) ValidationRules() []validate.ValidationRule {
 	}
 }
 
-func (req ListGrantsRequest) GetPaginationRequest() PaginationRequest {
-	return req.PaginationRequest
-}
-
 func (req ListGrantsRequest) SetPage(page int) Paginatable {
 	req.PaginationRequest.Page = page
 

--- a/api/group.go
+++ b/api/group.go
@@ -48,3 +48,14 @@ func (r UpdateUsersInGroupRequest) ValidationRules() []validate.ValidationRule {
 		validate.Required("id", r.GroupID),
 	}
 }
+
+func (req ListGroupsRequest) GetPaginationRequest() PaginationRequest {
+	return req.PaginationRequest
+}
+
+func (req ListGroupsRequest) SetPage(page int) Paginatable {
+
+	req.PaginationRequest.Page = page
+
+	return req
+}

--- a/api/group.go
+++ b/api/group.go
@@ -49,10 +49,6 @@ func (r UpdateUsersInGroupRequest) ValidationRules() []validate.ValidationRule {
 	}
 }
 
-func (req ListGroupsRequest) GetPaginationRequest() PaginationRequest {
-	return req.PaginationRequest
-}
-
 func (req ListGroupsRequest) SetPage(page int) Paginatable {
 
 	req.PaginationRequest.Page = page

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -3,7 +3,6 @@ package api
 import "github.com/infrahq/infra/internal/validate"
 
 type Paginatable interface {
-	GetPaginationRequest() PaginationRequest
 	SetPage(page int) Paginatable
 }
 

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -2,6 +2,11 @@ package api
 
 import "github.com/infrahq/infra/internal/validate"
 
+type Paginatable interface {
+	GetPaginationRequest() PaginationRequest
+	SetPage(page int) Paginatable
+}
+
 type PaginationRequest struct {
 	Page  int `form:"page"`
 	Limit int `form:"limit"`

--- a/api/provider.go
+++ b/api/provider.go
@@ -68,10 +68,6 @@ func (r ListProvidersRequest) ValidationRules() []validate.ValidationRule {
 	return nil
 }
 
-func (req ListProvidersRequest) GetPaginationRequest() PaginationRequest {
-	return req.PaginationRequest
-}
-
 func (req ListProvidersRequest) SetPage(page int) Paginatable {
 	req.PaginationRequest.Page = page
 

--- a/api/provider.go
+++ b/api/provider.go
@@ -67,3 +67,13 @@ func (r ListProvidersRequest) ValidationRules() []validate.ValidationRule {
 	// embedded PaginationRequest struct are not applied twice.
 	return nil
 }
+
+func (req ListProvidersRequest) GetPaginationRequest() PaginationRequest {
+	return req.PaginationRequest
+}
+
+func (req ListProvidersRequest) SetPage(page int) Paginatable {
+	req.PaginationRequest.Page = page
+
+	return req
+}

--- a/api/user.go
+++ b/api/user.go
@@ -68,10 +68,6 @@ func (r UpdateUserRequest) ValidationRules() []validate.ValidationRule {
 	}
 }
 
-func (req ListUsersRequest) GetPaginationRequest() PaginationRequest {
-	return req.PaginationRequest
-}
-
 func (req ListUsersRequest) SetPage(page int) Paginatable {
 	req.PaginationRequest.Page = page
 

--- a/api/user.go
+++ b/api/user.go
@@ -67,3 +67,13 @@ func (r UpdateUserRequest) ValidationRules() []validate.ValidationRule {
 		validate.StringRule{Name: "password", Value: r.Password, MinLength: 8},
 	}
 }
+
+func (req ListUsersRequest) GetPaginationRequest() PaginationRequest {
+	return req.PaginationRequest
+}
+
+func (req ListUsersRequest) SetPage(page int) Paginatable {
+	req.PaginationRequest.Page = page
+
+	return req
+}

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -50,7 +50,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list destinations")
-			destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations, nil)
+			destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -50,20 +50,20 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list destinations")
-			destinations, err := client.ListDestinations(api.ListDestinationsRequest{})
+			destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations, func(err error) error { return err })
 			if err != nil {
 				return err
 			}
 
 			switch format {
 			case "json":
-				jsonOutput, err := json.Marshal(destinations.Items)
+				jsonOutput, err := json.Marshal(destinations)
 				if err != nil {
 					return err
 				}
 				cli.Output(string(jsonOutput))
 			case "yaml":
-				yamlOutput, err := yaml.Marshal(destinations.Items)
+				yamlOutput, err := yaml.Marshal(destinations)
 				if err != nil {
 					return err
 				}
@@ -77,7 +77,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 				}
 
 				var rows []row
-				for _, d := range destinations.Items {
+				for _, d := range destinations {
 					status := DestinationStatusDisconnected
 					if d.Connected {
 						status = DestinationStatusConnected

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -50,7 +50,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list destinations")
-			destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations)
+			destinations, err := listAll(client.ListDestinations, api.ListDestinationsRequest{})
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -50,7 +50,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list destinations")
-			destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations, func(err error) error { return err })
+			destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations, nil)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -21,8 +21,7 @@ var (
 
 // User facing constant errors: to let user know why their command failed. Not meant for a stack trace, but a readable output of the reason for failure.
 var (
-	ErrTLSNotVerified    = errors.New(`The authenticity of the host can't be established.`)
-	ErrMissingPrivileges = errors.New("missing privileges")
+	ErrTLSNotVerified = errors.New(`The authenticity of the host can't be established.`)
 )
 
 type LoginError struct {

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -21,7 +21,8 @@ var (
 
 // User facing constant errors: to let user know why their command failed. Not meant for a stack trace, but a readable output of the reason for failure.
 var (
-	ErrTLSNotVerified = errors.New(`The authenticity of the host can't be established.`)
+	ErrTLSNotVerified    = errors.New(`The authenticity of the host can't be established.`)
+	ErrMissingPrivileges = errors.New("missing privileges")
 )
 
 type LoginError struct {

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -57,7 +57,7 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
-			grants, err := listAll(client, api.ListGrantsRequest{Resource: options.Destination}, api.Client.ListGrants)
+			grants, err := listAll(client.ListGrants, api.ListGrantsRequest{Resource: options.Destination})
 			if err != nil {
 				if errors.Is(err, ErrMissingPrivileges) {
 					return Error{
@@ -94,7 +94,7 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 }
 
 func userGrants(cli *CLI, client *api.Client, grants *[]api.Grant) (int, error) {
-	users, err := listAll(client, api.ListUsersRequest{}, api.Client.ListUsers)
+	users, err := listAll(client.ListUsers, api.ListUsersRequest{})
 	if err != nil {
 		if errors.Is(err, ErrMissingPrivileges) {
 			return 0, Error{
@@ -139,7 +139,7 @@ func userGrants(cli *CLI, client *api.Client, grants *[]api.Grant) (int, error) 
 }
 
 func groupGrants(cli *CLI, client *api.Client, grants *[]api.Grant) (int, error) {
-	groups, err := listAll(client, api.ListGroupsRequest{}, api.Client.ListGroups)
+	groups, err := listAll(client.ListGroups, api.ListGroupsRequest{})
 	if err != nil {
 		return 0, err
 	}

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -129,13 +129,13 @@ func userGrants(cli *CLI, client *api.Client, grants *[]api.Grant) (int, error) 
 }
 
 func groupGrants(cli *CLI, client *api.Client, grants *[]api.Grant) (int, error) {
-	groups, err := client.ListGroups(api.ListGroupsRequest{})
+	groups, err := listAll(client, api.ListGroupsRequest{}, api.Client.ListGroups, nil)
 	if err != nil {
 		return 0, err
 	}
 
 	mapGroups := make(map[uid.ID]api.Group)
-	for _, u := range groups.Items {
+	for _, u := range groups {
 		mapGroups[u.ID] = u
 	}
 

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -89,13 +89,13 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 }
 
 func userGrants(cli *CLI, client *api.Client, grants *[]api.Grant) (int, error) {
-	users, err := client.ListUsers(api.ListUsersRequest{})
+	users, err := listAll(client, api.ListUsersRequest{}, api.Client.ListUsers, handleListUserMissingPrivilige)
 	if err != nil {
 		return 0, err
 	}
 
 	mapUsers := make(map[uid.ID]api.User)
-	for _, u := range users.Items {
+	for _, u := range users {
 		mapUsers[u.ID] = u
 	}
 

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -59,11 +59,6 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 
 			grants, err := listAll(client.ListGrants, api.ListGrantsRequest{Resource: options.Destination})
 			if err != nil {
-				if errors.Is(err, ErrMissingPrivileges) {
-					return Error{
-						Message: fmt.Sprintf("Cannot list grants: %s", err.Error()),
-					}
-				}
 				return err
 			}
 
@@ -96,11 +91,6 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 func userGrants(cli *CLI, client *api.Client, grants *[]api.Grant) (int, error) {
 	users, err := listAll(client.ListUsers, api.ListUsersRequest{})
 	if err != nil {
-		if errors.Is(err, ErrMissingPrivileges) {
-			return 0, Error{
-				Message: fmt.Sprintf("Cannot list users for grants: %s", err.Error()),
-			}
-		}
 		return 0, err
 	}
 

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -80,12 +80,12 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 
 			var rows []row
 
-			groups, err := client.ListGroups(api.ListGroupsRequest{})
+			groups, err := listAll(client, api.ListGroupsRequest{}, api.Client.ListGroups, func(err error) error { return err })
 			if err != nil {
 				return err
 			}
 
-			for _, group := range groups.Items {
+			for _, group := range groups {
 				users, err := client.ListUsers(api.ListUsersRequest{Group: group.ID})
 				if err != nil {
 					return err

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -80,7 +80,7 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 
 			var rows []row
 
-			groups, err := listAll(client, api.ListGroupsRequest{}, api.Client.ListGroups, func(err error) error { return err })
+			groups, err := listAll(client, api.ListGroupsRequest{}, api.Client.ListGroups, nil)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -80,13 +80,13 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 
 			var rows []row
 
-			groups, err := listAll(client, api.ListGroupsRequest{}, api.Client.ListGroups)
+			groups, err := listAll(client.ListGroups, api.ListGroupsRequest{})
 			if err != nil {
 				return err
 			}
 
 			for _, group := range groups {
-				users, err := listAll(client, api.ListUsersRequest{Group: group.ID}, api.Client.ListUsers)
+				users, err := listAll(client.ListUsers, api.ListUsersRequest{Group: group.ID})
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -86,13 +86,13 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 			}
 
 			for _, group := range groups {
-				users, err := client.ListUsers(api.ListUsersRequest{Group: group.ID})
+				users, err := listAll(client, api.ListUsersRequest{Group: group.ID}, api.Client.ListUsers, nil)
 				if err != nil {
 					return err
 				}
 
 				var userNames []string
-				for _, user := range users.Items {
+				for _, user := range users {
 					userNames = append(userNames, user.Name)
 				}
 

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -80,13 +80,13 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 
 			var rows []row
 
-			groups, err := listAll(client, api.ListGroupsRequest{}, api.Client.ListGroups, nil)
+			groups, err := listAll(client, api.ListGroupsRequest{}, api.Client.ListGroups)
 			if err != nil {
 				return err
 			}
 
 			for _, group := range groups {
-				users, err := listAll(client, api.ListUsersRequest{Group: group.ID}, api.Client.ListUsers, nil)
+				users, err := listAll(client, api.ListUsersRequest{Group: group.ID}, api.Client.ListUsers)
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -62,7 +62,7 @@ func info(cli *CLI) error {
 		fmt.Fprintf(w, "Identity Provider:\t %s (%s)\n", provider.Name, provider.URL)
 	}
 
-	userGroups, err := listAll(client, api.ListGroupsRequest{UserID: config.UserID}, api.Client.ListGroups, nil)
+	userGroups, err := listAll(client, api.ListGroupsRequest{UserID: config.UserID}, api.Client.ListGroups)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -62,16 +62,16 @@ func info(cli *CLI) error {
 		fmt.Fprintf(w, "Identity Provider:\t %s (%s)\n", provider.Name, provider.URL)
 	}
 
-	userGroups, err := client.ListGroups(api.ListGroupsRequest{UserID: config.UserID})
+	userGroups, err := listAll(client, api.ListGroupsRequest{UserID: config.UserID}, api.Client.ListGroups, nil)
 	if err != nil {
 		return err
 	}
 
 	groups := "(none)"
 
-	if userGroups.Count > 0 {
-		g := make([]string, 0, userGroups.Count)
-		for _, userGroup := range userGroups.Items {
+	if len(userGroups) > 0 {
+		g := make([]string, 0, len(userGroups))
+		for _, userGroup := range userGroups {
 			g = append(g, userGroup.Name)
 		}
 

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -62,7 +62,7 @@ func info(cli *CLI) error {
 		fmt.Fprintf(w, "Identity Provider:\t %s (%s)\n", provider.Name, provider.URL)
 	}
 
-	userGroups, err := listAll(client, api.ListGroupsRequest{UserID: config.UserID}, api.Client.ListGroups)
+	userGroups, err := listAll(client.ListGroups, api.ListGroupsRequest{UserID: config.UserID})
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -214,7 +214,7 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list access keys")
-			keys, err = listAll(client, api.ListAccessKeysRequest{ShowExpired: options.ShowExpired, UserID: userID}, api.Client.ListAccessKeys)
+			keys, err = listAll(client.ListAccessKeys, api.ListAccessKeysRequest{ShowExpired: options.ShowExpired, UserID: userID})
 			if err != nil {
 				if errors.Is(err, ErrMissingPrivileges) {
 					return Error{

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -216,11 +215,6 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 			logging.Debugf("call server: list access keys")
 			keys, err = listAll(client.ListAccessKeys, api.ListAccessKeysRequest{ShowExpired: options.ShowExpired, UserID: userID})
 			if err != nil {
-				if errors.Is(err, ErrMissingPrivileges) {
-					return Error{
-						Message: fmt.Sprintf("Cannot list keys: %s", err.Error()),
-					}
-				}
 				return err
 			}
 

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -57,7 +57,7 @@ func kubernetesSetContext(cluster, namespace string) error {
 }
 
 func updateKubeConfig(client *api.Client, id uid.ID) error {
-	destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations)
+	destinations, err := listAll(client.ListDestinations, api.ListDestinationsRequest{})
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func updateKubeConfig(client *api.Client, id uid.ID) error {
 		return err
 	}
 
-	grants, err := listAll(client, api.ListGrantsRequest{User: id, ShowInherited: true}, api.Client.ListGrants)
+	grants, err := listAll(client.ListGrants, api.ListGrantsRequest{User: id, ShowInherited: true})
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -57,7 +57,7 @@ func kubernetesSetContext(cluster, namespace string) error {
 }
 
 func updateKubeConfig(client *api.Client, id uid.ID) error {
-	destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations, nil)
+	destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func updateKubeConfig(client *api.Client, id uid.ID) error {
 		return err
 	}
 
-	grants, err := listAll(client, api.ListGrantsRequest{User: id, ShowInherited: true}, api.Client.ListGrants, nil)
+	grants, err := listAll(client, api.ListGrantsRequest{User: id, ShowInherited: true}, api.Client.ListGrants)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -57,7 +57,7 @@ func kubernetesSetContext(cluster, namespace string) error {
 }
 
 func updateKubeConfig(client *api.Client, id uid.ID) error {
-	destinations, err := client.ListDestinations(api.ListDestinationsRequest{})
+	destinations, err := listAll(client, api.ListDestinationsRequest{}, api.Client.ListDestinations, nil)
 	if err != nil {
 		return err
 	}
@@ -67,12 +67,12 @@ func updateKubeConfig(client *api.Client, id uid.ID) error {
 		return err
 	}
 
-	grants, err := client.ListGrants(api.ListGrantsRequest{User: id, ShowInherited: true})
+	grants, err := listAll(client, api.ListGrantsRequest{User: id, ShowInherited: true}, api.Client.ListGrants, nil)
 	if err != nil {
 		return err
 	}
 
-	return writeKubeconfig(user, destinations.Items, grants.Items)
+	return writeKubeconfig(user, destinations, grants)
 }
 
 func writeKubeconfig(user *api.User, destinations []api.Destination, grants []api.Grant) error {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -542,7 +542,7 @@ func promptLocalLogin(cli *CLI) (*api.LoginRequestPasswordCredentials, error) {
 
 func listProviders(client *api.Client) ([]api.Provider, error) {
 	logging.Debugf("call server: list providers")
-	providers, err := client.ListProviders("")
+	providers, err := client.ListProviders(api.ListProvidersRequest{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/pagination.go
+++ b/internal/cmd/pagination.go
@@ -19,10 +19,6 @@ func listAll[Item any, Req api.Paginatable](listItems func(Req) (*api.ListRespon
 
 	res, err := listItems(req)
 	if err != nil {
-		if api.ErrorStatusCode(err) == 403 {
-			logging.Debugf("%s", err.Error())
-			return nil, ErrMissingPrivileges
-		}
 		return nil, err
 	}
 	users := make([]Item, 0, res.TotalCount)
@@ -37,10 +33,6 @@ func listAll[Item any, Req api.Paginatable](listItems func(Req) (*api.ListRespon
 		logging.Debugf("call server: page %d", page)
 		res, err = listItems(req)
 		if err != nil {
-			if api.ErrorStatusCode(err) == 403 {
-				logging.Debugf("%s", err.Error())
-				return nil, ErrMissingPrivileges
-			}
 			return nil, err
 		}
 		users = append(users, res.Items...)

--- a/internal/cmd/pagination.go
+++ b/internal/cmd/pagination.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/logging"
+)
+
+func listAll[Item any, Req api.Paginatable](client *api.Client, req Req, listItems func(api.Client, Req) (*api.ListResponse[Item], error), handleError func(err error) error) ([]Item, error) {
+
+	logging.Debugf("call server: page 1")
+	req = req.SetPage(1).(Req)
+	res, err := listItems(*client, req)
+	if err != nil {
+		return nil, handleError(err)
+	}
+	users := make([]Item, 0, res.TotalCount)
+	users = append(users, res.Items...)
+
+	// first page done in first request
+	for page := 2; page <= res.TotalPages; page++ {
+		logging.Debugf("call server: page %d", page)
+		req = req.SetPage(page).(Req)
+		res, err = listItems(*client, req)
+		if err != nil {
+			return nil, handleError(err)
+		}
+		users = append(users, res.Items...)
+	}
+
+	return users, nil
+}

--- a/internal/cmd/pagination.go
+++ b/internal/cmd/pagination.go
@@ -8,7 +8,7 @@ import (
 // listAll is a helper function that handles pagination and calls the given list request function.
 // listItems is the corresponding function in the API client that handles the Request "req".
 // handleError is a function that handles the error returned by the API client.
-func listAll[Item any, Req api.Paginatable](client *api.Client, req Req, listItems func(api.Client, Req) (*api.ListResponse[Item], error), handleError func(err error) error) ([]Item, error) {
+func listAll[Item any, Req api.Paginatable](client *api.Client, req Req, listItems func(api.Client, Req) (*api.ListResponse[Item], error)) ([]Item, error) {
 
 	logging.Debugf("call server: page 1")
 
@@ -19,16 +19,17 @@ func listAll[Item any, Req api.Paginatable](client *api.Client, req Req, listIte
 
 	res, err := listItems(*client, req)
 	if err != nil {
-		if handleError == nil {
-			return nil, err
+		if api.ErrorStatusCode(err) == 403 {
+			logging.Debugf("%s", err.Error())
+			return nil, ErrMissingPrivileges
 		}
-		return nil, handleError(err)
+		return nil, err
 	}
 	users := make([]Item, 0, res.TotalCount)
 	users = append(users, res.Items...)
 
 	for page := 2; page <= res.TotalPages; page++ {
-		req, ok := req.SetPage(1).(Req)
+		req, ok := req.SetPage(page).(Req)
 		if !ok {
 			panic("SetPage returned a different request type than expected")
 		}
@@ -36,10 +37,11 @@ func listAll[Item any, Req api.Paginatable](client *api.Client, req Req, listIte
 		logging.Debugf("call server: page %d", page)
 		res, err = listItems(*client, req)
 		if err != nil {
-			if handleError == nil {
-				return nil, err
+			if api.ErrorStatusCode(err) == 403 {
+				logging.Debugf("%s", err.Error())
+				return nil, ErrMissingPrivileges
 			}
-			return nil, handleError(err)
+			return nil, err
 		}
 		users = append(users, res.Items...)
 	}

--- a/internal/cmd/pagination.go
+++ b/internal/cmd/pagination.go
@@ -8,7 +8,7 @@ import (
 // listAll is a helper function that handles pagination and calls the given list request function.
 // listItems is the corresponding function in the API client that handles the Request "req".
 // handleError is a function that handles the error returned by the API client.
-func listAll[Item any, Req api.Paginatable](client *api.Client, req Req, listItems func(api.Client, Req) (*api.ListResponse[Item], error)) ([]Item, error) {
+func listAll[Item any, Req api.Paginatable](listItems func(Req) (*api.ListResponse[Item], error), req Req) ([]Item, error) {
 
 	logging.Debugf("call server: page 1")
 
@@ -17,7 +17,7 @@ func listAll[Item any, Req api.Paginatable](client *api.Client, req Req, listIte
 		panic("SetPage returned a different request type than expected")
 	}
 
-	res, err := listItems(*client, req)
+	res, err := listItems(req)
 	if err != nil {
 		if api.ErrorStatusCode(err) == 403 {
 			logging.Debugf("%s", err.Error())
@@ -35,7 +35,7 @@ func listAll[Item any, Req api.Paginatable](client *api.Client, req Req, listIte
 		}
 
 		logging.Debugf("call server: page %d", page)
-		res, err = listItems(*client, req)
+		res, err = listItems(req)
 		if err != nil {
 			if api.ErrorStatusCode(err) == 403 {
 				logging.Debugf("%s", err.Error())

--- a/internal/cmd/pagination.go
+++ b/internal/cmd/pagination.go
@@ -5,23 +5,40 @@ import (
 	"github.com/infrahq/infra/internal/logging"
 )
 
+// listAll is a helper function that handles pagination and calls the given list request function.
+// listItems is the corresponding function in the API client that handles the Request "req".
+// handleError is a function that handles the error returned by the API client.
 func listAll[Item any, Req api.Paginatable](client *api.Client, req Req, listItems func(api.Client, Req) (*api.ListResponse[Item], error), handleError func(err error) error) ([]Item, error) {
 
 	logging.Debugf("call server: page 1")
-	req = req.SetPage(1).(Req)
+
+	req, ok := req.SetPage(1).(Req)
+	if !ok {
+		panic("SetPage returned a different request type than expected")
+	}
+
 	res, err := listItems(*client, req)
 	if err != nil {
+		if handleError == nil {
+			return nil, err
+		}
 		return nil, handleError(err)
 	}
 	users := make([]Item, 0, res.TotalCount)
 	users = append(users, res.Items...)
 
-	// first page done in first request
 	for page := 2; page <= res.TotalPages; page++ {
+		req, ok := req.SetPage(1).(Req)
+		if !ok {
+			panic("SetPage returned a different request type than expected")
+		}
+
 		logging.Debugf("call server: page %d", page)
-		req = req.SetPage(page).(Req)
 		res, err = listItems(*client, req)
 		if err != nil {
+			if handleError == nil {
+				return nil, err
+			}
 			return nil, handleError(err)
 		}
 		users = append(users, res.Items...)

--- a/internal/cmd/pagination_test.go
+++ b/internal/cmd/pagination_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/infrahq/infra/api" // nolint
 	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
 )
 
 func TestListAll(t *testing.T) {

--- a/internal/cmd/pagination_test.go
+++ b/internal/cmd/pagination_test.go
@@ -44,9 +44,9 @@ func TestListAll(t *testing.T) {
 		})
 	})
 
-	t.Run("403", func(t *testing.T) {
-		_, err := listAll(mockListUsers, api.ListUsersRequest{Name: "403"})
-		assert.ErrorIs(t, err, ErrMissingPrivileges)
+	t.Run("error", func(t *testing.T) {
+		_, err := listAll(mockListUsers, api.ListUsersRequest{Name: "error"})
+		assert.Error(t, err, "default error")
 	})
 
 }

--- a/internal/cmd/pagination_test.go
+++ b/internal/cmd/pagination_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/api" // nolint
 	"gotest.tools/v3/assert"
 )
 

--- a/internal/cmd/pagination_test.go
+++ b/internal/cmd/pagination_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/infrahq/infra/api"
+	"gotest.tools/v3/assert"
+)
+
+func TestListAll(t *testing.T) {
+
+	t.Run("empty", func(t *testing.T) {
+		users, err := listAll(mockListUsers, api.ListUsersRequest{Name: "empty"})
+		assert.NilError(t, err)
+
+		assert.DeepEqual(t, users, []api.User{})
+	})
+
+	t.Run("one", func(t *testing.T) {
+		users, err := listAll(mockListUsers, api.ListUsersRequest{Name: "one"})
+		assert.NilError(t, err)
+
+		assert.DeepEqual(t, users, []api.User{
+			{Name: "jonathan@test.com"},
+		})
+	})
+
+	t.Run("two", func(t *testing.T) {
+		users, err := listAll(mockListUsers, api.ListUsersRequest{Name: "two"})
+		assert.NilError(t, err)
+
+		assert.DeepEqual(t, users, []api.User{{Name: "1@test.com"}, {Name: "2@test.com"}})
+
+	})
+
+	t.Run("five", func(t *testing.T) {
+		users, err := listAll(mockListUsers, api.ListUsersRequest{Name: "five"})
+		assert.NilError(t, err)
+
+		assert.DeepEqual(t, users, []api.User{
+			{Name: "1@test.com"}, {Name: "1@test.org"}, {Name: "2@test.com"}, {Name: "2@test.org"}, {Name: "3@test.com"},
+			{Name: "3@test.org"}, {Name: "4@test.com"}, {Name: "4@test.org"}, {Name: "5@test.com"}, {Name: "5@test.org"},
+		})
+	})
+
+	t.Run("403", func(t *testing.T) {
+		_, err := listAll(mockListUsers, api.ListUsersRequest{Name: "403"})
+		assert.ErrorIs(t, err, ErrMissingPrivileges)
+	})
+
+}
+
+func mockListUsers(req api.ListUsersRequest) (*api.ListResponse[api.User], error) {
+	switch req.Name {
+	case "empty":
+		return &api.ListResponse[api.User]{
+			Items:              []api.User{},
+			PaginationResponse: api.PaginationResponse{TotalPages: 0, TotalCount: 0, Page: req.Page},
+		}, nil
+	case "one":
+		return &api.ListResponse[api.User]{
+			Items:              []api.User{{Name: "jonathan@test.com"}},
+			PaginationResponse: api.PaginationResponse{TotalPages: 1, TotalCount: 1, Page: req.Page},
+		}, nil
+	case "two":
+		return &api.ListResponse[api.User]{
+			Items:              []api.User{{Name: fmt.Sprintf("%d@test.com", req.Page)}},
+			PaginationResponse: api.PaginationResponse{TotalPages: 2, TotalCount: 2, Page: req.Page},
+		}, nil
+	case "five":
+		return &api.ListResponse[api.User]{
+			Items:              []api.User{{Name: fmt.Sprintf("%d@test.com", req.Page)}, {Name: fmt.Sprintf("%d@test.org", req.Page)}},
+			PaginationResponse: api.PaginationResponse{TotalPages: 5, TotalCount: 5, Page: req.Page},
+		}, nil
+	case "403":
+		return nil, api.Error{Code: 403}
+	default:
+		return nil, Error{Message: "default error"}
+	}
+}

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -70,7 +70,7 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list providers")
-			providers, err := listAll(client, api.ListProvidersRequest{}, api.Client.ListProviders, nil)
+			providers, err := listAll(client, api.ListProvidersRequest{}, api.Client.ListProviders)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -70,7 +70,7 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list providers")
-			providers, err := listAll(client, api.ListProvidersRequest{}, api.Client.ListProviders)
+			providers, err := listAll(client.ListProviders, api.ListProvidersRequest{})
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -70,7 +70,7 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list providers")
-			providers, err := listAll(client, api.ListProvidersRequest{}, api.Client.ListProviders, func(err error) error { return err })
+			providers, err := listAll(client, api.ListProvidersRequest{}, api.Client.ListProviders, nil)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -70,20 +70,20 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list providers")
-			providers, err := client.ListProviders("")
+			providers, err := listAll(client, api.ListProvidersRequest{}, api.Client.ListProviders, func(err error) error { return err })
 			if err != nil {
 				return err
 			}
 
 			switch format {
 			case "json":
-				jsonOutput, err := json.Marshal(providers.Items)
+				jsonOutput, err := json.Marshal(providers)
 				if err != nil {
 					return err
 				}
 				cli.Output(string(jsonOutput))
 			case "yaml":
-				yamlOutput, err := yaml.Marshal(providers.Items)
+				yamlOutput, err := yaml.Marshal(providers)
 				if err != nil {
 					return err
 				}
@@ -96,7 +96,7 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 				}
 
 				var rows []row
-				for _, p := range providers.Items {
+				for _, p := range providers {
 					rows = append(rows, row{Name: p.Name, URL: p.URL, Kind: p.Kind})
 				}
 
@@ -199,7 +199,7 @@ func updateProvider(cli *CLI, name string, secret string) error {
 		return err
 	}
 
-	res, err := client.ListProviders(name)
+	res, err := client.ListProviders(api.ListProvidersRequest{Name: name})
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func newProvidersRemoveCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list providers named %q", args[0])
-			providers, err := client.ListProviders(args[0])
+			providers, err := client.ListProviders(api.ListProvidersRequest{Name: args[0]})
 			if err != nil {
 				return err
 			}
@@ -286,7 +286,7 @@ func newProvidersRemoveCmd(cli *CLI) *cobra.Command {
 
 func GetProviderByName(client *api.Client, name string) (*api.Provider, error) {
 	logging.Debugf("call server: list providers named %q", name)
-	providers, err := client.ListProviders(name)
+	providers, err := client.ListProviders(api.ListProvidersRequest{Name: name})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -131,7 +131,7 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 			var rows []row
 
 			logging.Debugf("call server: list users")
-			users, err := listAll(client, api.ListUsersRequest{}, api.Client.ListUsers)
+			users, err := listAll(client.ListUsers, api.ListUsersRequest{})
 			if err != nil {
 				if errors.Is(err, ErrMissingPrivileges) {
 					return Error{

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -133,11 +133,6 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 			logging.Debugf("call server: list users")
 			users, err := listAll(client.ListUsers, api.ListUsersRequest{})
 			if err != nil {
-				if errors.Is(err, ErrMissingPrivileges) {
-					return Error{
-						Message: fmt.Sprintf("Cannot list users: %s", err.Error()),
-					}
-				}
 				return err
 			}
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->
The `infra list ___` command now compiles its list of Items through multiple API requests (multiple pages) if there are more than 100 records.

The main logic is added in the `Paginatable` interface and `listAll` function.
## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->
