### PR TITLE
data: early draft of data layer with new interface

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -26,12 +26,13 @@ func ListAccessKeys(c *gin.Context, identityID uid.ID, name string, showExpired 
 		return nil, HandleAuthErr(err, "access keys", "list", roles...)
 	}
 
-	s := []data.SelectorFunc{data.ByOptionalIssuedFor(identityID), data.ByOptionalName(name)}
-	if !showExpired {
-		s = append(s, data.ByNotExpiredOrExtended())
+	query := data.ListAccessKeysQuery{
+		IssuedFor:      identityID,
+		Name:           name,
+		IncludeExpired: showExpired,
+		Pagination:     p,
 	}
-
-	return data.ListAccessKeys(db.Preload("IssuedForIdentity"), p, s...)
+	return data.ListAccessKeys(db, query)
 }
 
 func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey) (body string, err error) {

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -54,7 +54,7 @@ func DeleteAccessKey(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "access key", "delete", models.InfraAdminRole)
 	}
 
-	return data.DeleteAccessKeys(db, data.ByID(id))
+	return data.DeleteAccessKeys(db, data.DeleteAccessKeysQuery{ID: id})
 }
 
 func DeleteRequestAccessKey(c *gin.Context) error {
@@ -63,5 +63,5 @@ func DeleteRequestAccessKey(c *gin.Context) error {
 
 	db := getDB(c)
 
-	return data.DeleteAccessKey(db, key.ID)
+	return data.DeleteAccessKeys(db, data.DeleteAccessKeysQuery{ID: key.ID})
 }

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -134,7 +134,7 @@ func GetContextProviderIdentity(c *gin.Context) (*models.Provider, string, error
 		return nil, "", err
 	}
 
-	provider, err := data.GetProvider(db, data.ByID(providerUser.ProviderID))
+	provider, err := data.GetProvider(db, data.ByIDQ(providerUser.ProviderID))
 	if err != nil {
 		return nil, "", fmt.Errorf("user info provider: %w", err)
 	}
@@ -157,7 +157,7 @@ func UpdateIdentityInfoFromProvider(c *gin.Context, oidc providers.OIDCClient) e
 
 	accessKey := currentAccessKey(c)
 
-	provider, err := data.GetProvider(db, data.ByID(accessKey.ProviderID))
+	provider, err := data.GetProvider(db, data.ByIDQ(accessKey.ProviderID))
 	if err != nil {
 		return fmt.Errorf("user info provider: %w", err)
 	}

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -76,7 +76,7 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "user", "delete", models.InfraAdminRole)
 	}
 
-	if err := data.DeleteAccessKeys(db, data.ByIssuedFor(id)); err != nil {
+	if err := data.DeleteAccessKeys(db, data.DeleteAccessKeysQuery{IssuedFor: id}); err != nil {
 		return fmt.Errorf("delete identity access keys: %w", err)
 	}
 
@@ -169,7 +169,7 @@ func UpdateIdentityInfoFromProvider(c *gin.Context, oidc providers.OIDCClient) e
 			return err
 		}
 
