### PR TITLE
api: Validate org name using ValidateName

### DIFF
--- a/api/organization.go
+++ b/api/organization.go
@@ -30,6 +30,7 @@ type CreateOrganizationRequest struct {
 func (r CreateOrganizationRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.Required("name", r.Name),
+		ValidateName(r.Name),
 	}
 }
 

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -3291,6 +3291,9 @@
               "schema": {
                 "properties": {
                   "name": {
+                    "format": "[a-zA-Z0-9\\-_.]",
+                    "maxLength": 256,
+                    "minLength": 2,
                     "type": "string"
                   }
                 },


### PR DESCRIPTION
## Summary

To be consistent with (most) other names in our API.