### PR TITLE
fix: add missing middleware next

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -190,6 +190,7 @@ func unauthenticatedMiddleware() gin.HandlerFunc {
 			DBTxn:   getDB(c),
 		}
 		c.Set(access.RequestContextKey, rCtx)
+		c.Next()
 	}
 }
 


### PR DESCRIPTION
## Summary

I'm not sure how this middleware is working without this. I guess maybe none of the unauthenticated routes use the new `RequestContext`, so it's silently doing nothing?

This started failing tests when I added more things to this middleware, and adding the `c.Next` fixed it. 

Not sure how to reproduce with a test with the current code.