### PR TITLE
makefile: add command to start postgres for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,17 @@ tools:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	go install github.com/goreleaser/goreleaser@latest
 
+postgres:
+	docker run -d --name=postgres-dev --rm \
+		-e POSTGRES_PASSWORD=password123 \
+		--tmpfs=/var/lib/postgresql/data \
+		-p 5432:5432 \
+		postgres:14-alpine -c fsync=off -c full_page_writes=off
+	@echo
+	@echo Copy the line below into the shell used to run tests
+	@echo 'export POSTGRESQL_CONNECTION="host=localhost port=5432 user=postgres dbname=postgres password=password123"'
+
+
 lint:
 	golangci-lint run --fix
 


### PR DESCRIPTION
## Summary

I've been using something like this to start postgres in a container for running tests. I thought it might be useful for others.

You can use it by first running `make postgres`, then copying the `export ...` line it prints and running that command. If you use some kind of `.env` loader then you can add a file that sets it always. If you use an IDE to run tests you'll have to set that env var in the IDE.

The container is named `postgres-dev`, so it will fail to start multiple containers. You'd have to `docker rm -f postgres-dev` to remove the old container before starting a new one. You shouldn't need to start a new container very often. The tests cleanup the namespace after reach test run, so the same postgres instance can be re-used for as long as you want.

The container runs with the data directory on a `tmpfs`, and with `-c fsync=off -c full_page_writes=off`. Those settings are supposed to make queries run faster, but we are spending so much time on `gorm.AutoMigrate` right now that it's hard to measure their impact. I figured it wouldn't hurt to leave them for now. We can always remove them later if they cause problems.