### PR TITLE
Support running all tests against postgres

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -13,17 +13,23 @@ import (
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/testing/database"
 	"github.com/infrahq/infra/internal/testing/patch"
 	"github.com/infrahq/infra/uid"
 )
 
 func setupDB(t *testing.T) *gorm.DB {
-	driver, err := data.NewSQLiteDriver("file::memory:")
-	assert.NilError(t, err)
+	driver := database.PostgresDriver(t)
+	if driver == nil {
+		var err error
+		driver, err = data.NewSQLiteDriver("file::memory:")
+		assert.NilError(t, err)
+	}
 
 	patch.ModelsSymmetricKey(t)
 	db, err := data.NewDB(driver, nil)
 	assert.NilError(t, err)
+	t.Cleanup(data.InvalidateCache)
 
 	return db
 }

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func setupDB(t *testing.T) *gorm.DB {
-	driver := database.PostgresDriver(t)
+	driver := database.PostgresDriver(t, "_access")
 	if driver == nil {
 		var err error
 		driver, err = data.NewSQLiteDriver("file::memory:")

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -38,12 +37,7 @@ func TestListCmd(t *testing.T) {
 	srv, err := server.New(opts)
 	assert.NilError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	go func() {
-		assert.Check(t, srv.Run(ctx))
-	}()
+	ctx := runAndWait(t, srv.Run)
 
 	httpTransport := httpTransportForHostConfig(&ClientHostConfig{SkipTLSVerify: true})
 	c := apiClient(srv.Addrs.HTTPS.String(), "0000000001.adminadminadminadmin1234", httpTransport)

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -34,7 +34,7 @@ func TestListCmd(t *testing.T) {
 			{User: "manygrants@example.com", Resource: "moon", Role: "inhabitant"},
 		},
 	}
-	setupServerTLSOptions(t, &opts)
+	setupServerOptions(t, &opts)
 	srv, err := server.New(opts)
 	assert.NilError(t, err)
 

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -309,9 +309,11 @@ func setupServerOptions(t *testing.T, opts *server.Options) {
 	assert.NilError(t, err)
 	opts.TLS.Certificate = types.StringOrFile(cert)
 
-	pgDriver := database.PostgresDriver(t)
+	// TODO: why do tests fail when the same schemaSuffix is used?
+	suffix := "_cmd_" + t.Name()
+	pgDriver := database.PostgresDriver(t, suffix)
 	if pgDriver != nil {
-		dsn := os.Getenv("POSTGRESQL_CONNECTION") + " search_path=testing"
+		dsn := os.Getenv("POSTGRESQL_CONNECTION") + " search_path=testing" + suffix
 		opts.DBConnectionString = dsn
 	}
 }

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -41,12 +41,7 @@ func TestLoginCmd_SetupAdminOnFirstLogin(t *testing.T) {
 	srv, err := server.New(opts)
 	assert.NilError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	go func() {
-		assert.Check(t, srv.Run(ctx))
-	}()
+	ctx := runAndWait(t, srv.Run)
 
 	runStep(t, "first login prompts for setup", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
@@ -126,6 +121,29 @@ func TestLoginCmd_SetupAdminOnFirstLogin(t *testing.T) {
 	})
 }
 
+// runAndWait runs fn in a goroutine and adds a t.Cleanup function to wait for
+// the goroutine to exit before ending cleanup. runAndWait is used to ensure
+// that the goroutine exits before a new test starts.
+//
+// Returns the context used to cancel the goroutine so that it can be used by
+// other functions in the test.
+func runAndWait(t *testing.T, fn func(ctx context.Context) error) context.Context {
+	t.Helper()
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		t.Helper()
+		assert.Check(t, fn(ctx))
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	return ctx
+}
+
 func TestLoginCmd_Options(t *testing.T) {
 	dir := setupEnv(t)
 
@@ -141,12 +159,7 @@ func TestLoginCmd_Options(t *testing.T) {
 	srv, err := server.New(opts)
 	assert.NilError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	go func() {
-		assert.Check(t, srv.Run(ctx))
-	}()
+	ctx := runAndWait(t, srv.Run)
 
 	runStep(t, "login without background agent", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
@@ -320,12 +333,7 @@ func TestLoginCmd_TLSVerify(t *testing.T) {
 	srv, err := server.New(opts)
 	assert.NilError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	go func() {
-		assert.Check(t, srv.Run(ctx))
-	}()
+	ctx := runAndWait(t, srv.Run)
 
 	runStep(t, "reject server certificate", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/race"
 	"github.com/infrahq/infra/internal/server"
+	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/testing/database"
 	"github.com/infrahq/infra/uid"
 )
@@ -283,6 +284,7 @@ func setupEnv(t *testing.T) string {
 
 func setupServerOptions(t *testing.T, opts *server.Options) {
 	t.Helper()
+	t.Cleanup(data.InvalidateCache)
 
 	opts.Addr = server.ListenerOptions{HTTPS: "127.0.0.1:0", HTTP: "127.0.0.1:0"}
 

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func setupDB(t *testing.T) *gorm.DB {
+	t.Helper()
 	driver := database.PostgresDriver(t)
 	if driver == nil {
 		var err error

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -17,7 +17,7 @@ import (
 
 func setupDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	driver := database.PostgresDriver(t)
+	driver := database.PostgresDriver(t, "_authn")
 	if driver == nil {
 		var err error
 		driver, err = data.NewSQLiteDriver("file::memory:")

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -11,16 +11,22 @@ import (
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/testing/database"
 	"github.com/infrahq/infra/internal/testing/patch"
 )
 
 func setupDB(t *testing.T) *gorm.DB {
-	driver, err := data.NewSQLiteDriver("file::memory:")
-	assert.NilError(t, err)
+	driver := database.PostgresDriver(t)
+	if driver == nil {
+		var err error
+		driver, err = data.NewSQLiteDriver("file::memory:")
+		assert.NilError(t, err)
+	}
 
 	patch.ModelsSymmetricKey(t)
 	db, err := data.NewDB(driver, nil)
 	assert.NilError(t, err)
+	t.Cleanup(data.InvalidateCache)
 
 	// create the provider if it's missing
 	data.InfraProvider(db)

--- a/internal/server/authn/key_exchange_test.go
+++ b/internal/server/authn/key_exchange_test.go
@@ -16,9 +16,15 @@ import (
 func TestKeyExchangeAuthentication(t *testing.T) {
 	db := setupDB(t)
 
-	cases := map[string]map[string]interface{}{
+	type testCase struct {
+		setup       func(t *testing.T, db *gorm.DB) LoginMethod
+		expectedErr string
+		expected    func(t *testing.T, identity *models.Identity, provider *models.Provider)
+	}
+
+	cases := map[string]testCase{
 		"InvalidAccessKeyCannotBeExchanged": {
-			"setup": func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
 				user := &models.Identity{Name: "goku@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
@@ -27,12 +33,10 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 
 				return NewKeyExchangeAuthentication(invalidKey, time.Now().Add(5*time.Minute))
 			},
-			"verify": func(t *testing.T, identity *models.Identity, provider *models.Provider, err error) {
-				assert.ErrorContains(t, err, "could not get access key from database")
-			},
+			expectedErr: "could not get access key from database",
 		},
 		"ExpiredAccessKeyCannotBeExchanged": {
-			"setup": func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
 				user := &models.Identity{Name: "bulma@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
@@ -49,12 +53,10 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 
 				return NewKeyExchangeAuthentication(bearer, time.Now().Add(5*time.Minute))
 			},
-			"verify": func(t *testing.T, identity *models.Identity, provider *models.Provider, err error) {
-				assert.ErrorContains(t, err, data.ErrAccessKeyExpired.Error())
-			},
+			expectedErr: data.ErrAccessKeyExpired.Error(),
 		},
 		"AccessKeyCannotBeExchangedForLongerLived": {
-			"setup": func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
 				user := &models.Identity{Name: "krillin@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
@@ -71,12 +73,10 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 
 				return NewKeyExchangeAuthentication(bearer, time.Now().Add(5*time.Minute))
 			},
-			"verify": func(t *testing.T, identity *models.Identity, provider *models.Provider, err error) {
-				assert.ErrorContains(t, err, "cannot exchange an access key for another access key with a longer lifetime")
-			},
+			expectedErr: "cannot exchange an access key for another access key with a longer lifetime",
 		},
 		"AccessKeyCannotBeExchangedWhenUserNoLongerExists": {
-			"setup": func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
 				key := &models.AccessKey{
 					Name:       "no-user-key",
 					IssuedFor:  uid.New(), // simulate the user not existing
@@ -89,12 +89,10 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 
 				return NewKeyExchangeAuthentication(bearer, time.Now().Add(1*time.Minute))
 			},
-			"verify": func(t *testing.T, identity *models.Identity, provider *models.Provider, err error) {
-				assert.ErrorContains(t, err, "user is not valid")
-			},
+			expectedErr: "user is not valid",
 		},
 		"ValidAccessKeySuccess": {
-			"setup": func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
 				user := &models.Identity{Name: "cell@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
@@ -111,26 +109,25 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 
 				return NewKeyExchangeAuthentication(bearer, time.Now().Add(1*time.Minute))
 			},
-			"verify": func(t *testing.T, identity *models.Identity, provider *models.Provider, err error) {
-				assert.NilError(t, err)
+			expected: func(t *testing.T, identity *models.Identity, provider *models.Provider) {
 				assert.Equal(t, identity.Name, "cell@example.com")
 				assert.Equal(t, data.InfraProvider(db).ID, provider.ID)
 			},
 		},
 	}
 
-	for k, v := range cases {
-		t.Run(k, func(t *testing.T) {
-			setupFunc, ok := v["setup"].(func(*testing.T, *gorm.DB) LoginMethod)
-			assert.Assert(t, ok)
-			keyExchangeLogin := setupFunc(t, db)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			keyExchangeLogin := tc.setup(t, db)
 
 			identity, provider, _, err := keyExchangeLogin.Authenticate(context.Background(), db)
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
 
-			verifyFunc, ok := v["verify"].(func(*testing.T, *models.Identity, *models.Provider, error))
-			assert.Assert(t, ok)
-
-			verifyFunc(t, identity, provider, err)
+			assert.NilError(t, err)
+			tc.expected(t, identity, provider)
 		})
 	}
 }

--- a/internal/server/authn/key_exchange_test.go
+++ b/internal/server/authn/key_exchange_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/uid"
 )
 
 func TestKeyExchangeAuthentication(t *testing.T) {
@@ -77,9 +76,15 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 		},
 		"AccessKeyCannotBeExchangedWhenUserNoLongerExists": {
 			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
+				user := &models.Identity{Name: "notforlong@example.com"}
+				user.DeletedAt.Time = time.Now()
+				user.DeletedAt.Valid = true
+				err := data.CreateIdentity(db, user)
+				assert.NilError(t, err)
+
 				key := &models.AccessKey{
 					Name:       "no-user-key",
-					IssuedFor:  uid.New(), // simulate the user not existing
+					IssuedFor:  user.ID,
 					ProviderID: data.InfraProvider(db).ID,
 					ExpiresAt:  time.Now().Add(5 * time.Minute),
 				}

--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -2,11 +2,9 @@ package authn
 
 import (
 	"context"
-	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/ssoroka/slice"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
@@ -236,19 +234,15 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		db := setupDB(t)
-
-		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Set("db", db)
-
-		// setup fake identity provider
-		provider := &models.Provider{Name: "mockoidc", URL: "mockOIDC.example.com", Kind: models.ProviderKindOIDC}
-		err := data.CreateProvider(db, provider)
-		assert.NilError(t, err)
-
 		t.Run(name, func(t *testing.T) {
-			mockOIDC := tc.setup(t, db)
+			db := setupDB(t)
 
+			// setup fake identity provider
+			provider := &models.Provider{Name: "mockoidc", URL: "mockOIDC.example.com", Kind: models.ProviderKindOIDC}
+			err := data.CreateProvider(db, provider)
+			assert.NilError(t, err)
+
+			mockOIDC := tc.setup(t, db)
 			loginMethod := NewOIDCAuthentication(provider.ID, "mockOIDC.example.com/redirect", "AAA", mockOIDC)
 
 			u, _, _, err := loginMethod.Authenticate(context.Background(), db)

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
-	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -84,10 +83,6 @@ func NewSQLiteDriver(connection string) (gorm.Dialector, error) {
 	connection = uri.String()
 
 	return sqlite.Open(connection), nil
-}
-
-func NewPostgresDriver(connection string) (gorm.Dialector, error) {
-	return postgres.Open(connection), nil
 }
 
 func getDefaultSortFromType(t interface{}) string {

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/testing/database"
 	"github.com/infrahq/infra/internal/testing/patch"
 	"github.com/infrahq/infra/uid"
 )
@@ -33,28 +34,15 @@ func setupDB(t *testing.T, driver gorm.Dialector) *gorm.DB {
 
 var isEnvironmentCI = os.Getenv("CI") != ""
 
-func postgresDriver(t *testing.T) gorm.Dialector {
-	pgConn, ok := os.LookupEnv("POSTGRESQL_CONNECTION")
+func optionalPostgresDriver(t *testing.T) gorm.Dialector {
+	driver := database.PostgresDriver(t)
 	switch {
-	case !ok && isEnvironmentCI:
+	case driver == nil && isEnvironmentCI:
 		t.Fatal("CI must test all drivers, set POSTGRESQL_CONNECTION")
-	case !ok:
+	case driver == nil:
 		t.Skip("Set POSTGRESQL_CONNECTION to test against postgresql")
 	}
-
-	pgsql, err := NewPostgresDriver(pgConn)
-	assert.NilError(t, err, "postgresql driver")
-
-	db, err := gorm.Open(pgsql)
-	assert.NilError(t, err, "connect to postgresql")
-	t.Cleanup(func() {
-		assert.NilError(t, db.Exec("DROP SCHEMA IF EXISTS testing CASCADE").Error)
-	})
-	assert.NilError(t, db.Exec("CREATE SCHEMA testing").Error)
-
-	pgsql, err = NewPostgresDriver(pgConn + " search_path=testing")
-	assert.NilError(t, err, "postgresql driver")
-	return pgsql
+	return driver
 }
 
 // runDBTests against all supported databases. Defaults to only sqlite locally,
@@ -69,7 +57,7 @@ func runDBTests(t *testing.T, run func(t *testing.T, db *gorm.DB)) {
 		run(t, setupDB(t, sqlite))
 	})
 	t.Run("postgres", func(t *testing.T) {
-		pgsql := postgresDriver(t)
+		pgsql := optionalPostgresDriver(t)
 		run(t, setupDB(t, pgsql))
 	})
 }

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -34,8 +34,10 @@ func setupDB(t *testing.T, driver gorm.Dialector) *gorm.DB {
 
 var isEnvironmentCI = os.Getenv("CI") != ""
 
-func optionalPostgresDriver(t *testing.T) gorm.Dialector {
-	driver := database.PostgresDriver(t)
+// postgresDriver requires postgres to be available in a CI environment, and
+// marks the test as skipped when not in CI environment.
+func postgresDriver(t *testing.T) gorm.Dialector {
+	driver := database.PostgresDriver(t, "")
 	switch {
 	case driver == nil && isEnvironmentCI:
 		t.Fatal("CI must test all drivers, set POSTGRESQL_CONNECTION")
@@ -57,7 +59,7 @@ func runDBTests(t *testing.T, run func(t *testing.T, db *gorm.DB)) {
 		run(t, setupDB(t, sqlite))
 	})
 	t.Run("postgres", func(t *testing.T) {
-		pgsql := optionalPostgresDriver(t)
+		pgsql := postgresDriver(t)
 		run(t, setupDB(t, pgsql))
 	})
 }

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -11,29 +11,25 @@ import (
 )
 
 func TestDestinationSaveCreatedPersists(t *testing.T) {
-	driver, err := NewSQLiteDriver("file::memory:")
-	assert.NilError(t, err)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		destination := &models.Destination{
+			Name: "example-cluster-1",
+		}
 
-	db, err := NewDB(driver, nil)
-	assert.NilError(t, err)
+		err := CreateDestination(db, destination)
+		assert.NilError(t, err)
+		assert.Assert(t, !destination.CreatedAt.IsZero())
 
-	destination := &models.Destination{
-		Name: "example-cluster-1",
-	}
+		destination.Name = "example-cluster-2"
+		destination.CreatedAt = time.Time{}
 
-	err = CreateDestination(db, destination)
-	assert.NilError(t, err)
-	assert.Assert(t, !destination.CreatedAt.IsZero())
+		err = SaveDestination(db, destination)
+		assert.NilError(t, err)
 
-	destination.Name = "example-cluster-2"
-	destination.CreatedAt = time.Time{}
-
-	err = SaveDestination(db, destination)
-	assert.NilError(t, err)
-
-	destination, err = GetDestination(db, ByID(destination.ID))
-	assert.NilError(t, err)
-	assert.Assert(t, !destination.CreatedAt.IsZero())
+		destination, err = GetDestination(db, ByID(destination.ID))
+		assert.NilError(t, err)
+		assert.Assert(t, !destination.CreatedAt.IsZero())
+	})
 }
 
 func TestCountDestinationsByConnectedVersion(t *testing.T) {

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -404,12 +404,13 @@ INSERT INTO provider_users (identity_id, provider_id, id, created_at, updated_at
 
 	var initialSchema string
 	runStep(t, "initial schema", func(t *testing.T) {
-		db := setupDB(t, postgresDriver(t))
+		db := setupDB(t, optionalPostgresDriver(t))
 		initialSchema = dumpSchema(t, os.Getenv("POSTGRESQL_CONNECTION"))
+
 		assert.NilError(t, db.Exec("DROP SCHEMA IF EXISTS testing CASCADE").Error)
 	})
 
-	db, err := newRawDB(postgresDriver(t))
+	db, err := newRawDB(optionalPostgresDriver(t))
 	assert.NilError(t, err)
 	for i, tc := range testCases {
 		runStep(t, tc.label.Name, func(t *testing.T) {

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -404,13 +404,13 @@ INSERT INTO provider_users (identity_id, provider_id, id, created_at, updated_at
 
 	var initialSchema string
 	runStep(t, "initial schema", func(t *testing.T) {
-		db := setupDB(t, optionalPostgresDriver(t))
+		db := setupDB(t, postgresDriver(t))
 		initialSchema = dumpSchema(t, os.Getenv("POSTGRESQL_CONNECTION"))
 
 		assert.NilError(t, db.Exec("DROP SCHEMA IF EXISTS testing CASCADE").Error)
 	})
 
-	db, err := newRawDB(optionalPostgresDriver(t))
+	db, err := newRawDB(postgresDriver(t))
 	assert.NilError(t, err)
 	for i, tc := range testCases {
 		runStep(t, tc.label.Name, func(t *testing.T) {

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -503,7 +503,7 @@ func dumpSchema(t *testing.T, conn string) string {
 
 	out := new(bytes.Buffer)
 	// https://www.postgresql.org/docs/current/app-pgdump.html
-	cmd := exec.Command("pg_dump", "--no-owner", "--no-tablespaces", "--schema-only")
+	cmd := exec.Command("pg_dump", "--no-owner", "--no-tablespaces", "--schema-only", "--schema=testing")
 	cmd.Env = envs
 	cmd.Stdout = out
 	cmd.Stderr = os.Stderr

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -35,6 +35,7 @@ func setupDB(t *testing.T) *gorm.DB {
 	tpatch.ModelsSymmetricKey(t)
 	db, err := data.NewDB(driver, nil)
 	assert.NilError(t, err)
+	t.Cleanup(data.InvalidateCache)
 
 	t.Cleanup(func() {
 		sqlDB, err := db.DB()

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -99,7 +99,7 @@ func TestDBTimeout(t *testing.T) {
 	router.Use(
 		func(c *gin.Context) {
 			// this is a custom copy of the timeout middleware so I can grab and control the cancel() func. Otherwise the test is too flakey with timing race conditions.
-			ctx, cancel = context.WithTimeout(c, 100*time.Millisecond)
+			ctx, cancel = context.WithTimeout(c.Request.Context(), 100*time.Millisecond)
 			defer cancel()
 
 			c.Request = c.Request.WithContext(ctx)

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -26,7 +26,7 @@ import (
 
 func setupDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	driver := database.PostgresDriver(t)
+	driver := database.PostgresDriver(t, "_server")
 	if driver == nil {
 		var err error
 		driver, err = data.NewSQLiteDriver("file::memory:")

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func setupDB(t *testing.T) *gorm.DB {
+	t.Helper()
 	driver := database.PostgresDriver(t)
 	if driver == nil {
 		var err error
@@ -318,7 +319,7 @@ func TestHandleInfraDestinationHeader(t *testing.T) {
 
 		destination, err = data.GetDestination(db, data.ByOptionalUniqueID(destination.UniqueID))
 		assert.NilError(t, err)
-		assert.Equal(t, destination.LastSeenAt, time.Time{})
+		assert.Equal(t, destination.LastSeenAt.UTC(), time.Time{})
 	})
 
 	t.Run("good no destination", func(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -178,6 +178,15 @@ func (s *Server) Run(ctx context.Context) error {
 
 	err := group.Wait()
 	s.tel.Close()
+
+	if sqlDB, err := s.db.DB(); err != nil {
+		logging.L.Warn().Err(err).Msg("failed to get database conn to close")
+	} else {
+		if err := sqlDB.Close(); err != nil {
+			logging.L.Warn().Err(err).Msg("failed to close database connection")
+		}
+	}
+
 	if errors.Is(err, context.Canceled) {
 		return nil
 	}
@@ -330,7 +339,7 @@ func (s *Server) getPostgresConnectionString() (string, error) {
 		}
 
 		if s.options.DBParameters != "" {
-			fmt.Fprintf(&pgConn, "%s", s.options.DBParameters)
+			fmt.Fprint(&pgConn, s.options.DBParameters)
 		}
 	}
 

--- a/internal/testing/database/postgres.go
+++ b/internal/testing/database/postgres.go
@@ -11,9 +11,11 @@ import (
 type TestingT interface {
 	assert.TestingT
 	Cleanup(func())
+	Helper()
 }
 
 func PostgresDriver(t TestingT) gorm.Dialector {
+	t.Helper()
 	pgConn, ok := os.LookupEnv("POSTGRESQL_CONNECTION")
 	if !ok {
 		return nil

--- a/internal/testing/database/postgres.go
+++ b/internal/testing/database/postgres.go
@@ -1,0 +1,34 @@
+package database
+
+import (
+	"os"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gotest.tools/v3/assert"
+)
+
+type TestingT interface {
+	assert.TestingT
+	Cleanup(func())
+}
+
+func PostgresDriver(t TestingT) gorm.Dialector {
+	pgConn, ok := os.LookupEnv("POSTGRESQL_CONNECTION")
+	if !ok {
+		return nil
+	}
+
+	db, err := gorm.Open(postgres.Open(pgConn))
+	assert.NilError(t, err, "connect to postgresql")
+	t.Cleanup(func() {
+		assert.NilError(t, db.Exec("DROP SCHEMA IF EXISTS testing CASCADE").Error)
+		sqlDB, err := db.DB()
+		assert.NilError(t, err)
+		assert.NilError(t, sqlDB.Close())
+	})
+	assert.NilError(t, db.Exec("CREATE SCHEMA testing").Error)
+
+	pgsql := postgres.Open(pgConn + " search_path=testing")
+	return pgsql
+}


### PR DESCRIPTION
## Summary

Each test package needs to use a different schema name because `go test` will run tests for different packages in parallel. Since all packages can use the same PostgreSQL DB server they have to target different schemas. 

For some reason the `cmd` tests also seem to overlap, and I'm not sure why. It's possible the server processes keep running after the test ends, but logging suggests this isn't the case. For now I've worked around that by using a different schema name for each test function in `cmd`.


Best viewed by individual commit

Test failures included:
* [x] the database connection is not properly closed
* [x] tests don't call `data.InvalidateCache`
* [x] tests don't work with foreign key constraints
* [x] tests use different DB connections
* [x] infinite recursion in `TestDBTimeout`
* [x] `internal/cmd` tests still fail (but pass if a different schema name is used)
* [x] why do some test failures cause following tests to fail. It seems like cleanup is not done correctly somehow
