### PR TITLE
ci: fix path for go fuzz cache

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           key: go-fuzz-corpus-${{ matrix.name }}-${{ github.run_number }}
           restore-keys: go-fuzz-corpus-${{ matrix.name }}-
-          path: /home/runner/go/cache/fuzz
+          path: /home/runner/.cache/go-build/fuzz/
 
       - name: Set fuzz time
         run: echo "fuzz_time=5m" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

Looks like I missed this in #2631. I've been trying to figure out why the fuzz cache isn't working. I think it's two problems:

1. The `setup-go` action does restore a cache, but it only re-saves the cache when we update dependencies. So most of the time the fuzzer will redo work it's already done.
2. The `actions/cache` I added was not working. I just noticed that in the "Post Run" it says 

   > Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
   
   This PR should fix that problem by using the correct path.
   
   
With this change it looks to be working

> Cache saved with key: go-fuzz-corpus-FuzzID_MarshalText_RoundTrip_FromInt64-374