### PR TITLE
api: Introduce RequestContext, and reduce use of gin.Context

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -10,15 +10,6 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func currentAccessKey(c *gin.Context) *models.AccessKey {
-	accessKey, ok := c.MustGet("key").(*models.AccessKey)
-	if !ok {
-		return nil
-	}
-
-	return accessKey
-}
-
 func ListAccessKeys(c *gin.Context, identityID uid.ID, name string, showExpired bool, p *models.Pagination) ([]models.AccessKey, error) {
 	roles := []string{models.InfraAdminRole, models.InfraViewRole}
 	db, err := RequireInfraRole(c, roles...)
@@ -57,11 +48,7 @@ func DeleteAccessKey(c *gin.Context, id uid.ID) error {
 	return data.DeleteAccessKeys(db, data.ByID(id))
 }
 
-func DeleteRequestAccessKey(c *gin.Context) error {
+func DeleteRequestAccessKey(c RequestContext) error {
 	// does not need authorization check, this action is limited to the calling key
-	key := currentAccessKey(c)
-
-	db := getDB(c)
-
-	return data.DeleteAccessKey(db, key.ID)
+	return data.DeleteAccessKey(c.DBTxn, c.Authenticated.AccessKey.ID)
 }

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -91,8 +91,9 @@ func UpdateCredential(c *gin.Context, user *models.Identity, newPassword string)
 
 	if isSelf {
 		// if we updated our own password, remove the password-reset scope from our access key.
-		if k, ok := c.Get("key"); ok {
-			if accessKey, ok := k.(*models.AccessKey); ok {
+		if raw, ok := c.Get(RequestContextKey); ok {
+			if rCtx, ok := raw.(RequestContext); ok {
+				accessKey := rCtx.Authenticated.AccessKey
 				accessKey.Scopes = models.CommaSeparatedStrings{}
 				if err = data.SaveAccessKey(db, accessKey); err != nil {
 					return fmt.Errorf("updating access key: %w", err)

--- a/internal/access/request.go
+++ b/internal/access/request.go
@@ -1,0 +1,24 @@
+package access
+
+import (
+	"net/http"
+
+	"gorm.io/gorm"
+
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+const RequestContextKey = "requestContext"
+
+// RequestContext stores the http.Request, and values derived from the request
+// like the authenticated user. It also provides a database transaction.
+type RequestContext struct {
+	Request       *http.Request
+	DBTxn         *gorm.DB
+	Authenticated Authenticated
+}
+
+type Authenticated struct {
+	AccessKey *models.AccessKey
+	User      *models.Identity
+}

--- a/internal/access/request.go
+++ b/internal/access/request.go
@@ -18,6 +18,8 @@ type RequestContext struct {
 	Authenticated Authenticated
 }
 
+// Authenticated stores data about the authenticated user. If the AccessKey or
+// User are nil, it indicates that no user was authenticated.
 type Authenticated struct {
 	AccessKey *models.AccessKey
 	User      *models.Identity

--- a/internal/access/signup_test.go
+++ b/internal/access/signup_test.go
@@ -97,7 +97,7 @@ func TestSignupEnabled(t *testing.T) {
 	pass := "password"
 
 	t.Run("SignupUser", func(t *testing.T) {
-		c, _ := setup(t)
+		c, db := setup(t)
 
 		enabled, err := SignupEnabled(c)
 		assert.NilError(t, err)
@@ -118,10 +118,13 @@ func TestSignupEnabled(t *testing.T) {
 		assert.Equal(t, identity.ID, key.IssuedFor)
 		assert.Equal(t, requiresUpdate, false)
 
-		c.Set("identity", identity)
+		rCtx := RequestContext{
+			Authenticated: Authenticated{User: identity},
+			DBTxn:         db,
+		}
 
 		// check "admin" can create token
-		_, err = CreateToken(c)
+		_, err = CreateToken(rCtx)
 		assert.NilError(t, err)
 	})
 }

--- a/internal/access/token.go
+++ b/internal/access/token.go
@@ -3,20 +3,15 @@ package access
 import (
 	"fmt"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func CreateToken(c *gin.Context) (token *models.Token, err error) {
-	identity := AuthenticatedIdentity(c)
-	if identity == nil {
+func CreateToken(c RequestContext) (token *models.Token, err error) {
+	// does not need authorization check, limited to calling identity
+	if c.Authenticated.User == nil {
 		return nil, fmt.Errorf("no active identity")
 	}
 
-	// does not need authorization check, limited to calling identity
-	db := getDB(c)
-
-	return data.CreateIdentityToken(db, identity.ID)
+	return data.CreateIdentityToken(c.DBTxn, c.Authenticated.User.ID)
 }

--- a/internal/server/cookie.go
+++ b/internal/server/cookie.go
@@ -2,42 +2,66 @@ package server
 
 import (
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
-var (
-	CookieAuthorizationName = "auth"
-	CookieLoginName         = "login"
-	CookieDomain            = ""
-	CookiePath              = "/"
-	// while these vars look goofy, they avoid "magic number" arguments to SetCookie
-	CookieHTTPOnlyNotJavascriptAccessible = true    // setting HttpOnly to true means JS can't access it.
-	CookieSecureHTTPSOnly                 = true    // setting Secure to true means the cookie is only sent over https connections
-	CookieMaxAgeDeleteImmediately         = int(-1) // <0: delete immediately
-	CookieMaxAgeNoExpiry                  = int(0)  // zero has special meaning of "no expiry"
+const (
+	cookieAuthorizationName       = "auth"
+	cookieLoginName               = "login"
+	cookiePath                    = "/"
+	cookieMaxAgeDeleteImmediately = -1 // <0: delete immediately
+	cookieMaxAgeNoExpiry          = 0  // zero has special meaning of "no expiry"
 )
 
 func setAuthCookie(c *gin.Context, key string, expires time.Time) {
 	maxAge := int(time.Until(expires).Seconds())
-	if maxAge == CookieMaxAgeNoExpiry {
-		maxAge = CookieMaxAgeDeleteImmediately
+	if maxAge == cookieMaxAgeNoExpiry {
+		maxAge = cookieMaxAgeDeleteImmediately
 	}
 
-	secure := CookieSecureHTTPSOnly
+	secure := true
 	if c.Request.TLS == nil {
 		// if the request came over HTTP, then the cookie will need to be sent unsecured
 		secure = false
 	}
 
-	c.SetSameSite(http.SameSiteStrictMode)
-
-	c.SetCookie(CookieAuthorizationName, key, maxAge, CookiePath, CookieDomain, secure, CookieHTTPOnlyNotJavascriptAccessible)
-	c.SetCookie(CookieLoginName, "1", maxAge, CookiePath, CookieDomain, secure, CookieHTTPOnlyNotJavascriptAccessible)
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     cookieAuthorizationName,
+		Value:    url.QueryEscape(key),
+		MaxAge:   maxAge,
+		Path:     cookiePath,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   secure,
+		HttpOnly: true, // not accessible by javascript
+	})
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     cookieLoginName,
+		Value:    "1",
+		MaxAge:   maxAge,
+		Path:     cookiePath,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   secure,
+		HttpOnly: true, // not accessible by javascript
+	})
 }
 
-func deleteAuthCookie(c *gin.Context) {
-	c.SetCookie(CookieAuthorizationName, "", CookieMaxAgeDeleteImmediately, CookiePath, CookieDomain, CookieSecureHTTPSOnly, CookieHTTPOnlyNotJavascriptAccessible)
-	c.SetCookie(CookieLoginName, "", CookieMaxAgeDeleteImmediately, CookiePath, CookieDomain, CookieSecureHTTPSOnly, CookieHTTPOnlyNotJavascriptAccessible)
+func deleteAuthCookie(writer http.ResponseWriter) {
+	http.SetCookie(writer, &http.Cookie{
+		Name:     cookieAuthorizationName,
+		MaxAge:   cookieMaxAgeDeleteImmediately,
+		Path:     cookiePath,
+		Secure:   true, // only over https
+		HttpOnly: true, // not accessible by javascript
+	})
+
+	http.SetCookie(writer, &http.Cookie{
+		Name:     cookieLoginName,
+		MaxAge:   cookieMaxAgeDeleteImmediately,
+		Path:     cookiePath,
+		Secure:   true, // only over https
+		HttpOnly: true, // not accessible by javascript
+	})
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -180,8 +180,7 @@ func (a *API) Logout(c *gin.Context, r *api.EmptyRequest) (*api.EmptyResponse, e
 		return nil, err
 	}
 
-	deleteAuthCookie(c)
-
+	deleteAuthCookie(c.Writer)
 	return nil, nil
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -27,14 +27,16 @@ type API struct {
 }
 
 func (a *API) CreateToken(c *gin.Context, r *api.EmptyRequest) (*api.CreateTokenResponse, error) {
-	if access.AuthenticatedIdentity(c) != nil {
+	rCtx := getRequestContext(c)
+
+	if rCtx.Authenticated.User != nil {
 		err := a.UpdateIdentityInfoFromProvider(c)
 		if err != nil {
 			// this will fail if the user was removed from the IDP, which means they no longer are a valid user
 			return nil, fmt.Errorf("%w: failed to update identity info from provider: %s", internal.ErrUnauthorized, err)
 		}
 
-		token, err := access.CreateToken(c)
+		token, err := access.CreateToken(rCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -174,8 +176,8 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 	return &api.LoginResponse{UserID: key.IssuedFor, Name: key.IssuedForIdentity.Name, AccessKey: bearer, Expires: api.Time(expires), PasswordUpdateRequired: requiresUpdate}, nil
 }
 
-func (a *API) Logout(c *gin.Context, r *api.EmptyRequest) (*api.EmptyResponse, error) {
-	err := access.DeleteRequestAccessKey(c)
+func (a *API) Logout(c *gin.Context, _ *api.EmptyRequest) (*api.EmptyResponse, error) {
+	err := access.DeleteRequestAccessKey(getRequestContext(c))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +192,8 @@ func (a *API) Version(c *gin.Context, r *api.EmptyRequest) (*api.Version, error)
 
 // UpdateIdentityInfoFromProvider calls the identity provider used to authenticate this user session to update their current information
 func (a *API) UpdateIdentityInfoFromProvider(c *gin.Context) error {
-	provider, redirectURL, err := access.GetContextProviderIdentity(c)
+	rCtx := getRequestContext(c)
+	provider, redirectURL, err := access.GetContextProviderIdentity(rCtx)
 	if err != nil {
 		return err
 	}
@@ -199,12 +202,12 @@ func (a *API) UpdateIdentityInfoFromProvider(c *gin.Context) error {
 		return nil
 	}
 
-	oidc, err := a.providerClient(c, provider, redirectURL)
+	oidc, err := a.providerClient(rCtx.Request.Context(), provider, redirectURL)
 	if err != nil {
 		return fmt.Errorf("update provider client: %w", err)
 	}
 
-	return access.UpdateIdentityInfoFromProvider(c, oidc)
+	return access.UpdateIdentityInfoFromProvider(rCtx, oidc)
 }
 
 func (a *API) providerClient(ctx context.Context, provider *models.Provider, redirectURL string) (providers.OIDCClient, error) {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -132,7 +132,7 @@ func requireAccessKey(db *gorm.DB, req *http.Request) (authenticatedUser, error)
 		bearer = parts[1]
 	} else {
 		// Fall back to checking cookies
-		cookie, err := getCookie(req, CookieAuthorizationName)
+		cookie, err := getCookie(req, cookieAuthorizationName)
 		if err != nil {
 			return u, fmt.Errorf("%w: valid token not found in request", internal.ErrUnauthorized)
 		}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -110,7 +110,6 @@ func authenticatedMiddleware() gin.HandlerFunc {
 		c.Set(access.RequestContextKey, rCtx)
 
 		// TODO: remove
-		c.Set("key", authned.AccessKey)
 		c.Set("identity", authned.User)
 
 		if err := handleInfraDestinationHeader(c); err != nil {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -220,14 +220,12 @@ func TestRequireAccessKey(t *testing.T) {
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 
 				r.AddCookie(&http.Cookie{
-					Name:     CookieAuthorizationName,
-					Value:    "",
+					Name:     cookieAuthorizationName,
 					MaxAge:   int(time.Until(time.Now().Add(time.Minute * 1)).Seconds()),
-					Path:     CookiePath,
-					Domain:   CookieDomain,
+					Path:     cookiePath,
 					SameSite: http.SameSiteStrictMode,
-					Secure:   CookieSecureHTTPSOnly,
-					HttpOnly: CookieHTTPOnlyNotJavascriptAccessible,
+					Secure:   true,
+					HttpOnly: true,
 				})
 
 				r.Header.Add("Authorization", " ")

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -103,7 +103,7 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	authn.GET("/api/debug/pprof/*profile", pprofHandler)
 
 	// these endpoints do not require authentication
-	noAuthn := apiGroup.Group("/")
+	noAuthn := apiGroup.Group("/", unauthenticatedMiddleware())
 	get(a, noAuthn, "/api/signup", a.SignupEnabled)
 	post(a, noAuthn, "/api/signup", a.Signup)
 


### PR DESCRIPTION
## Summary

This PR also introduces a new `RequestContext` struct. I'd like to use this new type to limit our exposure to `gin.Context` (https://github.com/infrahq/internal/issues/19). We should be able to store other things on this context that we currently get from the API struct (Telemetry, server.Options, the ID of the infra provider, Org, etc). The `RequestContext` is used in one endpoint.

This PR replaces the `currentAccessKey` function with data from the `RequestContext`, and starts to replace `AuthenticatedIdentity` as well.

At the same time I noticed that our `SetCookie` operations were using a `gin.Context` helper. This helper provides no additional functionality over the stdlib function, and actually makes the call site harder to read because of the lack of struct keys.  So I removed the use of `gin.Context.SetCookie` as well.

Best viewed by individual commit.