### PR TITLE
fix: remove direct dependency on aws-sdk-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.5
-	github.com/aws/aws-sdk-go v1.44.56
+	github.com/aws/aws-sdk-go v1.44.56 // indirect
 	github.com/cli/browser v1.1.0
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-playground/validator/v10 v10.11.0


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Use the AWS API directly to get AWS cluster name. Use a combination of
instance metadata and AWS API. The instance metadata tags is not
sufficient because 1) it requires the user to explicitly enable
exporting instance tags (it's not enabled by default) and 2) the format
of the tags percludes it from being exposed through instance metadata
(they contain `/`).

Unfortunately, cannot remove aws-sdk-go completely because
infrahq/secrets depends on it.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2456 
