### PR TITLE
feat: passwordrequirements for cli edit user

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -64,7 +64,6 @@ func (r UpdateUserRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.Required("id", r.ID),
 		validate.Required("password", r.Password),
-		validate.StringRule{Name: "password", Value: r.Password, MinLength: 8},
 	}
 }
 

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -108,6 +108,25 @@ $ infra users edit janedoe@example.com --password`,
 	return cmd
 }
 
+// Parses the error to see if it is a password requirements error (and prints it)
+func passwordError(cli *CLI, err error) bool {
+	if api.ErrorStatusCode(err) == 400 {
+		var apiError api.Error
+		if errors.As(err, &apiError) {
+			for _, fe := range apiError.FieldErrors {
+				if fe.FieldName == "password" {
+					fmt.Fprintln(cli.Stdout, "  New password does not meet the following requirements:")
+					for _, pwe := range fe.Errors {
+						fmt.Fprintf(cli.Stdout, "  - %s\n", pwe)
+					}
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 func newUsersListCmd(cli *CLI) *cobra.Command {
 	var format string
 
@@ -267,18 +286,23 @@ func updateUser(cli *CLI, name string) error {
 	if isSelf {
 		req := &api.UpdateUserRequest{ID: config.UserID}
 
-		fmt.Fprintf(cli.Stderr, "  Enter a new password (min. length 8):\n")
+		fmt.Fprintf(cli.Stderr, "  Enter a new password:\n")
+
+	PROMPT:
 		req.Password, err = promptSetPassword(cli, "")
 		if err != nil {
 			return err
 		}
 
+		logging.Debugf("call server: update user %s", req.ID)
 		if _, err := client.UpdateUser(req); err != nil {
+			if passwordError(cli, err) {
+				goto PROMPT
+			}
 			return err
 		}
 
 		cli.Output("  Updated password")
-
 		return nil
 	}
 
@@ -373,14 +397,15 @@ PROMPT:
 }
 
 func checkPasswordRequirements(oldPassword string) survey.Validator {
+	// To do: move the old password check to the api level #2642
 	return func(val interface{}) error {
 		newPassword, ok := val.(string)
 		if !ok {
 			return fmt.Errorf("unexpected type for password: %T", val)
 		}
 
-		if len(newPassword) < 8 {
-			return fmt.Errorf("input must be at least 8 characters long")
+		if len(newPassword) == 0 {
+			return fmt.Errorf("Value is required")
 		}
 
 		if newPassword == oldPassword {


### PR DESCRIPTION
## Summary

This implements the password requirements check for the `users edit --password` command.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

Implements #2024
