### PR TITLE
fix: migrate sqlite3 db owner if changing security contexts

### DIFF
--- a/helm/charts/infra/templates/server/deployment.yaml
+++ b/helm/charts/infra/templates/server/deployment.yaml
@@ -89,6 +89,22 @@ spec:
             timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
           resources:
 {{- toYaml .Values.server.resources | nindent 12 }}
+{{- if .Values.server.persistence.enabled }}
+      initContainers:
+        - name: chown-sqlite3
+          image: alpine:latest
+          command: [sh, -c]
+          args:
+            - 'find /var/lib/infrahq/server -type f -name "sqlite3.*" -exec chown $RUN_AS_USER:$RUN_AS_GROUP {} \;'
+          env:
+            - name: RUN_AS_USER
+              value: "{{ .Values.server.securityContext.runAsUser | default .Values.server.podSecurityContext.runAsUser | default 1000 }}"
+            - name: RUN_AS_GROUP
+              value: "{{ .Values.server.securityContext.runAsGroup | default .Values.server.podSecurityContext.runAsGroup | default 1000 }}"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/infrahq/server
+{{- end }}
       volumes:
         - name: conf
           configMap:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

If the runtime user changes, the sqlite database files must change owners otherwise the server will no longer have write access to the database. In this PR, we add a new init container to change the owner of the database files. 

The init container is only created if the server deployment has persistence enabled. Deployments with persistence disabled or are using an external database are not affected.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2693 
