### PR TITLE
maintain: clarity around google group sync id

### DIFF
--- a/docs/identity-providers/google.md
+++ b/docs/identity-providers/google.md
@@ -48,7 +48,8 @@ infra providers add google \
     ![OAuth client details](../images/google-setup/connect-users-google-6.png)
 7. Remaining on the **APIs and Services > Credentials** dashboard and click **Create credentials > Service account**.
     ![Create service account](../images/google-setup/connect-users-google-7.png)
-    - Enter a **Service account ID** and note the service account's email. Click **Done** and finish creating the service account.
+    - Enter a **Service account ID** then click **Done**.
+    - Click on the service account you just created to view the **Service account details**. Note the service account's **Unique ID**, this will be used in step 10. 
 8. Navigate to **APIs and Services > Enabled APIs & services**.
   - Click **ENABLE APIS AND SERVICES**.
   - Search for **Admin SDK API**.
@@ -63,5 +64,5 @@ infra providers add google \
 10. You are now finished with configuration in the Google Cloud admin console. Open the Google Workspace admin console and navigate to **Security > API Controls > Domain-wide Delegation**.
   ![API controls](../images/google-setup/connect-users-google-10.png)
   - Click **Add new**.
-  - For **Client ID** enter the client ID noted in step 6.
+  - For **Client ID** enter the service account's unique ID noted in step 6.
   - For **OAuth scopes** enter **https://www.googleapis.com/auth/admin.directory.group.readonly**.


### PR DESCRIPTION
## Summary
The client ID to use in the final step of Google provider sync setup was confusing. Update the docs to make it more understandable. 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged