### PR TITLE
feat: do not prompt list of login methods if no providers are connected

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -564,6 +564,10 @@ func promptLoginOptions(cli *CLI, client *api.Client) (loginMethod loginMethod, 
 		return 0, nil, err
 	}
 
+	if len(providers) == 0 {
+		return localLogin, nil, nil
+	}
+
 	var options []string
 	for _, p := range providers {
 		options = append(options, fmt.Sprintf("%s (%s)", p.Name, p.URL))


### PR DESCRIPTION
## Summary

Before:
```
$ infra login
? Select a server: [Use arrows to move, type to filter]
> localhost


$ infra login
? Select a server: localhost
? Select a login method: [Use arrows to move, type to filter]
> Login with username and password
```

After:
```
$ infra login
? Select a server: [Use arrows to move, type to filter]
> localhost


$ infra login
? Select a server: localhost
? Username: 
```


## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2636
