### PR TITLE
fix: wait for logout to complete

### DIFF
--- a/ui/components/layouts/dashboard.js
+++ b/ui/components/layouts/dashboard.js
@@ -19,7 +19,7 @@ function Layout({ children }) {
   }
 
   async function logout() {
-    fetch('/api/logout', {
+    await fetch('/api/logout', {
       method: 'POST',
     })
     await mutate('/api/users/self', async () => undefined)


### PR DESCRIPTION
- await logout to complete before redirecting to login to prevent race condition

## Summary
Occasionally when you click "logout" the UI would still display the dashboard. This was due to redirecting to login before the logout response was received. Awaiting the logout response ensures we always redirect to login when a user clicks "logout".
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

Resolves #2526
