### PR TITLE
feat(helm): bind services to non-privileged port ranges

### DIFF
--- a/helm/charts/infra/templates/connector/configmap.yaml
+++ b/helm/charts/infra/templates/connector/configmap.yaml
@@ -12,6 +12,11 @@ data:
     name: {{ . }}
 {{- end }}
 
+    addr:
+{{- range $key, $val := .Values.connector.config.addr }}
+      {{ $key }}: ':{{ $val }}'
+{{- end }}
+
     server:
 {{- $accessKey := default "" .Values.connector.config.accessKey }}
 {{- if and $accessKey (or (hasPrefix "file:" $accessKey) (hasPrefix "env:" $accessKey)) }}

--- a/helm/charts/infra/templates/connector/deployment.yaml
+++ b/helm/charts/infra/templates/connector/deployment.yaml
@@ -62,10 +62,10 @@ spec:
 {{- end }}
           ports:
             - name: https
-              containerPort: 443
+              containerPort: {{ .Values.connector.config.addr.https }}
               protocol: TCP
             - name: metrics
-              containerPort: 9090
+              containerPort: {{ .Values.connector.config.addr.metrics }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm/charts/infra/templates/server/configmap.yaml
+++ b/helm/charts/infra/templates/server/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 {{- include "server.labels" . | nindent 4 }}
 data:
   infra.yaml: |
-{{- range $key, $val := omit .Values.server.config "providers" "grants" "users" "identities" "secrets" "keys" }}
+{{- range $key, $val := omit .Values.server.config "addr" "tls" "providers" "grants" "users" "identities" "secrets" "keys" }}
 {{- if kindIs "invalid" $val }}
     # skipping invalid value: {{ $val }} ({{ kindOf $val }})
 {{- else if kindIs "map" $val }}
@@ -24,6 +24,11 @@ data:
 {{- end }}
 
     version: 0.2
+
+    addr:
+{{- range $key, $val := .Values.server.config.addr }}
+      {{ $key }}: ':{{ $val }}'
+{{- end }}
 
 {{- if .Values.server.persistence.enabled }}
 

--- a/helm/charts/infra/templates/server/deployment.yaml
+++ b/helm/charts/infra/templates/server/deployment.yaml
@@ -61,13 +61,13 @@ spec:
 {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.server.config.addr.http }}
               protocol: TCP
             - name: https
-              containerPort: 443
+              containerPort: {{ .Values.server.config.addr.https }}
               protocol: TCP
             - name: metrics
-              containerPort: 9090
+              containerPort: {{ .Values.server.config.addr.metrics }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -382,6 +382,13 @@ server:
 
   ## Primary server configuration
   config:
+
+    ## Server container service ports
+    addr:
+      http: 8080
+      https: 8443
+      metrics: 9090
+
     ## Database name
     # dbName: ""
 
@@ -803,7 +810,13 @@ connector:
   affinity: {}
 
   ## Primary connector configuration
-  config: {}
+  config:
+
+    ## Connector container service ports
+    addr:
+      https: 9443
+      metrics: 9091
+
   ## Infra server access key
   #   accessKey: ""
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -233,10 +233,13 @@ func newConnectorCmd() *cobra.Command {
 // runConnector is a shim for testing
 var runConnector = connector.Run
 
-// defaultConnectorOptions is empty for now. It exists so that it can be
-// referenced by a test.
 func defaultConnectorOptions() connector.Options {
-	return connector.Options{}
+	return connector.Options{
+		Addr: connector.ListenerOptions{
+			HTTPS:   ":443",
+			Metrics: ":9090",
+		},
+	}
 }
 
 func NewRootCmd(cli *CLI) *cobra.Command {

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -385,6 +385,10 @@ caKey: /path/to/key
 
 	expected := connector.Options{
 		Name: "the-name",
+		Addr: connector.ListenerOptions{
+			HTTPS:   ":443",
+			Metrics: ":9090",
+		},
 		Server: connector.ServerOptions{
 			URL:                "the-server",
 			AccessKey:          "/var/run/secrets/key",

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -35,6 +35,8 @@ type Options struct {
 	Name   string
 	CACert string
 	CAKey  string
+
+	Addr ListenerOptions
 }
 
 type ServerOptions struct {
@@ -42,6 +44,11 @@ type ServerOptions struct {
 	AccessKey          string
 	SkipTLSVerify      bool
 	TrustedCertificate types.StringOrFile
+}
+
+type ListenerOptions struct {
+	HTTPS   string
+	Metrics string
 }
 
 func Run(ctx context.Context, options Options) error {
@@ -180,7 +187,7 @@ func Run(ctx context.Context, options Options) error {
 	metricsServer := &http.Server{
 		ReadHeaderTimeout: 30 * time.Second,
 		ReadTimeout:       60 * time.Second,
-		Addr:              ":9090",
+		Addr:              options.Addr.Metrics,
 		Handler:           metrics.NewHandler(promRegistry),
 		ErrorLog:          httpErrorLog,
 	}
@@ -199,7 +206,7 @@ func Run(ctx context.Context, options Options) error {
 	tlsServer := &http.Server{
 		ReadHeaderTimeout: 30 * time.Second,
 		ReadTimeout:       60 * time.Second,
-		Addr:              ":443",
+		Addr:              options.Addr.HTTPS,
 		TLSConfig:         tlsConfig,
 		Handler:           router,
 		ErrorLog:          httpErrorLog,


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Allow the bind addresses for server and connector to be configured through Helm.

Set a default bind address such that the pod can be run without additional privileges for binding to sub-1024 ports.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2737 
