### PR TITLE
fix(build): helm build/release is not able to publish artifacts

### DIFF
--- a/.github/workflows/cd-core.yaml
+++ b/.github/workflows/cd-core.yaml
@@ -43,7 +43,6 @@ jobs:
         with:
           name: binaries
           path: dist/
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-core.yaml
+++ b/.github/workflows/cd-core.yaml
@@ -10,6 +10,7 @@ on:
       - go.mod
       - go.sum
       - '**/*.go'
+  workflow_dispatch:
 
 jobs:
   release-name:

--- a/.github/workflows/cd-helm.yaml
+++ b/.github/workflows/cd-helm.yaml
@@ -21,11 +21,24 @@ jobs:
       - uses: azure/setup-helm@v1
       - run: |
           helm package -d helm helm/charts/*
+      - uses: actions/upload-artifact@v3
+        with:
+          name: helm
+          path: |
+            helm/charts/*.tgz
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [package]
+    steps:
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: helm
       - run: |
           for chart in *.tgz; do
             if aws s3 ls s3://${{ env.HELM_BUCKET }}/$chart && ! ${{ inputs.OVERRIDE_EXISTING }} ; then

--- a/.github/workflows/cd-ui.yaml
+++ b/.github/workflows/cd-ui.yaml
@@ -8,11 +8,11 @@ on:
       - v*
     paths:
       - 'ui/**'
+  workflow_dispatch:
 
 jobs:
   docker:
     runs-on: ubuntu-latest
-    needs: [release-name]
     env:
       IMAGE: infrahq/ui
       CONTEXT: ui


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The workflow previously consisted of two jobs. During refactoring this was consolidated into a single job but there were side effects. The main side effect is the build artifacts are no longer in the root directory. Instead of continuing with a single job, use two jobs.
