### PR TITLE
Replace gormigrate with a local forked and reduced copy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/getkin/kin-openapi v0.97.0
 	github.com/gin-contrib/gzip v0.0.6
 	github.com/gin-contrib/static v0.0.1
-	github.com/go-gormigrate/gormigrate/v2 v2.0.2
 	github.com/google/go-cmp v0.5.8
 	github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec
 	github.com/iancoleman/strcase v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -143,7 +143,6 @@ github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denisenkom/go-mssqldb v0.12.0 h1:VtrkII767ttSPNRfFekePK3sctr+joXgO58stqQbtUA=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/docker v20.10.14+incompatible h1:+T9/PRYWNDo5SZl5qS1r9Mo/0Q8AwxKKPtu9S1yxM0w=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -196,8 +195,6 @@ github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkPro
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-gormigrate/gormigrate/v2 v2.0.2 h1:YV4Lc5yMQX8ahVW0ENPq6sPhrhdkGukc6fPRYmZ1R6Y=
-github.com/go-gormigrate/gormigrate/v2 v2.0.2/go.mod h1:vld36QpBTfTzLealsHsmQQJK5lSwJt6wiORv+oFX8/I=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -226,7 +223,6 @@ github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl
 github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
 github.com/go-playground/validator/v10 v10.11.0 h1:0W+xRM511GY47Yy3bZUbJVitCNg2BOGlCyvTqsp/xIw=
 github.com/go-playground/validator/v10 v10.11.0/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
-github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
@@ -238,8 +234,6 @@ github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
-github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188 h1:+eHOFJl1BaXrQxKX+T06f78590z4qA2ZzBTqahsKSE4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -482,7 +476,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -1281,12 +1274,10 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gorm.io/driver/mysql v1.3.3 h1:jXG9ANrwBc4+bMvBcSl8zCfPBaVoPyBEBshA8dA93X8=
 gorm.io/driver/postgres v1.3.7 h1:FKF6sIMDHDEvvMF/XJvbnCl0nu6KSKUaPXevJ4r+VYQ=
 gorm.io/driver/postgres v1.3.7/go.mod h1:f02ympjIcgtHEGFMZvdgTxODZ9snAHDb4hXfigBVuNI=
 gorm.io/driver/sqlite v1.3.6 h1:Fi8xNYCUplOqWiPa3/GuCeowRNBRGTf62DEmhMDHeQQ=
 gorm.io/driver/sqlite v1.3.6/go.mod h1:Sg1/pvnKtbQ7jLXxfZa+jSHvoX8hoZA8cn4xllOMTgE=
-gorm.io/driver/sqlserver v1.3.2 h1:yYt8f/xdAKLY7lCCyXxIUEgZ/WsURos3dHrx8MKFGAk=
 gotest.tools/v3 v3.3.0 h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
 gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/server/data/migrator/LICENSE
