### PR TITLE
feat: org sign-up UI

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -332,8 +332,8 @@ func (c Client) Logout() error {
 	return err
 }
 
-func (c Client) Signup(req *SignupRequest) (*CreateAccessKeyResponse, error) {
-	return post[SignupRequest, CreateAccessKeyResponse](c, "/api/signup", req)
+func (c Client) Signup(req *SignupRequest) (*SignupResponse, error) {
+	return post[SignupRequest, SignupResponse](c, "/api/signup", req)
 }
 
 func (c Client) GetServerVersion() (*Version, error) {

--- a/internal/server/cookie.go
+++ b/internal/server/cookie.go
@@ -33,6 +33,7 @@ func setAuthCookie(c *gin.Context, key string, expires time.Time) {
 		Value:    url.QueryEscape(key),
 		MaxAge:   maxAge,
 		Path:     cookiePath,
+		Domain:   c.Request.Host,
 		SameSite: http.SameSiteStrictMode,
 		Secure:   secure,
 		HttpOnly: true, // not accessible by javascript
@@ -42,25 +43,28 @@ func setAuthCookie(c *gin.Context, key string, expires time.Time) {
 		Value:    "1",
 		MaxAge:   maxAge,
 		Path:     cookiePath,
+		Domain:   c.Request.Host,
 		SameSite: http.SameSiteStrictMode,
 		Secure:   secure,
 		HttpOnly: true, // not accessible by javascript
 	})
 }
 
-func deleteAuthCookie(writer http.ResponseWriter) {
-	http.SetCookie(writer, &http.Cookie{
+func deleteAuthCookie(c *gin.Context) {
+	http.SetCookie(c.Writer, &http.Cookie{
 		Name:     cookieAuthorizationName,
 		MaxAge:   cookieMaxAgeDeleteImmediately,
 		Path:     cookiePath,
+		Domain:   c.Request.Host,
 		Secure:   true, // only over https
 		HttpOnly: true, // not accessible by javascript
 	})
 
-	http.SetCookie(writer, &http.Cookie{
+	http.SetCookie(c.Writer, &http.Cookie{
 		Name:     cookieLoginName,
 		MaxAge:   cookieMaxAgeDeleteImmediately,
 		Path:     cookiePath,
+		Domain:   c.Request.Host,
 		Secure:   true, // only over https
 		HttpOnly: true, // not accessible by javascript
 	})

--- a/ui/__test__/signup.test.js
+++ b/ui/__test__/signup.test.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+import Signup from '../pages/signup/index'
+
+describe('Signup Component', () => {
+  it('should render', () => {
+    expect(() => render(<Signup />)).not.toThrow()
+  })
+
+  it('should render with correct state', () => {
+    render(<Signup />)
+    expect(screen.getByText('Welcome to Infra')).toBeInTheDocument()
+    expect(screen.getByLabelText('Email')).toHaveValue('')
+    expect(screen.getByLabelText('Password')).toHaveValue('')
+    expect(screen.getByLabelText('Confirm Password')).toHaveValue('')
+    expect(screen.getByLabelText('Organization')).toHaveValue('')
+    expect(screen.getByText('Get Started').closest('button')).toBeDisabled()
+  })
+})

--- a/ui/pages/_app.js
+++ b/ui/pages/_app.js
@@ -1,6 +1,5 @@
 import Head from 'next/head'
-import useSWR, { SWRConfig } from 'swr'
-import { useRouter } from 'next/router'
+import { SWRConfig } from 'swr'
 
 import '../lib/fetch'
 import '../lib/dayjs'
@@ -24,18 +23,6 @@ const swrConfig = {
 }
 
 export default function App({ Component, pageProps }) {
-  const { data: signup } = useSWR('/api/signup', swrConfig)
-  const router = useRouter()
-
-  if (!signup) {
-    return null
-  }
-
-  if (signup.enabled && router.pathname !== '/signup') {
-    router.replace('/signup')
-    return null
-  }
-
   const layout = Component.layout || (page => page)
 
   return (

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -1,7 +1,14 @@
 import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 
 export default function Index() {
-  useRouter().replace('/destinations')
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!router.isReady) return
+    // wait for router to be ready to prevent router from being rendered server-side
+    router.replace('/destinations')
+  })
 
   return null
 }


### PR DESCRIPTION
## Summary
Add orgs to Infra sign-up UI (note that it is going into the org_collab branch, not main).

- Updates UI
- Updates sign-up for separate org and domain
- Does not require org name to be unique

![image](https://user-images.githubusercontent.com/5853428/182986237-2e3e476c-1e92-4a25-9c19-06b0dd8b793c.png)

![image](https://user-images.githubusercontent.com/5853428/182986289-32bd7bcc-0936-4d39-a1a4-ac4fae91f1c0.png)

### Next steps 
#2801 
- Update the quickstart to direct new self-hosted deployments to the "sign-up" UI
- Update ingress when a new org subdomain is created
- https://github.com/infrahq/infra/issues/2806

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2822 
