### PR TITLE
feat(api): add totalUsers to groups endpoint

### DIFF
--- a/api/group.go
+++ b/api/group.go
@@ -6,10 +6,11 @@ import (
 )
 
 type Group struct {
-	ID      uid.ID `json:"id"`
-	Name    string `json:"name"`
-	Created Time   `json:"created"`
-	Updated Time   `json:"updated"`
+	ID         uid.ID `json:"id"`
+	Name       string `json:"name"`
+	Created    Time   `json:"created"`
+	Updated    Time   `json:"updated"`
+	TotalUsers int    `json:"totalUsers"`
 }
 
 type ListGroupsRequest struct {

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -81,3 +81,14 @@ func RemoveUsersFromGroup(db *gorm.DB, groupID uid.ID, idsToRemove []uid.ID) err
 	}
 	return nil
 }
+
+func GetUserCountFromGroup(db *gorm.DB, groupID uid.ID) (int64, error) {
+	// select count(*) from identities_groups where identities_groups.group_id = ?
+	var count int64
+	err := db.Count(&count).Table("identities_groups").Where("group_id = ?", groupID).Error
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -168,7 +168,8 @@ func TestAPI_ListGroups(t *testing.T) {
 		"id": "%[1]v",
 		"name": "humans",
 		"created": "%[2]v",
-		"updated": "%[2]v"
+		"updated": "%[2]v",
+		"totalUsers": 1
 	}]
 }`,
 					humans.ID.String(),

--- a/internal/server/models/group.go
+++ b/internal/server/models/group.go
@@ -13,14 +13,17 @@ type Group struct {
 	CreatedByProvider uid.ID
 
 	Identities []Identity `gorm:"many2many:identities_groups"`
+
+	TotalUsers int `gorm:"-:all"`
 }
 
 func (g *Group) ToAPI() *api.Group {
 	return &api.Group{
-		ID:      g.ID,
-		Created: api.Time(g.CreatedAt),
-		Updated: api.Time(g.UpdatedAt),
-		Name:    g.Name,
+		ID:         g.ID,
+		Created:    api.Time(g.CreatedAt),
+		Updated:    api.Time(g.UpdatedAt),
+		Name:       g.Name,
+		TotalUsers: g.TotalUsers,
 	}
 }
 

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -299,6 +299,10 @@
           "name": {
             "type": "string"
           },
+          "totalUsers": {
+            "format": "int",
+            "type": "integer"
+          },
           "updated": {
             "description": "formatted as an RFC3339 date-time",
             "example": "2022-03-14T09:48:00Z",
@@ -578,6 +582,10 @@
                 },
                 "name": {
                   "type": "string"
+                },
+                "totalUsers": {
+                  "format": "int",
+                  "type": "integer"
                 },
                 "updated": {
                   "description": "formatted as an RFC3339 date-time",


### PR DESCRIPTION
## Summary

Adds totalUsers (a count of users in a group) by counting from the identities_groups join table for use in the API/CLI.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2672 
