### PR TITLE
feat: add infra support admin user

### DIFF
--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -89,7 +89,7 @@ func CreateGrant(c *gin.Context, grant *models.Grant) error {
 	var db *gorm.DB
 	var err error
 
-	if grant.Privilege == models.InfraSupportAdminRole {
+	if grant.Privilege == models.InfraSupportAdminRole && grant.Resource == ResourceInfraAPI {
 		db, err = RequireInfraRole(c, models.InfraSupportAdminRole)
 	} else {
 		db, err = RequireInfraRole(c, models.InfraAdminRole)

--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -14,11 +14,11 @@ func ListOrganizations(c *gin.Context, name string, pg *models.Pagination) ([]mo
 		selectors = append(selectors, data.ByName(name))
 	}
 
-	db, err := RequireInfraRole(c, models.InfraAdminRole)
+	db, err := RequireInfraRole(c, models.InfraSupportAdminRole)
 	if err == nil {
 		return data.ListOrganizations(db, pg, selectors...)
 	}
-	err = HandleAuthErr(err, "organizations", "list", models.InfraAdminRole)
+	err = HandleAuthErr(err, "organizations", "list", models.InfraSupportAdminRole)
 
 	// TODO:
 	//    * Consider allowing a user to list their own organization
@@ -27,30 +27,27 @@ func ListOrganizations(c *gin.Context, name string, pg *models.Pagination) ([]mo
 }
 
 func GetOrganization(c *gin.Context, id uid.ID) (*models.Organization, error) {
-	roles := []string{models.InfraAdminRole}
-	db, err := RequireInfraRole(c, roles...)
+	db, err := RequireInfraRole(c, models.InfraSupportAdminRole)
 	if err != nil {
-		return nil, HandleAuthErr(err, "organizations", "get", roles...)
+		return nil, HandleAuthErr(err, "organizations", "get", models.InfraSupportAdminRole)
 	}
 
 	return data.GetOrganization(db, data.ByID(id))
 }
 
 func CreateOrganization(c *gin.Context, org *models.Organization) error {
-	roles := []string{models.InfraAdminRole}
-	db, err := RequireInfraRole(c, roles...)
+	db, err := RequireInfraRole(c, models.InfraSupportAdminRole)
 	if err != nil {
-		return HandleAuthErr(err, "organizations", "create", roles...)
+		return HandleAuthErr(err, "organizations", "create", models.InfraSupportAdminRole)
 	}
 
 	return data.CreateOrganization(db, org)
 }
 
 func DeleteOrganization(c *gin.Context, id uid.ID) error {
-	roles := []string{models.InfraAdminRole}
-	db, err := RequireInfraRole(c, roles...)
+	db, err := RequireInfraRole(c, models.InfraSupportAdminRole)
 	if err != nil {
-		return HandleAuthErr(err, "organizations", "delete", roles...)
+		return HandleAuthErr(err, "organizations", "delete", models.InfraSupportAdminRole)
 	}
 
 	return data.DeleteOrganizations(db, data.ByID(id))

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -83,13 +83,13 @@ func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
 		{
 			Subject:   uid.NewIdentityPolymorphicID(identity.ID),
 			Privilege: models.InfraAdminRole,
-			Resource:  "infra",
+			Resource:  ResourceInfraAPI,
 			CreatedBy: identity.ID,
 		},
 		{
 			Subject:   uid.NewIdentityPolymorphicID(identity.ID),
 			Privilege: models.InfraSupportAdminRole,
-			Resource:  "infra",
+			Resource:  ResourceInfraAPI,
 			CreatedBy: identity.ID,
 		},
 	}

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -80,13 +80,13 @@ func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
 	}
 
 	grants := []*models.Grant{
-		&models.Grant{
+		{
 			Subject:   uid.NewIdentityPolymorphicID(identity.ID),
 			Privilege: models.InfraAdminRole,
 			Resource:  "infra",
 			CreatedBy: identity.ID,
 		},
-		&models.Grant{
+		{
 			Subject:   uid.NewIdentityPolymorphicID(identity.ID),
 			Privilege: models.InfraSupportAdminRole,
 			Resource:  "infra",

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -79,15 +79,25 @@ func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
 		return nil, err
 	}
 
-	grant := &models.Grant{
-		Subject:   uid.NewIdentityPolymorphicID(identity.ID),
-		Privilege: models.InfraAdminRole,
-		Resource:  "infra",
-		CreatedBy: identity.ID,
+	grants := []*models.Grant{
+		&models.Grant{
+			Subject:   uid.NewIdentityPolymorphicID(identity.ID),
+			Privilege: models.InfraAdminRole,
+			Resource:  "infra",
+			CreatedBy: identity.ID,
+		},
+		&models.Grant{
+			Subject:   uid.NewIdentityPolymorphicID(identity.ID),
+			Privilege: models.InfraSupportAdminRole,
+			Resource:  "infra",
+			CreatedBy: identity.ID,
+		},
 	}
 
-	if err := data.CreateGrant(db, grant); err != nil {
-		return nil, err
+	for _, grant := range grants {
+		if err := data.CreateGrant(db, grant); err != nil {
+			return nil, err
+		}
 	}
 
 	return identity, nil

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -667,7 +667,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 				assert.DeepEqual(t, actual, expected, cmpAPIGrantJSON)
 			},
 		},
-		"unprivileged support admin grant": {
+		"admin can not grant infra support admin role": {
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 			},

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -565,85 +564,161 @@ func TestAPI_CreateGrant(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	reqBody := strings.NewReader(`
-		{
-		  "user": "TJ",
-		  "privilege": "admin-role",
-		  "resource": "some-cluster"
-		}`)
-
-	resp := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodPost, "/api/grants", reqBody)
-	assert.NilError(t, err)
-	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
-	req.Header.Add("Infra-Version", "0.12.3")
-
 	accessKey, err := data.ValidateAccessKey(srv.db, adminAccessKey(srv))
 	assert.NilError(t, err)
 
-	runStep(t, "full JSON response", func(t *testing.T) {
-		routes.ServeHTTP(resp, req)
-		assert.Equal(t, resp.Code, http.StatusCreated)
-
-		expected := jsonUnmarshal(t, fmt.Sprintf(`
-		{
-		  "id": "<any-valid-uid>",
-		  "created_by": "%[1]v",
-		  "privilege": "admin-role",
-		  "resource": "some-cluster",
-		  "user": "TJ",
-		  "created": "%[2]v",
-		  "updated": "%[2]v",
-		  "wasCreated": true
-		}`,
-			accessKey.IssuedFor,
-			time.Now().UTC().Format(time.RFC3339),
-		))
-		actual := jsonUnmarshal(t, resp.Body.String())
-		assert.DeepEqual(t, actual, expected, cmpAPIGrantJSON)
-	})
-
-	var newGrant api.Grant
-	err = json.NewDecoder(resp.Body).Decode(&newGrant)
+	someUser := models.Identity{Name: "someone@example.com"}
+	err = data.CreateIdentity(srv.db, &someUser)
 	assert.NilError(t, err)
 
-	runStep(t, "grant exists", func(t *testing.T) {
-		resp := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "/api/grants/"+newGrant.ID.String(), nil)
+	supportAdmin := models.Identity{Name: "support-admin@example.com"}
+	err = data.CreateIdentity(srv.db, &supportAdmin)
+	assert.NilError(t, err)
+
+	supportAdminGrant := models.Grant{
+		Subject:   supportAdmin.PolyID(),
+		Privilege: models.InfraSupportAdminRole,
+		Resource:  "infra",
+	}
+	err = data.CreateGrant(srv.db, &supportAdminGrant)
+	assert.NilError(t, err)
+
+	token := &models.AccessKey{
+		IssuedFor:  supportAdmin.ID,
+		ProviderID: data.InfraProvider(srv.db).ID,
+		ExpiresAt:  time.Now().Add(10 * time.Second),
+	}
+
+	supportAccessKeyStr, err := data.CreateAccessKey(srv.db, token)
+	assert.NilError(t, err)
+
+	type testCase struct {
+		setup    func(t *testing.T, req *http.Request)
+		expected func(t *testing.T, resp *httptest.ResponseRecorder)
+		body     api.CreateGrantRequest
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		body := jsonBody(t, tc.body)
+		req, err := http.NewRequest(http.MethodPost, "/api/grants", body)
 		assert.NilError(t, err)
-		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", "0.12.3")
 
-		routes.ServeHTTP(resp, req)
-		assert.Equal(t, resp.Code, http.StatusOK)
-
-		var getGrant api.Grant
-		err = json.NewDecoder(resp.Body).Decode(&getGrant)
-		assert.NilError(t, err)
-		assert.DeepEqual(t, getGrant, newGrant)
-	})
-
-	t.Run("missing required fields", func(t *testing.T) {
-		resp := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodPost, "/api/grants", strings.NewReader(`{}`))
-		assert.NilError(t, err)
-		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
-		req.Header.Add("Infra-Version", "0.13.6")
-
-		routes.ServeHTTP(resp, req)
-		assert.Equal(t, resp.Code, http.StatusBadRequest, resp.Body.String())
-
-		respBody := &api.Error{}
-		err = json.Unmarshal(resp.Body.Bytes(), respBody)
-		assert.NilError(t, err)
-
-		expected := []api.FieldError{
-			{Errors: []string{"one of (user, group) is required"}},
-			{FieldName: "privilege", Errors: []string{"is required"}},
-			{FieldName: "resource", Errors: []string{"is required"}},
+		if tc.setup != nil {
+			tc.setup(t, req)
 		}
-		assert.DeepEqual(t, respBody.FieldErrors, expected)
-	})
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+
+		tc.expected(t, resp)
+	}
+
+	testCases := map[string]testCase{
+		"missing required fields": {
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			body: api.CreateGrantRequest{},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusBadRequest, resp.Body.String())
+
+				respBody := &api.Error{}
+				err := json.Unmarshal(resp.Body.Bytes(), respBody)
+				assert.NilError(t, err)
+
+				expected := []api.FieldError{
+					{Errors: []string{"one of (user, group) is required"}},
+					{FieldName: "privilege", Errors: []string{"is required"}},
+					{FieldName: "resource", Errors: []string{"is required"}},
+				}
+				assert.DeepEqual(t, respBody.FieldErrors, expected)
+			},
+		},
+		"success": {
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			body: api.CreateGrantRequest{
+				User:      someUser.ID,
+				Privilege: models.InfraAdminRole,
+				Resource:  "some-cluster",
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusCreated)
+
+				expected := jsonUnmarshal(t, fmt.Sprintf(`
+				{
+					"id": "<any-valid-uid>",
+					"created_by": "%[1]v",
+					"privilege": "%[2]v",
+					"resource": "some-cluster",
+					"user": "%[3]v",
+					"created": "%[4]v",
+					"updated": "%[4]v",
+					"wasCreated": true
+				}`,
+					accessKey.IssuedFor,
+					models.InfraAdminRole,
+					someUser.ID.String(),
+					time.Now().UTC().Format(time.RFC3339),
+				))
+				actual := jsonUnmarshal(t, resp.Body.String())
+				assert.DeepEqual(t, actual, expected, cmpAPIGrantJSON)
+			},
+		},
+		"unprivileged support admin grant": {
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			body: api.CreateGrantRequest{
+				User:      someUser.ID,
+				Privilege: models.InfraSupportAdminRole,
+				Resource:  "infra",
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusForbidden)
+			},
+		},
+		"support admin grant": {
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+supportAccessKeyStr)
+			},
+			body: api.CreateGrantRequest{
+				User:      someUser.ID,
+				Privilege: models.InfraSupportAdminRole,
+				Resource:  "infra",
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusCreated)
+
+				expected := jsonUnmarshal(t, fmt.Sprintf(`
+				{
+					"id": "<any-valid-uid>",
+					"created_by": "%[1]v",
+					"privilege": "%[2]v",
+					"resource": "infra",
+					"user": "%[3]v",
+					"created": "%[4]v",
+					"updated": "%[4]v",
+					"wasCreated": true
+				}`,
+					supportAdmin.ID,
+					models.InfraSupportAdminRole,
+					someUser.ID.String(),
+					time.Now().UTC().Format(time.RFC3339),
+				))
+				actual := jsonUnmarshal(t, resp.Body.String())
+				assert.DeepEqual(t, actual, expected, cmpAPIGrantJSON)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
 }
 
 func TestAPI_DeleteGrant(t *testing.T) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -49,6 +49,14 @@ func withAdminUser(_ *testing.T, opts *Options) {
 	})
 }
 
