### PR TITLE
Add validation rules to provider requests

### DIFF
--- a/api/provider.go
+++ b/api/provider.go
@@ -10,8 +10,8 @@ type Provider struct {
 	Name     string   `json:"name" example:"okta"`
 	Created  Time     `json:"created"`
 	Updated  Time     `json:"updated"`
-	URL      string   `json:"url" validate:"required" example:"infrahq.okta.com"`
-	ClientID string   `json:"clientID" validate:"required" example:"0oapn0qwiQPiMIyR35d6"`
+	URL      string   `json:"url" example:"infrahq.okta.com"`
+	ClientID string   `json:"clientID" example:"0oapn0qwiQPiMIyR35d6"`
 	Kind     string   `json:"kind" example:"oidc"`
 	AuthURL  string   `json:"authURL" example:"https://example.com/oauth2/v1/authorize"`
 	Scopes   []string `json:"scopes" example:"['openid', 'email']"`

--- a/api/provider.go
+++ b/api/provider.go
@@ -18,20 +18,43 @@ type Provider struct {
 }
 
 type CreateProviderRequest struct {
-	Name         string `json:"name" validate:"required" example:"okta"`
-	URL          string `json:"url" validate:"required" example:"infrahq.okta.com"`
-	ClientID     string `json:"clientID" validate:"required" example:"0oapn0qwiQPiMIyR35d6"`
-	ClientSecret string `json:"clientSecret" validate:"required" example:"jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU"`
-	Kind         string `json:"kind" validate:"omitempty,oneof=oidc okta azure google" example:"oidc"`
+	Name         string `json:"name" example:"okta"`
+	URL          string `json:"url" example:"infrahq.okta.com"`
+	ClientID     string `json:"clientID" example:"0oapn0qwiQPiMIyR35d6"`
+	ClientSecret string `json:"clientSecret" example:"jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU"`
+	Kind         string `json:"kind" example:"oidc"`
+}
+
+var kinds = []string{"oidc", "okta", "azure", "google"}
+
+func (r CreateProviderRequest) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.Required("name", r.Name),
+		validate.Required("url", r.URL),
+		validate.Required("clientID", r.ClientID),
+		validate.Required("clientSecret", r.ClientSecret),
+		validate.Enum("kind", r.Kind, kinds),
+	}
 }
 
 type UpdateProviderRequest struct {
-	ID           uid.ID `uri:"id" json:"-" validate:"required"`
-	Name         string `json:"name" validate:"required" example:"okta"`
-	URL          string `json:"url" validate:"required" example:"infrahq.okta.com"`
-	ClientID     string `json:"clientID" validate:"required" example:"0oapn0qwiQPiMIyR35d6"`
-	ClientSecret string `json:"clientSecret" validate:"required" example:"jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU"`
-	Kind         string `json:"kind" validate:"omitempty,oneof=oidc okta azure google" example:"oidc"`
+	ID           uid.ID `uri:"id" json:"-"`
+	Name         string `json:"name" example:"okta"`
+	URL          string `json:"url" example:"infrahq.okta.com"`
+	ClientID     string `json:"clientID" example:"0oapn0qwiQPiMIyR35d6"`
+	ClientSecret string `json:"clientSecret" example:"jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU"`
+	Kind         string `json:"kind" example:"oidc"`
+}
+
+func (r UpdateProviderRequest) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.Required("id", r.ID),
+		validate.Required("name", r.Name),
+		validate.Required("url", r.URL),
+		validate.Required("clientID", r.ClientID),
+		validate.Required("clientSecret", r.ClientSecret),
+		validate.Enum("kind", r.Kind, kinds),
+	}
 }
 
 type ListProvidersRequest struct {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -635,11 +635,10 @@ func (a *API) UpdateIdentityInfoFromProvider(c *gin.Context) error {
 	return access.UpdateIdentityInfoFromProvider(c, oidc)
 }
 
-func (a *API) providerClient(c *gin.Context, provider *models.Provider, redirectURL string) (providers.OIDCClient, error) {
-	if val, ok := c.Get("oidc"); ok {
+func (a *API) providerClient(ctx context.Context, provider *models.Provider, redirectURL string) (providers.OIDCClient, error) {
+	if c := providers.OIDCClientFromContext(ctx); c != nil {
 		// oidc is added to the context during unit tests
-		oidc, _ := val.(providers.OIDCClient)
-		return oidc, nil
+		return c, nil
 	}
 
 	clientSecret, err := secrets.GetSecret(string(provider.ClientSecret), a.server.secrets)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -233,7 +233,7 @@ func (a *API) CreateProvider(c *gin.Context, r *api.CreateProviderRequest) (*api
 	}
 	provider.Kind = kind
 
-	if err := a.setProviderInforFromServer(c, provider); err != nil {
+	if err := a.setProviderInfoFromServer(c, provider); err != nil {
 		return nil, err
 	}
 
@@ -261,7 +261,7 @@ func (a *API) UpdateProvider(c *gin.Context, r *api.UpdateProviderRequest) (*api
 	}
 	provider.Kind = kind
 
-	if err := a.setProviderInforFromServer(c, provider); err != nil {
+	if err := a.setProviderInfoFromServer(c, provider); err != nil {
 		return nil, err
 	}
 
@@ -652,7 +652,7 @@ func (a *API) providerClient(c *gin.Context, provider *models.Provider, redirect
 }
 
 // setProviderInfoFromServer checks information provided by an OIDC server
-func (a *API) setProviderInforFromServer(c *gin.Context, provider *models.Provider) error {
+func (a *API) setProviderInfoFromServer(c *gin.Context, provider *models.Provider) error {
 	// create a provider client to validate the server and get its info
 	oidc, err := a.providerClient(c, provider, "http://localhost:8301")
 	if err != nil {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
-	"k8s.io/utils/strings/slices"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/generate"
@@ -432,40 +431,6 @@ func TestListKeys(t *testing.T) {
 
 		assert.Assert(t, len(resp2) > 0)
 	})
-}
-
-func TestListProviders(t *testing.T) {
-	s := setupServer(t, withAdminUser)
-	routes := s.GenerateRoutes(prometheus.NewRegistry())
-
-	testProvider := &models.Provider{Name: "mokta", Kind: models.ProviderKindOkta, AuthURL: "https://example.com/v1/auth", Scopes: []string{"openid", "email"}}
-
-	err := data.CreateProvider(s.db, testProvider)
-	assert.NilError(t, err)
-
-	dbProviders, err := data.ListProviders(s.db, &models.Pagination{})
-	assert.NilError(t, err)
-	assert.Equal(t, len(dbProviders), 2)
-
-	req, err := http.NewRequest(http.MethodGet, "/api/providers", nil)
-	assert.NilError(t, err)
-
-	req.Header.Add("Authorization", "Bearer "+adminAccessKey(s))
-	req.Header.Add("Infra-Version", "0.12.3")
-
-	resp := httptest.NewRecorder()
-	routes.ServeHTTP(resp, req)
-
-	assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
-
-	var apiProviders api.ListResponse[Provider]
-	err = json.Unmarshal(resp.Body.Bytes(), &apiProviders)
-	assert.NilError(t, err)
-
-	assert.Equal(t, len(apiProviders.Items), 1)
-	assert.Equal(t, apiProviders.Items[0].Name, "mokta")
-	assert.Equal(t, apiProviders.Items[0].AuthURL, "https://example.com/v1/auth")
-	assert.Assert(t, slices.Equal(apiProviders.Items[0].Scopes, []string{"openid", "email"}))
 }
 
 // withAdminUser may be used with setupServer to setup the server

--- a/internal/server/providers/oidc.go
+++ b/internal/server/providers/oidc.go
@@ -38,6 +38,21 @@ type OIDCClient interface {
 	GetUserInfo(ctx context.Context, providerUser *models.ProviderUser) (*UserInfoClaims, error)
 }
 
+type key struct{}
+
+var ctxKey = key{}
+
+func OIDCClientFromContext(ctx context.Context) OIDCClient {
+	if raw := ctx.Value(ctxKey); raw != nil {
+		return raw.(OIDCClient) // nolint:forcetypeassert
+	}
+	return nil
+}
+
+func WithOIDCClient(ctx context.Context, client OIDCClient) context.Context {
+	return context.WithValue(ctx, ctxKey, client)
+}
+
 type oidcClientImplementation struct {
 	ProviderID   uid.ID
 	Domain       string

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -667,10 +667,6 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "url",
-                "clientID"
-              ],
               "type": "object"
             },
             "type": "array"
@@ -834,11 +830,7 @@
             "example": "infrahq.okta.com",
             "type": "string"
           }
-        },
-        "required": [
-          "url",
-          "clientID"
-        ]
+        }
       },
       "SignupEnabledResponse": {
         "properties": {

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -26,6 +26,8 @@ type ExampleRequest struct {
 
 	TooLow  int
 	TooHigh int
+
+	Kind string
 }
 
 func (r ExampleRequest) ValidationRules() []ValidationRule {
@@ -56,9 +58,9 @@ func (r ExampleRequest) ValidationRules() []ValidationRule {
 		StringRule{
 			CharacterRanges: []CharRange{AlphabetLower},
 		},
-
 		IntRule{Name: "tooLow", Value: r.TooLow, Min: Int(20)},
 		IntRule{Name: "tooHigh", Value: r.TooHigh, Max: Int(20)},
+		Enum("kind", r.Kind, []string{"fruit", "legume", "grain"}),
 	}
 }
 
@@ -88,6 +90,7 @@ func TestValidate_AllRules(t *testing.T) {
 			WrongOnes:  "ah CAPS",
 			TooLow:     2,
 			TooHigh:    22,
+			Kind:       "fish",
 		}
 		err := Validate(r)
 		assert.ErrorContains(t, err, "validation failed: ")
@@ -106,6 +109,7 @@ func TestValidate_AllRules(t *testing.T) {
 			"tooMany":    {"length of string (6) must be no more than 5"},
 			"tooHigh":    {"value (22) must be at most 20"},
 			"tooLow":     {"value (2) must be at least 20"},
+			"kind":       {"must be one of (fruit, legume, grain)"},
 		}
 		assert.DeepEqual(t, fieldError, expected)
 	})


### PR DESCRIPTION
## Summary

Branched from #2570

This PR adds a new `Enum` rule to `internal/validate`, and adds validation rules for `CreateProvider`, and `UpdateProvider`. Also adds API handler tests for those operations.

Best viewed by individual commit. There are a couple small cleanups in separate commits.

## Related Issues

Related to https://github.com/infrahq/infra/issues/1763