### PR TITLE
Org collab fixaccesstests

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -56,10 +56,11 @@ func setupAccessTestContext(t *testing.T) (*gin.Context, *gorm.DB, *models.Provi
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Set("db", db)
 
-	err := data.SaveSettings(db, &models.Settings{
-		Model:     models.Model{OrganizationID: org.ID},
-		LengthMin: 8,
-	})
+	settings, err := data.GetSettings(db, org)
+	assert.NilError(t, err)
+
+	settings.LengthMin = 8
+	err = data.SaveSettings(db, settings)
 	assert.NilError(t, err)
 
 	admin := &models.Identity{Name: "admin@example.com"}

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -21,10 +21,15 @@ func TestSettingsPasswordRequirements(t *testing.T) {
 	_, err = CreateCredential(c, *user)
 	assert.NilError(t, err)
 
-	err = data.SaveSettings(db, &models.Settings{
-		LengthMin: 8,
-	})
+	org := getDefaultOrg(db)
+
+	settings, err := data.GetSettings(db, org)
 	assert.NilError(t, err)
+
+	settings.LengthMin = 8
+	err = data.SaveSettings(db, settings)
+	assert.NilError(t, err)
+
 	t.Run("Update user credentials fails if less than min length", func(t *testing.T) {
 		err := UpdateCredential(c, user, "short")
 		assert.ErrorContains(t, err, "validation failed: password")
@@ -32,7 +37,7 @@ func TestSettingsPasswordRequirements(t *testing.T) {
 	})
 
 	// Test min length success
-	settings, err := data.GetSettings(db, getDefaultOrg(db))
+	settings, err = data.GetSettings(db, getDefaultOrg(db))
 	assert.NilError(t, err)
 	settings.LengthMin = 5
 	err = data.SaveSettings(db, settings)

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/rs/zerolog"


### PR DESCRIPTION
## Summary

Instead of updating the already existing settings, a couple of the access tests were trying to create a new set of settings which caused issues.