+func withSupportAdminGrant(_ *testing.T, opts *Options) {
+	opts.Grants = append(opts.Grants, Grant{
+		User:     "admin@example.com",
+		Role:     "support-admin",
+		Resource: "infra",
+	})
+}
+
 func createAdmin(t *testing.T, db *gorm.DB) *models.Identity {
 	user := &models.Identity{
 		Name: "admin+" + generate.MathRandom(10, generate.CharsetAlphaNumeric),

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -155,12 +155,6 @@ func jsonUnmarshal(t *testing.T, raw string) interface{} {
 	return out
 }
 
-func runStep(t *testing.T, name string, fn func(t *testing.T)) {
-	if !t.Run(name, fn) {
-		t.FailNow()
-	}
-}
-
 var cmpAPIUserJSON = gocmp.Options{
 	gocmp.FilterPath(pathMapKey(`created`, `updated`, `lastSeenAt`), cmpApproximateTime),
 	gocmp.FilterPath(pathMapKey(`id`), cmpAnyValidUID),

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	InfraAdminRole     = "admin"
-	InfraViewRole      = "view"
-	InfraConnectorRole = "connector"
+	InfraSupportAdminRole = "support-admin"
+	InfraAdminRole        = "admin"
+	InfraViewRole         = "view"
+	InfraConnectorRole    = "connector"
 )
 
 // BasePermissionConnect is the first-principle permission that all other permissions are defined from.


### PR DESCRIPTION
## Summary

Add a support admin role which is separate from the admin role. This role is specifically for:

* performing CRUD operations on organizations (a normal admin shouldn't be able to do this)
* granting support admin access

This change additionally assigns the org permission on signup, although that will change when the signup endpoint morphs to allow users to create new organizations. It does not add the role for existing admins, since it's difficult to know who to assign the permission to.

Also in this change is a cleanup of the CreateGrant unit test to make it more straight forward, and the Organizations unit tests to remove some unnecessary code.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


