### PR TITLE
api: consolidate DatabaseMiddleware into other middleware

### DIFF
--- a/internal/access/settings.go
+++ b/internal/access/settings.go
@@ -3,16 +3,14 @@ package access
 import (
 	"fmt"
 
-	"github.com/gin-gonic/gin"
 	"gopkg.in/square/go-jose.v2"
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func GetPublicJWK(c *gin.Context) ([]jose.JSONWebKey, error) {
-	db := getDB(c)
-	settings, err := data.GetSettings(db)
+func GetPublicJWK(c RequestContext) ([]jose.JSONWebKey, error) {
+	settings, err := data.GetSettings(c.DBTxn)
 	if err != nil {
 		return nil, fmt.Errorf("could not get JWKs: %w", err)
 	}

--- a/internal/access/settings.go
+++ b/internal/access/settings.go
@@ -3,6 +3,7 @@ package access
 import (
 	"fmt"
 
+	"github.com/gin-gonic/gin"
 	"gopkg.in/square/go-jose.v2"
 
 	"github.com/infrahq/infra/internal/server/data"

--- a/internal/server/authn_test.go
+++ b/internal/server/authn_test.go
@@ -11,12 +11,15 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/uid"
 )
 
 func TestServerLimitsAccessWithTemporaryPassword(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes((prometheus.NewRegistry()))
+	_, err := data.InitializeSettings(srv.db)
+	assert.NilError(t, err)
 
 	// create a user
 	resp := createUser(t, srv, routes, "hubert@example.com")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin"
 	"github.com/infrahq/secrets"
+	"gopkg.in/square/go-jose.v2"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
@@ -45,6 +46,20 @@ func (a *API) CreateToken(c *gin.Context, r *api.EmptyRequest) (*api.CreateToken
 	}
 
 	return nil, fmt.Errorf("%w: no identity found in access key", internal.ErrUnauthorized)
+}
+
+type WellKnownJWKResponse struct {
+	Keys []jose.JSONWebKey `json:"keys"`
+}
+
+func wellKnownJWKsHandler(c *gin.Context, _ *api.EmptyRequest) (WellKnownJWKResponse, error) {
+	rCtx := getRequestContext(c)
+	keys, err := access.GetPublicJWK(rCtx)
+	if err != nil {
+		return WellKnownJWKResponse{}, err
+	}
+
+	return WellKnownJWKResponse{Keys: keys}, nil
 }
 
 func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api.ListResponse[api.AccessKey], error) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -3,12 +3,15 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
@@ -159,3 +162,77 @@ var cmpAPIUserJSON = gocmp.Options{
 	gocmp.FilterPath(pathMapKey(`created`, `updated`, `lastSeenAt`), cmpApproximateTime),
 	gocmp.FilterPath(pathMapKey(`id`), cmpAnyValidUID),
 }
+
+func TestWellKnownKWKs(t *testing.T) {
+	srv := setupServer(t, withAdminUser, withSupportAdminGrant)
+	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+
+	_, err := data.InitializeSettings(srv.db)
+	assert.NilError(t, err)
+
+	type testCase struct {
+		name     string
+		expected func(t *testing.T, resp *httptest.ResponseRecorder)
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		req, err := http.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
+		assert.NilError(t, err)
+		req.Header.Set("Infra-Version", apiVersionLatest)
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+
+		tc.expected(t, resp)
+	}
+
+	testCases := []testCase{
+		{
+			name: "success",
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+
+				body := jsonUnmarshal(t, resp.Body.String())
+				expected := map[string]any{
+					"keys": []any{
+						map[string]any{
+							"alg": "ED25519",
+							"crv": "Ed25519",
+							"kty": "OKP",
+							"use": "sig",
+							"kid": "<any-string>",
+							"x":   "<any-string>",
+						},
+					},
+				}
+				assert.DeepEqual(t, body, expected, cmpWellKnownJWKsJSON)
+			},
+		},
+		// TODO(orgs): add test case with other org
+		// TODO(orgs): add test case with non-existent org
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+var cmpWellKnownJWKsJSON = gocmp.Options{
+	gocmp.FilterPath(pathMapKey(`kid`, `x`), cmpAnyString),
+}
+
+// cmpAnyString is a gocmp.Option that allows a field to match any non-zero string.
+var cmpAnyString = gocmp.Comparer(func(x, y interface{}) bool {
+	xs, _ := x.(string)
+	ys, _ := y.(string)
+
+	if xs == "" || ys == "" {
+		return false
+	}
+	if xs == "<any-string>" || ys == "<any-string>" {
+		return true
+	}
+	return xs == ys
+})

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -99,7 +99,7 @@ func TestDBTimeout(t *testing.T) {
 			c.Set("ctx", ctx)
 			c.Next()
 		},
-		DatabaseMiddleware(db),
+		unauthenticatedMiddleware(db),
 	)
 	router.GET("/", func(c *gin.Context) {
 		db, ok := c.MustGet("db").(*gorm.DB)

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -33,10 +33,6 @@ func setupDB(t *testing.T) *gorm.DB {
 
 	// create the provider if it's missing.
 	data.InfraProvider(db)
-
-	err = data.SaveSettings(db, &models.Settings{})
-	assert.NilError(t, err)
-
 	return db
 }
 

--- a/internal/server/passwordreset_test.go
+++ b/internal/server/passwordreset_test.go
@@ -19,6 +19,8 @@ import (
 func TestPasswordResetFlow(t *testing.T) {
 	s := setupServer(t)
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
+	_, err := data.InitializeSettings(s.db)
+	assert.NilError(t, err)
 
 	email.TestMode = true
 
@@ -26,7 +28,7 @@ func TestPasswordResetFlow(t *testing.T) {
 		Name: "skeletor@example.com",
 	}
 
-	err := data.CreateIdentity(s.db, user)
+	err = data.CreateIdentity(s.db, user)
 	assert.NilError(t, err)
 
 	err = data.CreateCredential(s.db, &models.Credential{

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -53,12 +53,9 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	)
 
 	// This group of middleware only applies to non-ui routes
-	apiGroup := router.Group("/",
-		metrics.Middleware(promRegistry),
-		DatabaseMiddleware(a.server.db), // must be after TimeoutMiddleware to time out db queries.
-	)
+	apiGroup := router.Group("/", metrics.Middleware(promRegistry))
 
-	authn := apiGroup.Group("/", authenticatedMiddleware())
+	authn := apiGroup.Group("/", authenticatedMiddleware(a.server.db))
 
 	get(a, authn, "/api/users", a.ListUsers)
 	post(a, authn, "/api/users", a.CreateUser)
@@ -102,7 +99,7 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	authn.GET("/api/debug/pprof/*profile", pprofHandler)
 
 	// these endpoints do not require authentication
-	noAuthn := apiGroup.Group("/", unauthenticatedMiddleware())
+	noAuthn := apiGroup.Group("/", unauthenticatedMiddleware(a.server.db))
 	get(a, noAuthn, "/api/signup", a.SignupEnabled)
 	post(a, noAuthn, "/api/signup", a.Signup)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -329,6 +329,8 @@ func TestServer_PersistSignupUser(t *testing.T) {
 		opts.SessionExtensionDeadline = time.Minute
 	})
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
+	_, err := data.InitializeSettings(s.db)
+	assert.NilError(t, err)
 
 	var buf bytes.Buffer
 	email := "admin@email.com"
@@ -336,7 +338,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 
 	// run signup for "admin@email.com"
 	signupReq := api.SignupRequest{Name: email, Password: passwd}
-	err := json.NewEncoder(&buf).Encode(signupReq)
+	err = json.NewEncoder(&buf).Encode(signupReq)
 	assert.NilError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/signup", &buf)

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -540,6 +540,9 @@ func TestAPI_CreateUser(t *testing.T) {
 // Note this test is the result of a long conversation, don't change lightly.
 func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 	db := setupDB(t)
+	_, err := data.InitializeSettings(db)
+	assert.NilError(t, err)
+
 	a := &API{server: &Server{db: db}}
 	admin := createAdmin(t, db)
 
@@ -731,9 +734,11 @@ func TestAPI_DeleteUser(t *testing.T) {
 func TestAPI_UpdateUser(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	_, err := data.InitializeSettings(srv.db)
+	assert.NilError(t, err)
 
 	user := &models.Identity{Name: "salsa@example.com"}
-	err := data.CreateIdentity(srv.db, user)
+	err = data.CreateIdentity(srv.db, user)
 	assert.NilError(t, err)
 
 	type testCase struct {


### PR DESCRIPTION
## Summary

This PR consolidates `DatabaseMiddleware` into the existing `authenticatedMiddleware` and `unauthenticatedMiddleware`. This removes the need for these middleware to fetch the txn from `gin.Context`, they can use the txn directly.

This is the first step to fixing #2697. We'll need to do one of the following next, both of which require this change. Either we
1. use one txn for middleware, and a separate one for handlers. The txn for handlers would be managed from `wrappedHandler`.  This is my preference because it allows us to use different read modes, and isolation modes for the middleware and the handler.
2. use a single txn for both middleware and handlers, which would require moving the `(un)authenticatedMiddleware` into `wrappedHandler`. I think integrating those two is nice either way, but I like keeping separate txn.

Best viewed by individual commit.

## Related Issues

This moves us closer to being able to fix issue #2697
Related to https://github.com/infrahq/internal/issues/19
