### PR TITLE
fix: use unique org db context key

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -33,7 +33,7 @@ func setupDB(t *testing.T) *gorm.DB {
 	err = data.CreateOrganization(db, org)
 	assert.NilError(t, err)
 
-	db.Statement.Context = context.WithValue(db.Statement.Context, "org", org)
+	db.Statement.Context = context.WithValue(db.Statement.Context, data.OrgCtxKey{}, org)
 
 	return db
 }

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -29,7 +29,7 @@ func Signup(c *gin.Context, orgName, domain, name, password string) (*models.Ide
 		return nil, nil, err
 	}
 	c.Set("org", org)
-	db.Statement.Context = context.WithValue(db.Statement.Context, "org", org)
+	db.Statement.Context = context.WithValue(db.Statement.Context, data.OrgCtxKey{}, org)
 
 	identity := &models.Identity{
 		Model: models.Model{OrganizationID: org.ID},

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -27,7 +27,7 @@ func setupDB(t *testing.T) *gorm.DB {
 	assert.NilError(t, err)
 
 	// set this as the default org
-	db.Statement.Context = context.WithValue(db.Statement.Context, "org", org)
+	db.Statement.Context = context.WithValue(db.Statement.Context, data.OrgCtxKey{}, org)
 
 	// create the provider if it's missing
 	data.InfraProvider(db)

--- a/internal/server/authn/oidc.go
+++ b/internal/server/authn/oidc.go
@@ -52,9 +52,9 @@ func (a *oidcAuthn) Authenticate(ctx context.Context, db *gorm.DB) (*models.Iden
 			return nil, nil, AuthScope{}, fmt.Errorf("get user: %w", err)
 		}
 
-		org, ok := ctx.Value("org").(*models.Organization)
+		org, ok := ctx.Value(data.OrgCtxKey{}).(*models.Organization)
 		if !ok {
-			org, ok = db.Statement.Context.Value("org").(*models.Organization)
+			org, ok = db.Statement.Context.Value(data.OrgCtxKey{}).(*models.Organization)
 			if !ok {
 				return nil, nil, AuthScope{}, errors.New("organization not set")
 			}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -635,8 +635,8 @@ func (s Server) loadConfig(config Config) error {
 			return fmt.Errorf("loading org: %w", err)
 		}
 
-		s.db.Statement.Context = context.WithValue(s.db.Statement.Context, "org", org)
-		tx.Statement.Context = context.WithValue(tx.Statement.Context, "org", org)
+		s.db.Statement.Context = context.WithValue(s.db.Statement.Context, data.OrgCtxKey{}, org)
+		tx.Statement.Context = context.WithValue(tx.Statement.Context, data.OrgCtxKey{}, org)
 
 		if err := s.loadProviders(tx, org, config.Providers); err != nil {
 			return fmt.Errorf("load providers: %w", err)

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -129,7 +129,7 @@ func get[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) (*T, error)
 }
 
 func getOrg(db *gorm.DB) *models.Organization {
-	org, ok := db.Statement.Context.Value("org").(*models.Organization)
+	org, ok := db.Statement.Context.Value(OrgCtxKey{}).(*models.Organization)
 	if !ok {
 		panic("no org")
 	}

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -30,7 +30,7 @@ func setupDB(t *testing.T, driver gorm.Dialector) *gorm.DB {
 	err = CreateOrganization(db, org)
 	assert.NilError(t, err)
 
-	db.Statement.Context = context.WithValue(db.Statement.Context, "org", org)
+	db.Statement.Context = context.WithValue(db.Statement.Context, OrgCtxKey{}, org)
 
 	InfraProvider(db)
 
@@ -148,7 +148,6 @@ func TestPaginationSelector(t *testing.T) {
 		for i, user := range actual {
 			assert.Equal(t, user.Name, letters[i])
 		}
-
 	})
 }
 

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -6,6 +6,8 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
+type OrgCtxKey struct{}
+
 func CreateOrganization(db *gorm.DB, org *models.Organization) error {
 	return add(db, org)
 }

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -37,7 +37,7 @@ func createGroups(t *testing.T, db *gorm.DB, groups ...*models.Group) {
 
 func TestAPI_ListGroups(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	o := srv.db.Statement.Context.Value("org")
+	o := srv.db.Statement.Context.Value(data.OrgCtxKey{})
 	_, ok := o.(*models.Organization)
 	assert.Assert(t, ok)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
@@ -281,15 +281,13 @@ func TestAPI_DeleteGroup(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	var humans = models.Group{Name: "humans"}
+	humans := models.Group{Name: "humans"}
 	createGroups(t, srv.db, &humans)
 
-	var (
-		inGroup = models.Identity{
-			Name:   "inagroup@example.com",
-			Groups: []models.Group{humans},
-		}
-	)
+	inGroup := models.Identity{
+		Name:   "inagroup@example.com",
+		Groups: []models.Group{humans},
+	}
 
 	createIdentities(t, srv.db, &inGroup)
 
@@ -359,7 +357,7 @@ func TestAPI_UpdateUsersInGroup(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	var humans = models.Group{Name: "humans"}
+	humans := models.Group{Name: "humans"}
 	createGroups(t, srv.db, &humans)
 
 	var (

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -41,7 +41,7 @@ func TimeoutMiddleware(timeout time.Duration) gin.HandlerFunc {
 func DatabaseMiddleware(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		err := db.WithContext(c.Request.Context()).Transaction(func(tx *gorm.DB) error {
-			tx.Statement.Context = context.WithValue(tx.Statement.Context, "org", db.Statement.Context.Value("org"))
+			tx.Statement.Context = context.WithValue(tx.Statement.Context, data.OrgCtxKey{}, db.Statement.Context.Value(data.OrgCtxKey{}))
 			c.Set("db", tx)
 			c.Next()
 			return nil
@@ -199,7 +199,7 @@ func OrganizationFromDomain(defaultOrgName, defaultOrgDomain string) gin.Handler
 			c.Set("org", org)
 			// c.Request.WithContext(context.WithValue(c.Request.Context(), "org", org))
 			db := getDB(c)
-			db.Statement.Context = context.WithValue(db.Statement.Context, "org", org)
+			db.Statement.Context = context.WithValue(db.Statement.Context, data.OrgCtxKey{}, org)
 			c.Set("db", db)
 			logging.Debugf("organization set to %s for host %s", org.Name, host)
 		}

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -190,14 +190,14 @@ func TestAPI_CreateOrganization(t *testing.T) {
 }
 
 func setCurrentOrg(db *gorm.DB, org *models.Organization) {
-	db.Statement.Context = context.WithValue(db.Statement.Context, "org", org)
+	db.Statement.Context = context.WithValue(db.Statement.Context, data.OrgCtxKey{}, org)
 }
 
 func TestAPI_DeleteOrganization(t *testing.T) {
 	srv := setupServer(t, withAdminUser, withSupportAdminGrant)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	var first = &models.Organization{Name: "first"}
+	first := &models.Organization{Name: "first"}
 	createOrgs(t, srv.db, first)
 	setCurrentOrg(srv.db, first)
 	p := data.InfraProvider(srv.db)
@@ -215,7 +215,8 @@ func TestAPI_DeleteOrganization(t *testing.T) {
 	err := data.CreateIdentity(srv.db, user)
 	assert.NilError(t, err)
 
-	key := &models.AccessKey{Model: models.Model{OrganizationID: first.ID},
+	key := &models.AccessKey{
+		Model:      models.Model{OrganizationID: first.ID},
 		Name:       "foo",
 		ExpiresAt:  time.Now().Add(10 * time.Minute).UTC(),
 		IssuedFor:  user.ID,


### PR DESCRIPTION
- appease the lint gods

## Summary
Should use a unique context key for the org db context rather than a string to ensure uniqueness. 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades
