### PR TITLE
fix(helm): use config http(s) addrs

### DIFF
--- a/helm/charts/infra/templates/NOTES.txt
+++ b/helm/charts/infra/templates/NOTES.txt
@@ -29,7 +29,7 @@
 
   Start a port forward:
 
-  $ kubectl -n {{ .Release.Namespace }} port-forward deployments/{{ include "server.fullname" . }} 8080:80 8443:443
+  $ kubectl -n {{ .Release.Namespace }} port-forward deployments/{{ include "server.fullname" . }} 8080:{{ .Values.server.config.addr.http }} 8443:{{ .Values.server.config.addr.https }}
 
   Then visit:
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Instructions for ClusterIP infra-server port-forward does not reference the ports configured by the server.