### PR TITLE
Fix TestMetrics failing on the release branch

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -175,7 +175,7 @@ func Run(ctx context.Context, options Options) error {
 	proxy := httputil.NewSingleHostReverseProxy(proxyHost)
 	proxy.Transport = proxyTransport
 
-	promRegistry := metrics.NewRegistry()
+	promRegistry := metrics.NewRegistry(internal.FullVersion())
 	httpErrorLog := log.New(logging.NewFilteredHTTPLogger(), "", 0)
 	metricsServer := &http.Server{
 		Addr:     ":9090",

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -12,7 +12,7 @@ import (
 )
 
 func setupMetrics(db *gorm.DB) *prometheus.Registry {
-	registry := metrics.NewRegistry(apiVersion())
+	registry := metrics.NewRegistry(productVersion())
 
 	if rawDB, err := db.DB(); err == nil {
 		registry.MustRegister(collectors.NewDBStatsCollector(rawDB, db.Dialector.Name()))

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -12,7 +12,7 @@ import (
 )
 
 func setupMetrics(db *gorm.DB) *prometheus.Registry {
-	registry := metrics.NewRegistry()
+	registry := metrics.NewRegistry(apiVersion())
 
 	if rawDB, err := db.DB(); err == nil {
 		registry.MustRegister(collectors.NewDBStatsCollector(rawDB, db.Dialector.Name()))

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestMetrics(t *testing.T) {
 	run := func(db *gorm.DB, s string) []byte {
-		patchAPIVersion(t, "9.9.9")
+		patchProductVersion(t, "9.9.9")
 		registry := setupMetrics(db)
 
 		tempfile, err := ioutil.TempFile(t.TempDir(), t.Name())

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestMetrics(t *testing.T) {
 	run := func(db *gorm.DB, s string) []byte {
+		patchAPIVersion(t, "9.9.9")
 		registry := setupMetrics(db)
 
 		tempfile, err := ioutil.TempFile(t.TempDir(), t.Name())
@@ -36,7 +37,8 @@ func TestMetrics(t *testing.T) {
 
 	t.Run("build info", func(t *testing.T) {
 		actual := run(setupDB(t), `build_info({.*})? \d+`)
-		golden.Assert(t, string(actual), t.Name())
+		expected := `build_info{branch="main",commit="",date="",version="9.9.9"} 1`
+		assert.Equal(t, string(actual), expected)
 	})
 
 	t.Run("infra users", func(t *testing.T) {

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -384,7 +384,9 @@ func buildResponse(schemas openapi3.Schemas, rst reflect.Type) openapi3.Response
 	return resp
 }
 
-var apiVersion = internal.FullVersion
+// productVersion is a shim for testing. It allows us to patch the variable
+// so that tests expect a consistent value that does not change with every release.
+var productVersion = internal.FullVersion
 
 func buildRequest(r reflect.Type, op *openapi3.Operation, method string) {
 	if r.Kind() == reflect.Pointer {
@@ -403,7 +405,7 @@ func buildRequest(r reflect.Type, op *openapi3.Operation, method string) {
 		Required: true,
 		Schema: &openapi3.SchemaRef{
 			Value: &openapi3.Schema{
-				Example:     apiVersion(),
+				Example:     productVersion(),
 				Format:      `\d+\.\d+\(.\d+)?(-.\w(+\w)?)?`,
 				Type:        "string",
 				Description: "Version of the API being requested",

--- a/internal/server/openapi_test.go
+++ b/internal/server/openapi_test.go
@@ -16,7 +16,7 @@ import (
 // To update the expected value, run:
 //     go test ./internal/server -update
 func TestWriteOpenAPIDocToFile(t *testing.T) {
-	patchAPIVersion(t, "0.0.0")
+	patchProductVersion(t, "0.0.0")
 	s := Server{}
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
@@ -29,13 +29,13 @@ func TestWriteOpenAPIDocToFile(t *testing.T) {
 	golden.Assert(t, string(actual), "openapi3.json")
 }
 
-func patchAPIVersion(t *testing.T, version string) {
-	orig := apiVersion
-	apiVersion = func() string {
+func patchProductVersion(t *testing.T, version string) {
+	orig := productVersion
+	productVersion = func() string {
 		return version
 	}
 	t.Cleanup(func() {
-		apiVersion = orig
+		productVersion = orig
 	})
 
 }

--- a/internal/server/testdata/TestMetrics/build_info
+++ b/internal/server/testdata/TestMetrics/build_info
@@ -1,1 +1,0 @@
-build_info{branch="main",commit="",date="",version="0.13.7+dev"} 1

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,7 +18,7 @@ import (
 //   * standard process collector
 //   * standard go collector
 //   * build_info metric
-func NewRegistry() *prometheus.Registry {
+func NewRegistry(version string) *prometheus.Registry {
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	registry.MustRegister(collectors.NewGoCollector())
@@ -28,7 +28,7 @@ func NewRegistry() *prometheus.Registry {
 		Help: "A metric with a constant '1' value labeled by branch, version, commit, and date from which infra was built",
 		ConstLabels: prometheus.Labels{
 			"branch":  internal.Branch,
-			"version": internal.FullVersion(),
+			"version": version,
 			"commit":  internal.Commit,
 			"date":    internal.Date,
 		},


### PR DESCRIPTION
## Summary

This test depends on the product version, so the expected value changes
every time we create a new release branch, and after every release.

This commit fixes the problem by using the existing shim we added for
openapi doc generation. We can patch that shim in a test to set a
hardcoded version.

This way the expected value does not change when the product version
changes.

The test failure can be seen here: https://github.com/infrahq/infra/runs/7362326501?check_suite_focus=true