### PR TITLE
Remove pgValidate from providers

### DIFF
--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -131,7 +131,7 @@ func migrate(db *gorm.DB) error {
 					models.Model
 
 					Identity        string `gorm:"<-;uniqueIndex:,where:deleted_at is NULL"`
-					PasswordHash    []byte `validate:"required"`
+					PasswordHash    []byte
 					OneTimePassword bool
 				}
 

--- a/internal/server/providers/azure_test.go
+++ b/internal/server/providers/azure_test.go
@@ -125,7 +125,7 @@ func TestAzure_GetUserInfo(t *testing.T) {
 				"picture": "https://graph.microsoft.com/v1.0/me/photo/$value"
 			}`,
 			verifyFunc: func(t *testing.T, info *UserInfoClaims, err error) {
-				assert.ErrorContains(t, err, "failed on the 'required_without' tag")
+				assert.ErrorContains(t, err, "must include either a name or email")
 				assert.Assert(t, info == nil)
 			},
 		},

--- a/internal/server/providers/oidc_test.go
+++ b/internal/server/providers/oidc_test.go
@@ -413,7 +413,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 				}
 			},
 			verifyFunc: func(t *testing.T, accessToken, refreshToken string, accessTokenExpiry time.Time, email string, err error) {
-				assert.ErrorContains(t, err, "validation for 'Email' failed")
+				assert.ErrorContains(t, err, "missing an email address")
 				assert.Equal(t, accessToken, "")
 				assert.Equal(t, refreshToken, "")
 				assert.Assert(t, accessTokenExpiry.IsZero())
@@ -444,7 +444,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 				}
 			},
 			verifyFunc: func(t *testing.T, accessToken, refreshToken string, accessTokenExpiry time.Time, email string, err error) {
-				assert.ErrorContains(t, err, "'Email' failed on the 'excludesall' tag")
+				assert.ErrorContains(t, err, "claim has invalid email address")
 				assert.Equal(t, accessToken, "")
 				assert.Equal(t, refreshToken, "")
 				assert.Assert(t, accessTokenExpiry.IsZero())
@@ -591,7 +591,7 @@ func TestOIDC_GetUserInfo(t *testing.T) {
 					"groups": []
 				}`,
 			verifyFunc: func(t *testing.T, info *UserInfoClaims, err error) {
-				assert.ErrorContains(t, err, "required_without")
+				assert.ErrorContains(t, err, "must include either a name or email")
 				assert.Assert(t, info == nil)
 			},
 		},


### PR DESCRIPTION
## Summary

We can provide better error messages by validating the fields manually, so no need to use `internal/validate` here.

## Related Issues

Related to #2583
