### PR TITLE
fix: rollback postgres db transaction on fail

### DIFF
--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -216,7 +216,7 @@ func TestCreateTransactionError(t *testing.T) {
 
 		// attempt to re-create, which results in a conflict
 		err = add(tx, g)
-		assert.ErrorContains(t, err, "a grant with that id already exists")
+		assert.ErrorContains(t, err, "already exists")
 
 		// the same transaction should still be usable
 		_, err = get[models.Grant](tx, ByID(g.ID))

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -208,10 +208,12 @@ func TestDefaultSortFromType(t *testing.T) {
 func TestCreateTransactionError(t *testing.T) {
 	// on creation error (such as conflict) the database transaction should still be usable
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
-		db.Transaction(func(tx *gorm.DB) error {
+		err := db.Transaction(func(tx *gorm.DB) error {
 			g := &models.Grant{}
 			err := add(tx, g)
-			assert.NilError(t, err)
+			if err != nil {
+				return err
+			}
 
 			// attempt to re-create, which results in a conflict
 			err = add(tx, g)
@@ -219,9 +221,9 @@ func TestCreateTransactionError(t *testing.T) {
 
 			// the same transaction should still be usable
 			_, err = get[models.Grant](tx, ByID(g.ID))
-			assert.NilError(t, err)
-
-			return nil
+			return err
 		})
+
+		assert.NilError(t, err)
 	})
 }

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -193,7 +193,6 @@ func TestPaginationSelector(t *testing.T) {
 		for i, user := range actual {
 			assert.Equal(t, user.Name, letters[i])
 		}
-
 	})
 }
 
@@ -204,4 +203,23 @@ func TestDefaultSortFromType(t *testing.T) {
 	assert.Equal(t, getDefaultSortFromType(new(models.Group)), "name ASC")
 	assert.Equal(t, getDefaultSortFromType(new(models.Provider)), "name ASC")
 	assert.Equal(t, getDefaultSortFromType(new(models.Identity)), "name ASC")
+}
+
+func TestCreateTransactionError(t *testing.T) {
+	// on creation error (such a conflict) the database transaction should still be usable
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		tx := db.Begin()
+
+		g := &models.Grant{}
+		err := add(tx, g)
+		assert.NilError(t, err)
+
+		// attempt to re-create, which results in a conflict
+		err = add(tx, g)
+		assert.ErrorContains(t, err, "a grant with that id already exists")
+
+		// the same transaction should still be usable
+		_, err = get[models.Grant](tx, ByID(g.ID))
+		assert.NilError(t, err)
+	})
 }


### PR DESCRIPTION
- postgres db transaction needs to be rolled back on failure or it can't be re-used to make other database requests

## Summary
Postgres was failing with an internal server error on duplicate grant creation. The reason for this is that Postgres closes the DB transaction on error, but we would then attempt to read the existing grant on the same transaction.

Fix (as suggested by Steven) is to rollback the failed query in the case of a postgres database. 

This replaces the previous PR for the same issue: #2658 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2652
