### PR TITLE
improve: better error message for cert mismatch

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 		case errors.As(err, &unknownAuthErr):
 			// Cert error is most likely caused by mismatch between the client session and its cached server
 			// eg) server was re-installed, but the client cache was not cleared
-			fmt.Fprintf(os.Stderr, "Error: %v\n\nRun `infra login` again OR `infra logout --clear` to see if a new session resolves the issue.\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n\nTLS certificate is no longer valid with this server; to see if a new session resolves the issue, run `infra login` again OR `infra logout --clear`\n", err)
 		default:
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}

--- a/main.go
+++ b/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 
@@ -16,15 +16,17 @@ import (
 func main() {
 	if err := cmd.Run(context.Background(), os.Args[1:]...); err != nil {
 		var userErr cmd.Error
+		var unknownAuthErr x509.UnknownAuthorityError
+
 		switch {
 		case errors.Is(err, terminal.InterruptErr):
 			logging.Debugf("user interrupted the process")
 		case errors.As(err, &userErr):
 			fmt.Fprintln(os.Stderr, userErr.Error())
-		case strings.Contains(err.Error(), "x509: certificate signed by unknown authority"):
+		case errors.As(err, &unknownAuthErr):
 			// Cert error is most likely caused by mismatch between the client session and its cached server
 			// eg) server was re-installed, but the client cache was not cleared
-			fmt.Fprintf(os.Stderr, "Session certificate is no longer valid for this server; run 'infra login' to start a new session:\n\n%v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n\nTo see if the issue is with the client, run `infra login` again OR `infra logout --clear` to clear session\n", err)
 		default:
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 		case errors.As(err, &unknownAuthErr):
 			// Cert error is most likely caused by mismatch between the client session and its cached server
 			// eg) server was re-installed, but the client cache was not cleared
-			fmt.Fprintf(os.Stderr, "Error: %v\n\nTo see if the issue is with the client, run `infra login` again OR `infra logout --clear` to clear session\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n\nRun `infra login` again OR `infra logout --clear` to see if a new session resolves the issue.\n", err)
 		default:
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 
@@ -20,6 +21,10 @@ func main() {
 			logging.Debugf("user interrupted the process")
 		case errors.As(err, &userErr):
 			fmt.Fprintln(os.Stderr, userErr.Error())
+		case strings.Contains(err.Error(), "x509: certificate signed by unknown authority"):
+			// Cert error is most likely caused by mismatch between the client session and its cached server
+			// eg) server was re-installed, but the client cache was not cleared
+			fmt.Fprintf(os.Stderr, "Session certificate is no longer valid for this server; run 'infra login' to start a new session:\n\n%v\n", err)
 		default:
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}


### PR DESCRIPTION
## Summary

Adds a formal error message (along with the actual error) for cert mismatching the server.  


## Related Issues

Resolves #2898
