### PR TITLE
improve: descriptive container names

### DIFF
--- a/helm/charts/infra/templates/connector/deployment.yaml
+++ b/helm/charts/infra/templates/connector/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       securityContext:
 {{- toYaml .Values.connector.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Values.connector.componentName }}
           securityContext:
 {{- toYaml .Values.connector.securityContext | nindent 12 }}
           image: "{{ include "connector.image.repository" . }}:{{ include "connector.image.tag" . }}"

--- a/helm/charts/infra/templates/server/deployment.yaml
+++ b/helm/charts/infra/templates/server/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       securityContext:
 {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Values.server.componentName }}
           securityContext:
 {{- toYaml .Values.server.securityContext | nindent 12 }}
           image: "{{ include "server.image.repository" . }}:{{ include "server.image.tag" . }}"


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Container names are not always visible but when they are, they should
reflect the running container. .Chart.Name only produces infra, which
isn't very useful to differentiate between what _type_ of infra
deployment the container is.
