### PR TITLE
maintain: remove PaginationResponse omitemptys

### DIFF
--- a/api/pagination.go
+++ b/api/pagination.go
@@ -28,8 +28,8 @@ func (p PaginationRequest) ValidationRules() []validate.ValidationRule {
 }
 
 type PaginationResponse struct {
-	Page       int `json:"page,omitempty"`
-	Limit      int `json:"limit,omitempty"`
-	TotalPages int `json:"totalPages,omitempty"`
-	TotalCount int `json:"totalCount,omitempty"`
+	Page       int `json:"page"`
+	Limit      int `json:"limit"`
+	TotalPages int `json:"totalPages"`
+	TotalCount int `json:"totalCount"`
 }

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -245,7 +245,7 @@ func TestAPI_ListUsers(t *testing.T) {
 			urlPath: "/api/users?name=doesnotmatch",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK)
-				assert.Equal(t, resp.Body.String(), `{"page":1,"limit":100,"count":0,"items":[]}`)
+				assert.Equal(t, resp.Body.String(), `{"page":1,"limit":100,"totalPages":0,"totalCount":0,"count":0,"items":[]}`)
 			},
 		},
 		"name match": {

--- a/ui/pages/destinations/index.js
+++ b/ui/pages/destinations/index.js
@@ -332,10 +332,7 @@ export default function Destinations() {
   const limit = 13 // TODO: make limit dynamic
 
   const {
-    data: { items: destinations, totalPages, totalCount } = {
-      totalPages: 0,
-      totalCount: 0,
-    },
+    data: { items: destinations, totalPages, totalCount } = {},
     error,
     mutate,
   } = useSWR(`/api/destinations?page=${page}&limit=${limit}`)

--- a/ui/pages/groups/index.js
+++ b/ui/pages/groups/index.js
@@ -308,10 +308,7 @@ export default function Groups() {
   const page = router.query.p === undefined ? 1 : router.query.p
   const limit = 13
   const {
-    data: { items: groups, totalPages, totalCount } = {
-      totalPages: 1,
-      totalCount: 1,
-    },
+    data: { items: groups, totalPages, totalCount } = {},
     error,
     mutate,
   } = useSWR(`/api/groups?page=${page}&limit=${limit}`)

--- a/ui/pages/providers/index.js
+++ b/ui/pages/providers/index.js
@@ -91,10 +91,7 @@ export default function Providers() {
   const page = router.query.p === undefined ? 1 : router.query.p
   const limit = 13
   const {
-    data: { items: providers, totalPages, totalCount } = {
-      totalCount: 0,
-      totalPages: 0,
-    },
+    data: { items: providers, totalPages, totalCount } = {},
     error,
     mutate,
   } = useSWR(`/api/providers?page=${page}&limit=${limit}`)

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -257,10 +257,7 @@ export default function Users() {
   const page = router.query.p === undefined ? 1 : router.query.p
   const limit = 13
   const {
-    data: { items, totalPages, totalCount } = {
-      totalCount: 0,
-      totalPages: 0,
-    },
+    data: { items, totalPages, totalCount } = {},
     error,
     mutate,
   } = useSWR(`/api/users?page=${page}&limit=${limit}`)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

While pagination wasn't default/mandatory, all fields in the PaginationResponse used `omitempty`. 

However, this is no longer necessary and can cause bugs/unexpected behavior when the `totalPage` field is undefined instead of 0. This 'bug' was still present when writing pagination for the UI, but the defaults are no longer necessary.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
