### PR TITLE
fix: restore skipTLSVerify for connector helm template

### DIFF
--- a/helm/charts/infra/templates/connector/configmap.yaml
+++ b/helm/charts/infra/templates/connector/configmap.yaml
@@ -29,6 +29,10 @@ data:
       url: {{ . }}
 {{- end }}
 
+{{- with .Values.connector.config.skipTLSVerify }}
+      skipTLSVerify: {{ . }}
+{{- end }}
+
 {{- if include "server.enabled" . | eq "true" }}
       url: {{ .Release.Name }}-server.{{ .Release.Namespace }}
 


### PR DESCRIPTION
## Summary

Missed this in #2485