### PR TITLE
Add organization ID, and remove FKs and sequences

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -41,13 +41,8 @@ func setupAccessTestContext(t *testing.T) (*gin.Context, *gorm.DB, *models.Provi
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Set("db", db)
 
-	err := data.SaveSettings(db, &models.Settings{
-		LengthMin: 8,
-	})
-	assert.NilError(t, err)
-
 	admin := &models.Identity{Name: "admin@example.com"}
-	err = data.CreateIdentity(db, admin)
+	err := data.CreateIdentity(db, admin)
 	assert.NilError(t, err)
 
 	c.Set("identity", admin)

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -86,6 +86,11 @@ func TestUpdateCredentials(t *testing.T) {
 	_, err = CreateCredential(c, *user)
 	assert.NilError(t, err)
 
+	err = data.SaveSettings(db, &models.Settings{
+		LengthMin: 8,
+	})
+	assert.NilError(t, err)
+
 	t.Run("Update user credentials IS single use password", func(t *testing.T) {
 		err := UpdateCredential(c, user, "newPassword")
 		assert.NilError(t, err)

--- a/internal/access/passwordreset_test.go
+++ b/internal/access/passwordreset_test.go
@@ -13,12 +13,17 @@ import (
 func TestPasswordResetFlow(t *testing.T) {
 	c, db, _ := setupAccessTestContext(t)
 
+	err := data.SaveSettings(db, &models.Settings{
+		LengthMin: 8,
+	})
+	assert.NilError(t, err)
+
 	user := &models.Identity{
 		Name: "joe@example.com",
 	}
 
 	// setup user
-	err := CreateIdentity(c, user)
+	err = CreateIdentity(c, user)
 	assert.NilError(t, err)
 
 	err = data.CreateCredential(db, &models.Credential{

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -20,22 +20,22 @@ func SignupEnabled(c *gin.Context) (bool, error) {
 	db := getDB(c)
 
 	// use Unscoped because deleting identities, providers or grants should not re-enable signup
-	identities, err := data.Count[models.Identity](db.Unscoped(), data.NotName(models.InternalInfraConnectorIdentityName))
+	identities, err := data.GlobalCount[models.Identity](db.Unscoped(), data.NotName(models.InternalInfraConnectorIdentityName))
 	if err != nil {
 		return false, err
 	}
 
-	providers, err := data.Count[models.Provider](db.Unscoped(), data.NotProviderKind(models.ProviderKindInfra))
+	providers, err := data.GlobalCount[models.Provider](db.Unscoped(), data.NotProviderKind(models.ProviderKindInfra))
 	if err != nil {
 		return false, err
 	}
 
-	grants, err := data.Count[models.Grant](db.Unscoped(), data.NotPrivilege(models.InfraConnectorRole))
+	grants, err := data.GlobalCount[models.Grant](db.Unscoped(), data.NotPrivilege(models.InfraConnectorRole))
 	if err != nil {
 		return false, err
 	}
 
-	accessKeys, err := data.Count[models.AccessKey](db.Unscoped())
+	accessKeys, err := data.GlobalCount[models.AccessKey](db.Unscoped())
 	if err != nil {
 		return false, err
 	}

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -222,7 +222,7 @@ func TestSetOrg(t *testing.T) {
 
 	db := &gorm.DB{}
 	db.Statement = &gorm.Statement{
-		Context: context.WithValue(context.Background(), "org", org),
+		Context: WithOrg(context.Background(), org),
 	}
 	setOrg(db, model)
 	assert.Equal(t, model.OrganizationID, uid.ID(123456))

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -214,3 +214,16 @@ func TestCreateTransactionError(t *testing.T) {
 		assert.NilError(t, err)
 	})
 }
+
+func TestSetOrg(t *testing.T) {
+	model := &models.AccessKey{}
+	org := &models.Organization{}
+	org.ID = 123456
+
+	db := &gorm.DB{}
+	db.Statement = &gorm.Statement{
+		Context: context.WithValue(context.Background(), "org", org),
+	}
+	setOrg(db, model)
+	assert.Equal(t, model.OrganizationID, uid.ID(123456))
+}

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -395,6 +395,12 @@ INSERT INTO provider_users (identity_id, provider_id, id, created_at, updated_at
 				// column changes are tested with schema comparison
 			},
 		},
+		{
+			label: testCaseLine("2022-08-04T17:72"),
+			expected: func(t *testing.T, db *gorm.DB) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -389,6 +389,12 @@ INSERT INTO provider_users (identity_id, provider_id, id, created_at, updated_at
 				assert.DeepEqual(t, settings, expected)
 			},
 		},
+		{
+			label: testCaseLine("2022-07-27T15:54"),
+			expected: func(t *testing.T, db *gorm.DB) {
+				// column changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))
@@ -404,7 +410,9 @@ INSERT INTO provider_users (identity_id, provider_id, id, created_at, updated_at
 
 	var initialSchema string
 	runStep(t, "initial schema", func(t *testing.T) {
-		db := setupDB(t, postgresDriver(t))
+		patch.ModelsSymmetricKey(t)
+		db, err := NewDB(postgresDriver(t), nil)
+		assert.NilError(t, err)
 		initialSchema = dumpSchema(t, os.Getenv("POSTGRESQL_CONNECTION"))
 
 		assert.NilError(t, db.Exec("DROP SCHEMA IF EXISTS testing CASCADE").Error)

--- a/internal/server/data/migrator/migrator.go
+++ b/internal/server/data/migrator/migrator.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"gorm.io/gorm"
+
+	"github.com/infrahq/infra/internal/logging"
 )
 
 const initSchemaMigrationID = "SCHEMA_INIT"
@@ -201,8 +203,9 @@ func (g *Migrator) runMigration(migration *Migration) error {
 		return nil
 	}
 
+	logging.Infof("Running migration %s", migration.ID)
 	if err := migration.Migrate(g.tx); err != nil {
-		return err
+		return fmt.Errorf("failed to apply migration %v: %w", migration.ID, err)
 	}
 	return g.insertMigration(migration.ID)
 }

--- a/internal/server/data/migrator/migrator_test.go
+++ b/internal/server/data/migrator/migrator_test.go
@@ -344,7 +344,7 @@ func TestMigration_WithUseTransactionsShouldRollback(t *testing.T) {
 
 		// Migration should return an error and not leave around a Book table
 		err := m.Migrate()
-		assert.Error(t, err, "this transaction should be rolled back")
+		assert.ErrorContains(t, err, "this transaction should be rolled back")
 		assert.Assert(t, !HasTable(db, "books"))
 	}, "postgres", "sqlite3", "mssql")
 }

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -1,10 +1,31 @@
 package data
 
 import (
+	"context"
+
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/models"
 )
+
+type orgCtxKey struct{}
+
+// OrgFromContext returns the Organization stored using WithOrg.
+func OrgFromContext(ctx context.Context) *models.Organization {
+	org, ok := ctx.Value(orgCtxKey{}).(*models.Organization)
+	if !ok {
+		// TODO(orgs): panic("no org")
+		return &models.Organization{}
+	}
+	return org
+}
+
+// WithOrg sets an Organization in the context. The Organization will be used
+// by all query functions to insert,select, and modify entities within that
+// organization.
+func WithOrg(ctx context.Context, org *models.Organization) context.Context {
+	return context.WithValue(ctx, orgCtxKey{}, org)
+}
 
 func CreateOrganization(db *gorm.DB, org *models.Organization) error {
 	return add(db, org)

--- a/internal/server/data/passwordresettoken.go
+++ b/internal/server/data/passwordresettoken.go
@@ -3,6 +3,7 @@ package data
 import (
 	"time"
 
+	"github.com/infrahq/infra/uid"
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
@@ -17,6 +18,7 @@ func CreatePasswordResetToken(db *gorm.DB, user *models.Identity) (*models.Passw
 	}
 
 	prt := &models.PasswordResetToken{
+		ID:         uid.New(),
 		Token:      token,
 		IdentityID: user.ID,
 		ExpiresAt:  time.Now().Add(10 * time.Minute).UTC(),

--- a/internal/server/data/passwordresettoken.go
+++ b/internal/server/data/passwordresettoken.go
@@ -3,12 +3,12 @@ package data
 import (
 	"time"
 
-	"github.com/infrahq/infra/uid"
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func CreatePasswordResetToken(db *gorm.DB, user *models.Identity) (*models.PasswordResetToken, error) {

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE access_keys (
     extension_deadline timestamp with time zone,
     key_id text,
     secret_checksum bytea,
+    organization_id bigint,
     scopes text
 );
 
@@ -36,7 +37,8 @@ CREATE TABLE credentials (
     deleted_at timestamp with time zone,
     identity_id bigint,
     password_hash bytea,
-    one_time_password boolean
+    one_time_password boolean,
+    organization_id bigint
 );
 
 CREATE SEQUENCE credentials_id_seq
@@ -58,6 +60,7 @@ CREATE TABLE destinations (
     connection_url text,
     connection_ca text,
     last_seen_at timestamp with time zone,
+    organization_id bigint,
     version text,
     resources text,
     roles text
@@ -101,7 +104,8 @@ CREATE TABLE grants (
     subject text,
     privilege text,
     resource text,
-    created_by bigint
+    created_by bigint,
+    organization_id bigint
 );
 
 CREATE SEQUENCE grants_id_seq
@@ -120,6 +124,7 @@ CREATE TABLE groups (
     deleted_at timestamp with time zone,
     name text,
     created_by bigint,
+    organization_id bigint,
     created_by_provider bigint
 );
 
@@ -139,7 +144,8 @@ CREATE TABLE identities (
     deleted_at timestamp with time zone,
     name text,
     last_seen_at timestamp with time zone,
-    created_by bigint
+    created_by bigint,
+    organization_id bigint
 );
 
 CREATE TABLE identities_groups (
@@ -178,7 +184,8 @@ CREATE TABLE password_reset_tokens (
     id bigint NOT NULL,
     token text,
     identity_id bigint,
-    expires_at timestamp with time zone
+    expires_at timestamp with time zone,
+    organization_id bigint
 );
 
 CREATE SEQUENCE password_reset_tokens_id_seq
@@ -215,6 +222,7 @@ CREATE TABLE providers (
     kind text,
     auth_url text,
     scopes text,
+    organization_id bigint,
     private_key text,
     client_email text,
     domain_admin_email text
@@ -236,6 +244,7 @@ CREATE TABLE settings (
     deleted_at timestamp with time zone,
     private_jwk bytea,
     public_jwk bytea,
+    organization_id bigint,
     lowercase_min bigint DEFAULT 0,
     uppercase_min bigint DEFAULT 0,
     number_min bigint DEFAULT 0,

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -21,15 +21,6 @@ CREATE TABLE access_keys (
     scopes text
 );
 
-CREATE SEQUENCE access_keys_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE access_keys_id_seq OWNED BY access_keys.id;
-
 CREATE TABLE credentials (
     id bigint NOT NULL,
     created_at timestamp with time zone,
@@ -40,15 +31,6 @@ CREATE TABLE credentials (
     one_time_password boolean,
     organization_id bigint
 );
-
-CREATE SEQUENCE credentials_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE credentials_id_seq OWNED BY credentials.id;
 
 CREATE TABLE destinations (
     id bigint NOT NULL,
@@ -66,15 +48,6 @@ CREATE TABLE destinations (
     roles text
 );
 
-CREATE SEQUENCE destinations_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE destinations_id_seq OWNED BY destinations.id;
-
 CREATE TABLE encryption_keys (
     id bigint NOT NULL,
     created_at timestamp with time zone,
@@ -86,15 +59,6 @@ CREATE TABLE encryption_keys (
     algorithm text,
     root_key_id text
 );
-
-CREATE SEQUENCE encryption_keys_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE encryption_keys_id_seq OWNED BY encryption_keys.id;
 
 CREATE TABLE grants (
     id bigint NOT NULL,
@@ -108,15 +72,6 @@ CREATE TABLE grants (
     organization_id bigint
 );
 
-CREATE SEQUENCE grants_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE grants_id_seq OWNED BY grants.id;
-
 CREATE TABLE groups (
     id bigint NOT NULL,
     created_at timestamp with time zone,
@@ -127,15 +82,6 @@ CREATE TABLE groups (
     organization_id bigint,
     created_by_provider bigint
 );
-
-CREATE SEQUENCE groups_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE groups_id_seq OWNED BY groups.id;
 
 CREATE TABLE identities (
     id bigint NOT NULL,
@@ -153,15 +99,6 @@ CREATE TABLE identities_groups (
     group_id bigint NOT NULL
 );
 
-CREATE SEQUENCE identities_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE identities_id_seq OWNED BY identities.id;
-
 CREATE TABLE organizations (
     id bigint NOT NULL,
     created_at timestamp with time zone,
@@ -171,15 +108,6 @@ CREATE TABLE organizations (
     created_by bigint
 );
 
-CREATE SEQUENCE organizations_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
-
 CREATE TABLE password_reset_tokens (
     id bigint NOT NULL,
     token text,
@@ -187,15 +115,6 @@ CREATE TABLE password_reset_tokens (
     expires_at timestamp with time zone,
     organization_id bigint
 );
-
-CREATE SEQUENCE password_reset_tokens_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE password_reset_tokens_id_seq OWNED BY password_reset_tokens.id;
 
 CREATE TABLE provider_users (
     identity_id bigint NOT NULL,
@@ -228,15 +147,6 @@ CREATE TABLE providers (
     domain_admin_email text
 );
 
-CREATE SEQUENCE providers_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE providers_id_seq OWNED BY providers.id;
-
 CREATE TABLE settings (
     id bigint NOT NULL,
     created_at timestamp with time zone,
@@ -251,37 +161,6 @@ CREATE TABLE settings (
     symbol_min bigint DEFAULT 0,
     length_min bigint DEFAULT 8
 );
-
-CREATE SEQUENCE settings_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-ALTER SEQUENCE settings_id_seq OWNED BY settings.id;
-
-ALTER TABLE ONLY access_keys ALTER COLUMN id SET DEFAULT nextval('access_keys_id_seq'::regclass);
-
-ALTER TABLE ONLY credentials ALTER COLUMN id SET DEFAULT nextval('credentials_id_seq'::regclass);
-
-ALTER TABLE ONLY destinations ALTER COLUMN id SET DEFAULT nextval('destinations_id_seq'::regclass);
-
-ALTER TABLE ONLY encryption_keys ALTER COLUMN id SET DEFAULT nextval('encryption_keys_id_seq'::regclass);
-
-ALTER TABLE ONLY grants ALTER COLUMN id SET DEFAULT nextval('grants_id_seq'::regclass);
-
-ALTER TABLE ONLY groups ALTER COLUMN id SET DEFAULT nextval('groups_id_seq'::regclass);
-
-ALTER TABLE ONLY identities ALTER COLUMN id SET DEFAULT nextval('identities_id_seq'::regclass);
-
-ALTER TABLE ONLY organizations ALTER COLUMN id SET DEFAULT nextval('organizations_id_seq'::regclass);
-
-ALTER TABLE ONLY password_reset_tokens ALTER COLUMN id SET DEFAULT nextval('password_reset_tokens_id_seq'::regclass);
-
-ALTER TABLE ONLY providers ALTER COLUMN id SET DEFAULT nextval('providers_id_seq'::regclass);
-
-ALTER TABLE ONLY settings ALTER COLUMN id SET DEFAULT nextval('settings_id_seq'::regclass);
 
 ALTER TABLE ONLY access_keys
     ADD CONSTRAINT access_keys_pkey PRIMARY KEY (id);
@@ -322,39 +201,26 @@ ALTER TABLE ONLY providers
 ALTER TABLE ONLY settings
     ADD CONSTRAINT settings_pkey PRIMARY KEY (id);
 
-CREATE UNIQUE INDEX idx_access_keys_key_id ON access_keys USING btree (key_id) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_access_keys_key_id ON access_keys USING btree (organization_id, key_id) WHERE (deleted_at IS NULL);
 
-CREATE UNIQUE INDEX idx_access_keys_name ON access_keys USING btree (name) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_access_keys_name ON access_keys USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 
-CREATE UNIQUE INDEX idx_credentials_identity_id ON credentials USING btree (identity_id) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_credentials_identity_id ON credentials USING btree (organization_id, identity_id) WHERE (deleted_at IS NULL);
 
-CREATE UNIQUE INDEX idx_destinations_unique_id ON destinations USING btree (unique_id) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_destinations_unique_id ON destinations USING btree (organization_id, unique_id) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_encryption_keys_key_id ON encryption_keys USING btree (key_id);
 
-CREATE UNIQUE INDEX idx_grant_srp ON grants USING btree (subject, privilege, resource) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_grant_srp ON grants USING btree (organization_id, subject, privilege, resource) WHERE (deleted_at IS NULL);
 
-CREATE UNIQUE INDEX idx_groups_name ON groups USING btree (name) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_groups_name ON groups USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 
-CREATE UNIQUE INDEX idx_identities_name ON identities USING btree (name) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_identities_name ON identities USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_organizations_name ON organizations USING btree (name) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_password_reset_tokens_token ON password_reset_tokens USING btree (token);
 
-CREATE UNIQUE INDEX idx_providers_name ON providers USING btree (name) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_providers_name ON providers USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 
-ALTER TABLE ONLY access_keys
-    ADD CONSTRAINT fk_access_keys_issued_for_identity FOREIGN KEY (issued_for) REFERENCES identities(id);
-
-ALTER TABLE ONLY identities_groups
-    ADD CONSTRAINT fk_identities_groups_group FOREIGN KEY (group_id) REFERENCES groups(id);
-
-ALTER TABLE ONLY identities_groups
-    ADD CONSTRAINT fk_identities_groups_identity FOREIGN KEY (identity_id) REFERENCES identities(id);
-
-ALTER TABLE ONLY provider_users
-    ADD CONSTRAINT fk_provider_users_identity FOREIGN KEY (identity_id) REFERENCES identities(id);
-
-ALTER TABLE ONLY provider_users
-    ADD CONSTRAINT fk_provider_users_provider FOREIGN KEY (provider_id) REFERENCES providers(id);
+CREATE UNIQUE INDEX settings_org_id ON settings USING btree (organization_id) WHERE (deleted_at IS NULL);

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -50,6 +50,12 @@ func ByOptionalIDs(ids []uid.ID) SelectorFunc {
 	}
 }
 
+func ByOrgID(orgID uid.ID) SelectorFunc {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where("organization_id = ?", orgID)
+	}
+}
+
 func ByName(name string) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("name = ?", name)

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -23,7 +23,7 @@ func setupMetrics(db *gorm.DB) *prometheus.Registry {
 		Name:      "users",
 		Help:      "The total number of users",
 	}, []string{}, func() []metrics.Metric {
-		count, err := data.Count[models.Identity](db)
+		count, err := data.GlobalCount[models.Identity](db)
 		if err != nil {
 			logging.L.Warn().Err(err).Msg("users")
 			return []metrics.Metric{}
@@ -39,7 +39,7 @@ func setupMetrics(db *gorm.DB) *prometheus.Registry {
 		Name:      "groups",
 		Help:      "The total number of groups",
 	}, []string{}, func() []metrics.Metric {
-		count, err := data.Count[models.Group](db)
+		count, err := data.GlobalCount[models.Group](db)
 		if err != nil {
 			logging.L.Warn().Err(err).Msg("groups")
 			return []metrics.Metric{}
@@ -55,7 +55,7 @@ func setupMetrics(db *gorm.DB) *prometheus.Registry {
 		Name:      "grants",
 		Help:      "The total number of grants",
 	}, []string{}, func() []metrics.Metric {
-		count, err := data.Count[models.Grant](db)
+		count, err := data.GlobalCount[models.Grant](db)
 		if err != nil {
 			logging.L.Warn().Err(err).Msg("grants")
 			return []metrics.Metric{}

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -17,6 +17,7 @@ const ScopePasswordReset = "password-reset"
 // AccessKey is a session token presented to the Infra server as proof of authentication
 type AccessKey struct {
 	Model
+	OrganizationMember
 	Name string `gorm:"uniqueIndex:idx_access_keys_name,where:deleted_at is NULL"`
 	// IssuedFor is the ID of the user that this access key was created for
 	IssuedFor         uid.ID

--- a/internal/server/models/credential.go
+++ b/internal/server/models/credential.go
@@ -4,6 +4,7 @@ import "github.com/infrahq/infra/uid"
 
 type Credential struct {
 	Model
+	OrganizationMember
 
 	IdentityID      uid.ID `gorm:"<-;uniqueIndex:idx_credentials_identity_id,where:deleted_at is NULL"`
 	PasswordHash    []byte

--- a/internal/server/models/destination.go
+++ b/internal/server/models/destination.go
@@ -8,6 +8,7 @@ import (
 
 type Destination struct {
 	Model
+	OrganizationMember
 
 	Name          string
 	UniqueID      string `gorm:"uniqueIndex:idx_destinations_unique_id,where:deleted_at is NULL"`

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -34,6 +34,7 @@ const BasePermissionConnect = "connect"
 //
 type Grant struct {
 	Model
+	OrganizationMember
 
 	Subject   uid.PolymorphicID `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // usually an identity, but could be a role definition
 	Privilege string            `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // role or permission

--- a/internal/server/models/group.go
+++ b/internal/server/models/group.go
@@ -7,6 +7,7 @@ import (
 
 type Group struct {
 	Model
+	OrganizationMember
 
 	Name              string `gorm:"uniqueIndex:idx_groups_name,where:deleted_at is NULL"`
 	CreatedBy         uid.ID

--- a/internal/server/models/identity.go
+++ b/internal/server/models/identity.go
@@ -15,6 +15,7 @@ const (
 
 type Identity struct {
 	Model
+	OrganizationMember
 
 	Name       string    `gorm:"uniqueIndex:idx_identities_name,where:deleted_at is NULL"`
 	LastSeenAt time.Time // updated on when an identity uses a session token

--- a/internal/server/models/organization.go
+++ b/internal/server/models/organization.go
@@ -25,3 +25,11 @@ type OrganizationMember struct {
 	// OrganizationID of the organization this entity belongs to.
 	OrganizationID uid.ID
 }
+
+func (OrganizationMember) IsOrganizationMember() {}
+
+func (o *OrganizationMember) SetOrganizationID(id uid.ID) {
+	if o.OrganizationID == 0 {
+		o.OrganizationID = id
+	}
+}

--- a/internal/server/models/organization.go
+++ b/internal/server/models/organization.go
@@ -20,3 +20,8 @@ func (o *Organization) ToAPI() *api.Organization {
 		Name:    o.Name,
 	}
 }
+
+type OrganizationMember struct {
+	// OrganizationID of the organization this entity belongs to.
+	OrganizationID uid.ID
+}

--- a/internal/server/models/passwordresettoken.go
+++ b/internal/server/models/passwordresettoken.go
@@ -8,6 +8,7 @@ import (
 
 type PasswordResetToken struct {
 	ID uid.ID
+	OrganizationMember
 
 	Token      string    `validate:"required" gorm:"uniqueIndex"`
 	IdentityID uid.ID    `validate:"required"`

--- a/internal/server/models/provider.go
+++ b/internal/server/models/provider.go
@@ -44,6 +44,7 @@ func ParseProviderKind(kind string) (ProviderKind, error) {
 
 type Provider struct {
 	Model
+	OrganizationMember
 
 	Name         string `gorm:"uniqueIndex:idx_providers_name,where:deleted_at is NULL"`
 	URL          string

--- a/internal/server/models/settings.go
+++ b/internal/server/models/settings.go
@@ -6,6 +6,7 @@ import (
 
 type Settings struct {
 	Model
+	OrganizationMember
 
 	PrivateJWK EncryptedAtRestBytes
 	PublicJWK  []byte

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -65,27 +65,27 @@ func (t *Telemetry) Close() {
 }
 
 func (t *Telemetry) EnqueueHeartbeat() {
-	users, err := data.Count[models.Identity](t.db)
+	users, err := data.GlobalCount[models.Identity](t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}
 
-	groups, err := data.Count[models.Group](t.db)
+	groups, err := data.GlobalCount[models.Group](t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}
 
-	grants, err := data.Count[models.Grant](t.db)
+	grants, err := data.GlobalCount[models.Grant](t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}
 
-	providers, err := data.Count[models.Provider](t.db)
+	providers, err := data.GlobalCount[models.Provider](t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}
 
-	destinations, err := data.Count[models.Destination](t.db)
+	destinations, err := data.GlobalCount[models.Destination](t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}


### PR DESCRIPTION
## Summary

This PR cherry-picks 501cd0dd1e0b574c5aa1c8fa2ad9146b88543946,  the data parts of 02cd02c941d9cd016575cb05057285e958cdf9c3, and a bit of 0d1faf9fc40c5c0911fed950b80d18d1cd062178 for merging into main. Best viewed by individual commit.

I made a few changes as well:
* use interfaces instead of reflection for working with models
* use easier to read migration IDs, we started using these recently for new migraiotns
* use single statements for migrations
* remove double quotes from queries, and use caps consistently for sql keywords
* make the selector `ByOrgID` instead of `ByOrg`
* move the OrganizationID to an `OrganizationMember` so that tables that don't use it don't receive an org_id
* continue to require not-null for primary keys
* cascade the deletes of sequences to remove the other sequence data

I had to cherry-pick a couple of changes from #2862 so that AutoMigrate wouldn't create the wrong schema.