### PR TITLE
ci: pin golangci-lint version

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -93,6 +93,9 @@ jobs:
           go-version: "1.18"
           cache: true
       - uses: golangci/golangci-lint-action@v3.2.0
+        with:
+          version: v1.46.2
+          args: --verbose
 
   helm-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because the latest is hanging in CI and never finishing.

Let's see if this works.