### PR TITLE
fix: login page ui bug

### DIFF
--- a/ui/pages/login/index.js
+++ b/ui/pages/login/index.js
@@ -115,15 +115,22 @@ export default function Login() {
         Welcome back. Login with your credentials{' '}
         {providers?.length > 0 && 'or via your identity provider.'}
       </h2>
-      {providers?.length > 0 && <Providers providers={providers || []} />}
-      <div className='relative mt-4 w-full'>
-        <div className='absolute inset-0 flex items-center' aria-hidden='true'>
-          <div className='w-full border-t border-gray-800' />
-        </div>
-        <div className='relative flex justify-center text-sm'>
-          <span className='bg-black px-2 text-2xs text-gray-300'>OR</span>
-        </div>
-      </div>
+      {providers?.length > 0 && (
+        <>
+          <Providers providers={providers || []} />
+          <div className='relative mt-4 w-full'>
+            <div
+              className='absolute inset-0 flex items-center'
+              aria-hidden='true'
+            >
+              <div className='w-full border-t border-gray-800' />
+            </div>
+            <div className='relative flex justify-center text-sm'>
+              <span className='bg-black px-2 text-2xs text-gray-300'>OR</span>
+            </div>
+          </div>
+        </>
+      )}
       <form
         onSubmit={onSubmit}
         className='relative flex w-full max-w-sm flex-col'


### PR DESCRIPTION
## Summary
The current login page without provider looks like this

<img width="464" alt="Screen Shot 2022-07-25 at 10 12 50 AM" src="https://user-images.githubusercontent.com/63033505/180798438-76c18fe8-0505-409a-a7a8-045151a75206.png">

which the OR should be hidden when there is no provider

## 📷 
<img width="473" alt="Screen Shot 2022-07-25 at 10 12 58 AM" src="https://user-images.githubusercontent.com/63033505/180798543-4f7ba591-199e-432e-bf9c-3c50e2c54acf.png">
<img width="457" alt="Screen Shot 2022-07-25 at 10 18 57 AM" src="https://user-images.githubusercontent.com/63033505/180799333-60679f22-6a8c-4a92-a2b6-27f1c0747e02.png">

