### PR TITLE
Remove last use of go-playground/validator in models

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.56
 	github.com/cli/browser v1.1.0
 	github.com/gin-gonic/gin v1.8.1
-	github.com/go-playground/validator/v10 v10.11.0
+	github.com/go-playground/validator/v10 v10.11.0 // indirect
 	github.com/goware/urlx v0.3.2
 	github.com/hashicorp/vault/api v1.5.0 // indirect
 	github.com/jackc/pgconn v1.12.1

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -26,6 +26,13 @@ func secretChecksum(secret string) []byte {
 }
 
 func CreateAccessKey(db *gorm.DB, accessKey *models.AccessKey) (body string, err error) {
+	switch {
+	case accessKey.IssuedFor == 0:
+		return "", fmt.Errorf("issusedFor is required")
+	case accessKey.ProviderID == 0:
+		return "", fmt.Errorf("providerID is required")
+	}
+
 	if accessKey.KeyID == "" {
 		accessKey.KeyID = generate.MathRandom(models.AccessKeyKeyLength, generate.CharsetAlphaNumeric)
 	}

--- a/internal/server/data/credential.go
+++ b/internal/server/data/credential.go
@@ -1,17 +1,32 @@
 package data
 
 import (
+	"fmt"
+
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
+func validateCredential(c *models.Credential) error {
+	if len(c.PasswordHash) == 0 {
+		return fmt.Errorf("passwordHash is required")
+	}
+	return nil
+}
+
 func CreateCredential(db *gorm.DB, credential *models.Credential) error {
+	if err := validateCredential(credential); err != nil {
+		return err
+	}
 	return add(db, credential)
 }
 
 func SaveCredential(db *gorm.DB, credential *models.Credential) error {
+	if err := validateCredential(credential); err != nil {
+		return err
+	}
 	return save(db, credential)
 }
 

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -11,7 +11,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/go-playground/validator/v10"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"gorm.io/driver/postgres"
@@ -144,21 +143,11 @@ func list[T models.Modelable](db *gorm.DB, p *models.Pagination, selectors ...Se
 }
 
 func save[T models.Modelable](db *gorm.DB, model *T) error {
-	v := validator.New()
-	if err := v.Struct(model); err != nil {
-		return err
-	}
-
 	err := db.Save(model).Error
 	return handleError(err)
 }
 
 func add[T models.Modelable](db *gorm.DB, model *T) error {
-	v := validator.New()
-	if err := v.Struct(model); err != nil {
-		return err
-	}
-
 	err := db.Create(model).Error
 	return handleError(err)
 }

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"fmt"
 	"time"
 
 	"gorm.io/gorm"
@@ -10,16 +11,25 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+func validateDestination(dest *models.Destination) error {
+	if dest.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	return nil
+}
+
 func CreateDestination(db *gorm.DB, destination *models.Destination) error {
+	if err := validateDestination(destination); err != nil {
+		return err
+	}
 	return add(db, destination)
 }
 
 func SaveDestination(db *gorm.DB, destination *models.Destination) error {
-	if err := save(db, destination); err != nil {
+	if err := validateDestination(destination); err != nil {
 		return err
 	}
-
-	return nil
+	return save(db, destination)
 }
 
 func GetDestination(db *gorm.DB, selectors ...SelectorFunc) (*models.Destination, error) {

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"fmt"
+
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/logging"
@@ -9,6 +11,14 @@ import (
 )
 
 func CreateGrant(db *gorm.DB, grant *models.Grant) error {
+	switch {
+	case grant.Subject == "":
+		return fmt.Errorf("subject is required")
+	case grant.Privilege == "":
+		return fmt.Errorf("privilege is required")
+	case grant.Resource == "":
+		return fmt.Errorf("resource is required")
+	}
 	return add(db, grant)
 }
 

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -11,7 +11,21 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+func validateProvider(p *models.Provider) error {
+	switch {
+	case p.Name == "":
+		return fmt.Errorf("name is required")
+	case p.Kind == "":
+		return fmt.Errorf("kind is required")
+	default:
+		return nil
+	}
+}
+
 func CreateProvider(db *gorm.DB, provider *models.Provider) error {
+	if err := validateProvider(provider); err != nil {
+		return err
+	}
 	return add(db, provider)
 }
 
@@ -24,6 +38,9 @@ func ListProviders(db *gorm.DB, p *models.Pagination, selectors ...SelectorFunc)
 }
 
 func SaveProvider(db *gorm.DB, provider *models.Provider) error {
+	if err := validateProvider(provider); err != nil {
+		return err
+	}
 	return save(db, provider)
 }
 

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -17,13 +17,14 @@ const ScopePasswordReset = "password-reset"
 // AccessKey is a session token presented to the Infra server as proof of authentication
 type AccessKey struct {
 	Model
-	Name              string                `gorm:"uniqueIndex:idx_access_keys_name,where:deleted_at is NULL" validate:"excludes= "`
-	IssuedFor         uid.ID                `validate:"required"` // the ID of the identity that this access key was created for
-	IssuedForIdentity *Identity             `gorm:"foreignKey:IssuedFor"`
-	ProviderID        uid.ID                `validate:"required"`
+	Name string `gorm:"uniqueIndex:idx_access_keys_name,where:deleted_at is NULL"`
+	// IssuedFor is the ID of the user that this access key was created for
+	IssuedFor         uid.ID
+	IssuedForIdentity *Identity `gorm:"foreignKey:IssuedFor"`
+	ProviderID        uid.ID
 	Scopes            CommaSeparatedStrings // if set, scopes limit what the key can be used for
 
-	ExpiresAt         time.Time     `validate:"required"`
+	ExpiresAt         time.Time
 	Extension         time.Duration // how long to increase the lifetime extension deadline by
 	ExtensionDeadline time.Time
 

--- a/internal/server/models/credential.go
+++ b/internal/server/models/credential.go
@@ -6,6 +6,6 @@ type Credential struct {
 	Model
 
 	IdentityID      uid.ID `gorm:"<-;uniqueIndex:idx_credentials_identity_id,where:deleted_at is NULL"`
-	PasswordHash    []byte `validate:"required"`
+	PasswordHash    []byte
 	OneTimePassword bool
 }

--- a/internal/server/models/destination.go
+++ b/internal/server/models/destination.go
@@ -9,7 +9,7 @@ import (
 type Destination struct {
 	Model
 
-	Name       string `validate:"required"`
+	Name       string
 	UniqueID   string `gorm:"uniqueIndex:idx_destinations_unique_id,where:deleted_at is NULL"`
 	LastSeenAt time.Time
 

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -34,9 +34,9 @@ const BasePermissionConnect = "connect"
 type Grant struct {
 	Model
 
-	Subject   uid.PolymorphicID `validate:"required" gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // usually an identity, but could be a role definition
-	Privilege string            `validate:"required" gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // role or permission
-	Resource  string            `validate:"required" gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // Universal Resource Notation
+	Subject   uid.PolymorphicID `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // usually an identity, but could be a role definition
+	Privilege string            `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // role or permission
+	Resource  string            `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // Universal Resource Notation
 	CreatedBy uid.ID
 }
 

--- a/internal/server/models/provider.go
+++ b/internal/server/models/provider.go
@@ -45,8 +45,8 @@ func ParseProviderKind(kind string) (ProviderKind, error) {
 type Provider struct {
 	Model
 
-	Name         string       `gorm:"uniqueIndex:idx_providers_name,where:deleted_at is NULL" validate:"required"`
-	Kind         ProviderKind `validate:"required"`
+	Name         string `gorm:"uniqueIndex:idx_providers_name,where:deleted_at is NULL"`
+	Kind         ProviderKind
 	URL          string
 	ClientID     string
 	ClientSecret EncryptedAtRest

--- a/internal/server/models/provideruser.go
+++ b/internal/server/models/provideruser.go
@@ -10,12 +10,12 @@ import (
 type ProviderUser struct {
 	Model
 
-	ProviderID uid.ID `validate:"required"`
-	IdentityID uid.ID `validate:"required"`
+	ProviderID uid.ID
+	IdentityID uid.ID
 
-	Email      string `validate:"required"`
+	Email      string
 	Groups     CommaSeparatedStrings
-	LastUpdate time.Time `validate:"required"`
+	LastUpdate time.Time
 
 	RedirectURL string // needs to match the redirect URL specified when the token was issued for refreshing
 


### PR DESCRIPTION
## Summary

These validations are not of user input, but are safeguards for developers. They don't really benefit from the additional logic and indirection of internal/validate, so we can validate that fields are set by checking they are non-zero before a save or update.

## Related Issues


Resolves #2583
