### PR TITLE
api: remove integration with go-playground/validator

### DIFF
--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -86,21 +86,6 @@ func TestSendAPIError(t *testing.T) {
 				Message: "value for name already exists for user",
 			},
 		},
-		{
-			err: pgValidate.Struct(struct {
-				Email string `validate:"required,email" json:"email"`
-			}{}),
-			result: api.Error{
-				Code:    http.StatusBadRequest,
-				Message: "Email: is required",
-				FieldErrors: []api.FieldError{
-					{
-						FieldName: "Email",
-						Errors:    []string{"is required"},
-					},
-				},
-			},
-		},
 	}
 
 	for _, test := range tests {

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -175,7 +174,7 @@ func buildProperty(f reflect.StructField, t, parent reflect.Type, parentSchema *
 	}
 
 	s := &openapi3.Schema{}
-	setTagInfo(f, parent, s, parentSchema)
+	updateSchemaFromStructTags(f, s)
 	setTypeInfo(t, s)
 
 	if s.Type == "array" {
@@ -232,34 +231,13 @@ func WriteOpenAPIDocToFile(openAPIDoc openapi3.T, version string, filename strin
 	return nil
 }
 
-func setTagInfo(f reflect.StructField, parent reflect.Type, schema, parentSchema *openapi3.Schema) {
-	if example, ok := f.Tag.Lookup("example"); ok {
+func updateSchemaFromStructTags(field reflect.StructField, schema *openapi3.Schema) {
+	if example, ok := field.Tag.Lookup("example"); ok {
 		schema.Example = example
 	}
 
-	if note, ok := f.Tag.Lookup("note"); ok {
+	if note, ok := field.Tag.Lookup("note"); ok {
 		schema.Description = note
-	}
-
-	// TODO: remove with pgValidate
-	if validate, ok := f.Tag.Lookup("validate"); ok {
-		for _, val := range strings.Split(validate, ",") {
-			if val == "required" && parentSchema != nil {
-				parentSchema.Required = append(parentSchema.Required, getFieldName(f, parent))
-			}
-
-			if val == "email" {
-				schema.Format = "email"
-			}
-
-			if strings.HasPrefix(val, "min=") {
-				schema.MinLength = parseMinLength(val)
-			}
-
-			if strings.HasPrefix(val, "oneof=") {
-				schema.Enum = parseOneOf(val)
-			}
-		}
 	}
 }
 
@@ -462,30 +440,12 @@ func buildRequest(r reflect.Type, op *openapi3.Operation, method string) {
 			panic(fmt.Sprintf("field %q of struct %q must have a tag (json, form, or uri) with a name or '-'", f.Name, r.Name()))
 		}
 
-		// TODO: share this with setTagInfo
+		// TODO: share this with updateSchemaFromStructTags
 		if example, ok := f.Tag.Lookup("example"); ok {
 			p.Example = example
 		}
-
 		if note, ok := f.Tag.Lookup("note"); ok {
 			p.Description = note
-		}
-
-		// TODO: remove with pgValidate
-		if validate, ok := f.Tag.Lookup("validate"); ok {
-			for _, val := range strings.Split(validate, ",") {
-				if val == "required" {
-					p.Required = true
-				}
-
-				if val == "email" {
-					p.Schema.Value.Format = "email"
-				}
-
-				if strings.HasPrefix(val, "min=") {
-					p.Schema.Value.MinLength = parseMinLength(val)
-				}
-			}
 		}
 
 		op.AddParameter(p)
@@ -559,37 +519,4 @@ func getFieldName(f reflect.StructField, parent reflect.Type) string {
 	}
 
 	panic(fmt.Sprintf("field %q of struct %q must have a tag (json, form, or uri) with a name or '-'", f.Name, parent.Name()))
-}
-
-// TODO: remove with pgValidate
-func parseMinLength(tag string) uint64 {
-	minLength := strings.Split(tag, "min=")
-	if len(minLength) != 2 {
-		panic("min length tag does not match expected format")
-	}
-
-	len, err := strconv.ParseUint(minLength[1], 10, 64)
-	if err != nil {
-		panic("unexpected min length: " + err.Error())
-	}
-
-	return len
-}
-
-// TODO: remove with pgValidate
-func parseOneOf(tag string) []interface{} {
-	oneof := strings.Split(tag, "oneof=")
-	if len(oneof) != 2 {
-		panic("oneof tag does not match expected format")
-	}
-
-	values := strings.Split(oneof[1], " ")
-
-	// convert to a slice of interfaces to assign to the schema
-	enumInterface := make([]interface{}, len(values))
-	for i := range values {
-		enumInterface[i] = values[i]
-	}
-
-	return enumInterface
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -279,11 +279,6 @@ func bind(c *gin.Context, req interface{}) error {
 		}
 	}
 
-	// TODO: remove once all requests use internal/validate
-	if err := pgValidate.Struct(req); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
 	"github.com/infrahq/secrets"
 	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
@@ -116,7 +117,7 @@ func newServer(options Options) *Server {
 func New(options Options) (*Server, error) {
 	server := newServer(options)
 
-	if err := pgValidate.Struct(options); err != nil {
+	if err := validator.New().Struct(options); err != nil {
 		return nil, fmt.Errorf("invalid options: %w", err)
 	}
 

--- a/internal/server/validator.go
+++ b/internal/server/validator.go
@@ -1,5 +1,0 @@
-package server
-
-import "github.com/go-playground/validator/v10"
-
-var pgValidate = validator.New()


### PR DESCRIPTION
## Summary

Branched from #2593

Now that all API requests have been converted to `internal/validate` we can remove support for the `validate` tag from OpenAPI doc generation, and from the api handlers.

Other uses of pgValidate will be removed in #2583 

Resolves https://github.com/infrahq/infra/issues/1763
