### PR TITLE
maintain: unset default hpa scaling targets

### DIFF
--- a/helm/charts/infra/templates/server/horizontalpodautoscaler.yaml
+++ b/helm/charts/infra/templates/server/horizontalpodautoscaler.yaml
@@ -1,6 +1,8 @@
 {{- if include "server.enabled" . | eq "true" }}
 {{- if .Values.server.autoscaling.enabled }}
-{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2beta2
 {{- else }}
 apiVersion: autoscaling/v2beta1
@@ -18,18 +20,6 @@ spec:
   minReplicas: {{ .Values.server.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.server.autoscaling.maxReplicas }}
   metrics:
-{{- if .Values.server.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.server.autoscaling.targetCPUUtilizationPercentage }}
-{{- else }}
-        targetAverageUtilization: {{ .Values.server.autoscaling.targetCPUUtilizationPercentage }}
-{{- end }}
-{{- end }}
 {{- if .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -40,6 +30,18 @@ spec:
           averageUtilization: {{ .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
 {{- else }}
         targetAverageUtilization: {{ .Values.server.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}
+{{- end }}
+{{- if .Values.server.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.server.autoscaling.targetCPUUtilizationPercentage }}
+{{- else }}
+        targetAverageUtilization: {{ .Values.server.autoscaling.targetCPUUtilizationPercentage }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -354,7 +354,7 @@ server:
   #     cpu: 500m
   #     memory: 512Mi
 
-  ## Infra server autoscaling configurations
+  ## Infra server autoscaling configurations. Enabling autoscaling requires setting resources.
   autoscaling:
 
     ## Enable server autoscaling
@@ -367,10 +367,10 @@ server:
     maxReplicas: 3
 
     ## Target average CPU utilization percentage
-    targetCPUUtilizationPercentage: 50
+    # targetCPUUtilizationPercentage: 50
 
     ## Target average memory utilization percentage
-    targetMemoryUtilizationPercentage: 50
+    # targetMemoryUtilizationPercentage: 50
 
   ## Infra server node selector configurations
   nodeSelector: {}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

By default, we should not set a scaling target for CPU since it may add undesirable conditions to the HPA. Instead, the operator should set these manually. Also added a note about setting the server.resources. Otherwise the HPA has no metric to target.

Changed the order of cpu/memory. The order makes a difference in something like ArgoCD because the output manifest is compared to the live manifest and if there's even a small difference, the controller will constantly try to reconcile the two.