### PR TITLE
feat: truncate users in `infra groups list`

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -438,6 +438,13 @@ List groups
 infra groups list [flags]
 ```
 
+#### Options
+
+```
+      --no-truncate     Do not truncate the list of users for each group
+      --num-users int   The number of users to display in each group (default 8)
+```
+
 #### Options inherited from parent commands
 
 ```

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -63,7 +63,7 @@ func newGroupsCmd(cli *CLI) *cobra.Command {
 
 func newGroupsListCmd(cli *CLI) *cobra.Command {
 	var noTruncate bool
-	const truncateCount int = 8
+	var numUsers int
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -95,9 +95,9 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 					if err != nil {
 						return err
 					}
-				} else {
+				} else if numUsers != 0 {
 					userRes, err := client.ListUsers(api.ListUsersRequest{
-						PaginationRequest: api.PaginationRequest{Limit: truncateCount},
+						PaginationRequest: api.PaginationRequest{Limit: numUsers},
 						Group:             group.ID,
 					})
 					if err != nil {
@@ -111,7 +111,7 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 					userNames = append(userNames, user.Name)
 				}
 
-				if !noTruncate && group.TotalUsers > truncateCount {
+				if !noTruncate && group.TotalUsers > numUsers {
 					userNames = append(userNames, "...")
 				}
 
@@ -132,6 +132,7 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&noTruncate, "no-truncate", false, "Do not truncate the list of users for each group")
+	cmd.Flags().IntVar(&numUsers, "num-users", 8, "The number of users to display in each group")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

In order to prevent clutter when running infra groups list, this change limits the number of users displayed for each group (by default 8). For this reason, I also added a `COUNT` column so users can easily see how many users are in a group.

The change also adds two flags: `--no-truncate`, which keeps the old behavior and `--num-users` which changes the limit.

https://github.com/infrahq/infra/pull/2767 should be merged in the same release in order to fix the `COUNT` field. We also should consider adding an easy way to list all users in a group (i.e. `infra users list --group Engineering`)


## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2762 
