### PR TITLE
Integrate loadKey with init schema

### DIFF
--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -41,6 +41,14 @@ func NewDB(connection gorm.Dialector, loadDBKey func(db *gorm.DB) error) (*gorm.
 	if err := m.Migrate(); err != nil {
 		return nil, fmt.Errorf("migration failed: %w", err)
 	}
+
+	// Call initializeSchema again to apply implicit migrations handled by
+	// gorm.AutoMigrate. In the future we will replace this call with
+	// explicit migrations for all database changes.
+	if err := initializeSchema(db); err != nil {
+		return nil, fmt.Errorf("auto-migrate failed: %w", err)
+	}
+
 	return db, nil
 }
 

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -476,7 +476,6 @@ func migrations() []*migrator.Migration {
 		addAuthURLAndScopeToProviders(),
 		setDestinationLastSeenAt(),
 		deleteDuplicateGrants(),
-		addFieldsFor_0_14(),
 		dropDeletedProviderUsers(),
 		// next one here
 	}
@@ -636,20 +635,4 @@ func dropDeletedProviderUsers() *migrator.Migration {
 func deleteDuplicates(tx *gorm.DB, group string, model models.Modelable) error {
 	subQuery := tx.Select("min(id)").Group(group).Model(model)
 	return tx.Where("id NOT in (?)", subQuery).Delete(model).Error
-}
-
-// nolint:revive
-func addFieldsFor_0_14() *migrator.Migration {
-	return &migrator.Migration{
-		ID: "2022-07-21T18:28",
-		Migrate: func(tx *gorm.DB) error {
-			if err := tx.AutoMigrate(&models.Provider{}); err != nil {
-				return err
-			}
-			if err := tx.AutoMigrate(&models.Settings{}); err != nil {
-				return err
-			}
-			return nil
-		},
-	}
 }

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -17,10 +17,8 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func migrate(db *gorm.DB) error {
-	opts := migrator.DefaultOptions
-	opts.InitSchema = preMigrate
-	m := migrator.New(db, opts, []*migrator.Migration{
+func migrations() []*migrator.Migration {
+	return []*migrator.Migration{
 		// rename grants.identity -> grants.subject
 		{
 			ID: "202203231621", // date the migration was created
@@ -79,7 +77,7 @@ func migrate(db *gorm.DB) error {
 
 				var keys []AccessKey
 
-				err := db.Find(&keys).Error
+				err := tx.Find(&keys).Error
 				if err != nil {
 					return fmt.Errorf("migrating access key identities: %w", err)
 				}
@@ -115,7 +113,7 @@ func migrate(db *gorm.DB) error {
 						SecretChecksum: key.SecretChecksum,
 					}
 
-					if err := SaveAccessKey(db, convertedKey); err != nil {
+					if err := SaveAccessKey(tx, convertedKey); err != nil {
 						return fmt.Errorf("save converted key: %w", err)
 					}
 				}
@@ -139,7 +137,7 @@ func migrate(db *gorm.DB) error {
 
 				var creds []Credential
 
-				if err := db.Find(&creds).Error; err != nil {
+				if err := tx.Find(&creds).Error; err != nil {
 					return fmt.Errorf("migrating creds: %w", err)
 				}
 
@@ -169,7 +167,7 @@ func migrate(db *gorm.DB) error {
 						OneTimePassword: cred.OneTimePassword,
 					}
 
-					if err := CreateCredential(db, convertedCred); err != nil {
+					if err := CreateCredential(tx, convertedCred); err != nil {
 						return fmt.Errorf("create converted cred: %w", err)
 					}
 				}
@@ -224,7 +222,7 @@ func migrate(db *gorm.DB) error {
 
 					var machines []Machine
 
-					if err := db.Find(&machines).Error; err != nil {
+					if err := tx.Find(&machines).Error; err != nil {
 						return fmt.Errorf("migrating machine identities: %w", err)
 					}
 
@@ -235,7 +233,7 @@ func migrate(db *gorm.DB) error {
 							LastSeenAt: machine.LastSeenAt,
 						}
 
-						if err := SaveIdentity(db, identity); err != nil {
+						if err := SaveIdentity(tx, identity); err != nil {
 							return fmt.Errorf("saving migrated machine identity: %w", err)
 						}
 					}
@@ -251,7 +249,7 @@ func migrate(db *gorm.DB) error {
 			Migrate: func(tx *gorm.DB) error {
 				logging.Infof("running migration 202203301647")
 				if tx.Migrator().HasTable("machines") {
-					grants, err := ListGrants(db, nil)
+					grants, err := ListGrants(tx, nil)
 					if err != nil {
 						return err
 					}
@@ -262,7 +260,7 @@ func migrate(db *gorm.DB) error {
 							identitySubject = strings.TrimPrefix(identitySubject, "u:")
 							identitySubject = strings.TrimPrefix(identitySubject, "m:")
 							grants[i].Subject = uid.PolymorphicID(fmt.Sprintf("%s:%s", "i", identitySubject))
-							if err := save(db, &grants[i]); err != nil {
+							if err := save(tx, &grants[i]); err != nil {
 								return fmt.Errorf("update identity grant: %w", err)
 							}
 						}
@@ -292,7 +290,7 @@ func migrate(db *gorm.DB) error {
 			Migrate: func(tx *gorm.DB) error {
 				logging.Infof("running migration 202204061643")
 				if tx.Migrator().HasTable("access_keys") {
-					keys, err := ListAccessKeys(db, nil)
+					keys, err := ListAccessKeys(tx, nil)
 					if err != nil {
 						return err
 					}
@@ -300,7 +298,7 @@ func migrate(db *gorm.DB) error {
 					for i := range keys {
 						if strings.Contains(keys[i].Name, " ") {
 							keys[i].Name = strings.ReplaceAll(keys[i].Name, " ", "-")
-							err := SaveAccessKey(db, &keys[i])
+							err := SaveAccessKey(tx, &keys[i])
 							if err != nil {
 								return err
 							}
@@ -346,7 +344,7 @@ func migrate(db *gorm.DB) error {
 
 					infraProviderID := providerIDs["infra"]
 
-					users, err := ListIdentities(db, nil, func(db *gorm.DB) *gorm.DB {
+					users, err := ListIdentities(tx, nil, func(db *gorm.DB) *gorm.DB {
 						return db.Where("provider_id != ?", infraProviderID)
 					})
 					if err != nil {
@@ -355,7 +353,7 @@ func migrate(db *gorm.DB) error {
 
 					for _, user := range users {
 						logging.Debugf("migrating user %s", user.ID.String())
-						newUser, err := GetIdentity(db, ByName(user.Name), func(db *gorm.DB) *gorm.DB {
+						newUser, err := GetIdentity(tx, ByName(user.Name), func(db *gorm.DB) *gorm.DB {
 							return db.Where("provider_id = ?", infraProviderID)
 						})
 						if err != nil {
@@ -429,7 +427,7 @@ func migrate(db *gorm.DB) error {
 				// to convert the plaintext field to encrypted, load it with SkipSymmetricKey, then save without it.
 				models.SkipSymmetricKey = true
 				settings := []Settings{}
-				err := db.Model(Settings{}).Find(&settings).Error
+				err := tx.Model(Settings{}).Find(&settings).Error
 				if err != nil {
 					models.SkipSymmetricKey = false
 					return err
@@ -437,7 +435,7 @@ func migrate(db *gorm.DB) error {
 
 				models.SkipSymmetricKey = false
 				for _, setting := range settings {
-					if err := db.Save(setting).Error; err != nil {
+					if err := tx.Save(setting).Error; err != nil {
 						return err
 					}
 				}
@@ -478,26 +476,10 @@ func migrate(db *gorm.DB) error {
 		addAuthURLAndScopeToProviders(),
 		setDestinationLastSeenAt(),
 		deleteDuplicateGrants(),
+		addFieldsFor_0_14(),
 		dropDeletedProviderUsers(),
 		// next one here
-	})
-	if err := m.Migrate(); err != nil {
-		return err
 	}
-
-	// initializeSchema so that for simple things like adding db fields
-	// we don't necessarily need to do a migration.
-	// TODO: why not do this before migrate in all cases?
-	return initializeSchema(db)
-}
-
-func preMigrate(db *gorm.DB) error {
-	if db.Migrator().HasTable("providers") {
-		// don't initialize the schema if tables already exist.
-		return nil
-	}
-
-	return initializeSchema(db)
 }
 
 func initializeSchema(db *gorm.DB) error {
@@ -654,4 +636,20 @@ func dropDeletedProviderUsers() *migrator.Migration {
 func deleteDuplicates(tx *gorm.DB, group string, model models.Modelable) error {
 	subQuery := tx.Select("min(id)").Group(group).Model(model)
 	return tx.Where("id NOT in (?)", subQuery).Delete(model).Error
+}
+
+// nolint:revive
+func addFieldsFor_0_14() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-07-21T18:28",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.AutoMigrate(&models.Provider{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&models.Settings{}); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
 }

--- a/internal/server/data/migrator/migrator.go
+++ b/internal/server/data/migrator/migrator.go
@@ -20,6 +20,10 @@ type Options struct {
 	// function is run, migrator will create the migrations table and populate
 	// it with the IDs of all the currently defined migrations.
 	InitSchema func(*gorm.DB) error
+
+	// LoadKey is an optional function to initialize an encryption key from the
+	// database, that is used to encrypt other fields.
+	LoadKey func(*gorm.DB) error
 }
 
 // Migration represents a database migration (a modification to be made on the database).
@@ -50,6 +54,11 @@ var DefaultOptions = Options{
 
 // New returns a new Migrator.
 func New(db *gorm.DB, options Options, migrations []*Migration) *Migrator {
+	if options.LoadKey == nil {
+		options.LoadKey = func(db *gorm.DB) error {
+			return nil
+		}
+	}
 	return &Migrator{
 		db:         db,
 		options:    options,
@@ -74,15 +83,19 @@ func (g *Migrator) Migrate() error {
 		return err
 	}
 
-	canInitializeSchema, err := g.shouldInitializeSchema()
-	if err != nil {
+	initSchema, err := g.mustInitializeSchema()
+	switch {
+	case err != nil:
 		return err
-	}
-	if canInitializeSchema {
+	case initSchema:
 		if err := g.runInitSchema(); err != nil {
 			return err
 		}
 		return g.commit()
+	}
+
+	if err := g.options.LoadKey(g.tx); err != nil {
+		return fmt.Errorf("load key: %w", err)
 	}
 
 	for _, migration := range g.migrations {
@@ -177,7 +190,7 @@ func (g *Migrator) runInitSchema() error {
 			return err
 		}
 	}
-	return nil
+	return g.options.LoadKey(g.tx)
 }
 
 func (g *Migrator) runMigration(migration *Migration) error {
@@ -211,7 +224,7 @@ func (g *Migrator) migrationRan(m *Migration) (bool, error) {
 	return count > 0, err
 }
 
-func (g *Migrator) shouldInitializeSchema() (bool, error) {
+func (g *Migrator) mustInitializeSchema() (bool, error) {
 	migrationRan, err := g.migrationRan(&Migration{ID: initSchemaMigrationID})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Summary

Branched from #2722

Pass `loadKey` to migrator so that we don't have to duplicate some of the "has schema been intialized" logic.


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2066
