### PR TITLE
fix: run as non-root user by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,9 @@ FROM alpine
 COPY --from=builder /go/src/github.com/infrahq/infra/infra /bin/infra
 EXPOSE 80
 EXPOSE 443
+ARG USER=infra
+ARG GROUP=infra
+RUN addgroup -g 1000 $GROUP && adduser -u 1000 -DG $GROUP $USER
+USER $USER:$GROUP
 ENTRYPOINT ["/bin/infra"]
 CMD ["server"]


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Create and run as a non-root user (infra) by default.

Changing the run-as user through Kubernetes pod security contexts requires #2689. The server currently creates a `.infra` directory in the running user's home directory. If the security context `runAsUser` does not exist or does not have a home directory, Infra will errorneously try to create the `.infra` directory under `/` and error out with `permission denied`.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2688 
