### PR TITLE
WIP: fix: check grant exists before create

### DIFF
--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -185,6 +185,8 @@ func handleError(err error) error {
 		return nil
 	}
 
+	logging.L.Debug().Err(err).Msg("database query failed")
+
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
 		switch pgErr.Code {

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -61,7 +61,6 @@ func TestMigration_202204111503(t *testing.T) {
 	grants, err := ListGrants(db, &models.Pagination{}, BySubject(ids[0].PolyID()))
 	assert.NilError(t, err)
 	assert.Assert(t, len(grants) == 1)
-
 }
 
 func TestMigration_202204211705(t *testing.T) {


### PR DESCRIPTION
- the db transaction is closed when create errors, need to check if grant exists first

## Summary
Postgres was failing with an internal server error on duplicate grant creation. The reason for this is that Postgres closes the DB transaction on error, but we would then attempt to read the existing grant on the same transaction.

Fix is to check if a grant exists before creating it.

Started on writing some Postgres server tests here, but hit some issues with too many open connections. Will re-visit server Postgres tests.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2652
