### PR TITLE
fix: force release version in goreleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       RELEASE_NAME:
         type: string
+        required: true
 
 jobs:
   binaries:
@@ -29,7 +30,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --skip-publish
+          args: release --rm-dist --skip-publish --snapshot
       - uses: actions/upload-artifact@v3
         with:
           name: binaries

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,10 @@ on:
     inputs:
       RELEASE_NAME:
         type: string
+        required: true
       ENVIRONMENT:
         type: string
+        required: true
     secrets:
       AWS_REGION:
         required: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,7 +64,7 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}-checksums.txt"
 snapshot:
-  name_template: "{{ .RawVersion }}-dev"
+  name_template: "{{ .Env.RELEASE_NAME }}"
 blobs:
   - provider: s3
     region: us-east-2


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Unfortunately goreleaser's release version is firmly tied to git tags.
In this case, this coupling is detrimental as there's an intermediate
step which requires goreleaser to build artifacts for a nonexistent tag.

Goreleaser doesn't have many options to modifying its version string so
we have to resort to always building a snapshot which derives its value
from the env var RELEASE_NAME. This also means any job that wants to run
the build workflow must set RELEASE_NAME

https://goreleaser.com/customization/snapshots/

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2522
