### PR TITLE
fix: load env var RELEASE_NAME into goreleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist --skip-publish --snapshot
+        env:
+          RELEASE_NAME: ${{ inputs.RELEASE_NAME }}
       - uses: actions/upload-artifact@v3
         with:
           name: binaries


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The variable is a GitHub actions input variable and needs to be exposed to the env.

This fixes a miss in https://github.com/infrahq/infra/pull/2591 which causes the job to fail

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2522
