### PR TITLE
Add a test case to show that initial schema matches a migrated schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.3.1 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.11.0 // indirect
-	github.com/jackc/pgx/v4 v4.16.1 // indirect
+	github.com/jackc/pgx/v4 v4.16.1
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -42,13 +42,6 @@ func NewDB(connection gorm.Dialector, loadDBKey func(db *gorm.DB) error) (*gorm.
 		return nil, fmt.Errorf("migration failed: %w", err)
 	}
 
-	// Call initializeSchema again to apply implicit migrations handled by
-	// gorm.AutoMigrate. In the future we will replace this call with
-	// explicit migrations for all database changes.
-	if err := initializeSchema(db); err != nil {
-		return nil, fmt.Errorf("auto-migrate failed: %w", err)
-	}
-
 	return db, nil
 }
 

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -52,7 +52,7 @@ func dbDrivers(t *testing.T) []gorm.Dialector {
 		db, err := gorm.Open(pgsql)
 		assert.NilError(t, err, "connect to postgresql")
 		t.Cleanup(func() {
-			assert.NilError(t, db.Exec("DROP SCHEMA testing CASCADE").Error)
+			assert.NilError(t, db.Exec("DROP SCHEMA IF EXISTS testing CASCADE").Error)
 		})
 		assert.NilError(t, db.Exec("CREATE SCHEMA testing").Error)
 

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -51,26 +51,26 @@ func migrations() []*migrator.Migration {
 		deleteDuplicateGrants(),
 		dropDeletedProviderUsers(),
 		removeDeletedIdentitiesFromGroups(),
+		addFieldsFor_0_14_3(),
 		// next one here
 	}
 }
 
 func initializeSchema(db *gorm.DB) error {
 	tables := []interface{}{
-		&models.Identity{},
+		&models.ProviderUser{},
 		&models.Group{},
-		&models.Grant{},
+		&models.Identity{},
 		&models.Provider{},
+		&models.Grant{},
 		&models.Destination{},
 		&models.AccessKey{},
 		&models.Settings{},
 		&models.EncryptionKey{},
 		&models.Credential{},
-		&models.ProviderUser{},
 		&models.Organization{},
 		&models.PasswordResetToken{},
 	}
-
 	for _, table := range tables {
 		if err := db.AutoMigrate(table); err != nil {
 			return err
@@ -220,6 +220,87 @@ func removeDeletedIdentitiesFromGroups() *migrator.Migration {
 		ID: "2022-07-28T12:46",
 		Migrate: func(tx *gorm.DB) error {
 			return tx.Exec("DELETE FROM identities_groups WHERE identity_id in (SELECT id FROM identities WHERE deleted_at IS NOT NULL)").Error
+		},
+	}
+}
+
+// addFieldsFor_0_14_3 adds all migrations that were previously applied by a
+// second call to gorm.AutoMigrate. In this release we're removing the
+// unconditional call to gorm.AutoMigrate in favor of having explicit migrations
+// for all changes.
+//
+// To account for all the existing migrations that were applied by AutoMigrate
+// we have to call it here again on any tables that have had changes.
+//
+// In the future we should use ALTER TABLE sql statements instead of AutoMigrate.
+//
+// nolint:revive
+func addFieldsFor_0_14_3() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-07-21T18:28",
+		Migrate: func(tx *gorm.DB) error {
+			if err := tx.AutoMigrate(&models.Provider{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&models.Settings{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&models.Organization{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&models.AccessKey{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&models.Credential{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&models.Destination{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&models.ProviderUser{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&models.Group{}); err != nil {
+				return err
+			}
+			if err := tx.AutoMigrate(&models.PasswordResetToken{}); err != nil {
+				return err
+			}
+
+			if err := tx.Exec(`
+ALTER TABLE credentials DROP COLUMN IF EXISTS one_time_password_used;
+
+ALTER TABLE provider_users DROP COLUMN IF EXISTS id;
+ALTER TABLE provider_users DROP COLUMN IF EXISTS created_at;
+ALTER TABLE provider_users DROP COLUMN IF EXISTS updated_at;
+`).Error; err != nil {
+				return err
+			}
+
+			if !tx.Migrator().HasConstraint("provider_users", "provider_users_pkey") {
+				if err := tx.Exec(`
+ALTER TABLE ONLY provider_users
+	ADD CONSTRAINT fk_provider_users_identity FOREIGN KEY (identity_id) REFERENCES identities(id);
+
+ALTER TABLE ONLY provider_users
+	ADD CONSTRAINT fk_provider_users_provider FOREIGN KEY (provider_id) REFERENCES providers(id);
+
+ALTER TABLE provider_users ADD CONSTRAINT provider_users_pkey
+	PRIMARY KEY (identity_id, provider_id);
+
+`).Error; err != nil {
+					return err
+				}
+			}
+
+			if !tx.Migrator().HasIndex("grants", "idx_grant_srp") {
+				stmt := `CREATE UNIQUE INDEX idx_grant_srp ON testing.grants USING btree (subject, privilege, resource) WHERE (deleted_at IS NULL);`
+				if err := tx.Exec(stmt).Error; err != nil {
+					return err
+				}
+			}
+
+			return nil
 		},
 	}
 }

--- a/internal/server/data/testdata/migrations/202204281130-postgres.sql
+++ b/internal/server/data/testdata/migrations/202204281130-postgres.sql
@@ -282,8 +282,8 @@ ALTER TABLE identities OWNER TO postgres;
 --
 
 CREATE TABLE identities_groups (
-    group_id bigint NOT NULL,
-    identity_id bigint NOT NULL
+    identity_id bigint NOT NULL,
+    group_id bigint NOT NULL
 );
 
 
@@ -330,8 +330,8 @@ CREATE TABLE provider_users (
     created_at timestamp with time zone,
     updated_at timestamp with time zone,
     deleted_at timestamp with time zone,
-    provider_id bigint,
     identity_id bigint,
+    provider_id bigint,
     email text,
     groups text,
     last_update timestamp with time zone,
@@ -679,7 +679,7 @@ ALTER TABLE ONLY groups
 --
 
 ALTER TABLE ONLY identities_groups
-    ADD CONSTRAINT identities_groups_pkey PRIMARY KEY (group_id, identity_id);
+    ADD CONSTRAINT identities_groups_pkey PRIMARY KEY (identity_id, group_id);
 
 
 --

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -22,7 +22,6 @@ type AccessKey struct {
 	IssuedFor         uid.ID
 	IssuedForIdentity *Identity `gorm:"foreignKey:IssuedFor"`
 	ProviderID        uid.ID
-	Scopes            CommaSeparatedStrings // if set, scopes limit what the key can be used for
 
 	ExpiresAt         time.Time
 	Extension         time.Duration // how long to increase the lifetime extension deadline by
@@ -31,6 +30,8 @@ type AccessKey struct {
 	KeyID          string `gorm:"<-;uniqueIndex:idx_access_keys_key_id,where:deleted_at is NULL"`
 	Secret         string `gorm:"-"`
 	SecretChecksum []byte
+
+	Scopes CommaSeparatedStrings // if set, scopes limit what the key can be used for
 }
 
 func (ak *AccessKey) ToAPI() *api.AccessKey {

--- a/internal/server/models/destination.go
+++ b/internal/server/models/destination.go
@@ -9,14 +9,13 @@ import (
 type Destination struct {
 	Model
 
-	Name       string
-	UniqueID   string `gorm:"uniqueIndex:idx_destinations_unique_id,where:deleted_at is NULL"`
-	LastSeenAt time.Time
-
-	Version string
-
+	Name          string
+	UniqueID      string `gorm:"uniqueIndex:idx_destinations_unique_id,where:deleted_at is NULL"`
 	ConnectionURL string
 	ConnectionCA  string
+
+	LastSeenAt time.Time
+	Version    string
 
 	Resources CommaSeparatedStrings
 	Roles     CommaSeparatedStrings

--- a/internal/server/models/organization.go
+++ b/internal/server/models/organization.go
@@ -10,8 +10,6 @@ type Organization struct {
 
 	Name      string `gorm:"uniqueIndex:idx_organizations_name,where:deleted_at is NULL"`
 	CreatedBy uid.ID
-
-	Identities []Identity `gorm:"many2many:identities_organizations"`
 }
 
 func (o *Organization) ToAPI() *api.Organization {

--- a/internal/server/models/provider.go
+++ b/internal/server/models/provider.go
@@ -46,13 +46,13 @@ type Provider struct {
 	Model
 
 	Name         string `gorm:"uniqueIndex:idx_providers_name,where:deleted_at is NULL"`
-	Kind         ProviderKind
 	URL          string
 	ClientID     string
 	ClientSecret EncryptedAtRest
+	CreatedBy    uid.ID
+	Kind         ProviderKind
 	AuthURL      string
 	Scopes       CommaSeparatedStrings
-	CreatedBy    uid.ID
 
 	// fields used to directly query an external API
 	PrivateKey       EncryptedAtRest

--- a/internal/server/models/provideruser.go
+++ b/internal/server/models/provideruser.go
@@ -8,8 +8,8 @@ import (
 
 // ProviderUser is a cache of the provider's user and their groups, plus any authentication-specific information for that provider.
 type ProviderUser struct {
-	ProviderID uid.ID `gorm:"primaryKey"`
 	IdentityID uid.ID `gorm:"primaryKey"`
+	ProviderID uid.ID `gorm:"primaryKey"`
 
 	Email      string
 	Groups     CommaSeparatedStrings


### PR DESCRIPTION
## Summary


This PR removes the second call to gorm.AutoMigrate, and adds a test to show that the initial schema matches the migrated schema.

From now on all migrations must be explicit, no more auto-creating of columns or constraints using AutoMigrate.

The migration test is updated to dump both the initial schema and the migrated schema, to ensure that they match.

Removing this extra call to AutoMigrate required making a few changes:

* Add migrations that were previously done implicitly by the calls to AutoMigrate.

* For some reason the schema file we use for migrations has composite primary keys and columns in a different order from the initial schema. I guess gorm.AutoMigrate changes the order based on something in the code. I attempted to re-order the list of tables in `initializeSchema` many times, but none of the orders were able to reproduce the exactly correct result. Some problems were fixed, and a couple were not. So for now I made some small changes to the saved schema which allows the test to pass.

* Also re-order the list in initializeSchema to have it match the migrated schema.

* Also re-order some fields in the models struct, so that they match the order in the migrated schema.

## Related Issues

Related to https://github.com/infrahq/infra/issues/2768