### PR TITLE
maintain: remove email migration from login

### DIFF
--- a/api/login.go
+++ b/api/login.go
@@ -21,16 +21,12 @@ func (r LoginRequestOIDC) ValidationRules() []validate.ValidationRule {
 
 type LoginRequestPasswordCredentials struct {
 	Name     string `json:"name"`
-	Email    string `json:"email"` // #1825: remove, this is for migration
 	Password string `json:"password"`
 }
 
 func (r LoginRequestPasswordCredentials) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		validate.RequireOneOf(
-			validate.Field{Name: "name", Value: r.Name},
-			validate.Field{Name: "email", Value: r.Email},
-		),
+		validate.Required("name", r.Name),
 		validate.Required("password", r.Password),
 	}
 }

--- a/api/signup.go
+++ b/api/signup.go
@@ -8,18 +8,13 @@ type SignupEnabledResponse struct {
 
 type SignupRequest struct {
 	Name     string `json:"name"`
-	Email    string `json:"email"` // #1825: remove, this is for migration
 	Password string `json:"password"`
 }
 
 func (r SignupRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
+		validate.Required("name", r.Name),
 		validate.Required("password", r.Password),
-		validate.RequireOneOf(
-			validate.Field{Name: "name", Value: r.Name},
-			validate.Field{Name: "email", Value: r.Email},
-		),
 		validate.Email("name", r.Name),
-		validate.Email("email", r.Email),
 	}
 }

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -703,10 +703,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 				AccessKey: "TllVlekkUz.NFnxSlaPQLosgkNsyzaMttfC",
 			},
 			{
-				Email: "john@email.com",
-			},
-			{
-				Email:    "sarah@email.com",
+				Name:     "sarah@email.com",
 				Password: "supersecret",
 			},
 		},
@@ -754,7 +751,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 
 	identities, err := data.ListIdentities(s.db, &models.Pagination{})
 	assert.NilError(t, err)
-	assert.Equal(t, 6, len(identities)) // john@example.com, sarah@example.com, test@example.com, connector, r2d2, c3po
+	assert.Equal(t, 5, len(identities)) // john@example.com, sarah@example.com, test@example.com, connector, r2d2, c3po
 
 	err = s.db.Model(&models.Group{}).Count(&groups).Error
 	assert.NilError(t, err)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -116,11 +116,6 @@ func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.User, error) {
 		return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)
 	}
 
-	if r.Name == "" {
-		// #1825: remove, this is for migration
-		r.Name = r.Email
-	}
-
 	identity, err := access.Signup(c, r.Name, r.Password)
 	if err != nil {
 		return nil, err
@@ -141,10 +136,6 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 	case r.AccessKey != "":
 		loginMethod = authn.NewKeyExchangeAuthentication(r.AccessKey, expires)
 	case r.PasswordCredentials != nil:
-		if r.PasswordCredentials.Name == "" {
-			// #1825: remove, this is for migration
-			r.PasswordCredentials.Name = r.PasswordCredentials.Email
-		}
 		loginMethod = authn.NewPasswordCredentialAuthentication(r.PasswordCredentials.Name, r.PasswordCredentials.Password)
 	case r.OIDC != nil:
 		provider, err := access.GetProvider(c, r.OIDC.ProviderID)

--- a/internal/server/login_test.go
+++ b/internal/server/login_test.go
@@ -152,8 +152,8 @@ func TestAPI_Login(t *testing.T) {
 
 				expected := []api.FieldError{
 					{
-						FieldName: "passwordCredentials",
-						Errors:    []string{"one of (name, email) is required"},
+						FieldName: "passwordCredentials.name",
+						Errors:    []string{"is required"},
 					},
 					{
 						FieldName: "passwordCredentials.password",
@@ -199,5 +199,4 @@ func TestAPI_Login(t *testing.T) {
 			run(t, tc)
 		})
 	}
-
 }

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -35,7 +35,7 @@ func TestAPI_Signup(t *testing.T) {
 		tc.expected(t, resp)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			name: "missing name and password",
 			setup: func(t *testing.T) api.SignupRequest {
@@ -49,7 +49,7 @@ func TestAPI_Signup(t *testing.T) {
 				assert.NilError(t, err)
 
 				expected := []api.FieldError{
-					{Errors: []string{"one of (name, email) is required"}},
+					{FieldName: "name", Errors: []string{"is required"}},
 					{FieldName: "password", Errors: []string{"is required"}},
 				}
 				assert.DeepEqual(t, respBody.FieldErrors, expected)

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -2909,22 +2909,7 @@
                     "type": "object"
                   },
                   "passwordCredentials": {
-                    "oneOf": [
-                      {
-                        "required": [
-                          "name"
-                        ]
-                      },
-                      {
-                        "required": [
-                          "email"
-                        ]
-                      }
-                    ],
                     "properties": {
-                      "email": {
-                        "type": "string"
-                      },
                       "name": {
                         "type": "string"
                       },
@@ -2933,6 +2918,7 @@
                       }
                     },
                     "required": [
+                      "name",
                       "password"
                     ],
                     "type": "object"
@@ -3766,23 +3752,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "oneOf": [
-                  {
-                    "required": [
-                      "name"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "email"
-                    ]
-                  }
-                ],
                 "properties": {
-                  "email": {
-                    "format": "email",
-                    "type": "string"
-                  },
                   "name": {
                     "format": "email",
                     "type": "string"
@@ -3792,6 +3762,7 @@
                   }
                 },
                 "required": [
+                  "name",
                   "password"
                 ],
                 "type": "object"


### PR DESCRIPTION
## Summary
When we removed identity `kinds` we standardized users to have a `name` rather than an `email`. This was before our migration code, so there was some manual conversion left in. This change cleans up these conversions.

Not adding this to the migrator as the change was on a much older version that is most likely not in use anywhere.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1825 
