### PR TITLE
fix: destinations query errors in postgres

### DIFF
--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/models"
@@ -33,4 +34,26 @@ func TestDestinationSaveCreatedPersists(t *testing.T) {
 	destination, err = GetDestination(db, ByID(destination.ID))
 	assert.NilError(t, err)
 	assert.Assert(t, !destination.CreatedAt.IsZero())
+}
+
+func TestCountDestinationsByConnectedVersion(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		assert.NilError(t, CreateDestination(db, &models.Destination{Name: "1", UniqueID: "1", LastSeenAt: time.Now()}))
+		assert.NilError(t, CreateDestination(db, &models.Destination{Name: "2", UniqueID: "2", Version: "", LastSeenAt: time.Now().Add(-10 * time.Minute)}))
+		assert.NilError(t, CreateDestination(db, &models.Destination{Name: "3", UniqueID: "3", Version: "0.1.0", LastSeenAt: time.Now()}))
+		assert.NilError(t, CreateDestination(db, &models.Destination{Name: "4", UniqueID: "4", Version: "0.1.0"}))
+		assert.NilError(t, CreateDestination(db, &models.Destination{Name: "5", UniqueID: "5", Version: "0.1.0"}))
+
+		actual, err := CountDestinationsByConnectedVersion(db)
+		assert.NilError(t, err)
+
+		expected := []destinationsCount{
+			{Connected: false, Version: "", Count: 1},
+			{Connected: true, Version: "", Count: 1},
+			{Connected: false, Version: "0.1.0", Count: 2},
+			{Connected: true, Version: "0.1.0", Count: 1},
+		}
+
+		assert.DeepEqual(t, actual, expected)
+	})
 }

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -77,3 +77,17 @@ func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
 
 	return deleteAll[models.Provider](db, ByIDs(ids))
 }
+
+type providersCount struct {
+	Kind  string
+	Count float64
+}
+
+func CountProvidersByKind(db *gorm.DB) ([]providersCount, error) {
+	var results []providersCount
+	if err := db.Raw("SELECT kind, COUNT(*) as count FROM providers WHERE deleted_at IS NULL GROUP BY kind").Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -168,3 +168,26 @@ func TestRecreateProviderSameDomain(t *testing.T) {
 		assert.NilError(t, err)
 	})
 }
+
+func TestCountProvidersByKind(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "oidc", Kind: "oidc"}))
+		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "okta", Kind: "okta"}))
+		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "okta2", Kind: "okta"}))
+		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "azure", Kind: "azure"}))
+		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "google", Kind: "google"}))
+
+		actual, err := CountProvidersByKind(db)
+		assert.NilError(t, err)
+
+		expected := []providersCount{
+			{Kind: "azure", Count: 1},
+			{Kind: "google", Count: 1},
+			{Kind: "infra", Count: 1},
+			{Kind: "oidc", Count: 1},
+			{Kind: "okta", Count: 2},
+		}
+
+		assert.DeepEqual(t, actual, expected)
+	})
+}


### PR DESCRIPTION
## Summary

postgres complains the last_seen_at select param isn't in `GROUP BY` even though it is because gorm templates out the comparison value as two distinct values.

Improve testability by moving the complex queries to the data package where it can be easily tested against both sqlite and postgres. Also revert the more basic count queries back to using `data.Count`. Changing these to a raw query was premature.