### PR TITLE
improve: remove msg for api errors

### DIFF
--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -97,7 +97,7 @@ func sendAPIError(c *gin.Context, err error) {
 		Str("path", c.Request.URL.Path).
 		Int32("statusCode", resp.Code).
 		Str("remoteAddr", c.Request.RemoteAddr).
-		Msg("api request error")
+		Msg("")
 
 	c.JSON(int(resp.Code), resp)
 	c.Abort()


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`Msg` and similar functions sets the `message` field in the log json.
It's not very useful in the case of API errors because the interesting
bits are in the other attributes. Having a message field causes the
`message` to be highlighted in aggregators like Datadog which makes it
harder to see the interesting bits.
