### PR TITLE
fix: data migration of group index name

### DIFF
--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -37,11 +37,11 @@ func migrations() []*migrator.Migration {
 				return nil
 			},
 		},
+		// drop old Groups index; new index will be created automatically
 		{
-			ID: "202206081027",
+			ID: "2022-06-08T10:27-fixed",
 			Migrate: func(tx *gorm.DB) error {
-				_ = tx.Migrator().DropConstraint(&models.Group{}, "idx_groups_name_provider_id")
-				return nil
+				return tx.Exec(`DROP INDEX IF EXISTS idx_groups_name_provider_id`).Error
 			},
 		},
 		addKindToProviders(),

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -89,7 +89,7 @@ func TestMigrations(t *testing.T) {
 			},
 		},
 		{
-			label: testCaseLine("202206081027"),
+			label: testCaseLine("2022-06-08T10:27-fixed"),
 			expected: func(t *testing.T, db *gorm.DB) {
 				// dropped constraints are tested by schema comparison
 			},


### PR DESCRIPTION
## Summary

I extracted this fix from #2804 so it can be reviewed directly.

This was a bug in one of our existing migrations. I guess we never noticed because we ignored the error. The test that was added in #2804 noticed the problem. The thing being removed is an index, not a constraint.

I fixed this in place, but changed the name of the migration. This will act like a new migration and run for everyone. But it should check if the index exists first, so it will be a no-op for anyone who doesn't have this index.

I'll cherry-pick this fix back into #2804 which has test coverage for it.