### PR TITLE
fix(revert): run as non-root user by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,5 @@ FROM alpine
 COPY --from=builder /go/src/github.com/infrahq/infra/infra /bin/infra
 EXPOSE 80
 EXPOSE 443
-ARG USER=infra
-ARG GROUP=infra
-RUN addgroup -g 1000 $GROUP && adduser -u 1000 -DG $GROUP $USER
-USER $USER:$GROUP
 ENTRYPOINT ["/bin/infra"]
 CMD ["server"]


### PR DESCRIPTION
Reverts infrahq/infra#2693

Reverting this change for now since there's implication when migrating from a previous version without default non-root. The scope of this change is significantly greater than initially expected. This revert will only affect the default runtime user. The user can still override the runtime user by specifying a security context or pod security context when deploying to Kubernetes.

```yaml
server:
  podSecurityContext:
    runAsUser: 999
    runAsGroup: 999
    runAsNonRoot: true
```

```yaml
connector:
  podSecurityContext:
    runAsUser: 999
    runAsGroup: 999
    runAsNonRoot: true
```