### PR TITLE
fix: validation accepts names of length 2

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -62,7 +62,7 @@ func ValidateName(value string) validate.StringRule {
 	return validate.StringRule{
 		Value:     value,
 		Name:      "name",
-		MinLength: 3,
+		MinLength: 2,
 		MaxLength: 256,
 		CharacterRanges: []validate.CharRange{
 			validate.AlphabetLower,

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -1046,7 +1046,7 @@
                   "name": {
                     "format": "[a-zA-Z0-9\\-_.]",
                     "maxLength": 256,
-                    "minLength": 3,
+                    "minLength": 2,
                     "type": "string"
                   },
                   "ttl": {
@@ -1393,7 +1393,7 @@
                   "name": {
                     "format": "[a-zA-Z0-9\\-_.]",
                     "maxLength": 256,
-                    "minLength": 3,
+                    "minLength": 2,
                     "type": "string"
                   },
                   "resources": {
@@ -1732,7 +1732,7 @@
                   "name": {
                     "format": "[a-zA-Z0-9\\-_.]",
                     "maxLength": 256,
-                    "minLength": 3,
+                    "minLength": 2,
                     "type": "string"
                   },
                   "resources": {


### PR DESCRIPTION
## Summary

Changes name validation to have minLength of 2 and updated openapi doc.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2701 
