### PR TITLE
fix: linter: add read-header timeouts for all servers

### DIFF
--- a/internal/cmd/local_server.go
+++ b/internal/cmd/local_server.go
@@ -36,7 +36,10 @@ const defaultTimeout = 300000 * time.Millisecond
 var pages embed.FS
 
 func newLocalServer() (*LocalServer, error) {
-	ls := &LocalServer{ResultChan: make(chan CodeResponse, 1), srv: &http.Server{Addr: "127.0.0.1:8301"}}
+	ls := &LocalServer{
+		ResultChan: make(chan CodeResponse, 1),
+		srv:        &http.Server{ReadHeaderTimeout: 30 * time.Second, ReadTimeout: 60 * time.Second, Addr: "127.0.0.1:8301"},
+	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -178,9 +178,11 @@ func Run(ctx context.Context, options Options) error {
 	promRegistry := setupMetrics()
 	httpErrorLog := log.New(logging.NewFilteredHTTPLogger(), "", 0)
 	metricsServer := &http.Server{
-		Addr:     ":9090",
-		Handler:  metrics.NewHandler(promRegistry),
-		ErrorLog: httpErrorLog,
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		Addr:              ":9090",
+		Handler:           metrics.NewHandler(promRegistry),
+		ErrorLog:          httpErrorLog,
 	}
 
 	go func() {
@@ -195,10 +197,12 @@ func Run(ctx context.Context, options Options) error {
 		proxyMiddleware(proxy, authn, k8s.Config.BearerToken),
 	)
 	tlsServer := &http.Server{
-		Addr:      ":443",
-		TLSConfig: tlsConfig,
-		Handler:   router,
-		ErrorLog:  httpErrorLog,
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		Addr:              ":443",
+		TLSConfig:         tlsConfig,
+		Handler:           router,
+		ErrorLog:          httpErrorLog,
 	}
 
 	logging.Infof("starting infra connector (%s) - https:%s metrics:%s", internal.FullVersion(), tlsServer.Addr, metricsServer.Addr)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -228,9 +228,11 @@ func (s *Server) listen() error {
 
 	httpErrorLog := log.New(logging.NewFilteredHTTPLogger(), "", 0)
 	metricsServer := &http.Server{
-		Addr:     s.options.Addr.Metrics,
-		Handler:  metrics.NewHandler(promRegistry),
-		ErrorLog: httpErrorLog,
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		Addr:              s.options.Addr.Metrics,
+		Handler:           metrics.NewHandler(promRegistry),
+		ErrorLog:          httpErrorLog,
 	}
 
 	var err error
@@ -240,9 +242,11 @@ func (s *Server) listen() error {
 	}
 
 	plaintextServer := &http.Server{
-		Addr:     s.options.Addr.HTTP,
-		Handler:  router,
-		ErrorLog: httpErrorLog,
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		Addr:              s.options.Addr.HTTP,
+		Handler:           router,
+		ErrorLog:          httpErrorLog,
 	}
 	s.Addrs.HTTP, err = s.setupServer(plaintextServer)
 	if err != nil {
@@ -255,10 +259,12 @@ func (s *Server) listen() error {
 	}
 
 	tlsServer := &http.Server{
-		Addr:      s.options.Addr.HTTPS,
-		TLSConfig: tlsConfig,
-		Handler:   router,
-		ErrorLog:  httpErrorLog,
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		Addr:              s.options.Addr.HTTPS,
+		TLSConfig:         tlsConfig,
+		Handler:           router,
+		ErrorLog:          httpErrorLog,
 	}
 	s.Addrs.HTTPS, err = s.setupServer(tlsServer)
 	if err != nil {

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -61,6 +61,7 @@ func TestTLSConfigFromOptions(t *testing.T) {
 		assert.NilError(t, err)
 
 		l = tls.NewListener(l, config)
+		// nolint:gosec
 		srv := http.Server{Handler: noopHandler}
 
 		go func() {


### PR DESCRIPTION
## Summary

fixes an issue with the upcoming 1.47.0 golangci linter

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