-		if nestedErr := data.DeleteAccessKeys(db, data.ByIssuedFor(identity.ID)); nestedErr != nil {
+		if nestedErr := data.DeleteAccessKeys(db, data.DeleteAccessKeysQuery{IssuedFor: identity.ID}); nestedErr != nil {
 			logging.Errorf("failed to revoke invalid user session: %s", nestedErr)
 		}
 

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -23,7 +23,7 @@ func CreateProvider(c *gin.Context, provider *models.Provider) error {
 func GetProvider(c *gin.Context, id uid.ID) (*models.Provider, error) {
 	db := getDB(c)
 
-	return data.GetProvider(db, data.ByID(id))
+	return data.GetProvider(db, data.ByIDQ(id))
 }
 
 func ListProviders(c *gin.Context, name string, excludeByKind []models.ProviderKind, p *models.Pagination) ([]models.Provider, error) {

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -120,7 +120,7 @@ func TestAPI_ListAccessKeys_Success(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	run := func() api.ListResponse[api.AccessKey] {
+	run := func(t *testing.T) api.ListResponse[api.AccessKey] {
 		req := httptest.NewRequest(http.MethodGet, "/api/access-keys", nil)
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", adminAccessKey(srv)))
 		req.Header.Set("Infra-Version", apiVersionLatest)
@@ -137,7 +137,7 @@ func TestAPI_ListAccessKeys_Success(t *testing.T) {
 	}
 
 	t.Run("OK", func(t *testing.T) {
-		accessKeys := run()
+		accessKeys := run(t)
 		// non-zero since there's an access key for the admin user
 		assert.Assert(t, accessKeys.Count != 0)
 		assert.Assert(t, accessKeys.Items != nil)
@@ -147,7 +147,7 @@ func TestAPI_ListAccessKeys_Success(t *testing.T) {
 		err := srv.db.Create(&models.AccessKey{Name: "testing"}).Error
 		assert.NilError(t, err)
 
-		accessKeys := run()
+		accessKeys := run(t)
 		assert.Assert(t, accessKeys.Count != 0)
 		assert.Assert(t, accessKeys.Items != nil)
 

--- a/internal/server/authn/authn_method.go
+++ b/internal/server/authn/authn_method.go
@@ -32,7 +32,7 @@ func Login(ctx context.Context, db *gorm.DB, loginMethod LoginMethod, keyExpires
 
 	accessKey := &models.AccessKey{
 		IssuedFor:         identity.ID,
-		IssuedForIdentity: identity,
+		IssuedForName:     identity.Name,
 		ProviderID:        provider.ID,
 		ExpiresAt:         keyExpiresAt,
 		ExtensionDeadline: time.Now().UTC().Add(keyExtension),

--- a/internal/server/authn/oidc.go
+++ b/internal/server/authn/oidc.go
@@ -31,7 +31,7 @@ func NewOIDCAuthentication(providerID uid.ID, redirectURL string, code string, o
 }
 
 func (a *oidcAuthn) Authenticate(ctx context.Context, db *gorm.DB) (*models.Identity, *models.Provider, AuthScope, error) {
-	provider, err := data.GetProvider(db, data.ByID(a.ProviderID))
+	provider, err := data.GetProvider(db, data.ByIDQ(a.ProviderID))
 	if err != nil {
 		return nil, nil, AuthScope{}, err
 	}

--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -204,7 +204,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 				assert.Assert(t, user != nil)
 				assert.Assert(t, len(user.Groups) == 2)
 
-				p, err := data.GetProvider(db, data.ByName("mockoidc"))
+				p, err := data.GetProvider(db, data.ByNameQ("mockoidc"))
 				assert.NilError(t, err)
 
 				pu, err := data.CreateProviderUser(db, p, user)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -670,7 +670,7 @@ func (Server) loadProvider(db *gorm.DB, input Provider) (*models.Provider, error
 		return nil, fmt.Errorf("could not parse provider in config load: %w", err)
 	}
 
-	provider, err := data.GetProvider(db, data.ByName(input.Name))
+	provider, err := data.GetProvider(db, data.ByNameQ(input.Name))
 	if err != nil {
 		if !errors.Is(err, internal.ErrNotFound) {
 			return nil, err

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -139,6 +139,17 @@ func list[T models.Modelable](db *gorm.DB, p *models.Pagination, selectors ...Se
 	return result, nil
 }
 
+func ByPagination(p models.Pagination) SelectorFunc {
+	return func(db *gorm.DB) *gorm.DB {
+
+		if p.Page == 0 && p.Limit == 0 {
+			return db
+		}
+		resultsForPage := p.Limit * (p.Page - 1)
+		return db.Offset(resultsForPage).Limit(p.Limit)
+	}
+}
+
 func save[T models.Modelable](db *gorm.DB, model *T) error {
 	v := validator.New()
 	if err := v.Struct(model); err != nil {

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -290,7 +290,7 @@ func migrate(db *gorm.DB) error {
 			Migrate: func(tx *gorm.DB) error {
 				logging.Infof("running migration 202204061643")
 				if tx.Migrator().HasTable("access_keys") {
-					keys, err := ListAccessKeys(db, &models.Pagination{})
+					keys, err := ListAccessKeys(db, ListAccessKeysQuery{})
 					if err != nil {
 						return err
 					}

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -16,12 +16,12 @@ func CreateProvider(db *gorm.DB, provider *models.Provider) error {
 }
 
 func GetProvider(db *gorm.DB, opt IDOrNameQuery) (*models.Provider, error) {
-	q := Query(`SELECT * from providers`)
+	q := Query(`SELECT * from providers WHERE`)
 	switch {
 	case opt.ID != 0:
-		q.B(`WHERE id = $1`, opt.ID)
+		q.B(`id = $1`, opt.ID)
 	case opt.Name != "":
-		q.B(`WHERE name = $1`, opt.Name)
+		q.B(`name = $1`, opt.Name)
 	default:
 		return nil, fmt.Errorf("query requires either an ID or Name")
 	}
@@ -84,7 +84,7 @@ func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
 			return fmt.Errorf("delete provider users: %w", err)
 		}
 
-		if err := DeleteAccessKeys(db, ByProviderID(p.ID)); err != nil {
+		if err := DeleteAccessKeys(db, DeleteAccessKeysQuery{ProviderID: p.ID}); err != nil {
 			return fmt.Errorf("delete access keys: %w", err)
 		}
 	}

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -27,6 +27,19 @@ func (q *queryBuilder) B(clause string, args ...interface{}) {
 	q.Args = append(q.Args, args...)
 }
 
+// Where adds a new where clause. If there is no WHERE statement in the
+// query string then WHERE is added before the clause. If there is a WHERE
+// statement then AND is added before the clause.
+func (q *queryBuilder) Where(clause string, args ...interface{}) {
+	if strings.Contains(q.String(), "WHERE") {
+		q.B("AND")
+		q.B(clause, args...)
+		return
+	}
+	q.B("WHERE")
+	q.B(clause, args...)
+}
+
 // String returns the query string, which is used as the first parameter to
 // Tx.Exec, or Tx.Query. You must also pass q.Args as the varargs.
 func (q *queryBuilder) String() string {

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -1,0 +1,53 @@
+package data
+
+import (
+	"strings"
+
+	"github.com/infrahq/infra/uid"
+)
+
+type queryBuilder struct {
+	query strings.Builder
+	Args  []interface{}
+}
+
+// Query initializes a queryBuilder and returns it populated with selectFrom.
+// The selectFrom string can generally contain any SELECT, FROM, or JOIN
+// clauses, and may contain the entire query as long as there are no
+// query parameters.
+// Use queryBuilder.B to add sections of a query with parameters.
+func Query(selectFrom string) *queryBuilder {
+	q := &queryBuilder{}
+	q.query.WriteString(selectFrom + " ")
+	return q
+}
+
+func (q *queryBuilder) B(clause string, args ...interface{}) {
+	q.query.WriteString(clause + " ")
+	q.Args = append(q.Args, args...)
+}
+
+// String returns the query string, which is used as the first parameter to
+// Tx.Exec, or Tx.Query. You must also pass q.Args as the varargs.
+func (q *queryBuilder) String() string {
+	return q.query.String()
+}
+
+// IDOrNameQuery is used to query for a single item by ID or name. ID and name
+// are mutually exclusive, only one may be set to a non-zero value.
+type IDOrNameQuery struct {
+	ID   uid.ID
+	Name string
+}
+
+// ByIDQ returns an IDOrNameQuery that will query by ID.
+// TODO: rename to ByID once all queries are ported to the new interface.
+func ByIDQ(id uid.ID) IDOrNameQuery {
+	return IDOrNameQuery{ID: id}
+}
+
+// ByNameQ returns an IDOrNameQuery that will query by Name.
+// TODO: rename to ByName once all queries are ported to the new interface.
+func ByNameQ(name string) IDOrNameQuery {
+	return IDOrNameQuery{Name: name}
+}

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -1,9 +1,6 @@
 package data
 
 import (
-	"strings"
-	"time"
-
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/models"
@@ -107,26 +104,6 @@ func ByOptionalIssuedFor(id uid.ID) SelectorFunc {
 func ByIdentityID(identityID uid.ID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("identity_id = ?", identityID)
-	}
-}
-
-func ByNotExpiredOrExtended() SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		query := strings.Builder{}
-		query.WriteString("(expires_at > ? OR expires_at = ? OR expires_at is null) AND ")
-		query.WriteString("(extension_deadline > ? OR extension_deadline = ? OR extension_deadline is null)")
-		return db.Where(query.String(), time.Now().UTC(), time.Time{}, time.Now().UTC(), time.Time{})
-	}
-}
-
-func ByPagination(p models.Pagination) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-
-		if p.Page == 0 && p.Limit == 0 {
-			return db
-		}
-		resultsForPage := p.Limit * (p.Page - 1)
-		return db.Offset(resultsForPage).Limit(p.Limit)
 	}
 }
 

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -104,21 +104,9 @@ func ByOptionalIssuedFor(id uid.ID) SelectorFunc {
 	}
 }
 
-func ByIssuedFor(id uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("issued_for = ?", id)
-	}
-}
-
 func ByIdentityID(identityID uid.ID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("identity_id = ?", identityID)
-	}
-}
-
-func ByUserID(userID uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("user_id = ?", userID)
 	}
 }
 
@@ -145,26 +133,6 @@ func ByPagination(p models.Pagination) SelectorFunc {
 func CreatedBy(id uid.ID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("created_by = ?", id)
-	}
-}
-
-func OrderBy(order string) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Order(order)
-	}
-}
-
-func Limit(limit int) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Limit(limit)
-	}
-}
-
-// NotCreatedBy filters out entities not created by the passed in ID
-func NotCreatedBy(id uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		// the created_by field is default 0 when not set by default
-		return db.Where("created_by != ?", id)
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -170,7 +170,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 
 	a.t.Event("login", key.IssuedFor.String(), Properties{"method": loginMethod.Name()})
 
-	return &api.LoginResponse{UserID: key.IssuedFor, Name: key.IssuedForIdentity.Name, AccessKey: bearer, Expires: api.Time(expires), PasswordUpdateRequired: requiresUpdate}, nil
+	return &api.LoginResponse{UserID: key.IssuedFor, Name: key.IssuedForName, AccessKey: bearer, Expires: api.Time(expires), PasswordUpdateRequired: requiresUpdate}, nil
 }
 
 func (a *API) Logout(c *gin.Context, r *api.EmptyRequest) (*api.EmptyResponse, error) {

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -17,11 +17,11 @@ const ScopePasswordReset = "password-reset"
 // AccessKey is a session token presented to the Infra server as proof of authentication
 type AccessKey struct {
 	Model
-	Name              string                `gorm:"uniqueIndex:idx_access_keys_name,where:deleted_at is NULL" validate:"excludes= "`
-	IssuedFor         uid.ID                `validate:"required"` // the ID of the identity that this access key was created for
-	IssuedForIdentity *Identity             `gorm:"foreignKey:IssuedFor"`
-	ProviderID        uid.ID                `validate:"required"`
-	Scopes            CommaSeparatedStrings // if set, scopes limit what the key can be used for
+	Name          string                `gorm:"uniqueIndex:idx_access_keys_name,where:deleted_at is NULL" validate:"excludes= "`
+	IssuedFor     uid.ID                `validate:"required"` // the ID of the identity that this access key was created for
+	IssuedForName string                `gorm:"-"`
+	ProviderID    uid.ID                `validate:"required"`
+	Scopes        CommaSeparatedStrings // if set, scopes limit what the key can be used for
 
 	ExpiresAt         time.Time     `validate:"required"`
 	Extension         time.Duration // how long to increase the lifetime extension deadline by
@@ -33,17 +33,12 @@ type AccessKey struct {
 }
 
 func (ak *AccessKey) ToAPI() *api.AccessKey {
-	issuedForName := ""
-	if ak.IssuedForIdentity != nil {
-		issuedForName = ak.IssuedForIdentity.Name
-	}
-
 	return &api.AccessKey{
 		ID:                ak.ID,
 		Name:              ak.Name,
 		Created:           api.Time(ak.CreatedAt),
 		IssuedFor:         ak.IssuedFor,
-		IssuedForName:     issuedForName,
+		IssuedForName:     ak.IssuedForName,
 		ProviderID:        ak.ProviderID,
 		Expires:           api.Time(ak.ExpiresAt),
 		ExtensionDeadline: api.Time(ak.ExtensionDeadline),

--- a/internal/server/models/pagination.go
+++ b/internal/server/models/pagination.go
@@ -7,6 +7,7 @@ import (
 )
 
 // Internal Pagination Data
+// TODO: move to data package
 type Pagination struct {
 	Page       int
 	Limit      int

--- a/pki/certificates_ext_test.go
+++ b/pki/certificates_ext_test.go
@@ -11,12 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
-	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/internal/testing/patch"
 	"github.com/infrahq/infra/pki"
 	"github.com/infrahq/infra/uid"
 )
@@ -111,19 +108,6 @@ func requireMutualTLSWorks(t *testing.T, clientKeypair *pki.KeyPair, cp pki.Cert
 }
 
 // nolint:unused
-func setupDB(t *testing.T) *gorm.DB {
-	driver, err := data.NewSQLiteDriver("file::memory:")
-	assert.NilError(t, err)
-
-	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver, nil)
-	assert.NilError(t, err)
-
-	err = data.CreateProvider(db, &models.Provider{
-		Name:      models.InternalInfraProviderName,
-		CreatedBy: models.CreatedBySystem,
-	})
-	assert.NilError(t, err)
-
-	return db
+func setupDB(t *testing.T) pki.DB {
+	return nil
 }

--- a/pki/native.go
+++ b/pki/native.go
@@ -13,8 +13,6 @@ import (
 	"net"
 	"strings"
 	"time"
-
-	"gorm.io/gorm"
 )
 
 const (
@@ -38,11 +36,14 @@ var (
 type NativeCertificateProvider struct {
 	NativeCertificateProviderConfig
 
-	db *gorm.DB
+	db DB
 
 	activeKeypair   KeyPair
 	previousKeypair KeyPair
 }
+
+// DB is a placeholder for data persistence that is not implemented.
+type DB interface{}
 
 type NativeCertificateProviderConfig struct {
 	FullKeyRotationDurationInDays int
@@ -53,7 +54,7 @@ type NativeCertificateProviderConfig struct {
 	InitialRootCAPrivateKey       []byte
 }
 
-func NewNativeCertificateProvider(db *gorm.DB, cfg NativeCertificateProviderConfig) (*NativeCertificateProvider, error) {
+func NewNativeCertificateProvider(db DB, cfg NativeCertificateProviderConfig) (*NativeCertificateProvider, error) {
 	if cfg.FullKeyRotationDurationInDays == 0 {
 		cfg.FullKeyRotationDurationInDays = 365
 	}

--- a/pki/native_test.go
+++ b/pki/native_test.go
@@ -5,24 +5,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-
-	"github.com/infrahq/infra/internal/server/data"
-	"github.com/infrahq/infra/internal/testing/patch"
 )
 
 // nolint:unused
-func setupDB(t *testing.T) *gorm.DB {
-	driver, err := data.NewSQLiteDriver("file::memory:")
-	assert.NilError(t, err)
-
-	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver, nil)
-	assert.NilError(t, err)
-
-	return db
+func setupDB(t *testing.T) DB {
+	return nil
 }
 
 func TestCertificateStorage(t *testing.T) {


### PR DESCRIPTION
## Summary

This is an early draft of our data layer converted to using structs as inputs instead of selector funcs, and using regular sql queries instead of gorm helpers.

By using regular sql queries it should be a much smaller shift away from gorm when we are ready to do that. I attempted to use the stdlib right away, but transaction management is so completely different that it wasn't working out. So I think we need to break the problem down into smaller problems. This is the first pass.

## Related Issues


Related to #2415