### PR TITLE
feat: load database configuration options using infra secrets

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -310,18 +310,28 @@ func (s *Server) getPostgresConnectionString() (string, error) {
 
 	if s.options.DBHost != "" {
 		// config has separate postgres parameters set, combine them into a connection DSN now
-		fmt.Fprintf(&pgConn, "host=%s ", s.options.DBHost)
+		host, err := secrets.GetSecret(s.options.DBHost, s.secrets)
+		if err != nil {
+			return "", fmt.Errorf("postgres host: %w", err)
+		}
+
+		fmt.Fprintf(&pgConn, "host=%s ", host)
 
 		if s.options.DBUsername != "" {
-			fmt.Fprintf(&pgConn, "user=%s ", s.options.DBUsername)
+			username, err := secrets.GetSecret(s.options.DBUsername, s.secrets)
+			if err != nil {
+				return "", fmt.Errorf("postgres username: %w", err)
+			}
+
+			fmt.Fprintf(&pgConn, "user=%s ", username)
 
 			if s.options.DBPassword != "" {
-				pass, err := secrets.GetSecret(s.options.DBPassword, s.secrets)
+				password, err := secrets.GetSecret(s.options.DBPassword, s.secrets)
 				if err != nil {
-					return "", fmt.Errorf("postgres secret: %w", err)
+					return "", fmt.Errorf("postgres password: %w", err)
 				}
 
-				fmt.Fprintf(&pgConn, "password=%s ", pass)
+				fmt.Fprintf(&pgConn, "password=%s ", password)
 			}
 		}
 
@@ -330,7 +340,12 @@ func (s *Server) getPostgresConnectionString() (string, error) {
 		}
 
 		if s.options.DBName != "" {
-			fmt.Fprintf(&pgConn, "dbname=%s ", s.options.DBName)
+			name, err := secrets.GetSecret(s.options.DBName, s.secrets)
+			if err != nil {
+				return "", fmt.Errorf("postgres name: %w", err)
+			}
+
+			fmt.Fprintf(&pgConn, "dbname=%s ", name)
 		}
 
 		if s.options.DBParameters != "" {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

This allows the configuration values to come from `file:`, `env:` or any other configured secret provider instead of only handling raw configuration values.

fix: infra_destinations metrics in postgres

The previous query failed locally when running with postgres database. It complained about the `last_seen_at` column not being a part of `GROUP BY`. This is due to the two separate query args seen by postgres as distinct values. I tried using `sql.NamedArgs` but it produced the same result. Ended up using a subquery which seems to be cleaner. For some reason the postgres variant of the unit test wasn't able to find this

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
