### PR TITLE
maintain: move expected error to trace level

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -67,10 +67,6 @@ func UseFileLogger(filepath string) {
 	L = newLogger(writer)
 }
 
-func Tracef(format string, v ...interface{}) {
-	L.Trace().Msgf(format, v...)
-}
-
 func Debugf(format string, v ...interface{}) {
 	L.Debug().Msgf(format, v...)
 }

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -67,6 +67,10 @@ func UseFileLogger(filepath string) {
 	L = newLogger(writer)
 }
 
+func Tracef(format string, v ...interface{}) {
+	L.Trace().Msgf(format, v...)
+}
+
 func Debugf(format string, v ...interface{}) {
 	L.Debug().Msgf(format, v...)
 }

--- a/internal/server/providers/oidc.go
+++ b/internal/server/providers/oidc.go
@@ -110,7 +110,7 @@ func (o *oidcClientImplementation) Validate(ctx context.Context) error {
 				return newValidationError("clientSecret")
 			}
 		}
-		logging.Debugf("%s", err.Error())
+		logging.Tracef("validating oidc provider resulted in: %s. this may be expected.", err.Error())
 	}
 
 	// return nil for all other errors, because the request was made with an

--- a/internal/server/providers/oidc.go
+++ b/internal/server/providers/oidc.go
@@ -110,7 +110,7 @@ func (o *oidcClientImplementation) Validate(ctx context.Context) error {
 				return newValidationError("clientSecret")
 			}
 		}
-		logging.Tracef("validating oidc provider resulted in: %s. this may be expected.", err.Error())
+		logging.L.Trace().Err(err).Msg("error validating oidc provider, this is expected")
 	}
 
 	// return nil for all other errors, because the request was made with an


### PR DESCRIPTION
## Summary
I just had a hard time debugging a problem with this error message in the debug logs. Moving the log to trace level with some extra context because an error here is expected and means things are working correctly.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged