### PR TITLE
feat: new org setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ helm repo update
 helm install infra infrahq/infra
 ```
 
-Next, find the exposed hostname:
+Next, find the Infra sign-up endpoint:
 
 ```
-kubectl get service infra-server -o jsonpath="{.status.loadBalancer.ingress[*]['ip', 'hostname']}" -w
+INFRA_HOST=$(kubectl get services/infra-server -o jsonpath="{.status.loadBalancer.ingress[*]['ip', 'hostname']}") && echo "https://"$INFRA_HOST"/signup"
 ```
 
-Open this hostname in your browser to get started
+Open this URL in your web browser to get started
 
 ## Connectors
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -25,47 +25,13 @@ helm repo update
 helm install infra infrahq/infra
 ```
 
-Next, log into your instance of Infra to setup your admin account:
+Next, find the Infra sign-up endpoint:
 
 ```
-infra login localhost
+INFRA_HOST=$(kubectl get services/infra-server -o jsonpath="{.status.loadBalancer.ingress[*]['ip', 'hostname']}") && echo "https://"$INFRA_HOST"/signup"
 ```
 
-{% callout type="info" %}
-You may be prompted to verify the fingerprint of the server's TLS certificate. The fingerprint can be found in the server logs:
-
-```
-kubectl logs --tail=-1 -l 'app.kubernetes.io/name=infra-server' | grep fingerprint
-```
-
-If you're not using Docker Desktop, you'll be need to specify a different endpoint than `localhost`. This endpoint can be found via the following `kubectl` command:
-
-```
-kubectl get service infra-server -o jsonpath="{.status.loadBalancer.ingress[*]['ip', 'hostname']}" -w
-```
-
-Note: it may take a few minutes for the LoadBalancer to be provisioned.
-
-If your load balancer does not have a hostname (often true for GKE and AKS clusters), Infra will not be able to automatically
-create a TLS certificate for the server. On GKE you can use the hostname `<LoadBalancer IP>.bc.googleusercontent.com` instead
-of `localhost`.
-
-
-Otherwise you'll need to configure the LoadBalancer with a static IP and hostname (see
-[GKE docs](https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip), or
-[AKS docs](https://docs.microsoft.com/en-us/azure/aks/static-ip#create-a-static-ip-address)).
-Alternatively you can use the `--skip-tls-verify` with `infra login`, or setup your own TLS certificates for Infra.
-
-{% /callout %}
-
-Once the server is deployed, download the CA certificate that was generated for the server and save it to a file.
-This certificate will be used by the CLI and by connectors to establish secure TLS
-communication with the server.
-
-```
-kubectl get secrets/infra-server-ca --template='{{index .data "ca.crt"}}' | base64 --decode > infra.ca
-```
-
+Open this URL in your web browser to get started
 
 ## Connect a Kubernetes cluster
 

--- a/helm/charts/infra/templates/NOTES.txt
+++ b/helm/charts/infra/templates/NOTES.txt
@@ -4,35 +4,33 @@
 
 {{- if include "server.enabled" . | eq "true" }}
 
-  To get started, login via the Infra CLI
+  To get started, navigate to your Infra host in a web browser 
 
 {{- if .Values.server.ingress.enabled }}
 {{- with first .Values.server.ingress.hosts }}
 
-  $ infra login {{ . }}
+  https://{{ . }}/signup
 
 {{- end }}
 {{- else if eq .Values.server.service.type "NodePort" }}
 
-  $ NODE_HOST=$(kubectl -n {{ .Release.Namespace }} get nodes -o jsonpath="{.status.addresses[0].address}")
-  $ NODE_PORT=$(kubectl -n {{ .Release.Namespace }} get services/{{ include "server.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
-  $ infra login $NODE_HOST:NODE_PORT
+  To find your signup link run:
+  $ NODE_HOST=$(kubectl -n {{ .Release.Namespace }} get nodes -o jsonpath="{.status.addresses[0].address}") && NODE_PORT=$(kubectl -n {{ .Release.Namespace }} get services/{{ include "server.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}") && echo "https://"$NODE_HOST:$NODE_PORT"/signup"
 
 {{- else if eq .Values.server.service.type "LoadBalancer" }}
 
   NOTE: It may take a few minutes for the LoadBalancer to become available.
-  You can watch the status of by running `kubectl -n {{ .Release.Namespace }} get services/{{ include "server.fullname" . }} -w`
-
-  $ LOADBALANCER=$(kubectl -n {{ .Release.Namespace }} get services/{{ include "server.fullname" . }} -o jsonpath="{.status.loadBalancer.ingress[*]['ip', 'hostname']}")
-  $ infra login $LOADBALANCER
+  
+  To find your signup link run:
+  $ INFRA_HOST=$(kubectl -n {{ .Release.Namespace }} get services/{{ include "server.fullname" . }} -o jsonpath="{.status.loadBalancer.ingress[*]['ip', 'hostname']}") && echo "https://"$INFRA_HOST"/signup"
 
 {{- else if contains .Values.server.service.type "ClusterIP" }}
 
+  To expose access to Infra run:
   $ kubectl -n {{ .Release.Namespace }} port-forward deployments/{{ include "server.fullname" . }} 8080:80 8443:443
 
-  Infra API server is now accessible on localhost:8443
-
-  $ infra login localhost:8443
+  Infra is now accessible at localhost:8443
+  Get started by signing up: https://localhost:8443/signup
 
 {{- end }}
 


### PR DESCRIPTION
- direct users to the UI during setup
- remove some extra information from the quick-start

## Summary
During the initial deploy of self-hosted Infra direct the admin to the UI after the initial deployment to setup their admin user org, and continue with other setup.

This change assumes we will make further improvements to the initial admin experience by guiding them through the UI rather than the docs. 
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

Resolves #2822 
