### PR TITLE
fix: kube config permissions user read/write

### DIFF
--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/goware/urlx"
 	"k8s.io/client-go/tools/clientcmd"
@@ -206,7 +206,7 @@ func safelyWriteConfigToFile(kubeConfig clientcmdapi.Config, fileToWrite string)
 		return err
 	}
 
-	temp, err := os.Create(fmt.Sprintf("%s/infra-kube-config-%d", configDir, time.Now().Unix()))
+	temp, err := ioutil.TempFile(configDir, "infra-kube-config-")
 	if err != nil {
 		return fmt.Errorf("failed to create temp kube config file: %w", err)
 	}

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -63,7 +63,7 @@ func TestWriteKubeconfig(t *testing.T) {
 	assert.NilError(t, err)
 
 	permissions := configFileStats.Mode().Perm()
-	assert.Assert(t, permissions == 0o600) // kube config should not be world or group readable, only user read/write
+	assert.Equal(t, int(permissions), 0o600) // kube config should not be world or group readable, only user read/write
 
 	actual, err := clientConfig().RawConfig()
 	assert.NilError(t, err)

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,7 +19,8 @@ func TestWriteKubeconfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
-	t.Setenv("KUBECONFIG", filepath.Join(home, "nonexistent", "kubeconfig"))
+	kubeConfigPath := filepath.Join(home, "nonexistent", "kubeconfig")
+	t.Setenv("KUBECONFIG", kubeConfigPath)
 
 	user := api.User{Name: "user"}
 	destinations := []api.Destination{
@@ -56,6 +58,12 @@ func TestWriteKubeconfig(t *testing.T) {
 			"user": {},
 		},
 	}
+
+	configFileStats, err := os.Stat(kubeConfigPath)
+	assert.NilError(t, err)
+
+	permissions := configFileStats.Mode().Perm()
+	assert.Assert(t, permissions == 0o600) // kube config should not be world or group readable, only user read/write
 
 	actual, err := clientConfig().RawConfig()
 	assert.NilError(t, err)


### PR DESCRIPTION
## Summary
You may have noticed warnings about kube config file permissions. This fixes the permissions to be only user read/write.

os.Create sets the file to world and group readable, this causes kubectl to warn the user, revert to ioutil.TempFile which sets the kube config to 0o600. This is still Windows compatible because it explicitly closes the file, so it won't cause a regression of #2586.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

## Related Issues

Resolves #2699 
