### PR TITLE
fix: google instructions missing a step towards the end

### DIFF
--- a/docs/identity-providers/google.md
+++ b/docs/identity-providers/google.md
@@ -60,8 +60,9 @@ infra providers add google \
     - Select the **JSON** key type and click **CREATE**.
     - A private key JSON file will automatically download, note the **private_key** in this file. This will be the `service-account-key` in the `providers add` command.
   ![Service account key](../images/google-setup/connect-users-google-9.png)
-10. You are now finished with configuration in the Google Cloud admin console. Open the Google Workspace admin console and navigate to **Security > API Controls > Domain-wide Delegation**.
+10. You are now finished with configuration in the Google Cloud admin console. Open the Google Workspace admin console and navigate to **Security > Access and Data Controls > API Controls > Domain-wide Delegation**.
   ![API controls](../images/google-setup/connect-users-google-10.png)
+  - Click **Manage Domain Wide Delegation**
   - Click **Add new**.
   - For **Client ID** enter the client ID noted in step 6.
   - For **OAuth scopes** enter **https://www.googleapis.com/auth/admin.directory.group.readonly**.


### PR DESCRIPTION
in the google identity provider docs

Signed-off-by: Matthew Williams <m@technovangelist.com>

## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
