### PR TITLE
fix: infra keys list works with postgres

### DIFF
--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -134,8 +134,8 @@ func ByNotExpired() SelectorFunc {
 func ByNotExpiredOrExtended() SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		query := strings.Builder{}
-		query.WriteString("(expires_at > ? OR expires_at is ? OR expires_at is null) AND ")
-		query.WriteString("(extension_deadline > ? OR extension_deadline is ? OR extension_deadline is null)")
+		query.WriteString("(expires_at > ? OR expires_at = ? OR expires_at is null) AND ")
+		query.WriteString("(extension_deadline > ? OR extension_deadline = ? OR extension_deadline is null)")
 		return db.Where(query.String(), time.Now().UTC(), time.Time{}, time.Now().UTC(), time.Time{})
 	}
 }

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -122,15 +122,6 @@ func ByUserID(userID uid.ID) SelectorFunc {
 	}
 }
 
-func ByNotExpired() SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.
-			Where("expires_at > ?", time.Now().UTC()).
-			Or("expires_at is ?", time.Time{}).
-			Or("expires_at is null")
-	}
-}
-
 func ByNotExpiredOrExtended() SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		query := strings.Builder{}


### PR DESCRIPTION
## Summary

Quick fix for keys list on postgres. Changes `is` to `=`.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2451 
Resolves #2578 
