### PR TITLE
fix: docker images tags latest for dev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,8 +106,10 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: infrahq/infra
+          flavor: latest=false
           tags: |
             type=raw,value=${{ inputs.RELEASE_NAME }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
             type=match,pattern=.*-(.*),group=1,value=${{ inputs.RELEASE_NAME }}
       - uses: docker/setup-buildx-action@v2
       - uses: docker/build-push-action@v3

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - id: candidate-name
         run: |
-          apt-get update && apt-get install -y jq
           CANDIDATE_NAME=$(jq -r '.["."]' <.release-please-manifest.json)-dev
           echo "::set-output name=candidate_name::$CANDIDATE_NAME"
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The default conditions for `latest` tag enable it in the release-please branch. This causes dev images to also be released as `latest` which is bad.

Also remove unnecessary `apt-get install jq`; `jq` is already installed on the github runners and this command also requires `sudo` which means it also errors.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2581 
