### PR TITLE
maintain: google idp experience

### DIFF
--- a/docs/identity-providers/google.md
+++ b/docs/identity-providers/google.md
@@ -13,9 +13,8 @@ infra providers add google \
   --url accounts.google.com \
   --client-id <your google client id> \
   --client-secret <your google client secret> \
-  --service-account-key <your google service account's private key> \
-  --service-account-email <your google service account's email> \
-  --domain-admin <your google workspace domain admin's email> \
+  --service-account-key <path to your google service account's private key file> \
+  --workspace-domain-admin <your google workspace domain admin's email> \
   --kind google
 ```
 
@@ -61,7 +60,7 @@ infra providers add google \
     - Select the **JSON** key type and click **CREATE**.
     - A private key JSON file will automatically download, note the **private_key** in this file. This will be the `service-account-key` in the `providers add` command.
   ![Service account key](../images/google-setup/connect-users-google-9.png)
-10. You are now finished with configuration in the Google Cloud admin console. Open the Google Workspace admin console and navigate to **Security > Access and Data Controls > API Controls > Domain-wide Delegation**.
+10. You are now finished with configuration in the Google Cloud admin console. Open the Google Workspace admin console and navigate to **Security > Access and Data Controls > API Controls > Manage Domain-wide Delegation**.
   ![API controls](../images/google-setup/connect-users-google-10.png)
   - Click **Manage Domain Wide Delegation**
   - Click **Add new**.

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -625,19 +625,19 @@ infra providers add PROVIDER [flags]
 $ infra providers add okta --url example.okta.com --client-id 0oa3sz06o6do0muoW5d7 --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --kind okta
 
 # Connect Google to Infra with group sync
-$ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0muoW5d7 --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --service-account-key ~/client-123.json --service-account-email hello@example.com --domain-admin admin@example.com --kind google
+$ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0muoW5d7 --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --service-account-key ~/client-123.json --workspace-domain-admin admin@example.com --kind google
 ```
 
 #### Options
 
 ```
-      --client-id string               OIDC client ID
-      --client-secret string           OIDC client secret
-      --domain-admin string            The email of your Google workspace domain admin
-      --kind string                    The identity provider kind. One of 'oidc, okta, azure, or google' (default "oidc")
-      --service-account-email string   The email assigned to the Infra service client in Google
-      --service-account-key filepath   The private key used to make authenticated requests to Google's API
-      --url string                     Base URL of the domain of the OIDC identity provider (eg. acme.okta.com)
+      --client-id string                OIDC client ID
+      --client-secret string            OIDC client secret
+      --kind string                     The identity provider kind. One of 'oidc, okta, azure, or google' (default "oidc")
+      --service-account-email string    The email assigned to the Infra service client in Google
+      --service-account-key filepath    The private key used to make authenticated requests to Google's API, can be a file or the key string directly
+      --url string                      Base URL of the domain of the OIDC identity provider (eg. acme.okta.com)
+      --workspace-domain-admin string   The email of your Google Workspace domain admin
 ```
 
 #### Options inherited from parent commands
@@ -661,17 +661,17 @@ infra providers edit PROVIDER [flags]
 $ infra providers edit okta --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN
 
 # Connect Google to Infra with group sync
-$ infra providers edit google --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --service-account-key ~/client-123.json --service-account-email hello@example.com --domain-admin admin@example.com
+$ infra providers edit google --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --service-account-key ~/client-123.json --service-account-email hello@example.com --workspace-domain-admin admin@example.com
 
 ```
 
 #### Options
 
 ```
-      --client-secret string           Set a new client secret
-      --domain-admin string            The email of your Google workspace domain admin
-      --service-account-email string   The email assigned to the Infra service client in Google
-      --service-account-key filepath   The private key used to make authenticated requests to Google's API
+      --client-secret string            Set a new client secret
+      --service-account-email string    The email assigned to the Infra service client in Google
+      --service-account-key filepath    The private key used to make authenticated requests to Google's API
+      --workspace-domain-admin string   The email of your Google workspace domain admin
 ```
 
 #### Options inherited from parent commands

--- a/internal/cmd/providers_test.go
+++ b/internal/cmd/providers_test.go
@@ -148,7 +148,7 @@ func TestProvidersAddCmd(t *testing.T) {
 			"--kind", "google",
 			"--service-account-key", "-----BEGIN PRIVATE KEY-----\naaa=\n-----END PRIVATE KEY-----\n",
 			"--service-account-email", "example@tenant.iam.gserviceaccount.com",
-			"--domain-admin", "admin@example.com",
+			"--workspace-domain-admin", "admin@example.com",
 		)
 		assert.NilError(t, err)
 
@@ -178,7 +178,7 @@ func TestProvidersAddCmd(t *testing.T) {
 			"--kind", "okta",
 			"--service-account-key", "-----BEGIN PRIVATE KEY-----\naaa=\n-----END PRIVATE KEY-----\n",
 			"--service-account-email", "example@tenant.iam.gserviceaccount.com",
-			"--domain-admin", "admin@example.com",
+			"--workspace-domain-admin", "admin@example.com",
 		)
 
 		assert.ErrorContains(t, err, "field(s) [\"clientEmail\" \"domainAdminEmail\" \"privateKey\"] are only applicable to Google identity providers")
@@ -321,7 +321,7 @@ func TestProvidersEditCmd(t *testing.T) {
 			"--client-secret", "google-client-secret-2",
 			"--service-account-key", "-----BEGIN PRIVATE KEY-----\naaa=\n-----END PRIVATE KEY-----\n",
 			"--service-account-email", "example@tenant.iam.gserviceaccount.com",
-			"--domain-admin", "admin@example.com",
+			"--workspace-domain-admin", "admin@example.com",
 		)
 		assert.NilError(t, err)
 

--- a/ui/pages/providers/add/details.js
+++ b/ui/pages/providers/add/details.js
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useSWRConfig } from 'swr'
+import { InformationCircleIcon } from '@heroicons/react/outline'
+
 
 import Fullscreen from '../../../components/layouts/fullscreen'
 import ErrorMessage from '../../../components/error-message'
@@ -245,8 +247,8 @@ export default function ProvidersAddDetails() {
               </a>
             </label>
             <div className='mt-4'>
-              <label className='text-3xs uppercase text-gray-400'>
-                Private Key
+              <label className='text-3xs uppercase text-gray-400' title='upload the private key json file that was created for your service account'>
+                Private Key <InformationCircleIcon className='ml-0.5 h-[1rem] w-[1rem] inline'/>
               </label>
               <input
                 type='file'


### PR DESCRIPTION
- align CLI and UI setup
- give info about private key in ui

## Summary
Improving the understandability of the Google provider setup experience. This change makes the CLI match the UI (both prompt for the service account key file), gives extra context in the UI, and improves flag naming for the domain admin.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2747
