### PR TITLE
Add default organization

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -31,7 +31,7 @@ func setupDB(t *testing.T) *gorm.DB {
 	assert.NilError(t, err)
 	t.Cleanup(data.InvalidateCache)
 
-	return db
+	return db.DB
 }
 
 func setupAccessTestContext(t *testing.T) (*gin.Context, *gorm.DB, *models.Provider) {

--- a/internal/access/signup_test.go
+++ b/internal/access/signup_test.go
@@ -22,8 +22,6 @@ func TestSignupEnabled(t *testing.T) {
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Request = (&http.Request{}).WithContext(context.Background())
 		c.Set("db", db)
-		_, err := data.InitializeSettings(db)
-		assert.NilError(t, err)
 		return c, db
 	}
 

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -29,10 +29,7 @@ func setupDB(t *testing.T) *gorm.DB {
 	assert.NilError(t, err)
 	t.Cleanup(data.InvalidateCache)
 
-	// create the provider if it's missing
-	data.InfraProvider(db)
-
-	return db
+	return db.DB
 }
 
 func TestLogin(t *testing.T) {

--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -187,7 +187,13 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 				user := &models.Identity{Name: "eugwnw@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
-				err = db.Model(user).Association("Groups").Append([]models.Group{{Name: "Foo"}, {Name: "existing3"}})
+
+				for _, name := range []string{"Foo", "existing3"} {
+					group := &models.Group{Name: name}
+					err = data.CreateGroup(db, group)
+					assert.NilError(t, err)
+					user.Groups = append(user.Groups, *group)
+				}
 				assert.NilError(t, err)
 				assert.Assert(t, len(user.Groups) == 2)
 

--- a/internal/server/authn_test.go
+++ b/internal/server/authn_test.go
@@ -11,15 +11,12 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/uid"
 )
 
 func TestServerLimitsAccessWithTemporaryPassword(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes((prometheus.NewRegistry()))
-	_, err := data.InitializeSettings(srv.db)
-	assert.NilError(t, err)
 
 	// create a user
 	resp := createUser(t, srv, routes, "hubert@example.com")

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -429,16 +429,18 @@ func TestLoadConfigWithProviders(t *testing.T) {
 	err = s.db.Where("name = ?", "okta").First(&okta).Error
 	assert.NilError(t, err)
 
+	defaultOrg := data.OrgFromContext(s.db.Statement.Context)
 	expected := models.Provider{
-		Model:        okta.Model,     // not relevant
-		CreatedBy:    okta.CreatedBy, // not relevant
-		Name:         "okta",
-		URL:          "demo.okta.com",
-		ClientID:     "client-id",
-		ClientSecret: "client-secret",
-		Kind:         models.ProviderKindOIDC, // the kind gets the default value
-		AuthURL:      "dev.okta.com/oauth2/default/v1/token",
-		Scopes:       []string{"openid", "email"},
+		Model:              okta.Model,     // not relevant
+		CreatedBy:          okta.CreatedBy, // not relevant
+		Name:               "okta",
+		URL:                "demo.okta.com",
+		ClientID:           "client-id",
+		ClientSecret:       "client-secret",
+		Kind:               models.ProviderKindOIDC, // the kind gets the default value
+		AuthURL:            "dev.okta.com/oauth2/default/v1/token",
+		Scopes:             []string{"openid", "email"},
+		OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrg.ID},
 	}
 
 	cmpProvider := cmp.Options{
@@ -457,15 +459,16 @@ func TestLoadConfigWithProviders(t *testing.T) {
 	assert.NilError(t, err)
 
 	expected = models.Provider{
-		Model:        azure.Model,     // not relevant
-		CreatedBy:    azure.CreatedBy, // not relevant
-		Name:         "azure",
-		URL:          "demo.azure.com",
-		ClientID:     "client-id",
-		ClientSecret: "client-secret",
-		Kind:         models.ProviderKindAzure, // when specified, the kind is set
-		AuthURL:      "demo.azure.com/oauth2/v2.0/authorize",
-		Scopes:       []string{"openid", "email"},
+		Model:              azure.Model,     // not relevant
+		CreatedBy:          azure.CreatedBy, // not relevant
+		Name:               "azure",
+		URL:                "demo.azure.com",
+		ClientID:           "client-id",
+		ClientSecret:       "client-secret",
+		Kind:               models.ProviderKindAzure, // when specified, the kind is set
+		AuthURL:            "demo.azure.com/oauth2/v2.0/authorize",
+		Scopes:             []string{"openid", "email"},
+		OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrg.ID},
 	}
 
 	assert.DeepEqual(t, azure, expected, cmpProvider)
@@ -475,18 +478,19 @@ func TestLoadConfigWithProviders(t *testing.T) {
 	assert.NilError(t, err)
 
 	expected = models.Provider{
-		Model:            google.Model,     // not relevant
-		CreatedBy:        google.CreatedBy, // not relevant
-		Name:             "google",
-		URL:              "accounts.google.com",
-		ClientID:         "client-id",
-		ClientSecret:     "client-secret",
-		Kind:             models.ProviderKindGoogle,
-		AuthURL:          "https://accounts.google.com/o/oauth2/v2/auth",
-		Scopes:           []string{"openid", "email"},
-		PrivateKey:       "-----BEGIN PRIVATE KEY-----\naaa=\n-----END PRIVATE KEY-----\n",
-		ClientEmail:      "example@tenant.iam.gserviceaccount.com",
-		DomainAdminEmail: "admin@example.com",
+		Model:              google.Model,     // not relevant
+		CreatedBy:          google.CreatedBy, // not relevant
+		Name:               "google",
+		URL:                "accounts.google.com",
+		ClientID:           "client-id",
+		ClientSecret:       "client-secret",
+		Kind:               models.ProviderKindGoogle,
+		AuthURL:            "https://accounts.google.com/o/oauth2/v2/auth",
+		Scopes:             []string{"openid", "email"},
+		PrivateKey:         "-----BEGIN PRIVATE KEY-----\naaa=\n-----END PRIVATE KEY-----\n",
+		ClientEmail:        "example@tenant.iam.gserviceaccount.com",
+		DomainAdminEmail:   "admin@example.com",
+		OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrg.ID},
 	}
 
 	assert.DeepEqual(t, google, expected, cmpProvider)
@@ -834,16 +838,18 @@ func TestLoadConfigUpdate(t *testing.T) {
 	err = s.db.Where("name = ?", "atko").First(&provider).Error
 	assert.NilError(t, err)
 
+	defaultOrg := data.OrgFromContext(s.db.Statement.Context)
 	expected := models.Provider{
-		Model:        provider.Model,     // not relevant
-		CreatedBy:    provider.CreatedBy, // not relevant
-		Name:         "atko",
-		URL:          "demo.atko.com",
-		ClientID:     "client-id-2",
-		ClientSecret: "client-secret-2",
-		Kind:         models.ProviderKindOIDC, // the kind gets the default value
-		AuthURL:      "demo.okta.com/v1/auth",
-		Scopes:       []string{"openid", "email", "groups"},
+		Model:              provider.Model,     // not relevant
+		CreatedBy:          provider.CreatedBy, // not relevant
+		Name:               "atko",
+		URL:                "demo.atko.com",
+		ClientID:           "client-id-2",
+		ClientSecret:       "client-secret-2",
+		Kind:               models.ProviderKindOIDC, // the kind gets the default value
+		AuthURL:            "demo.okta.com/v1/auth",
+		Scopes:             []string{"openid", "email", "groups"},
+		OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrg.ID},
 	}
 
 	cmpProvider := cmp.Options{

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -42,14 +42,20 @@ func NewDB(connection gorm.Dialector, loadDBKey func(db *gorm.DB) error) (*DB, e
 	}
 
 	// TODO: initialize, and populate settings and org on DB
+	dataDB := &DB{DB: db}
+	if err := initialize(dataDB); err != nil {
+		return nil, fmt.Errorf("initialize: %w", err)
+	}
 
-	return &DB{DB: db}, nil
+	return dataDB, nil
 }
 
 // DB wraps the underlying database and provides access to the default org,
 // and settings.
 type DB struct {
 	*gorm.DB // embedded for now to minimize the diff
+
+	DefaultOrgSettings *models.Settings
 }
 
 func (db *DB) Close() error {
@@ -81,6 +87,17 @@ func newRawDB(connection gorm.Dialector) (*gorm.DB, error) {
 	}
 
 	return db, nil
+}
+
+func initialize(db *DB) error {
+	// TODO: set org
+
+	var err error
+	db.DefaultOrgSettings, err = initializeSettings(db.DB)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func NewSQLiteDriver(connection string) (gorm.Dialector, error) {

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -24,12 +24,10 @@ func setupDB(t *testing.T, driver gorm.Dialector) *gorm.DB {
 	db, err := NewDB(driver, nil)
 	assert.NilError(t, err)
 
-	InfraProvider(db)
-
 	logging.PatchLogger(t, zerolog.NewTestWriter(t))
 	t.Cleanup(InvalidateCache)
 
-	return db
+	return db.DB
 }
 
 var isEnvironmentCI = os.Getenv("CI") != ""

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -137,13 +137,12 @@ func TestDatabaseSelectors(t *testing.T) {
 }
 
 func TestPaginationSelector(t *testing.T) {
-	letters := make([]string, 0, 26)
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+		letters := make([]string, 0, 26)
 		for r := 'a'; r < 'a'+26; r++ {
 			letters = append(letters, string(r))
 			g := &models.Identity{Name: string(r)}
-			err := db.Create(g).Error
-			assert.NilError(t, err)
+			assert.NilError(t, CreateIdentity(db, g))
 		}
 
 		p := models.Pagination{Page: 1, Limit: 10}

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -401,6 +401,35 @@ INSERT INTO provider_users (identity_id, provider_id, id, created_at, updated_at
 				// schema changes are tested with schema comparison
 			},
 		},
+		{
+			label: testCaseLine("2022-08-10T13:35"),
+			expected: func(t *testing.T, db *gorm.DB) {
+				stmt := `SELECT id, name, created_at, updated_at FROM organizations`
+				rows, err := db.Raw(stmt).Rows()
+				assert.NilError(t, err)
+
+				var orgs []models.Organization
+				for rows.Next() {
+					org := models.Organization{}
+					err := rows.Scan(&org.ID, &org.Name, &org.CreatedAt, &org.UpdatedAt)
+					assert.NilError(t, err)
+					orgs = append(orgs, org)
+				}
+
+				now := time.Now()
+				expected := []models.Organization{
+					{
+						Model: models.Model{
+							ID:        99,
+							CreatedAt: now,
+							UpdatedAt: now,
+						},
+						Name: "Default",
+					},
+				}
+				assert.DeepEqual(t, orgs, expected, cmpModel)
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -35,7 +35,7 @@ func CreateOrganization(db *gorm.DB, org *models.Organization) error {
 	}
 
 	db.Statement.Context = WithOrg(db.Statement.Context, org)
-	_, err = InitializeSettings(db)
+	_, err = initializeSettings(db)
 	if err != nil {
 		return fmt.Errorf("initializing org settings: %w", err)
 	}

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"fmt"
 
 	"gorm.io/gorm"
 
@@ -28,7 +29,20 @@ func WithOrg(ctx context.Context, org *models.Organization) context.Context {
 }
 
 func CreateOrganization(db *gorm.DB, org *models.Organization) error {
-	return add(db, org)
+	err := add(db, org)
+	if err != nil {
+		return fmt.Errorf("creating org: %w", err)
+	}
+
+	db.Statement.Context = WithOrg(db.Statement.Context, org)
+	_, err = InitializeSettings(db)
+	if err != nil {
+		return fmt.Errorf("initializing org settings: %w", err)
+	}
+
+	// TODO: create infra provider here too?
+
+	return nil
 }
 
 func GetOrganization(db *gorm.DB, selectors ...SelectorFunc) (*models.Organization, error) {

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -14,7 +14,7 @@ type orgCtxKey struct{}
 // OrgFromContext returns the Organization stored using WithOrg.
 func OrgFromContext(ctx context.Context) *models.Organization {
 	org, ok := ctx.Value(orgCtxKey{}).(*models.Organization)
-	if !ok {
+	if !ok || org == nil {
 		// TODO(orgs): panic("no org")
 		return &models.Organization{}
 	}

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -40,8 +40,14 @@ func CreateOrganization(db *gorm.DB, org *models.Organization) error {
 		return fmt.Errorf("initializing org settings: %w", err)
 	}
 
-	// TODO: create infra provider here too?
-
+	infraProvider := &models.Provider{
+		Name:               models.InternalInfraProviderName,
+		Kind:               models.ProviderKindInfra,
+		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+	}
+	if err := CreateProvider(db, infraProvider); err != nil {
+		return fmt.Errorf("failed to create infra provider: %w", err)
+	}
 	return nil
 }
 

--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -13,6 +13,8 @@ import (
 )
 
 func InitializeSettings(db *gorm.DB) (*models.Settings, error) {
+	org := OrgFromContext(db.Statement.Context)
+
 	settings, err := GetSettings(db)
 	if settings != nil {
 		return settings, err
@@ -45,12 +47,13 @@ func InitializeSettings(db *gorm.DB) (*models.Settings, error) {
 	}
 
 	settings = &models.Settings{
-		PrivateJWK: secs,
-		PublicJWK:  pubs,
+		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+		PrivateJWK:         secs,
+		PublicJWK:          pubs,
 	}
 
 	// Attrs() assigns the field iff the record is not found
-	if err := db.FirstOrCreate(&settings).Error; err != nil {
+	if err := db.Where("organization_id = ?", org.ID).FirstOrCreate(&settings).Error; err != nil {
 		return nil, err
 	}
 
@@ -58,8 +61,10 @@ func InitializeSettings(db *gorm.DB) (*models.Settings, error) {
 }
 
 func GetSettings(db *gorm.DB) (*models.Settings, error) {
+	org := OrgFromContext(db.Statement.Context)
+
 	var settings models.Settings
-	if err := db.First(&settings).Error; err != nil {
+	if err := db.Where("organization_id = ?", org.ID).First(&settings).Error; err != nil {
 		return nil, err
 	}
 

--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -12,7 +12,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func InitializeSettings(db *gorm.DB) (*models.Settings, error) {
+func initializeSettings(db *gorm.DB) (*models.Settings, error) {
 	org := OrgFromContext(db.Statement.Context)
 
 	settings, err := GetSettings(db)
@@ -72,5 +72,13 @@ func GetSettings(db *gorm.DB) (*models.Settings, error) {
 }
 
 func SaveSettings(db *gorm.DB, settings *models.Settings) error {
+	// TODO: clean this up by having the query use the organization_id instead of the
+	// primary key in the WHERE.
+	existing, err := GetSettings(db)
+	if err != nil {
+		return err
+	}
+	settings.ID = existing.ID
+
 	return save(db, settings)
 }

--- a/internal/server/data/settings_test.go
+++ b/internal/server/data/settings_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 	"time"
 
-	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/opt"
 
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func TestInitializeSettings(t *testing.T) {
@@ -33,12 +34,15 @@ func TestInitializeSettings(t *testing.T) {
 	})
 }
 
-var cmpModel = gocmp.Options{
-	gocmp.FilterPath(opt.PathField(models.Model{}, "CreatedAt"),
-		opt.TimeWithThreshold(2*time.Second)),
-	gocmp.FilterPath(opt.PathField(models.Model{}, "UpdatedAt"),
-		opt.TimeWithThreshold(2*time.Second)),
+var cmpModel = cmp.Options{
+	cmp.FilterPath(opt.PathField(models.Model{}, "ID"), anyValidUID),
+	cmp.FilterPath(opt.PathField(models.Model{}, "CreatedAt"), opt.TimeWithThreshold(2*time.Second)),
+	cmp.FilterPath(opt.PathField(models.Model{}, "UpdatedAt"), opt.TimeWithThreshold(2*time.Second)),
 }
+
+var anyValidUID = cmp.Comparer(func(x, y uid.ID) bool {
+	return x > 0 && y > 0
+})
 
 func runStep(t *testing.T, name string, fn func(t *testing.T)) {
 	if !t.Run(name, fn) {

--- a/internal/server/data/settings_test.go
+++ b/internal/server/data/settings_test.go
@@ -18,7 +18,7 @@ func TestInitializeSettings(t *testing.T) {
 		var settings *models.Settings
 		runStep(t, "first call creates new settings", func(t *testing.T) {
 			var err error
-			settings, err = InitializeSettings(db)
+			settings, err = initializeSettings(db)
 			assert.NilError(t, err)
 
 			assert.Assert(t, settings.ID != 0)
@@ -27,7 +27,7 @@ func TestInitializeSettings(t *testing.T) {
 		})
 
 		runStep(t, "next call returns existing settings", func(t *testing.T) {
-			nextSettings, err := InitializeSettings(db)
+			nextSettings, err := initializeSettings(db)
 			assert.NilError(t, err)
 			assert.DeepEqual(t, settings, nextSettings, cmpModel)
 		})

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -45,7 +45,7 @@ func TestAPI_ListGroups(t *testing.T) {
 		others = models.Group{Name: "others"}
 	)
 
-	createGroups(t, srv.db, &humans, &second)
+	createGroups(t, srv.db, &humans, &second, &others)
 
 	var (
 		idInGroup = models.Identity{

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -167,9 +167,6 @@ func TestWellKnownKWKs(t *testing.T) {
 	srv := setupServer(t, withAdminUser, withSupportAdminGrant)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	_, err := data.InitializeSettings(srv.db)
-	assert.NilError(t, err)
-
 	type testCase struct {
 		name     string
 		expected func(t *testing.T, resp *httptest.ResponseRecorder)

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -42,6 +42,7 @@ func setupDB(t *testing.T) *gorm.DB {
 		assert.NilError(t, db.Close())
 	})
 
+	db.Statement.Context = data.WithOrg(db.Statement.Context, db.DefaultOrg)
 	return db.DB
 }
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -39,14 +39,10 @@ func setupDB(t *testing.T) *gorm.DB {
 	t.Cleanup(data.InvalidateCache)
 
 	t.Cleanup(func() {
-		sqlDB, err := db.DB()
-		assert.NilError(t, err)
-		assert.NilError(t, sqlDB.Close())
+		assert.NilError(t, db.Close())
 	})
 
-	// create the provider if it's missing.
-	data.InfraProvider(db)
-	return db
+	return db.DB
 }
 
 func issueToken(t *testing.T, db *gorm.DB, identityName string, sessionDuration time.Duration) string {

--- a/internal/server/models/organization.go
+++ b/internal/server/models/organization.go
@@ -5,6 +5,8 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+const DefaultOrganizationName = "Default"
+
 type Organization struct {
 	Model
 

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -77,7 +77,7 @@ func TestAPI_ListOrganizations(t *testing.T) {
 				var actual api.ListResponse[api.Organization]
 				err := json.NewDecoder(resp.Body).Decode(&actual)
 				assert.NilError(t, err)
-				assert.Equal(t, len(actual.Items), 3)
+				assert.Equal(t, len(actual.Items), 4)
 			},
 		},
 		"page 2": {
@@ -91,8 +91,8 @@ func TestAPI_ListOrganizations(t *testing.T) {
 				var actual api.ListResponse[api.Organization]
 				err := json.NewDecoder(resp.Body).Decode(&actual)
 				assert.NilError(t, err)
-				assert.Equal(t, len(actual.Items), 1)
-				assert.Equal(t, api.PaginationResponse{Page: 2, Limit: 2, TotalCount: 3, TotalPages: 2}, actual.PaginationResponse)
+				assert.Equal(t, len(actual.Items), 2)
+				assert.Equal(t, api.PaginationResponse{Page: 2, Limit: 2, TotalCount: 4, TotalPages: 2}, actual.PaginationResponse)
 			},
 		},
 	}

--- a/internal/server/passwordreset_test.go
+++ b/internal/server/passwordreset_test.go
@@ -19,8 +19,6 @@ import (
 func TestPasswordResetFlow(t *testing.T) {
 	s := setupServer(t)
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
-	_, err := data.InitializeSettings(s.db)
-	assert.NilError(t, err)
 
 	email.TestMode = true
 
@@ -28,7 +26,7 @@ func TestPasswordResetFlow(t *testing.T) {
 		Name: "skeletor@example.com",
 	}
 
-	err = data.CreateIdentity(s.db, user)
+	err := data.CreateIdentity(s.db, user)
 	assert.NilError(t, err)
 
 	err = data.CreateCredential(s.db, &models.Credential{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -136,13 +136,8 @@ func New(options Options) (*Server, error) {
 	// TODO: store data.DB on server
 	server.db = db.DB
 
-	settings, err := data.InitializeSettings(server.db)
-	if err != nil {
-		return nil, fmt.Errorf("settings: %w", err)
-	}
-
 	if options.EnableTelemetry {
-		server.tel = NewTelemetry(server.db, settings.ID)
+		server.tel = NewTelemetry(server.db, db.DefaultOrgSettings.ID)
 	}
 
 	if err := server.loadConfig(server.options.Config); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,10 +129,12 @@ func New(options Options) (*Server, error) {
 		return nil, fmt.Errorf("driver: %w", err)
 	}
 
-	server.db, err = data.NewDB(driver, server.loadDBKey)
+	db, err := data.NewDB(driver, server.loadDBKey)
 	if err != nil {
 		return nil, fmt.Errorf("db: %w", err)
 	}
+	// TODO: store data.DB on server
+	server.db = db.DB
 
 	settings, err := data.InitializeSettings(server.db)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -329,8 +329,6 @@ func TestServer_PersistSignupUser(t *testing.T) {
 		opts.SessionExtensionDeadline = time.Minute
 	})
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
-	_, err := data.InitializeSettings(s.db)
-	assert.NilError(t, err)
 
 	var buf bytes.Buffer
 	email := "admin@email.com"
@@ -338,7 +336,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 
 	// run signup for "admin@email.com"
 	signupReq := api.SignupRequest{Name: email, Password: passwd}
-	err = json.NewEncoder(&buf).Encode(signupReq)
+	err := json.NewEncoder(&buf).Encode(signupReq)
 	assert.NilError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/signup", &buf)

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -540,8 +540,6 @@ func TestAPI_CreateUser(t *testing.T) {
 // Note this test is the result of a long conversation, don't change lightly.
 func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 	db := setupDB(t)
-	_, err := data.InitializeSettings(db)
-	assert.NilError(t, err)
 
 	a := &API{server: &Server{db: db}}
 	admin := createAdmin(t, db)
@@ -734,11 +732,9 @@ func TestAPI_DeleteUser(t *testing.T) {
 func TestAPI_UpdateUser(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
-	_, err := data.InitializeSettings(srv.db)
-	assert.NilError(t, err)
 
 	user := &models.Identity{Name: "salsa@example.com"}
-	err = data.CreateIdentity(srv.db, user)
+	err := data.CreateIdentity(srv.db, user)
 	assert.NilError(t, err)
 
 	type testCase struct {

--- a/pki/certificates_ext_test.go
+++ b/pki/certificates_ext_test.go
@@ -14,9 +14,7 @@ import (
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
-	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/internal/testing/patch"
 	"github.com/infrahq/infra/pki"
 	"github.com/infrahq/infra/uid"
 )
@@ -113,18 +111,5 @@ func requireMutualTLSWorks(t *testing.T, clientKeypair *pki.KeyPair, cp pki.Cert
 
 // nolint:unused
 func setupDB(t *testing.T) *gorm.DB {
-	driver, err := data.NewSQLiteDriver("file::memory:")
-	assert.NilError(t, err)
-
-	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver, nil)
-	assert.NilError(t, err)
-
-	err = data.CreateProvider(db, &models.Provider{
-		Name:      models.InternalInfraProviderName,
-		CreatedBy: models.CreatedBySystem,
-	})
-	assert.NilError(t, err)
-
-	return db
+	return nil
 }

--- a/pki/native_test.go
+++ b/pki/native_test.go
@@ -8,21 +8,11 @@ import (
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-
-	"github.com/infrahq/infra/internal/server/data"
-	"github.com/infrahq/infra/internal/testing/patch"
 )
 
 // nolint:unused
 func setupDB(t *testing.T) *gorm.DB {
-	driver, err := data.NewSQLiteDriver("file::memory:")
-	assert.NilError(t, err)
-
-	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver, nil)
-	assert.NilError(t, err)
-
-	return db
+	return nil
 }
 
 func TestCertificateStorage(t *testing.T) {


### PR DESCRIPTION
Branched from #2896

Adds the default org as a migration, and migrates existing data to the org.
For new installs and in tests the default org, settings, and infra provider are created by `NewDB`. 

