### PR TITLE
data: add safeguard for comma separated strings

### DIFF
--- a/internal/server/models/types.go
+++ b/internal/server/models/types.go
@@ -2,33 +2,9 @@ package models
 
 import (
 	"database/sql/driver"
-	"encoding/base64"
 	"fmt"
 	"strings"
 )
-
-type Base64 []byte
-
-func (f Base64) Value() (driver.Value, error) {
-	r := base64.StdEncoding.EncodeToString([]byte(f))
-
-	return r, nil
-}
-
-func (f *Base64) Scan(v interface{}) error {
-	b, err := base64.StdEncoding.DecodeString(string(v.(string)))
-	if err != nil {
-		return fmt.Errorf("base64 decoding field: %w", err)
-	}
-
-	*f = Base64(b)
-
-	return nil
-}
-
-func (f Base64) GormDataType() string {
-	return "text"
-}
 
 type CommaSeparatedStrings []string
 
@@ -50,7 +26,7 @@ func (s *CommaSeparatedStrings) Scan(v interface{}) error {
 		parts = parts[1:]
 	}
 
-	*s = CommaSeparatedStrings(parts)
+	*s = parts
 
 	return nil
 }

--- a/internal/server/models/types.go
+++ b/internal/server/models/types.go
@@ -9,7 +9,12 @@ import (
 type CommaSeparatedStrings []string
 
 func (s CommaSeparatedStrings) Value() (driver.Value, error) {
-	return strings.Join([]string(s), ","), nil
+	for _, v := range s {
+		if strings.Contains(v, ",") {
+			return nil, fmt.Errorf("can not store values that include commas")
+		}
+	}
+	return strings.Join(s, ","), nil
 }
 
 func (s *CommaSeparatedStrings) Scan(v interface{}) error {
@@ -18,7 +23,7 @@ func (s *CommaSeparatedStrings) Scan(v interface{}) error {
 	}
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("expected string type for %v", v)
+		return fmt.Errorf("expected string type for comma separated string, got %T", v)
 	}
 	parts := strings.Split(str, ",")
 
@@ -27,7 +32,6 @@ func (s *CommaSeparatedStrings) Scan(v interface{}) error {
 	}
 
 	*s = parts
-
 	return nil
 }
 

--- a/internal/server/models/types_test.go
+++ b/internal/server/models/types_test.go
@@ -22,6 +22,12 @@ func TestCommaSeparatedStringsValue(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, test.expected, val)
 	}
+
+	t.Run("invalid input", func(t *testing.T) {
+		input := []string{"ok", "with, comma"}
+		_, err := CommaSeparatedStrings(input).Value()
+		assert.Error(t, err, "can not store values that include commas")
+	})
 }
 
 func TestCommaSeparatedStringsScan(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR removes an unused and untested type from `models`, and adds a safeguard to `CommaSeparatedStrings` to prevent saving a value to the database that we won't be able to retrieve later.

The other options presented in #2068 would be nice, but will require database migrations for a bunch of fields, so is a lot more work. This safeguard is sufficient to prevent problems until we invest in one of the more involved solutions.

## Related Issues

Related to #2068, but we might want to keep that open in case we do want to support commas in values at some point.
