### PR TITLE
feat: `infra` shell completion

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -743,7 +743,7 @@ infra about [flags]
 ```
 ### `infra completion`
 
-Generate completions
+Generate shell auto-completion for the CLI
 
 #### Description
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -741,3 +741,59 @@ infra about [flags]
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
+### `infra completion`
+
+Generate completions
+
+#### Description
+
+To load completions:
+
+Bash:
+
+  $ source <(infra completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ infra completion bash > /etc/bash_completion.d/infra
+  # macOS:
+  $ infra completion bash > /usr/local/etc/bash_completion.d/infra
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ infra completion zsh > "${fpath[1]}/_infra"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ infra completion fish | source
+
+  # To load completions for each session, execute once:
+  $ infra completion fish > ~/.config/fish/completions/infra.fish
+
+PowerShell:
+
+  PS> infra completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> infra completion powershell > infra.ps1
+  # and source this file from your PowerShell profile.
+
+
+```
+infra completion
+```
+
+#### Options inherited from parent commands
+
+```
+      --help               Display help
+      --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
+```

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -287,6 +287,7 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 
 	rootCmd.SetHelpCommandGroup("Other commands:")
 	rootCmd.AddCommand(newAboutCmd())
+	rootCmd.AddCommand(newCompletionsCmd())
 	rootCmd.SetUsageTemplate(usageTemplate())
 	return rootCmd
 }

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -53,17 +54,23 @@ PowerShell:
 		DisableFlagsInUseLine: true,
 		Group:                 "Other commands:",
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.ExactValidArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			switch args[0] {
+			shell := filepath.Base(os.Getenv("SHELL"))
+			if len(args) > 0 {
+				shell = args[0]
+			}
+
+			switch shell {
 			case "bash":
-				cmd.Root().GenBashCompletion(os.Stdout)
+				cmd.Root().GenBashCompletion(os.Stdout) // nolint
 			case "zsh":
-				cmd.Root().GenZshCompletion(os.Stdout)
+				cmd.Root().GenZshCompletion(os.Stdout) // nolint
 			case "fish":
-				cmd.Root().GenFishCompletion(os.Stdout, true)
+				cmd.Root().GenFishCompletion(os.Stdout, true) // nolint
 			case "powershell":
-				cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+				cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout) // nolint
+			default:
+				fmt.Fprintf(os.Stdout, "No completions found for specified shell.\n")
 			}
 		},
 	}

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -11,7 +11,7 @@ import (
 func newCompletionsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "completion",
-		Short: "Generate completions",
+		Short: "Generate shell auto-completion for the CLI",
 		Long: fmt.Sprintf(`To load completions:
 
 Bash:

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompletionsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "completion",
+		Short: "Generate completions",
+		Long: fmt.Sprintf(`To load completions:
+
+Bash:
+
+  $ source <(%[1]s completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ %[1]s completion bash > /etc/bash_completion.d/%[1]s
+  # macOS:
+  $ %[1]s completion bash > /usr/local/etc/bash_completion.d/%[1]s
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ %[1]s completion fish | source
+
+  # To load completions for each session, execute once:
+  $ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
+
+PowerShell:
+
+  PS> %[1]s completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> %[1]s completion powershell > %[1]s.ps1
+  # and source this file from your PowerShell profile.
+`, `infra`),
+		DisableFlagsInUseLine: true,
+		Group:                 "Other commands:",
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactValidArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Adds shell completion using the [default code provided by cobra](https://github.com/spf13/cobra/blob/main/shell_completions.md) which adds static completion of commands. Dynamic completion could be added if wanted.

Note, the command couldn't be auto-generated in order to add it to the `Other commands` group.
## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #252 
