### PR TITLE
feat: add default org prompt

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -7,12 +7,14 @@ type SignupEnabledResponse struct {
 }
 
 type SignupRequest struct {
+	OrgName  string `json:"orgName"`
 	Name     string `json:"name"`
 	Password string `json:"password"`
 }
 
 func (r SignupRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
+		validate.Required("orgName", r.OrgName),
 		validate.Required("name", r.Name),
 		validate.Required("password", r.Password),
 		validate.Email("name", r.Name),

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -45,7 +45,7 @@ func SignupEnabled(c *gin.Context) (bool, error) {
 
 // Signup creates a user identity using the supplied name and password and
 // grants the identity "admin" access to Infra.
-func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
+func Signup(c *gin.Context, orgName, name, password string) (*models.Identity, error) {
 	// no authorization is setup yet
 	db := getDB(c)
 
@@ -54,9 +54,14 @@ func Signup(c *gin.Context, name, password string) (*models.Identity, error) {
 		return nil, err
 	}
 
-	identity := &models.Identity{Name: name}
+	organization := &models.Organization{Name: orgName}
+	if err := data.CreateOrganization(db, organization); err != nil {
+		return nil, err
+	}
 
-	if err := data.CreateIdentity(db, identity); err != nil {
+	identity := &models.Identity{Name: name}
+	identity.OrganizationID = organization.ID
+	if err = data.CreateIdentity(db, identity); err != nil {
 		return nil, err
 	}
 

--- a/internal/access/signup_test.go
+++ b/internal/access/signup_test.go
@@ -93,6 +93,7 @@ func TestSignupEnabled(t *testing.T) {
 		assert.Assert(t, !enabled)
 	})
 
+	orgName := "Test Org"
 	user := "admin@infrahq.com"
 	pass := "password"
 
@@ -103,7 +104,7 @@ func TestSignupEnabled(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, enabled, true)
 
-		identity, err := Signup(c, user, pass)
+		identity, err := Signup(c, orgName, user, pass)
 		assert.NilError(t, err)
 		assert.Equal(t, identity.Name, user)
 

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -60,6 +60,8 @@ func TestLoginCmd_SetupAdminOnFirstLogin(t *testing.T) {
 		})
 
 		exp := expector{console: console}
+		exp.ExpectString(t, "Organization Name:")
+		exp.Send(t, "Test Org\n")
 		exp.ExpectString(t, "Email:")
 		exp.Send(t, "admin@example.com\n")
 		exp.ExpectString(t, "Password")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -116,7 +116,7 @@ func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.User, error) {
 		return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)
 	}
 
-	identity, err := access.Signup(c, r.Name, r.Password)
+	identity, err := access.Signup(c, r.OrgName, r.Name, r.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -326,11 +326,12 @@ func TestServer_PersistSignupUser(t *testing.T) {
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
 	var buf bytes.Buffer
+	orgName := "Test Org"
 	email := "admin@email.com"
 	passwd := "supersecretpassword"
 
 	// run signup for "admin@email.com"
-	signupReq := api.SignupRequest{Name: email, Password: passwd}
+	signupReq := api.SignupRequest{OrgName: orgName, Name: email, Password: passwd}
 	err := json.NewEncoder(&buf).Encode(signupReq)
 	assert.NilError(t, err)
 

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -50,6 +50,7 @@ func TestAPI_Signup(t *testing.T) {
 
 				expected := []api.FieldError{
 					{FieldName: "name", Errors: []string{"is required"}},
+					{FieldName: "orgName", Errors: []string{"is required"}},
 					{FieldName: "password", Errors: []string{"is required"}},
 				}
 				assert.DeepEqual(t, respBody.FieldErrors, expected)

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -4275,11 +4275,15 @@
                     "format": "email",
                     "type": "string"
                   },
+                  "orgName": {
+                    "type": "string"
+                  },
                   "password": {
                     "type": "string"
                   }
                 },
                 "required": [
+                  "orgName",
                   "name",
                   "password"
                 ],


### PR DESCRIPTION
## Summary

This changes the initial sign-in to ask for an Organization name. The sign-up flow for other organizations will still change after this, but this at least provides an initial org (and is backward compatible to single orgs).

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades
