### PR TITLE
maintain: fix data test

### DIFF
--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -112,7 +112,7 @@ func TestPaginationSelector(t *testing.T) {
 		for r := 'a'; r < 'a'+26; r++ {
 			letters = append(letters, string(r))
 			g := &models.Identity{Name: string(r)}
-			err := db.Create(g).Error
+			err := add(db, g)
 			assert.NilError(t, err)
 		}
 


### PR DESCRIPTION
## Summary

`db.Create()` doesn't add the org ID, which was getting by-passed in a pagination test. This change switches it out to use `add()` instead.

