### PR TITLE
fix: remove group name validation

### DIFF
--- a/api/group.go
+++ b/api/group.go
@@ -32,15 +32,8 @@ type CreateGroupRequest struct {
 
 func (r CreateGroupRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		validateGroupName(r.Name),
 		validate.Required("name", r.Name),
 	}
-}
-
-func validateGroupName(value string) validate.StringRule {
-	nameRule := ValidateName(value)
-	nameRule.CharacterRanges = append(nameRule.CharacterRanges, validate.AtSign)
-	return nameRule
 }
 
 type UpdateUsersInGroupRequest struct {

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -102,7 +102,7 @@ func TestAPI_CreateAccessKey(t *testing.T) {
 				assert.NilError(t, err)
 
 				expected := []api.FieldError{
-					{FieldName: "name", Errors: []string{"character / at position 34 is not allowed"}},
+					{FieldName: "name", Errors: []string{"character '/' at position 34 is not allowed"}},
 				}
 				assert.DeepEqual(t, respBody.FieldErrors, expected)
 			},

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -2446,9 +2446,6 @@
               "schema": {
                 "properties": {
                   "name": {
-                    "format": "[a-zA-Z0-9\\-_.@]",
-                    "maxLength": 256,
-                    "minLength": 3,
                     "type": "string"
                   }
                 },

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -88,7 +88,7 @@ func (s StringRule) Validate() *Failure {
 	if len(s.CharacterRanges) > 0 {
 		for i, c := range value {
 			if !inRange(s.CharacterRanges, c) {
-				add("character %c at position %v is not allowed", c, i)
+				add("character %q at position %v is not allowed", c, i)
 				break
 			}
 		}

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -45,7 +45,21 @@ func TestStringRule_Validate(t *testing.T) {
 		expected := Error{
 			"strField": {
 				"length of string is 12, must be no more than 10",
-				"character ~ at position 6 is not allowed",
+				"character '~' at position 6 is not allowed",
+			},
+		}
+		assert.DeepEqual(t, verr, expected)
+	})
+	t.Run("character ranges whitespace", func(t *testing.T) {
+		r := StringExample{Field: "almost valid"}
+		err := Validate(r)
+
+		var verr Error
+		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
+		expected := Error{
+			"strField": {
+				"length of string is 12, must be no more than 10",
+				`character ' ' at position 6 is not allowed`,
 			},
 		}
 		assert.DeepEqual(t, verr, expected)

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -109,7 +109,7 @@ func TestValidate_AllRules(t *testing.T) {
 			"emailOther": {`email address must not contain display name "Display Name"`},
 			"tooFew":     {"length of string is 1, must be at least 5"},
 			"tooMany":    {"length of string is 6, must be no more than 5"},
-			"wrongOnes":  {"character C at position 2 is not allowed"},
+			"wrongOnes":  {"character 'C' at position 2 is not allowed"},
 			"tooHigh":    {"value 22 must be at most 20"},
 			"tooLow":     {"value 2 must be at least 20"},
 			"kind":       {"must be one of (fruit, legume, grain)"},


### PR DESCRIPTION
## Summary

Group names can come from providers, which may allow any characters. So we need to support all characters group names unless we do some kind of internal mapping between names. For now we'll need to remove our validation of group name.

Also improve the error message when the invalid character is a space