### PR TITLE
fix: remove deleted identities from identities_groups

### DIFF
--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -85,12 +85,12 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 
 	groups, err := data.ListGroups(db, nil, data.ByGroupMember(id))
 	if err != nil {
-		return fmt.Errorf("delete identity from groups: %w", err)
+		return fmt.Errorf("list groups for identity: %w", err)
 	}
 	for _, group := range groups {
 		err = data.RemoveUsersFromGroup(db, group.ID, []uid.ID{id})
 		if err != nil {
-			return fmt.Errorf("delete identity from groups: %w", err)
+			return fmt.Errorf("delete group membership for identity: %w", err)
 		}
 	}
 	// if an identity does not have credentials in the Infra provider this won't be found, but we can proceed

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -82,8 +82,8 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	err = data.CreateGrant(db, grantDestination)
 	assert.NilError(t, err)
 
-	group := models.Group{Name: "Group"}
-	err = data.CreateGroup(db, &group)
+	group := &models.Group{Name: "Group"}
+	err = data.CreateGroup(db, group)
 	assert.NilError(t, err)
 	err = data.AddUsersToGroup(db, group.ID, []uid.ID{identity.ID})
 	assert.NilError(t, err)
@@ -105,7 +105,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(grants), 0)
 
-	group, err := data.GetGroup(db, data.ByID(groups[0].ID))
+	group, err = data.GetGroup(db, data.ByID(group.ID))
 	assert.NilError(t, err)
 	assert.Equal(t, group.TotalUsers, 0)
 }

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -82,11 +82,10 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	err = data.CreateGrant(db, grantDestination)
 	assert.NilError(t, err)
 
-	err = data.CreateGroup(db, &models.Group{Name: "Group"})
+	group := models.Group{Name: "Group"}
+	err = data.CreateGroup(db, &group)
 	assert.NilError(t, err)
-	groups, err := data.ListGroups(db, nil)
-	assert.NilError(t, err)
-	err = data.AddUsersToGroup(db, groups[0].ID, []uid.ID{identity.ID})
+	err = data.AddUsersToGroup(db, group.ID, []uid.ID{identity.ID})
 	assert.NilError(t, err)
 
 	// delete the identity, and make sure all their resources are gone

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -124,6 +124,18 @@ func DeleteIdentities(db *gorm.DB, selectors ...SelectorFunc) error {
 		if err != nil {
 			return err
 		}
+
+		groups, err := ListGroups(db, nil, ByGroupMember(i.ID))
+		if err != nil {
+			return err
+		}
+
+		for _, group := range groups {
+			err = RemoveUsersFromGroup(db, group.ID, []uid.ID{i.ID})
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return deleteAll[models.Identity](db, ByIDs(ids))

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -50,6 +50,7 @@ func migrations() []*migrator.Migration {
 		setDestinationLastSeenAt(),
 		deleteDuplicateGrants(),
 		dropDeletedProviderUsers(),
+		removeDeletedIdentitiesFromGroups(),
 		// next one here
 	}
 }
@@ -210,6 +211,17 @@ func dropDeletedProviderUsers() *migrator.Migration {
 				return tx.Migrator().DropColumn(&models.ProviderUser{}, "deleted_at")
 			}
 			return nil
+		},
+	}
+}
+<<<<<<< HEAD
+=======
+
+func removeDeletedIdentitiesFromGroups() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-07-28T12:46",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.Exec("DELETE FROM identities_groups WHERE identity_id in (SELECT id FROM identities WHERE deleted_at IS NOT NULL)").Error
 		},
 	}
 }

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -214,8 +214,6 @@ func dropDeletedProviderUsers() *migrator.Migration {
 		},
 	}
 }
-<<<<<<< HEAD
-=======
 
 func removeDeletedIdentitiesFromGroups() *migrator.Migration {
 	return &migrator.Migration{


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->
Deleted users were still showing up in the `identities_groups` table, as though they still had group membership. This caused `group.UserCount` to be off.

This change removes users from all groups on user deletion and adds a migration to remove previously deleted users from groups.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2766 
