### PR TITLE
ci: disable caching in lint, and restore cache in fuzz

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -39,6 +39,12 @@ jobs:
           go-version: '1.18'
           cache: true
 
+      - uses: actions/cache@v3
+        with:
+          key: go-fuzz-corpus-${{ matrix.name }}-${{ github.run_number }}
+          restore-keys: go-fuzz-corpus-${{ matrix.name }}-
+          path: /home/runner/go/cache/fuzz
+
       - name: Set fuzz time
         run: echo "fuzz_time=5m" >> $GITHUB_ENV
         if: "${{ github.event_name == 'pull_request' }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -96,6 +96,9 @@ jobs:
         with:
           version: v1.46.2
           args: --verbose
+          # setup-go already restores the build and module cache
+          skip-build-cache: true
+          skip-pkg-cache: true
 
   helm-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The caching in the lint action duplicates the cache we already have from `setup-go`. Using the second cache causes ~23000 lines of warnings in the lint step.  Disabling the cache should prevent that.

Also restore the caching of the fuzz corpus. I had removed the cache because I thought the setup-go cache would take care of it, but it turns out that setup-go only caches go/cache/mod, not all of go/cache.
