### PR TITLE
api: combine the two authenticated middleware

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -50,35 +50,34 @@ func DatabaseMiddleware(db *gorm.DB) gin.HandlerFunc {
 	}
 }
 
-func DestinationMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		uniqueID := c.GetHeader("Infra-Destination")
-		if uniqueID != "" {
-			destinations, err := access.ListDestinations(c, uniqueID, "", &models.Pagination{Limit: 1})
-			if err != nil {
-				return
-			}
+func handleInfraDestinationHeader(c *gin.Context) error {
+	uniqueID := c.Request.Header.Get("Infra-Destination")
+	if uniqueID == "" {
+		return nil
+	}
 
-			switch len(destinations) {
-			case 0:
-				// destination does not exist yet, noop
-			case 1:
-				destination := destinations[0]
-				// only save if there's significant difference between LastSeenAt and Now
-				if time.Since(destination.LastSeenAt) > time.Second {
-					destination.LastSeenAt = time.Now()
-					if err := access.SaveDestination(c, &destination); err != nil {
-						sendAPIError(c, err)
-						return
-					}
-				}
-			default:
-				sendAPIError(c, fmt.Errorf("multiple destinations found for unique ID %q", uniqueID))
-				return
+	// TODO: use GetDestination(ByUniqueID())
+	destinations, err := access.ListDestinations(c, uniqueID, "", &models.Pagination{Limit: 1})
+	if err != nil {
+		return err
+	}
+
+	switch len(destinations) {
+	case 0:
+		// destination does not exist yet, noop
+		return nil
+	case 1:
+		destination := destinations[0]
+		// only save if there's significant difference between LastSeenAt and Now
+		if time.Since(destination.LastSeenAt) > time.Second {
+			destination.LastSeenAt = time.Now()
+			if err := access.SaveDestination(c, &destination); err != nil {
+				return fmt.Errorf("failed to update destination lastSeenAt: %w", err)
 			}
 		}
-
-		c.Next()
+		return nil
+	default:
+		return fmt.Errorf("multiple destinations found for unique ID %q", uniqueID)
 	}
 }
 
@@ -92,8 +91,10 @@ func getDB(c *gin.Context) *gorm.DB {
 	return db
 }
 
-// AuthenticationMiddleware validates the incoming token
-func AuthenticationMiddleware() gin.HandlerFunc {
+// authenticatedMiddleware is applied to all routes that require authentication.
+// It validates the access key, and updates the lastSeenAt of the user, and
+// possibly also of the destination.
+func authenticatedMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		db := getDB(c)
 		authnUser, err := requireAccessKey(db, c.Request)
@@ -105,6 +106,11 @@ func AuthenticationMiddleware() gin.HandlerFunc {
 		// TODO: save authnUser in a single key
 		c.Set("key", authnUser.AccessKey)
 		c.Set("identity", authnUser.User)
+
+		if err := handleInfraDestinationHeader(c); err != nil {
+			sendAPIError(c, err)
+			return
+		}
 		c.Next()
 	}
 }

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -113,7 +113,7 @@ func TestDBTimeout(t *testing.T) {
 	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
 }
 
-func TestRequireAuthentication(t *testing.T) {
+func TestRequireAccessKey(t *testing.T) {
 	cases := map[string]map[string]interface{}{
 		"AccessKeyValid": {
 			"authFunc": func(t *testing.T, db *gorm.DB, c *gin.Context) {
@@ -250,7 +250,7 @@ func TestRequireAuthentication(t *testing.T) {
 			assert.Assert(t, ok)
 			authFunc(t, db, c)
 
-			err := RequireAccessKey(c)
+			_, err := requireAccessKey(db, c.Request)
 
 			verifyFunc, ok := v["verifyFunc"].(func(*testing.T, *gin.Context, error))
 			assert.Assert(t, ok)

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -260,7 +260,7 @@ func TestRequireAccessKey(t *testing.T) {
 	}
 }
 
-func TestDestinationMiddleware(t *testing.T) {
+func TestHandleInfraDestinationHeader(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 	db := srv.db


### PR DESCRIPTION
## Summary

I've been trying to tackle a few large problems at the same time, but keep ending up with a change that is too big. This is my third attempt at this. The change in this PR is not really that interesting, it's just a refactor, but I believe it should help me make progress on some other problems (separate txn for middleware, passing DB into access functions, removing state from the API struct, etc).

This PR refactors the two middleware that were used for authenticated endpoints. It converts both to regular functions that return errors. Those two functions are then combined in a single smaller middleware.

Best viewed with [Hide Whitespace](https://github.com/infrahq/infra/pull/2700/files?w=1).

Related to https://github.com/infrahq/internal/issues/19, https://github.com/infrahq/internal/issues/20, and #2697
