### PR TITLE
infra chart: typo in server labels helper function

### DIFF
--- a/helm/charts/infra/templates/server/_helpers.tpl
+++ b/helm/charts/infra/templates/server/_helpers.tpl
@@ -52,7 +52,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if or .Values.server.labels .Values.global.labels }}
-{{ merge .Values.server.labels .Values.global.server.labels | toYaml }}
+{{ merge .Values.server.labels .Values.global.labels | toYaml }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary

Small typo fix in server's labels helper function, was referencing a non-existing key in the global values block

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
