### PR TITLE
feat: make infra server read-only at runtime

### DIFF
--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -120,7 +120,9 @@ server:
   #   fsGroup: 2000
 
   ## Security context for the server container
-  securityContext: {}
+  securityContext: {
+    readOnlyRootFilesystem: true
+  }
   #   runAsUser: 999
   #   runAsGroup: 999
   #   readOnlyRootFilesystem: true

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -120,8 +120,9 @@ server:
   #   fsGroup: 2000
 
   ## Security context for the server container
-  securityContext: 
+  securityContext:
     readOnlyRootFilesystem: true
+    # runAsUser: 1000
 
   ## Liveness probe for the default backend
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
@@ -613,8 +614,9 @@ connector:
   #   fsGroup: 2000
 
   ## Security context for the connector container
-  securityContext: 
+  securityContext:
     readOnlyRootFilesystem: true
+    # runAsUser: 1000
 
   ## Liveness probe for the default backend
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -122,7 +122,7 @@ server:
   ## Security context for the server container
   securityContext:
     readOnlyRootFilesystem: true
-    # runAsUser: 1000
+    # runAsUser: 999
 
   ## Liveness probe for the default backend
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
@@ -616,7 +616,7 @@ connector:
   ## Security context for the connector container
   securityContext:
     readOnlyRootFilesystem: true
-    # runAsUser: 1000
+    # runAsUser: 999
 
   ## Liveness probe for the default backend
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -120,12 +120,8 @@ server:
   #   fsGroup: 2000
 
   ## Security context for the server container
-  securityContext: {
+  securityContext: 
     readOnlyRootFilesystem: true
-  }
-  #   runAsUser: 999
-  #   runAsGroup: 999
-  #   readOnlyRootFilesystem: true
 
   ## Liveness probe for the default backend
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
@@ -617,11 +613,8 @@ connector:
   #   fsGroup: 2000
 
   ## Security context for the connector container
-  securityContext: {}
-  #   runAsUser: 999
-  #   runAsGroup: 999
-  #   readOnlyRootFilesystem: true
-
+  securityContext: 
+    readOnlyRootFilesystem: true
 
   ## Liveness probe for the default backend
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -27,7 +27,7 @@ func newAgentCmd() *cobra.Command {
 		Args:   NoArgs,
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			infraDir, err := infraHomeDir()
+			infraDir, err := initInfraHomeDir()
 			if err != nil {
 				panic(err)
 			}
@@ -101,7 +101,7 @@ func execAgent() error {
 }
 
 func readStoredAgentProcessID() (int, error) {
-	infraDir, err := infraHomeDir()
+	infraDir, err := initInfraHomeDir()
 	if err != nil {
 		return 0, err
 	}
@@ -124,7 +124,7 @@ func readStoredAgentProcessID() (int, error) {
 
 // writeAgentProcessConfig saves details about the agent to config
 func writeAgentConfig(pid int) error {
-	infraDir, err := infraHomeDir()
+	infraDir, err := initInfraHomeDir()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -57,6 +57,15 @@ func infraHomeDir() (string, error) {
 
 	infraDir := filepath.Join(homeDir, ".infra")
 
+	return infraDir, nil
+}
+
+func initInfraHomeDir() (string, error) {
+	infraDir, err := infraHomeDir()
+	if err != nil {
+		return "", err
+	}
+
 	if err := os.MkdirAll(infraDir, os.ModePerm); err != nil {
 		return "", err
 	}
@@ -65,7 +74,7 @@ func infraHomeDir() (string, error) {
 }
 
 func readConfig() (*ClientConfig, error) {
-	infraDir, err := infraHomeDir()
+	infraDir, err := initInfraHomeDir()
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +129,7 @@ func readConfig() (*ClientConfig, error) {
 }
 
 func writeConfig(config *ClientConfig) error {
-	infraDir, err := infraHomeDir()
+	infraDir, err := initInfraHomeDir()
 	if err != nil {
 		return err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -242,7 +242,7 @@ func (s *Server) listen() error {
 		return err
 	}
 
-	tlsConfig, err := tlsConfigFromOptions(s.secrets, s.options.TLSCache, s.options.TLS)
+	tlsConfig, err := tlsConfigFromOptions(s.secrets, s.options.TLS)
 	if err != nil {
 		return fmt.Errorf("tls config: %w", err)
 	}

--- a/internal/server/tls.go
+++ b/internal/server/tls.go
@@ -60,7 +60,6 @@ func tlsConfigFromOptions(
 	if opts.ACME {
 		manager := &autocert.Manager{
 			Prompt: autocert.AcceptTOS,
-			// Cache:  autocert.DirCache(tlsCacheDir),
 			// TODO: according to the docs HostPolicy should be set to prevent
 			// a DoS attack on certificate requests.
 			// See https://github.com/infrahq/infra/issues/2484

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -28,7 +28,7 @@ func TestTLSConfigFromOptions(t *testing.T) {
 			Certificate: types.StringOrFile(golden.Get(t, "pki/localhost.crt")),
 			PrivateKey:  "file:testdata/pki/localhost.key",
 		}
-		config, err := tlsConfigFromOptions(storage, t.TempDir(), opts)
+		config, err := tlsConfigFromOptions(storage, opts)
 		assert.NilError(t, err)
 
 		srv := httptest.NewUnstartedServer(noopHandler)
@@ -57,7 +57,7 @@ func TestTLSConfigFromOptions(t *testing.T) {
 			CA:           types.StringOrFile(ca),
 			CAPrivateKey: "file:testdata/pki/ca.key",
 		}
-		config, err := tlsConfigFromOptions(storage, t.TempDir(), opts)
+		config, err := tlsConfigFromOptions(storage, opts)
 		assert.NilError(t, err)
 
 		l, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
## Summary
Best practices for Kubernetes security suggest setting `readOnlyRootFilesystem` on pods to ensure they are always in the expected state. This change enables this flag by default and removes filesystem writes from the server runtime.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

## Related Issues

Resolves #2689 
