### PR TITLE
fix(helm): Change default podSecurityContext & securityContext

### DIFF
--- a/helm/charts/infra/Chart.yaml
+++ b/helm/charts/infra/Chart.yaml
@@ -3,6 +3,6 @@ name: infra
 description: A Helm chart for Infra
 type: application
 ## {x-release-please-start-version}
-version: 0.14.2
-appVersion: 0.14.2
+version: 0.14.1
+appVersion: 0.14.1
 ## {x-release-please-end}

--- a/helm/charts/infra/Chart.yaml
+++ b/helm/charts/infra/Chart.yaml
@@ -3,6 +3,6 @@ name: infra
 description: A Helm chart for Infra
 type: application
 ## {x-release-please-start-version}
-version: 0.14.1
-appVersion: 0.14.1
+version: 0.14.2
+appVersion: 0.14.2
 ## {x-release-please-end}

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -116,13 +116,14 @@ server:
   podAnnotations: {}
 
   ## Security context for the server pod
-  podSecurityContext: {}
-  #   fsGroup: 2000
+  podSecurityContext:
+    fsGroup: 1000
 
   ## Security context for the server container
   securityContext:
     readOnlyRootFilesystem: true
-    # runAsUser: 999
+    runAsUser: 1000
+    runAsGroup: 1000
 
   ## Liveness probe for the default backend
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes


### PR DESCRIPTION

## Summary
- Update helm chart to 0.14.2
- change default podSecurityContext to set fsGroup
- set securityContext runAsUser & runAsGroup by default to match dockerfile.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves [#2740]

-->

Resolves [#2740]
