### PR TITLE
Replace the last of AutoMigrate

### DIFF
--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -56,7 +56,7 @@ func migrations() []*migrator.Migration {
 		deleteDuplicateGrants(),
 		dropDeletedProviderUsers(),
 		removeDeletedIdentitiesFromGroups(),
-		addFieldsFor_0_14_3(),
+		addFieldsForPreviouslyImplicitMigrations(),
 		addOrganizations(),
 		scopeUniqueIndicesToOrganization(),
 		addDefaultOrganization(),
@@ -259,7 +259,7 @@ func removeDeletedIdentitiesFromGroups() *migrator.Migration {
 	}
 }
 
-// addFieldsFor_0_14_3 adds all migrations that were previously applied by a
+// addFieldsForPreviouslyImplicitMigrations adds all migrations that were previously applied by a
 // second call to gorm.AutoMigrate. In this release we're removing the
 // unconditional call to gorm.AutoMigrate in favor of having explicit migrations
 // for all changes.
@@ -270,7 +270,7 @@ func removeDeletedIdentitiesFromGroups() *migrator.Migration {
 // In the future we should use ALTER TABLE sql statements instead of AutoMigrate.
 //
 // nolint:revive
-func addFieldsFor_0_14_3() *migrator.Migration {
+func addFieldsForPreviouslyImplicitMigrations() *migrator.Migration {
 	return &migrator.Migration{
 		ID: "2022-07-21T18:28",
 		Migrate: func(tx *gorm.DB) error {
@@ -371,7 +371,7 @@ ALTER TABLE provider_users DROP COLUMN IF EXISTS updated_at;
 				return err
 			}
 
-			if !tx.Migrator().HasConstraint("provider_users", "provider_users_pkey") {
+			if !migrator.HasConstraint(tx, "provider_users", "provider_users_pkey") {
 				if err := tx.Exec(`
 ALTER TABLE ONLY provider_users
 	ADD CONSTRAINT fk_provider_users_identity FOREIGN KEY (identity_id) REFERENCES identities(id);
@@ -387,11 +387,10 @@ ALTER TABLE provider_users ADD CONSTRAINT provider_users_pkey
 				}
 			}
 
-			if !tx.Migrator().HasIndex("grants", "idx_grant_srp") {
-				stmt := `CREATE UNIQUE INDEX idx_grant_srp ON grants USING btree (subject, privilege, resource) WHERE (deleted_at IS NULL);`
-				if err := tx.Exec(stmt).Error; err != nil {
-					return err
-				}
+			if err := tx.Exec(`
+CREATE UNIQUE INDEX IF NOT EXISTS idx_grant_srp ON grants USING btree (subject, privilege, resource) WHERE (deleted_at IS NULL);
+			`).Error; err != nil {
+				return err
 			}
 
 			return nil

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -274,7 +274,13 @@ func addFieldsFor_0_14_3() *migrator.Migration {
 	return &migrator.Migration{
 		ID: "2022-07-21T18:28",
 		Migrate: func(tx *gorm.DB) error {
-			if err := tx.AutoMigrate(&models.Settings{}); err != nil {
+			if err := tx.Exec(`
+ALTER TABLE settings ADD COLUMN IF NOT EXISTS lowercase_min bigint DEFAULT 0;
+ALTER TABLE settings ADD COLUMN IF NOT EXISTS uppercase_min bigint DEFAULT 0;
+ALTER TABLE settings ADD COLUMN IF NOT EXISTS number_min bigint DEFAULT 0;
+ALTER TABLE settings ADD COLUMN IF NOT EXISTS symbol_min bigint DEFAULT 0;
+ALTER TABLE settings ADD COLUMN IF NOT EXISTS length_min bigint DEFAULT 8;
+			`).Error; err != nil {
 				return err
 			}
 			if !migrator.HasTable(tx, "organizations") {

--- a/internal/server/data/migrator/helpers.go
+++ b/internal/server/data/migrator/helpers.go
@@ -1,6 +1,8 @@
 package migrator
 
-import "gorm.io/gorm"
+import (
+	"gorm.io/gorm"
+)
 
 type Tx interface {
 	Exec(stmt string, args ...any) *gorm.DB
@@ -47,7 +49,7 @@ func HasColumn(tx *gorm.DB, table string, column string) bool {
 			WHERE type = 'table' AND name = ?
 			AND sql LIKE ?
 		`
-		column = "%`" + column + "`%"
+		column = "% " + column + " %"
 	}
 
 	if err := tx.Raw(stmt, table, column).Scan(&count).Error; err != nil {

--- a/internal/server/data/migrator/helpers.go
+++ b/internal/server/data/migrator/helpers.go
@@ -55,3 +55,30 @@ func HasColumn(tx *gorm.DB, table string, column string) bool {
 	}
 	return count != 0
 }
+
+// HasConstraint returns true if the database table has the constraint. Returns
+// false if the database table does not have the constraint, or if there was a
+// failure querying the database.
+func HasConstraint(tx *gorm.DB, table string, constraint string) bool {
+	var count int
+	stmt := `
+		SELECT count(*)
+		FROM information_schema.table_constraints
+		WHERE table_schema = CURRENT_SCHEMA()
+		AND table_name = ? AND constraint_name = ?
+	`
+	if tx.Dialector.Name() == "sqlite" {
+		stmt = `
+			SELECT count(*)
+			FROM sqlite_master
+			WHERE type = 'table' AND tbl_name = ?
+			AND sql LIKE ?
+		`
+		constraint = "%CONSTRAINT `" + constraint + "`%"
+	}
+
+	if err := tx.Raw(stmt, table, constraint).Scan(&count).Error; err != nil {
+		return false
+	}
+	return count != 0
+}

--- a/internal/server/data/migrator/helpers_test.go
+++ b/internal/server/data/migrator/helpers_test.go
@@ -1,0 +1,1 @@
+package migrator

--- a/internal/server/data/migrator/helpers_test.go
+++ b/internal/server/data/migrator/helpers_test.go
@@ -1,1 +1,60 @@
 package migrator
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+	"gotest.tools/v3/assert"
+)
+
+func setupExampleTable(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if db.Dialector.Name() == "sqlite" {
+		t.Skip("does not work with sqlite")
+	}
+
+	db.Exec("DROP TABLE example")
+
+	var exampleTable = `
+CREATE TABLE example (
+    id bigint,
+    value text
+);
+ALTER TABLE example ADD CONSTRAINT example_pkey PRIMARY KEY (id);
+`
+	err := db.Exec(exampleTable).Error
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		db.Exec("DROP TABLE example")
+	})
+}
+
+func TestHasTable(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		setupExampleTable(t, db)
+
+		assert.Assert(t, HasTable(db, "example"))
+		assert.Assert(t, !HasTable(db, "nope"))
+	})
+}
+
+func TestHasColumn(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		setupExampleTable(t, db)
+
+		assert.Assert(t, HasColumn(db, "example", "id"))
+		assert.Assert(t, HasColumn(db, "example", "value"))
+		assert.Assert(t, !HasColumn(db, "example", "other"))
+		assert.Assert(t, !HasColumn(db, "missing", "id"))
+	})
+}
+
+func TestHasConstraint(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		setupExampleTable(t, db)
+
+		assert.Assert(t, HasConstraint(db, "example", "example_pkey"))
+		assert.Assert(t, !HasConstraint(db, "example", "other_pkey"))
+		assert.Assert(t, !HasConstraint(db, "other", "example_pkey"))
+	})
+}

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -17,8 +17,8 @@ CREATE TABLE access_keys (
     extension_deadline timestamp with time zone,
     key_id text,
     secret_checksum bytea,
-    organization_id bigint,
-    scopes text
+    scopes text,
+    organization_id bigint
 );
 
 CREATE TABLE credentials (
@@ -42,10 +42,10 @@ CREATE TABLE destinations (
     connection_url text,
     connection_ca text,
     last_seen_at timestamp with time zone,
-    organization_id bigint,
     version text,
     resources text,
-    roles text
+    roles text,
+    organization_id bigint
 );
 
 CREATE TABLE encryption_keys (
@@ -79,8 +79,8 @@ CREATE TABLE groups (
     deleted_at timestamp with time zone,
     name text,
     created_by bigint,
-    organization_id bigint,
-    created_by_provider bigint
+    created_by_provider bigint,
+    organization_id bigint
 );
 
 CREATE TABLE identities (
@@ -142,10 +142,10 @@ CREATE TABLE providers (
     kind text,
     auth_url text,
     scopes text,
-    organization_id bigint,
     private_key text,
     client_email text,
-    domain_admin_email text
+    domain_admin_email text,
+    organization_id bigint
 );
 
 CREATE TABLE settings (
@@ -155,12 +155,12 @@ CREATE TABLE settings (
     deleted_at timestamp with time zone,
     private_jwk bytea,
     public_jwk bytea,
-    organization_id bigint,
     lowercase_min bigint DEFAULT 0,
     uppercase_min bigint DEFAULT 0,
     number_min bigint DEFAULT 0,
     symbol_min bigint DEFAULT 0,
-    length_min bigint DEFAULT 8
+    length_min bigint DEFAULT 8,
+    organization_id bigint
 );
 
 ALTER TABLE ONLY access_keys

--- a/internal/server/models/encryption_test.go
+++ b/internal/server/models/encryption_test.go
@@ -17,6 +17,14 @@ type StructForTesting struct {
 	ASecret models.EncryptedAtRest
 }
 
+func (s StructForTesting) Schema() string {
+	return `
+CREATE TABLE struct_for_testings (
+	id integer PRIMARY KEY,
+	a_secret text
+);`
+}
+
 func TestEncryptedAtRest(t *testing.T) {
 	patch.ModelsSymmetricKey(t)
 
@@ -26,8 +34,7 @@ func TestEncryptedAtRest(t *testing.T) {
 	db, err := data.NewDB(driver, nil)
 	assert.NilError(t, err)
 
-	err = db.AutoMigrate(&StructForTesting{})
-	assert.NilError(t, err)
+	assert.NilError(t, db.Exec(StructForTesting{}.Schema()).Error)
 
 	id := uid.New()
 


### PR DESCRIPTION
## Summary

Branched from #2845

This PR replaces the last of the calls to `gorm.AutoMigrate` and `gorm.Migrator`. The only remaining calls to `gorm.AutoMigrate` are in a function we are using for sqlite compatibility, and to catch any new implicit migrations that might be added from other PRs.  I'm thinking of leaving those in until this merges (to catch problems during merge and rebase), and removing it immediately in a follow up.

## Related Issues

Resolves #2768
