### PR TITLE
fix: rename input label

### DIFF
--- a/ui/__test__/login.test.js
+++ b/ui/__test__/login.test.js
@@ -51,7 +51,7 @@ describe('Login Component', () => {
     render(<Login />)
 
     expect(screen.getByText('Login to Infra')).toBeInTheDocument()
-    expect(screen.getByLabelText('Username or Email')).toHaveValue('')
+    expect(screen.getByLabelText('Email')).toHaveValue('')
     expect(screen.getByLabelText('Password')).toHaveValue('')
     expect(screen.getByText('Login').closest('button')).toBeDisabled()
   })
@@ -82,13 +82,11 @@ describe('Login Component', () => {
   it('should not enable the login button when enter username only', () => {
     render(<Login />)
 
-    const usernameInput = screen.getByLabelText('Username or Email')
+    const usernameInput = screen.getByLabelText('Email')
     fireEvent.change(usernameInput, {
       target: { value: 'example@infrahq.com' },
     })
-    expect(screen.getByLabelText('Username or Email')).toHaveValue(
-      'example@infrahq.com'
-    )
+    expect(screen.getByLabelText('Email')).toHaveValue('example@infrahq.com')
     expect(screen.getByLabelText('Password')).toHaveValue('')
     expect(screen.getByText('Login').closest('button')).toBeDisabled()
   })
@@ -96,7 +94,7 @@ describe('Login Component', () => {
   it('should enable the login button when enter both username and password', () => {
     render(<Login />)
 
-    const usernameInput = screen.getByLabelText('Username or Email')
+    const usernameInput = screen.getByLabelText('Email')
     fireEvent.change(usernameInput, {
       target: { value: 'example@infrahq.com' },
     })
@@ -106,9 +104,7 @@ describe('Login Component', () => {
       target: { value: 'password' },
     })
 
-    expect(screen.getByLabelText('Username or Email')).toHaveValue(
-      'example@infrahq.com'
-    )
+    expect(screen.getByLabelText('Email')).toHaveValue('example@infrahq.com')
     expect(screen.getByLabelText('Password')).toHaveValue('password')
     expect(screen.getByText('Login').closest('button')).not.toBeDisabled()
   })

--- a/ui/pages/login/index.js
+++ b/ui/pages/login/index.js
@@ -130,13 +130,13 @@ export default function Login() {
       >
         <div className='my-2 w-full'>
           <label htmlFor='name' className='text-3xs uppercase text-gray-500'>
-            Username or Email
+            Email
           </label>
           <input
             required
             autoFocus
             id='name'
-            placeholder='enter your username or email'
+            placeholder='enter your email'
             onChange={e => {
               setName(e.target.value)
               setError('')

--- a/ui/pages/signup/index.js
+++ b/ui/pages/signup/index.js
@@ -85,12 +85,12 @@ export default function Signup() {
       <form onSubmit={onSubmit} className='flex w-full max-w-sm flex-col'>
         <div className='my-2 w-full'>
           <label htmlFor='name' className='text-3xs uppercase text-gray-500'>
-            Username or Email
+            Email
           </label>
           <input
             autoFocus
             name='name'
-            placeholder='enter your username or email'
+            placeholder='enter your email'
             onChange={e => {
               setName(e.target.value)
               setErrors({})


### PR DESCRIPTION
## Summary
Rename the input label to `Email` instead of `Username or Email` since we only accept email for this field and we also run the email validation on the field as well. 
