### PR TITLE
improve: replace request log host with localAddr

### DIFF
--- a/internal/logging/middleware.go
+++ b/internal/logging/middleware.go
@@ -43,7 +43,7 @@ func Middleware() gin.HandlerFunc {
 		log := L.With().
 			Str("method", method).
 			Str("path", c.Request.URL.Path).
-			Str("host", c.Request.Host).
+			Str("localAddr", c.Request.Host).
 			Str("remoteAddr", c.Request.RemoteAddr).
 			Str("userAgent", c.Request.UserAgent()).
 			Int64("contentLength", c.Request.ContentLength).


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Host may be misunderstood to mean the server the request is hosted
rather the address used to address the service. There's also a
nice symmetry between localAddr and remoteAddr.