### PR TITLE
fix: resize provider icon on table

### DIFF
--- a/ui/pages/providers/index.js
+++ b/ui/pages/providers/index.js
@@ -23,7 +23,7 @@ const columns = [
         <div className='flex h-7 w-7 flex-none items-center justify-center rounded-md border border-gray-800'>
           <img
             alt='provider icon'
-            className='h-2'
+            className='h-3'
             src={`/providers/${provider.kind}.svg`}
           />
         </div>


### PR DESCRIPTION
## Summary
the provider icon on the table was too small - resize to `height: .75rem`

## 📷 

<img width="359" alt="Screen Shot 2022-07-18 at 12 51 53 PM" src="https://user-images.githubusercontent.com/63033505/179562822-bba77fce-1827-480d-ab29-a697598dbfa6.png">
<img width="345" alt="Screen Shot 2022-07-18 at 12 51 26 PM" src="https://user-images.githubusercontent.com/63033505/179562823-8086b443-ccba-4b67-824e-70dea11604af.png">
<img width="365" alt="Screen Shot 2022-07-18 at 12 49 50 PM" src="https://user-images.githubusercontent.com/63033505/179562824-642beb00-ba8c-4995-aa3e-31e2c392cec4.png">


## Related Issues
Resolves #2598 
