### PR TITLE
maintain: paginate in api by default

### DIFF
--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -127,7 +128,7 @@ func HandleAuthErr(err error, resource, operation string, roles ...string) error
 
 // Can checks if an identity has a privilege that means it can perform an action on a resource
 func Can(db *gorm.DB, identity uid.PolymorphicID, privilege, resource string) (bool, error) {
-	grants, err := data.ListGrants(db, nil, data.BySubject(identity), data.ByPrivilege(privilege), data.ByResource(resource))
+	grants, err := data.ListGrants(db, &models.Pagination{Limit: 1}, data.BySubject(identity), data.ByPrivilege(privilege), data.ByResource(resource))
 	if err != nil {
 		return false, fmt.Errorf("has grants: %w", err)
 	}

--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -9,7 +9,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/data"
-	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -59,7 +58,7 @@ func RequireInfraRole(c *gin.Context, oneOfRoles ...string) (*gorm.DB, error) {
 	}
 
 	// check if they belong to a group that is authorized
-	groups, err := data.ListGroups(db, &models.Pagination{}, data.ByGroupMember(identity.ID))
+	groups, err := data.ListGroups(db, nil, data.ByGroupMember(identity.ID))
 	if err != nil {
 		return nil, fmt.Errorf("auth user groups: %w", err)
 	}
@@ -128,7 +127,7 @@ func HandleAuthErr(err error, resource, operation string, roles ...string) error
 
 // Can checks if an identity has a privilege that means it can perform an action on a resource
 func Can(db *gorm.DB, identity uid.PolymorphicID, privilege, resource string) (bool, error) {
-	grants, err := data.ListGrants(db, &models.Pagination{}, data.BySubject(identity), data.ByPrivilege(privilege), data.ByResource(resource))
+	grants, err := data.ListGrants(db, nil, data.BySubject(identity), data.ByPrivilege(privilege), data.ByResource(resource))
 	if err != nil {
 		return false, fmt.Errorf("has grants: %w", err)
 	}

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -72,7 +72,7 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 }
 
 func userInGroup(db *gorm.DB, authnUserID uid.ID, groupID uid.ID) bool {
-	groups, err := data.ListGroups(db, nil, data.ByGroupMember(authnUserID), data.ByID(groupID))
+	groups, err := data.ListGroups(db, &models.Pagination{Limit: 1}, data.ByGroupMember(authnUserID), data.ByID(groupID))
 	if err != nil {
 		return false
 	}

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -72,7 +72,7 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 }
 
 func userInGroup(db *gorm.DB, authnUserID uid.ID, groupID uid.ID) bool {
-	groups, err := data.ListGroups(db, &models.Pagination{}, data.ByGroupMember(authnUserID), data.ByID(groupID))
+	groups, err := data.ListGroups(db, nil, data.ByGroupMember(authnUserID), data.ByID(groupID))
 	if err != nil {
 		return false
 	}

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -89,7 +89,7 @@ func DeleteGroup(c *gin.Context, id uid.ID) error {
 }
 
 func checkIdentitiesInList(db *gorm.DB, ids []uid.ID) ([]uid.ID, error) {
-	identities, err := data.ListIdentities(db, &models.Pagination{}, data.ByIDs(ids))
+	identities, err := data.ListIdentities(db, nil, data.ByIDs(ids))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -29,7 +29,7 @@ func TestListIdentities(t *testing.T) {
 	assert.NilError(t, err)
 
 	// test fetch all identities
-	ids, err := ListIdentities(c, "", 0, nil, &models.Pagination{})
+	ids, err := ListIdentities(c, "", 0, nil, nil)
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(ids), 4) // the two identities created, the admin one used to call these access functions, and the internal connector identity
@@ -94,7 +94,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	_, err = data.GetCredential(db, data.ByIdentityID(identity.ID))
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 
-	grants, err := data.ListGrants(db, &models.Pagination{}, data.BySubject(identity.PolyID()))
+	grants, err := data.ListGrants(db, nil, data.BySubject(identity.PolyID()))
 	assert.NilError(t, err)
 	assert.Equal(t, len(grants), 0)
 }

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -636,7 +636,7 @@ func TestLoadConfigPruneConfig(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, int64(3), grants) // 2 from config, 1 internal connector
 
-	identities, err := data.ListIdentities(s.db, &models.Pagination{})
+	identities, err := data.ListIdentities(s.db, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, 2, len(identities))
 
@@ -671,7 +671,7 @@ func TestLoadConfigPruneConfig(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, int64(1), grants) // connector
 
-	identities, err = data.ListIdentities(s.db, &models.Pagination{})
+	identities, err = data.ListIdentities(s.db, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, 1, len(identities))
 
@@ -749,7 +749,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 	assert.Equal(t, privileges["view"], 0)
 	assert.Equal(t, privileges["connector"], 1)
 
-	identities, err := data.ListIdentities(s.db, &models.Pagination{})
+	identities, err := data.ListIdentities(s.db, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, 5, len(identities)) // john@example.com, sarah@example.com, test@example.com, connector, r2d2, c3po
 
@@ -843,7 +843,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 	assert.Equal(t, privileges["view"], 2)
 	assert.Equal(t, privileges["connector"], 1)
 
-	identities, err = data.ListIdentities(s.db, &models.Pagination{})
+	identities, err = data.ListIdentities(s.db, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, 2, len(identities))
 

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -95,7 +95,7 @@ func DeleteAccessKey(db *gorm.DB, id uid.ID) error {
 }
 
 func DeleteAccessKeys(db *gorm.DB, selectors ...SelectorFunc) error {
-	toDelete, err := list[models.AccessKey](db, &models.Pagination{}, selectors...)
+	toDelete, err := list[models.AccessKey](db, nil, selectors...)
 	if err != nil {
 		return err
 	}

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -193,11 +193,11 @@ func TestListAccessKeys(t *testing.T) {
 		_, err = CreateAccessKey(db, token)
 		assert.NilError(t, err)
 
-		keys, err := ListAccessKeys(db, &models.Pagination{}, ByNotExpiredOrExtended())
+		keys, err := ListAccessKeys(db, nil, ByNotExpiredOrExtended())
 		assert.NilError(t, err)
 		assert.Assert(t, len(keys) == 1)
 
-		keys, err = ListAccessKeys(db, &models.Pagination{})
+		keys, err = ListAccessKeys(db, nil)
 		assert.NilError(t, err)
 		assert.Assert(t, len(keys) == 3)
 	})

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -127,13 +127,15 @@ func list[T models.Modelable](db *gorm.DB, p *models.Pagination, selectors ...Se
 		db = selector(db)
 	}
 
-	var count int64
-	if err := db.Model((*T)(nil)).Count(&count).Error; err != nil {
-		return nil, err
-	}
-	p.SetTotalCount(int(count))
+	if p != nil {
+		var count int64
+		if err := db.Model((*T)(nil)).Count(&count).Error; err != nil {
+			return nil, err
+		}
+		p.SetTotalCount(int(count))
 
-	db = ByPagination(*p)(db)
+		db = ByPagination(*p)(db)
+	}
 
 	result := make([]T, 0)
 	if err := db.Model((*T)(nil)).Find(&result).Error; err != nil {

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -117,7 +117,7 @@ func TestDatabaseSelectors(t *testing.T) {
 		t.Logf("DB pointer: %p", tx)
 
 		// query using one of our helpers and selectors
-		_, err := ListGrants(tx, &models.Pagination{}, ByID(534))
+		_, err := ListGrants(tx, nil, ByID(534))
 		assert.NilError(t, err)
 
 		// query with Model and Where
@@ -136,7 +136,7 @@ func TestDatabaseSelectors(t *testing.T) {
 	assert.NilError(t, err)
 
 	// query using one of our helpers and selectors
-	_, err = ListGrants(db, &models.Pagination{}, ByID(534))
+	_, err = ListGrants(db, nil, ByID(534))
 	assert.NilError(t, err)
 
 	// query with Model and Where

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -31,7 +31,7 @@ func ListDestinations(db *gorm.DB, p *models.Pagination, selectors ...SelectorFu
 }
 
 func DeleteDestinations(db *gorm.DB, selector SelectorFunc) error {
-	toDelete, err := ListDestinations(db, &models.Pagination{}, selector)
+	toDelete, err := ListDestinations(db, nil, selector)
 	if err != nil {
 		return err
 	}

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -21,7 +21,7 @@ func ListGrants(db *gorm.DB, p *models.Pagination, selectors ...SelectorFunc) ([
 }
 
 func DeleteGrants(db *gorm.DB, selectors ...SelectorFunc) error {
-	toDelete, err := list[models.Grant](db, &models.Pagination{}, selectors...)
+	toDelete, err := list[models.Grant](db, nil, selectors...)
 	if err != nil {
 		return err
 	}

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -31,7 +31,7 @@ func TestDuplicateGrant(t *testing.T) {
 		err = CreateGrant(db, &g2)
 		assert.ErrorContains(t, err, "already exists")
 
-		grants, err := ListGrants(db, &models.Pagination{}, BySubject("i:1234567"), ByResource("infra"))
+		grants, err := ListGrants(db, nil, BySubject("i:1234567"), ByResource("infra"))
 		assert.NilError(t, err)
 		assert.Assert(t, is.Len(grants, 1))
 

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -28,7 +28,7 @@ func ByGroupMember(id uid.ID) SelectorFunc {
 }
 
 func DeleteGroups(db *gorm.DB, selectors ...SelectorFunc) error {
-	toDelete, err := ListGroups(db, &models.Pagination{}, selectors...)
+	toDelete, err := ListGroups(db, nil, selectors...)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func DeleteGroups(db *gorm.DB, selectors ...SelectorFunc) error {
 			return err
 		}
 
-		identities, err := ListIdentities(db, &models.Pagination{}, []SelectorFunc{ByOptionalIdentityGroupID(g.ID)}...)
+		identities, err := ListIdentities(db, nil, []SelectorFunc{ByOptionalIdentityGroupID(g.ID)}...)
 		if err != nil {
 			return err
 		}

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -99,7 +99,7 @@ func TestListGroups(t *testing.T) {
 		createIdentities(t, db, &firstUser, &secondUser)
 
 		t.Run("all", func(t *testing.T) {
-			actual, err := ListGroups(db, &models.Pagination{})
+			actual, err := ListGroups(db, nil)
 			assert.NilError(t, err)
 			expected := []models.Group{
 				{Name: "Engineering"},
@@ -110,7 +110,7 @@ func TestListGroups(t *testing.T) {
 		})
 
 		t.Run("filter by name", func(t *testing.T) {
-			actual, err := ListGroups(db, &models.Pagination{}, ByName(engineers.Name))
+			actual, err := ListGroups(db, nil, ByName(engineers.Name))
 			assert.NilError(t, err)
 			expected := []models.Group{
 				{Name: "Engineering"},
@@ -119,7 +119,7 @@ func TestListGroups(t *testing.T) {
 		})
 
 		t.Run("filter by identity membership", func(t *testing.T) {
-			actual, err := ListGroups(db, &models.Pagination{}, ByGroupMember(firstUser.ID))
+			actual, err := ListGroups(db, nil, ByGroupMember(firstUser.ID))
 			assert.NilError(t, err)
 			expected := []models.Group{
 				{Name: "Engineering"},
@@ -203,7 +203,7 @@ func TestAddUsersToGroup(t *testing.T) {
 		createIdentities(t, db, &bond, &bourne, &bauer)
 
 		t.Run("add identities to group", func(t *testing.T) {
-			actual, err := ListIdentities(db, &models.Pagination{}, []SelectorFunc{ByOptionalIdentityGroupID(everyone.ID)}...)
+			actual, err := ListIdentities(db, nil, []SelectorFunc{ByOptionalIdentityGroupID(everyone.ID)}...)
 			assert.NilError(t, err)
 			expected := []models.Identity{bond}
 			assert.DeepEqual(t, actual, expected, cmpModelsIdentityShallow)
@@ -211,7 +211,7 @@ func TestAddUsersToGroup(t *testing.T) {
 			err = AddUsersToGroup(db, everyone.ID, []uid.ID{bourne.ID, bauer.ID})
 			assert.NilError(t, err)
 
-			actual, err = ListIdentities(db, &models.Pagination{}, []SelectorFunc{ByOptionalIdentityGroupID(everyone.ID)}...)
+			actual, err = ListIdentities(db, nil, []SelectorFunc{ByOptionalIdentityGroupID(everyone.ID)}...)
 			assert.NilError(t, err)
 			expected = []models.Identity{bauer, bond, bourne}
 			assert.DeepEqual(t, actual, expected, cmpModelsIdentityShallow)

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -111,7 +111,7 @@ func DeleteIdentity(db *gorm.DB, id uid.ID) error {
 }
 
 func DeleteIdentities(db *gorm.DB, selectors ...SelectorFunc) error {
-	toDelete, err := ListIdentities(db.Select("id"), &models.Pagination{}, selectors...)
+	toDelete, err := ListIdentities(db.Select("id"), nil, selectors...)
 	if err != nil {
 		return err
 	}

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -96,35 +96,35 @@ func TestListIdentities(t *testing.T) {
 		createIdentities(t, db, &bond, &bourne, &bauer)
 
 		t.Run("list all", func(t *testing.T) {
-			identities, err := ListIdentities(db, &models.Pagination{})
+			identities, err := ListIdentities(db, nil)
 			assert.NilError(t, err)
 			expected := []models.Identity{bauer, bond, bourne}
 			assert.DeepEqual(t, identities, expected, cmpModelsIdentityShallow)
 		})
 
 		t.Run("filter by name", func(t *testing.T) {
-			identities, err := ListIdentities(db, &models.Pagination{}, ByName(bourne.Name))
+			identities, err := ListIdentities(db, nil, ByName(bourne.Name))
 			assert.NilError(t, err)
 			expected := []models.Identity{bourne}
 			assert.DeepEqual(t, identities, expected, cmpModelsIdentityShallow)
 		})
 
 		t.Run("filter identities by group", func(t *testing.T) {
-			actual, err := ListIdentities(db, &models.Pagination{}, ByOptionalIdentityGroupID(everyone.ID))
+			actual, err := ListIdentities(db, nil, ByOptionalIdentityGroupID(everyone.ID))
 			assert.NilError(t, err)
 			expected := []models.Identity{bauer, bond, bourne}
 			assert.DeepEqual(t, actual, expected, cmpModelsIdentityShallow)
 		})
 
 		t.Run("filter identities by different group", func(t *testing.T) {
-			actual, err := ListIdentities(db, &models.Pagination{}, ByOptionalIdentityGroupID(engineers.ID))
+			actual, err := ListIdentities(db, nil, ByOptionalIdentityGroupID(engineers.ID))
 			assert.NilError(t, err)
 			expected := []models.Identity{bond}
 			assert.DeepEqual(t, actual, expected, cmpModelsIdentityShallow)
 		})
 
 		t.Run("filter identities by group and name", func(t *testing.T) {
-			actual, err := ListIdentities(db, &models.Pagination{}, ByOptionalIdentityGroupID(everyone.ID), ByName(bauer.Name))
+			actual, err := ListIdentities(db, nil, ByOptionalIdentityGroupID(everyone.ID), ByName(bauer.Name))
 			assert.NilError(t, err)
 			expected := []models.Identity{bauer}
 			assert.DeepEqual(t, actual, expected, cmpModelsIdentityShallow)

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -249,7 +249,7 @@ func migrate(db *gorm.DB) error {
 			Migrate: func(tx *gorm.DB) error {
 				logging.Infof("running migration 202203301647")
 				if tx.Migrator().HasTable("machines") {
-					grants, err := ListGrants(db, &models.Pagination{})
+					grants, err := ListGrants(db, nil)
 					if err != nil {
 						return err
 					}
@@ -290,7 +290,7 @@ func migrate(db *gorm.DB) error {
 			Migrate: func(tx *gorm.DB) error {
 				logging.Infof("running migration 202204061643")
 				if tx.Migrator().HasTable("access_keys") {
-					keys, err := ListAccessKeys(db, &models.Pagination{})
+					keys, err := ListAccessKeys(db, nil)
 					if err != nil {
 						return err
 					}
@@ -344,7 +344,7 @@ func migrate(db *gorm.DB) error {
 
 					infraProviderID := providerIDs["infra"]
 
-					users, err := ListIdentities(db, &models.Pagination{}, func(db *gorm.DB) *gorm.DB {
+					users, err := ListIdentities(db, nil, func(db *gorm.DB) *gorm.DB {
 						return db.Where("provider_id != ?", infraProviderID)
 					})
 					if err != nil {

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -54,11 +54,11 @@ func TestMigration_202204111503(t *testing.T) {
 	db, err := NewDB(driver, nil)
 	assert.NilError(t, err)
 
-	ids, err := ListIdentities(db, &models.Pagination{}, ByName("steven@example.com"))
+	ids, err := ListIdentities(db, nil, ByName("steven@example.com"))
 	assert.NilError(t, err)
 	assert.Assert(t, len(ids) == 1)
 	// check that merged identity has unique grants
-	grants, err := ListGrants(db, &models.Pagination{}, BySubject(ids[0].PolyID()))
+	grants, err := ListGrants(db, nil, BySubject(ids[0].PolyID()))
 	assert.NilError(t, err)
 	assert.Assert(t, len(grants) == 1)
 

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -28,8 +28,7 @@ func SaveProvider(db *gorm.DB, provider *models.Provider) error {
 }
 
 func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
-	// Better solution here needed when Pagination becomes mandatory, Replace with a multiple-page "ListAll" function?
-	toDelete, err := ListProviders(db, &models.Pagination{}, selectors...)
+	toDelete, err := ListProviders(db, nil, selectors...)
 	if err != nil {
 		return fmt.Errorf("listing providers: %w", err)
 	}
@@ -38,8 +37,7 @@ func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
 	for _, p := range toDelete {
 		ids = append(ids, p.ID)
 
-		// Same as toDelete
-		providerUsers, err := ListProviderUsers(db, &models.Pagination{}, ByProviderID(p.ID))
+		providerUsers, err := ListProviderUsers(db, nil, ByProviderID(p.ID))
 		if err != nil {
 			return fmt.Errorf("listing provider users: %w", err)
 		}

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -75,11 +75,11 @@ func TestListProviders(t *testing.T) {
 
 		createProviders(t, db, providerDevelop, providerProduction)
 
-		providers, err := ListProviders(db, &models.Pagination{}, NotName(models.InternalInfraProviderName))
+		providers, err := ListProviders(db, nil, NotName(models.InternalInfraProviderName))
 		assert.NilError(t, err)
 		assert.Equal(t, 2, len(providers))
 
-		providers, err = ListProviders(db, &models.Pagination{}, ByOptionalName("okta-development"))
+		providers, err = ListProviders(db, nil, ByOptionalName("okta-development"))
 		assert.NilError(t, err)
 		assert.Equal(t, 1, len(providers))
 	})
@@ -104,7 +104,7 @@ func TestDeleteProviders(t *testing.T) {
 			err = CreateProvider(db, &providerProduction)
 			assert.NilError(t, err)
 
-			providers, err := ListProviders(db, &models.Pagination{}, NotName(models.InternalInfraProviderName))
+			providers, err := ListProviders(db, nil, NotName(models.InternalInfraProviderName))
 			assert.NilError(t, err)
 			assert.Assert(t, len(providers) >= 2)
 

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -204,7 +204,7 @@ func TestSyncProviderUser(t *testing.T) {
 					assert.Assert(t, puGroups["Developers"])
 
 					// check that the direct user-to-group relation was updated
-					storedGroups, err := ListGroups(db, &models.Pagination{}, ByGroupMember(pu.IdentityID))
+					storedGroups, err := ListGroups(db, nil, ByGroupMember(pu.IdentityID))
 					assert.NilError(t, err)
 
 					userGroups := make(map[string]bool)

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -69,7 +69,7 @@ func CreateIdentityToken(db *gorm.DB, identityID uid.ID) (token *models.Token, e
 		return nil, err
 	}
 
-	identityGroups, err := ListGroups(db, &models.Pagination{}, ByGroupMember(identityID))
+	identityGroups, err := ListGroups(db, nil, ByGroupMember(identityID))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -65,7 +65,7 @@ func (a *API) CreateGrant(c *gin.Context, r *api.CreateGrantRequest) (*api.Creat
 	var ucerr data.UniqueConstraintError
 
 	if errors.As(err, &ucerr) {
-		grants, err := access.ListGrants(c, grant.Subject, grant.Resource, grant.Privilege, false, &models.Pagination{})
+		grants, err := access.ListGrants(c, grant.Subject, grant.Resource, grant.Privilege, false, nil)
 
 		if err != nil {
 			return nil, err
@@ -93,7 +93,7 @@ func (a *API) DeleteGrant(c *gin.Context, r *api.Resource) (*api.EmptyResponse, 
 	}
 
 	if grant.Resource == access.ResourceInfraAPI && grant.Privilege == models.InfraAdminRole {
-		infraAdminGrants, err := access.ListGrants(c, "", grant.Resource, grant.Privilege, false, &models.Pagination{})
+		infraAdminGrants, err := access.ListGrants(c, "", grant.Resource, grant.Privilege, false, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -333,6 +333,10 @@ func TestAPI_ListGrants(t *testing.T) {
 				expected := jsonUnmarshal(t, fmt.Sprintf(`
 					{
 						"count": 1,
+						"limit": 100,
+						"page": 1,
+						"totalPages": 1,
+						"totalCount": 1,
 						"items": [{
 							"id": "<any-valid-uid>",
 							"created_by": "%[1]v",
@@ -652,7 +656,7 @@ func TestAPI_DeleteGrant(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("last infra admin is deleted", func(t *testing.T) {
-		infraAdminGrants, err := data.ListGrants(srv.db, &models.Pagination{}, data.ByPrivilege(models.InfraAdminRole), data.ByResource("infra"))
+		infraAdminGrants, err := data.ListGrants(srv.db, nil, data.ByPrivilege(models.InfraAdminRole), data.ByResource("infra"))
 		assert.NilError(t, err)
 		assert.Assert(t, len(infraAdminGrants) == 1)
 

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -164,6 +164,10 @@ func TestAPI_ListGroups(t *testing.T) {
 				expected := jsonUnmarshal(t, fmt.Sprintf(`
 {
 	"count": 1,
+	"limit": 100,
+	"page": 1,
+	"totalPages": 1,
+	"totalCount": 1,
 	"items": [{
 		"id": "%[1]v",
 		"name": "humans",
@@ -332,7 +336,7 @@ func TestAPI_DeleteGroup(t *testing.T) {
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusNoContent, resp.Body.String())
-				actual, err := data.ListGroups(srv.db, &models.Pagination{}, data.ByID(humans.ID))
+				actual, err := data.ListGroups(srv.db, nil, data.ByID(humans.ID))
 				assert.NilError(t, err)
 				assert.Equal(t, len(actual), 0)
 			},
@@ -409,7 +413,7 @@ func TestAPI_UpdateUsersInGroup(t *testing.T) {
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
-				idents, err := data.ListIdentities(srv.db, &models.Pagination{}, []data.SelectorFunc{data.ByOptionalIdentityGroupID(humans.ID)}...)
+				idents, err := data.ListIdentities(srv.db, nil, []data.SelectorFunc{data.ByOptionalIdentityGroupID(humans.ID)}...)
 				assert.NilError(t, err)
 				assert.DeepEqual(t, idents, []models.Identity{first, second}, cmpModelsIdentityShallow)
 			},
@@ -426,7 +430,7 @@ func TestAPI_UpdateUsersInGroup(t *testing.T) {
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
-				idents, err := data.ListIdentities(srv.db, &models.Pagination{}, []data.SelectorFunc{data.ByOptionalIdentityGroupID(humans.ID)}...)
+				idents, err := data.ListIdentities(srv.db, nil, []data.SelectorFunc{data.ByOptionalIdentityGroupID(humans.ID)}...)
 				assert.NilError(t, err)
 				assert.Assert(t, len(idents) == 0)
 			},

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -53,7 +53,7 @@ func DestinationMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		uniqueID := c.GetHeader("Infra-Destination")
 		if uniqueID != "" {
-			destinations, err := access.ListDestinations(c, uniqueID, "", nil)
+			destinations, err := access.ListDestinations(c, uniqueID, "", &models.Pagination{Limit: 1})
 			if err != nil {
 				return
 			}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -53,7 +53,7 @@ func DestinationMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		uniqueID := c.GetHeader("Infra-Destination")
 		if uniqueID != "" {
-			destinations, err := access.ListDestinations(c, uniqueID, "", &models.Pagination{})
+			destinations, err := access.ListDestinations(c, uniqueID, "", nil)
 			if err != nil {
 				return
 			}

--- a/internal/server/models/pagination.go
+++ b/internal/server/models/pagination.go
@@ -15,9 +15,6 @@ type Pagination struct {
 }
 
 func RequestToPagination(pr api.PaginationRequest) Pagination {
-	if pr.Limit == 0 && pr.Page == 0 {
-		return Pagination{} // temporary so pagination is disabled by default
-	}
 	page, limit := 1, 100
 
 	if pr.Limit != 0 {
@@ -44,7 +41,7 @@ func PaginationToResponse(p Pagination) api.PaginationResponse {
 }
 
 func (p *Pagination) SetTotalCount(count int) {
-	if p.Page != 0 && p.Limit != 0 {
+	if p.Limit != 0 {
 		p.TotalCount = count
 		p.TotalPages = int(math.Ceil(float64(count) / float64(p.Limit)))
 	}

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -32,7 +32,7 @@ func TestAPI_ListProviders(t *testing.T) {
 	err := data.CreateProvider(s.db, testProvider)
 	assert.NilError(t, err)
 
-	dbProviders, err := data.ListProviders(s.db, &models.Pagination{})
+	dbProviders, err := data.ListProviders(s.db, nil)
 	assert.NilError(t, err)
 	assert.Equal(t, len(dbProviders), 2)
 

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -176,8 +176,6 @@ func TestAPI_GetUser(t *testing.T) {
 	}
 }
 
-var defaultPagination api.PaginationResponse
-
 func TestAPI_ListUsers(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
@@ -244,7 +242,7 @@ func TestAPI_ListUsers(t *testing.T) {
 			urlPath: "/api/users?name=doesnotmatch",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK)
-				assert.Equal(t, resp.Body.String(), `{"count":0,"items":[]}`)
+				assert.Equal(t, resp.Body.String(), `{"page":1,"limit":100,"count":0,"items":[]}`)
 			},
 		},
 		"name match": {
@@ -260,7 +258,7 @@ func TestAPI_ListUsers(t *testing.T) {
 					Items: []api.User{
 						{Name: "me@example.com"},
 					},
-					PaginationResponse: defaultPagination,
+					PaginationResponse: api.PaginationResponse{Page: 1, Limit: 100, TotalPages: 1, TotalCount: 1},
 				}
 				assert.DeepEqual(t, actual, expected, cmpAPIUserShallow)
 			},
@@ -280,7 +278,7 @@ func TestAPI_ListUsers(t *testing.T) {
 						{Name: "me@example.com"},
 						{Name: "other@example.com"},
 					},
-					PaginationResponse: defaultPagination,
+					PaginationResponse: api.PaginationResponse{Page: 1, Limit: 100, TotalPages: 1, TotalCount: 3},
 				}
 				assert.DeepEqual(t, actual, expected, cmpAPIUserShallow)
 			},
@@ -304,7 +302,7 @@ func TestAPI_ListUsers(t *testing.T) {
 						{Name: "other-HAL@example.com"},
 						{Name: "other@example.com"},
 					},
-					PaginationResponse: defaultPagination,
+					PaginationResponse: api.PaginationResponse{Page: 1, Limit: 100, TotalPages: 1, TotalCount: 7},
 				}
 				assert.DeepEqual(t, actual, expected, cmpAPIUserShallow)
 			},
@@ -356,7 +354,7 @@ func TestAPI_ListUsers(t *testing.T) {
 					Items: []api.User{
 						{Name: anotherID.Name},
 					},
-					PaginationResponse: defaultPagination,
+					PaginationResponse: api.PaginationResponse{Page: 1, Limit: 100, TotalPages: 1, TotalCount: 1},
 				}
 				assert.DeepEqual(t, actual, expected, cmpAPIUserShallow)
 			},


### PR DESCRIPTION
## Summary

List requests in the API will be paginated by default (Page 1 and Limit 100 if not specified). If users are writing against the API directly, then they must switch through pages themselves to get all results.

Internal ListRequests can pass in `nil` to avoid pagination. Pre-existing calls now pass in `nil` instead of `&models.Pagination{}`.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->