### PR TITLE
feat(api): hide connector by default through showSystem query parameter

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -165,7 +165,7 @@ func (c Client) ListUsers(req ListUsersRequest) (*ListResponse[User], error) {
 	})
 	return get[ListResponse[User]](c, "/api/users",
 		Query{"name": {req.Name}, "group": {req.Group.String()}, "ids": ids,
-			"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)}})
+			"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)}, "showSystem": {strconv.FormatBool(req.ShowSystem)}})
 }
 
 func (c Client) GetUser(id uid.ID) (*User, error) {

--- a/api/user.go
+++ b/api/user.go
@@ -25,9 +25,10 @@ type User struct {
 }
 
 type ListUsersRequest struct {
-	Name  string   `form:"name"`
-	Group uid.ID   `form:"group"`
-	IDs   []uid.ID `form:"ids"`
+	Name       string   `form:"name"`
+	Group      uid.ID   `form:"group"`
+	IDs        []uid.ID `form:"ids"`
+	ShowSystem bool     `form:"showSystem"`
 	PaginationRequest
 }
 

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -114,7 +114,7 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 	return data.DeleteIdentity(db, id)
 }
 
-func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID, p *models.Pagination) ([]models.Identity, error) {
+func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID, showSystem bool, p *models.Pagination) ([]models.Identity, error) {
 	roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
 	db, err := RequireInfraRole(c, roles...)
 	if err != nil {
@@ -125,6 +125,10 @@ func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID, p
 		data.ByOptionalName(name),
 		data.ByOptionalIDs(ids),
 		data.ByOptionalIdentityGroupID(groupID),
+	}
+
+	if !showSystem {
+		selectors = append(selectors, data.NotName(models.InternalInfraConnectorIdentityName))
 	}
 
 	return data.ListIdentities(db.Preload("Providers"), p, selectors...)

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -30,7 +30,7 @@ func TestListIdentities(t *testing.T) {
 	assert.NilError(t, err)
 
 	// test fetch all identities
-	ids, err := ListIdentities(c, "", 0, nil, nil)
+	ids, err := ListIdentities(c, "", 0, nil, true, nil)
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(ids), 4) // the two identities created, the admin one used to call these access functions, and the internal connector identity

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -4937,6 +4937,13 @@
           },
           {
             "in": "query",
+            "name": "showSystem",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
             "name": "page",
             "schema": {
               "format": "int",

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -14,7 +14,7 @@ import (
 
 func (a *API) ListUsers(c *gin.Context, r *api.ListUsersRequest) (*api.ListResponse[api.User], error) {
 	p := models.RequestToPagination(r.PaginationRequest)
-	users, err := access.ListIdentities(c, r.Name, r.Group, r.IDs, &p)
+	users, err := access.ListIdentities(c, r.Name, r.Group, r.IDs, r.ShowSystem, &p)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (a *API) CreateUser(c *gin.Context, r *api.CreateUserRequest) (*api.CreateU
 	infraProvider := access.InfraProvider(c)
 
 	// infra identity creation should be attempted even if an identity is already known
-	identities, err := access.ListIdentities(c, user.Name, 0, nil, &models.Pagination{Limit: 2})
+	identities, err := access.ListIdentities(c, user.Name, 0, nil, false, &models.Pagination{Limit: 2})
 	if err != nil {
 		return nil, fmt.Errorf("list identities: %w", err)
 	}

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -287,7 +287,7 @@ func TestAPI_ListUsers(t *testing.T) {
 			},
 		},
 		"no filter": {
-			urlPath: "/api/users",
+			urlPath: "/api/users?showSystem=true",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK)
 
@@ -310,6 +310,29 @@ func TestAPI_ListUsers(t *testing.T) {
 				assert.DeepEqual(t, actual, expected, cmpAPIUserShallow)
 			},
 		},
+		"hide connector": {
+			urlPath: "/api/users",
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK)
+
+				var actual api.ListResponse[api.User]
+				err := json.NewDecoder(resp.Body).Decode(&actual)
+				assert.NilError(t, err)
+				expected := api.ListResponse[api.User]{
+					Count: 6,
+					Items: []api.User{
+						{Name: "AnotherUser@example.com"},
+						{Name: "HAL@example.com"},
+						{Name: "admin@example.com"},
+						{Name: "me@example.com"},
+						{Name: "other-HAL@example.com"},
+						{Name: "other@example.com"},
+					},
+					PaginationResponse: api.PaginationResponse{Page: 1, Limit: 100, TotalPages: 1, TotalCount: 6},
+				}
+				assert.DeepEqual(t, actual, expected, cmpAPIUserShallow)
+			},
+		},
 		"no authorization": {
 			urlPath: "/api/users",
 			setup: func(t *testing.T, req *http.Request) {
@@ -320,7 +343,7 @@ func TestAPI_ListUsers(t *testing.T) {
 			},
 		},
 		"page 2 limit 2": {
-			urlPath: "/api/users?limit=2&page=2",
+			urlPath: "/api/users?limit=2&page=2&showSystem=true",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK)
 

--- a/ui/components/grant-form.js
+++ b/ui/components/grant-form.js
@@ -22,9 +22,7 @@ export default function GrantForm({ roles, onSubmit = () => {} }) {
   const filtered = [
     ...users.map(u => ({ ...u, user: true })),
     ...groups.map(g => ({ ...g, group: true })),
-  ]
-    .filter(s => s?.name?.toLowerCase()?.includes(query.toLowerCase()))
-    .filter(s => s.name !== 'connector')
+  ].filter(s => s?.name?.toLowerCase()?.includes(query.toLowerCase()))
 
   return (
     <form

--- a/ui/pages/destinations/add.js
+++ b/ui/pages/destinations/add.js
@@ -38,7 +38,7 @@ export default function DestinationsAdd() {
 
     setConnected(false)
 
-    let res = await fetch('/api/users?name=connector')
+    let res = await fetch('/api/users?name=connector&showSystem=true')
     const { items: connectors } = await res.json()
 
     // TODO (https://github.com/infrahq/infra/issues/2056): handle the case where connector does not exist

--- a/ui/pages/groups/add.js
+++ b/ui/pages/groups/add.js
@@ -18,7 +18,6 @@ function EmailsSelectInput({ selectedEmails, setSelectedEmails }) {
 
   const filteredEmail = [...users.map(u => ({ ...u, user: true }))]
     .filter(s => s?.name?.toLowerCase()?.includes(query.toLowerCase()))
-    .filter(s => s.name !== 'connector')
     .filter(s => !selectedEmailsId?.includes(s.id))
 
   function removeSelectedEmail(email) {

--- a/ui/pages/groups/index.js
+++ b/ui/pages/groups/index.js
@@ -75,7 +75,6 @@ function EmailsSelectInput({
 
   const filteredEmail = [...users.map(u => ({ ...u, user: true }))]
     .filter(s => s?.name?.toLowerCase()?.includes(query.toLowerCase()))
-    .filter(s => s.name !== 'connector')
     .filter(s => !selectedEmailsId?.includes(s.id))
     .filter(s => !existMembers?.includes(s.id))
 

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -262,7 +262,7 @@ export default function Users() {
     mutate,
   } = useSWR(`/api/users?page=${page}&limit=${limit}`)
   const { admin, loading: adminLoading } = useAdmin()
-  const users = items?.filter(u => u.name !== 'connector')
+  const users = items
   const table = useTable({
     columns,
     data: users || [],


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->
Currently the connector shows up in the user list. Although the connector is technically a user, it's not really useful for users to see it as it's mostly internal and we've considered changing the architecture altogether (see https://github.com/infrahq/infra/issues/2238). 

This also prevents pagination issues with the UI (as it was hiding the connector and displaying the wrong item count) and makes the UI and CLI consistent.

I checked for cases where we'd need to enable `showSystem`, but if I missed any use cases where the connector needs to be shown, please let me know.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2733 
