### PR TITLE
fix(cli): send SNI value with infra login for certificate generation

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -124,12 +125,18 @@ func httpTransportForHostConfig(config *ClientHostConfig) *http.Transport {
 		}
 	}
 
+	tlsConfig := &tls.Config{
+		//nolint:gosec // We may purposely set insecureskipverify via a flag
+		InsecureSkipVerify: config.SkipTLSVerify,
+		RootCAs:            pool,
+	}
+
+	if ip := net.ParseIP(config.Host); ip != nil {
+		tlsConfig.ServerName = "infra.internal"
+	}
+
 	return &http.Transport{
-		TLSClientConfig: &tls.Config{
-			//nolint:gosec // We may purposely set insecureskipverify via a flag
-			InsecureSkipVerify: config.SkipTLSVerify,
-			RootCAs:            pool,
-		},
+		TLSClientConfig: tlsConfig,
 	}
 }
 


### PR DESCRIPTION
This draft PR demonstrates sending an additional SNI value on `infra login` and subsequent requests

Fixes https://github.com/infrahq/infra/issues/2600

In the future we should consider leaving TLS & certificate management up to the user since it is invariably better to use a public certificate (or signed by an internal team-specific CA)