+++ b/internal/server/data/migrator/LICENSE
@@ -1,0 +1,8 @@
+MIT License
+Copyright (c) 2016 Andrey Nering
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/internal/server/data/migrator/migrator.go
+++ b/internal/server/data/migrator/migrator.go
@@ -1,0 +1,283 @@
+package migrator
+
+import (
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+const initSchemaMigrationID = "SCHEMA_INIT"
+
+// Options define options for all migrations.
+type Options struct {
+	// TableName is the migration table.
+	TableName string
+	// IDColumnName is the name of column where the migration id will be stored.
+	IDColumnName string
+	// IDColumnSize is the length of the migration id column
+	IDColumnSize int
+	// UseTransaction makes Migrator execute migrations inside a single transaction.
+	// Keep in mind that not all databases support DDL commands inside transactions.
+	UseTransaction bool
+
+	// InitSchema is used to create the database when no migrations table exists.
+	// This function should create all tables, and constraints. After this
+	// function is run, migrator will create the migrations table and populate
+	// it with the IDs of all the currently defined migrations.
+	InitSchema func(*gorm.DB) error
+}
+
+// Migration represents a database migration (a modification to be made on the database).
+type Migration struct {
+	// ID is the migration identifier. Usually a timestamp like "201601021504".
+	ID string
+	// Migrate is a function that will br executed while running this migration.
+	Migrate func(*gorm.DB) error
+	// Rollback will be executed on rollback. Can be nil.
+	Rollback func(*gorm.DB) error
+}
+
+// Migrator represents a collection of all migrations of a database schema.
+type Migrator struct {
+	db         *gorm.DB
+	tx         *gorm.DB
+	options    Options
+	migrations []*Migration
+}
+
+// DefaultOptions can be used if you don't want to think about options.
+var DefaultOptions = Options{
+	TableName:      "migrations",
+	IDColumnName:   "id",
+	IDColumnSize:   255,
+	UseTransaction: false,
+}
+
+// New returns a new Migrator.
+func New(db *gorm.DB, options Options, migrations []*Migration) *Migrator {
+	if options.TableName == "" {
+		options.TableName = DefaultOptions.TableName
+	}
+	if options.IDColumnName == "" {
+		options.IDColumnName = DefaultOptions.IDColumnName
+	}
+	if options.IDColumnSize == 0 {
+		options.IDColumnSize = DefaultOptions.IDColumnSize
+	}
+	return &Migrator{
+		db:         db,
+		options:    options,
+		migrations: migrations,
+	}
+}
+
+// Migrate executes all migrations that did not run yet.
+func (g *Migrator) Migrate() error {
+	if g.options.InitSchema == nil && len(g.migrations) == 0 {
+		return fmt.Errorf("there are no migrations")
+	}
+
+	if err := g.validate(); err != nil {
+		return err
+	}
+
+	rollback := g.begin()
+	defer rollback()
+
+	// TODO: do this in shouldInitializeSchema instead
+	if err := g.createMigrationTableIfNotExists(); err != nil {
+		return err
+	}
+
+	if g.options.InitSchema != nil { // TODO: remove this if
+		canInitializeSchema, err := g.shouldInitializeSchema()
+		if err != nil {
+			return err
+		}
+		if canInitializeSchema {
+			if err := g.runInitSchema(); err != nil {
+				return err
+			}
+			return g.commit()
+		}
+	}
+
+	for _, migration := range g.migrations {
+		if err := g.runMigration(migration); err != nil {
+			return err
+		}
+	}
+	return g.commit()
+}
+
+func (g *Migrator) validate() error {
+	lookup := make(map[string]struct{}, len(g.migrations))
+	ids := make([]string, len(g.migrations))
+
+	for _, m := range g.migrations {
+		switch m.ID {
+		case "":
+			return fmt.Errorf("migration is missing an ID")
+		case initSchemaMigrationID:
+			return fmt.Errorf("migration can not use reserved ID: %v", m.ID)
+		}
+		if _, ok := lookup[m.ID]; ok {
+			return fmt.Errorf("duplicate migration ID: %v", m.ID)
+		}
+		lookup[m.ID] = struct{}{}
+		ids = append(ids, m.ID)
+	}
+	return nil
+}
+
+func (g *Migrator) checkIDExist(migrationID string) error {
+	if migrationID == initSchemaMigrationID {
+		return nil
+	}
+	for _, migrate := range g.migrations {
+		if migrate.ID == migrationID {
+			return nil
+		}
+	}
+	return fmt.Errorf("migration ID %v does not exist", migrationID)
+}
+
+// RollbackTo undoes migrations up to the given migration that matches the `migrationID`.
+// Migration with the matching `migrationID` is not rolled back.
+func (g *Migrator) RollbackTo(migrationID string) error {
+	if len(g.migrations) == 0 {
+		return fmt.Errorf("there are no migrations")
+	}
+
+	if err := g.checkIDExist(migrationID); err != nil {
+		return err
+	}
+
+	rollback := g.begin()
+	defer rollback()
+
+	for i := len(g.migrations) - 1; i >= 0; i-- {
+		migration := g.migrations[i]
+		if migration.ID == migrationID {
+			break
+		}
+		switch migrationRan, err := g.migrationRan(migration); {
+		case err != nil:
+			return err
+		case migrationRan:
+			if err := g.rollbackMigration(migration); err != nil {
+				return err
+			}
+		}
+	}
+	return g.commit()
+}
+
+func (g *Migrator) rollbackMigration(m *Migration) error {
+	if m.Rollback == nil {
+		return errors.New("migration can not be rollback back")
+	}
+
+	if err := m.Rollback(g.tx); err != nil {
+		return err
+	}
+
+	// TODO: use queryBuilder or hardcode table and column names
+	sql := fmt.Sprintf("DELETE FROM %s WHERE %s = ?", g.options.TableName, g.options.IDColumnName)
+	return g.tx.Exec(sql, m.ID).Error
+}
+
+func (g *Migrator) runInitSchema() error {
+	if err := g.options.InitSchema(g.tx); err != nil {
+		return err
+	}
+	if err := g.insertMigration(initSchemaMigrationID); err != nil {
+		return err
+	}
+	for _, migration := range g.migrations {
+		if err := g.insertMigration(migration.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *Migrator) runMigration(migration *Migration) error {
+	switch migrationRan, err := g.migrationRan(migration); {
+	case err != nil:
+		return err
+	case migrationRan:
+		return nil
+	}
+
+	if err := migration.Migrate(g.tx); err != nil {
+		return err
+	}
+	return g.insertMigration(migration.ID)
+}
+
+func (g *Migrator) createMigrationTableIfNotExists() error {
+	// TODO: replace gorm helper
+	if g.tx.Migrator().HasTable(g.options.TableName) {
+		return nil
+	}
+
+	// TODO: use queryBuilder or hardcode table and column names
+	sql := fmt.Sprintf("CREATE TABLE %s (%s VARCHAR(%d) PRIMARY KEY)", g.options.TableName, g.options.IDColumnName, g.options.IDColumnSize)
+	return g.tx.Exec(sql).Error
+}
+
+// TODO: select all values from the table once, instead of selecting each
+// individually
+func (g *Migrator) migrationRan(m *Migration) (bool, error) {
+	var count int64
+	err := g.tx.
+		Table(g.options.TableName).
+		Where(fmt.Sprintf("%s = ?", g.options.IDColumnName), m.ID).
+		Count(&count).
+		Error
+	return count > 0, err
+}
+
+func (g *Migrator) shouldInitializeSchema() (bool, error) {
+	migrationRan, err := g.migrationRan(&Migration{ID: initSchemaMigrationID})
+	if err != nil {
+		return false, err
+	}
+	if migrationRan {
+		return false, nil
+	}
+
+	// If the ID doesn't exist, we also want the list of migrations to be empty
+	var count int64
+	err = g.tx.
+		Table(g.options.TableName).
+		Count(&count).
+		Error
+	return count == 0, err
+}
+
+func (g *Migrator) insertMigration(id string) error {
+	// TODO: use queryBuilder, or hardcode table and column name
+	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES (?)", g.options.TableName, g.options.IDColumnName)
+	return g.tx.Exec(sql, id).Error
+}
+
+func (g *Migrator) begin() func() {
+	if g.options.UseTransaction {
+		g.tx = g.db.Begin()
+		return func() {
+			g.tx.Rollback()
+		}
+	}
+	g.tx = g.db
+	return func() {}
+}
+
+func (g *Migrator) commit() error {
+	if g.options.UseTransaction {
+		return g.tx.Commit().Error
+	}
+	return nil
+}

--- a/internal/server/data/migrator/migrator.go
+++ b/internal/server/data/migrator/migrator.go
@@ -95,7 +95,6 @@ func (g *Migrator) Migrate() error {
 
 func (g *Migrator) validate() error {
 	lookup := make(map[string]struct{}, len(g.migrations))
-	ids := make([]string, len(g.migrations))
 
 	for _, m := range g.migrations {
 		switch m.ID {
@@ -108,7 +107,6 @@ func (g *Migrator) validate() error {
 			return fmt.Errorf("duplicate migration ID: %v", m.ID)
 		}
 		lookup[m.ID] = struct{}{}
-		ids = append(ids, m.ID)
 	}
 	return nil
 }

--- a/internal/server/data/migrator/migrator_test.go
+++ b/internal/server/data/migrator/migrator_test.go
@@ -1,0 +1,400 @@
+package migrator
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gotest.tools/v3/assert"
+)
+
+type database struct {
+	dialect string
+	driver  gorm.Dialector
+}
+
+var migrations = []*Migration{
+	{
+		ID: "201608301400",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&Person{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Migrator().DropTable("people")
+		},
+	},
+	{
+		ID: "201608301430",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&Pet{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Migrator().DropTable("pets")
+		},
+	},
+}
+
+var extendedMigrations = append(migrations, &Migration{
+	ID: "201807221927",
+	Migrate: func(tx *gorm.DB) error {
+		return tx.AutoMigrate(&Book{})
+	},
+	Rollback: func(tx *gorm.DB) error {
+		return tx.Migrator().DropTable("books")
+	},
+})
+
+var failingMigration = []*Migration{
+	{
+		ID: "201904231300",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.AutoMigrate(&Book{}); err != nil {
+				return err
+			}
+			return errors.New("this transaction should be rolled back")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	},
+}
+
+type Person struct {
+	gorm.Model
+	Name string
+}
+
+type Pet struct {
+	gorm.Model
+	Name     string
+	PersonID int
+}
+
+type Book struct {
+	gorm.Model
+	Name     string
+	PersonID int
+}
+
+func TestMigration(t *testing.T) {
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		m := New(db, DefaultOptions, migrations)
+
+		err := m.Migrate()
+		assert.NilError(t, err)
+		assert.Assert(t, db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, db.Migrator().HasTable(&Pet{}))
+		assert.Equal(t, int64(2), tableCount(t, db, "migrations"))
+
+		err = m.RollbackTo(migrations[len(migrations)-2].ID)
+		assert.NilError(t, err)
+		assert.Assert(t, db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, !db.Migrator().HasTable(&Pet{}))
+		assert.Equal(t, int64(1), tableCount(t, db, "migrations"))
+
+		err = m.RollbackTo(initSchemaMigrationID)
+		assert.NilError(t, err)
+		assert.Assert(t, !db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, !db.Migrator().HasTable(&Pet{}))
+		assert.Equal(t, int64(0), tableCount(t, db, "migrations"))
+	})
+}
+
+func TestRollbackTo(t *testing.T) {
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		m := New(db, DefaultOptions, extendedMigrations)
+
+		// First, apply all migrations.
+		err := m.Migrate()
+		assert.NilError(t, err)
+		assert.Assert(t, db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, db.Migrator().HasTable(&Pet{}))
+		assert.Assert(t, db.Migrator().HasTable(&Book{}))
+		assert.Equal(t, int64(3), tableCount(t, db, "migrations"))
+
+		// Rollback to the first migration: only the last 2 migrations are expected to be rolled back.
+		err = m.RollbackTo("201608301400")
+		assert.NilError(t, err)
+		assert.Assert(t, db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, !db.Migrator().HasTable(&Pet{}))
+		assert.Assert(t, !db.Migrator().HasTable(&Book{}))
+		assert.Equal(t, int64(1), tableCount(t, db, "migrations"))
+	})
+}
+
+// If initSchema is defined, but no migrations are provided,
+// then initSchema is executed.
+func TestInitSchemaNoMigrations(t *testing.T) {
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		m := New(db, DefaultOptions, []*Migration{})
+		m.options.InitSchema = func(tx *gorm.DB) error {
+			if err := tx.AutoMigrate(&Person{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&Pet{}); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		assert.NilError(t, m.Migrate())
+		assert.Assert(t, db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, db.Migrator().HasTable(&Pet{}))
+		assert.Equal(t, int64(1), tableCount(t, db, "migrations"))
+	})
+}
+
+// If initSchema is defined and migrations are provided,
+// then initSchema is executed and the migration IDs are stored,
+// even though the relevant migrations are not applied.
+func TestInitSchemaWithMigrations(t *testing.T) {
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		m := New(db, DefaultOptions, migrations)
+		m.options.InitSchema = func(tx *gorm.DB) error {
+			if err := tx.AutoMigrate(&Person{}); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		assert.NilError(t, m.Migrate())
+		assert.Assert(t, db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, !db.Migrator().HasTable(&Pet{}))
+		assert.Equal(t, int64(3), tableCount(t, db, "migrations"))
+	})
+}
+
+// If the schema has already been initialised,
+// then initSchema() is not executed, even if defined.
+func TestInitSchemaAlreadyInitialised(t *testing.T) {
+	type Car struct {
+		gorm.Model
+	}
+
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		m := New(db, DefaultOptions, []*Migration{})
+
+		// Migrate with empty initialisation
+		m.options.InitSchema = func(tx *gorm.DB) error {
+			return nil
+		}
+		assert.NilError(t, m.Migrate())
+
+		// Then migrate again, this time with a non-empty initialisation
+		// This second initialisation should not happen!
+		m.options.InitSchema = func(tx *gorm.DB) error {
+			if err := tx.AutoMigrate(&Car{}); err != nil {
+				return err
+			}
+			return nil
+		}
+		assert.NilError(t, m.Migrate())
+
+		assert.Assert(t, !db.Migrator().HasTable(&Car{}))
+		assert.Equal(t, int64(1), tableCount(t, db, "migrations"))
+	})
+}
+
+// If the schema has not already been initialised,
+// but any other migration has already been applied,
+// then initSchema() is not executed, even if defined.
+func TestInitSchemaExistingMigrations(t *testing.T) {
+	type Car struct {
+		gorm.Model
+	}
+
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		m := New(db, DefaultOptions, migrations)
+
+		// Migrate without initialisation
+		assert.NilError(t, m.Migrate())
+
+		// Then migrate again, this time with a non-empty initialisation
+		// This initialisation should not happen!
+		m.options.InitSchema = func(tx *gorm.DB) error {
+			if err := tx.AutoMigrate(&Car{}); err != nil {
+				return err
+			}
+			return nil
+		}
+		assert.NilError(t, m.Migrate())
+
+		assert.Assert(t, !db.Migrator().HasTable(&Car{}))
+		assert.Equal(t, int64(2), tableCount(t, db, "migrations"))
+	})
+}
+
+func TestMissingID(t *testing.T) {
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		migrationsMissingID := []*Migration{
+			{
+				Migrate: func(tx *gorm.DB) error {
+					return nil
+				},
+			},
+		}
+
+		m := New(db, DefaultOptions, migrationsMissingID)
+		assert.ErrorContains(t, m.Migrate(), "migration is missing an ID")
+	})
+}
+
+func TestReservedID(t *testing.T) {
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		migrationsReservedID := []*Migration{
+			{
+				ID: "SCHEMA_INIT",
+				Migrate: func(tx *gorm.DB) error {
+					return nil
+				},
+			},
+		}
+
+		m := New(db, DefaultOptions, migrationsReservedID)
+		err := m.Migrate()
+		assert.ErrorContains(t, err, "migration can not use reserved ID")
+	})
+}
+
+func TestDuplicatedID(t *testing.T) {
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		migrationsDuplicatedID := []*Migration{
+			{
+				ID: "201705061500",
+				Migrate: func(tx *gorm.DB) error {
+					return nil
+				},
+			},
+			{
+				ID: "201705061500",
+				Migrate: func(tx *gorm.DB) error {
+					return nil
+				},
+			},
+		}
+
+		m := New(db, DefaultOptions, migrationsDuplicatedID)
+		err := m.Migrate()
+		assert.ErrorContains(t, err, "duplicate migration ID: 201705061500")
+	})
+}
+
+func TestEmptyMigrationList(t *testing.T) {
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		t.Run("with empty list", func(t *testing.T) {
+			m := New(db, DefaultOptions, []*Migration{})
+			err := m.Migrate()
+			assert.Error(t, err, "there are no migrations")
+		})
+
+		t.Run("with nil list", func(t *testing.T) {
+			m := New(db, DefaultOptions, nil)
+			err := m.Migrate()
+			assert.Error(t, err, "there are no migrations")
+		})
+	})
+}
+
+func TestMigration_WithUseTransactions(t *testing.T) {
+	options := DefaultOptions
+	options.UseTransaction = true
+
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		m := New(db, options, migrations)
+
+		err := m.Migrate()
+		assert.NilError(t, err)
+		assert.Assert(t, db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, db.Migrator().HasTable(&Pet{}))
+		assert.Equal(t, int64(2), tableCount(t, db, "migrations"))
+
+		err = m.RollbackTo(migrations[len(migrations)-2].ID)
+		assert.NilError(t, err)
+		assert.Assert(t, db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, !db.Migrator().HasTable(&Pet{}))
+		assert.Equal(t, int64(1), tableCount(t, db, "migrations"))
+
+		err = m.RollbackTo(initSchemaMigrationID)
+		assert.NilError(t, err)
+		assert.Assert(t, !db.Migrator().HasTable(&Person{}))
+		assert.Assert(t, !db.Migrator().HasTable(&Pet{}))
+		assert.Equal(t, int64(0), tableCount(t, db, "migrations"))
+	}, "postgres", "sqlite3", "mssql")
+}
+
+func TestMigration_WithUseTransactionsShouldRollback(t *testing.T) {
+	options := DefaultOptions
+	options.UseTransaction = true
+
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		assert.Assert(t, true)
+		m := New(db, options, failingMigration)
+
+		// Migration should return an error and not leave around a Book table
+		err := m.Migrate()
+		assert.Error(t, err, "this transaction should be rolled back")
+		assert.Assert(t, !db.Migrator().HasTable(&Book{}))
+	}, "postgres", "sqlite3", "mssql")
+}
+
+func TestMigrate_WithUnknownMigrationsInTable(t *testing.T) {
+	forEachDatabase(t, func(t *testing.T, db *gorm.DB) {
+		options := DefaultOptions
+		m := New(db, options, migrations)
+
+		// Migrate without initialisation
+		assert.NilError(t, m.Migrate())
+
+		n := New(db, DefaultOptions, migrations[:1])
+		assert.NilError(t, n.Migrate())
+	})
+}
+
+func tableCount(t *testing.T, db *gorm.DB, tableName string) (count int64) {
+	assert.NilError(t, db.Table(tableName).Count(&count).Error)
+	return
+}
+
+func forEachDatabase(t *testing.T, fn func(t *testing.T, database *gorm.DB), dialects ...string) {
+	dir := t.TempDir()
+
+	databases := []database{
+		{dialect: "sqlite3", driver: sqlite.Open("file:" + filepath.Join(dir, "sqlite3.db"))},
+	}
+
+	if pg := os.Getenv("PG_CONN_STRING"); pg != "" {
+		databases = append(databases, database{
+			dialect: "postgres", driver: postgres.Open(pg),
+		})
+	}
+
+	for _, database := range databases {
+		if len(dialects) > 0 && !contains(dialects, database.dialect) {
+			t.Skipf("test is not supported by [%s] dialect", database.dialect)
+		}
+
+		// Ensure defers are not stacked up for each DB
+		t.Run(database.driver.Name(), func(t *testing.T) {
+			db, err := gorm.Open(database.driver, &gorm.Config{})
+			assert.NilError(t, err, "Could not connect to database %s, %v", database.dialect, err)
+
+			// ensure tables do not exists
+			assert.NilError(t, db.Migrator().DropTable("migrations", "people", "pets"))
+
+			fn(t, db)
+		})
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, straw := range haystack {
+		if straw == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Background

Today we use `gormigrate` to manage our database migrations. It works well, but we have a couple problems:
1. it requires `gorm.DB`, so if we ever want to replace `gorm` we'll have to replace `gormigrate` as well. The core logic for running migrations is pretty trivial, barely 50 lines. So we don't need a big complex framework for migrations. The logic in `gormigrate` is quite reasonable, so by forking this library we can keep the small bit we need, while changing the interface used to implement a migration.
2. we have a somewhat unique requirement for loading the data key out of the database. On a fresh install this has to happen after initializing the schema, but on an upgrade it must happen before running migrations (in case we need the key as part of one of the migrations).  To handle that we've had to implement part of the migration checks out of the migrator. By forking and including our version locally we can modify the migrator to work the way we need it to. This should allow us to fix #2066

## Summary

This PR replaces `gormigrate` with a fork that removes a lot of the stuff we don't use. The full change history can be seen here: https://github.com/dnephin/go-dbmigrator/commits/main. The new package is included at `internal/server/data/migrator` so that we can easily make changes to it. Making it a local package also allows us to remove options we don't need.

Some of the things removed include:
* removed dependency on databases we don't use
* remove check for unknown migration IDs in the table - we expect to remove some migrations from code after a few releases, because they are no longer necessary
* remove `MigrateTo`, `RollbackMigration`, and `RollbackLast` we don't use these methods, and generally they aren't safe to use.
* typed errors and error variables - we don't expect to need to handle any of these errors in any special way, so we don't need these variables or types


## Related Issues

Related to #2066, and #2685
