### PR TITLE
improve: skip server selection and update docs for auto-login

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -35,6 +35,11 @@ $ infra login --provider okta
 # Login with an access key
 $ export INFRA_ACCESS_KEY=1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy
 $ infra login
+
+# Login with pre-set provider and server
+$ export INFRA_SERVER=example.infrahq.com
+$ export INFRA_PROVIDER=google
+$ infra login
 ```
 
 #### Options

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -26,7 +26,6 @@ import (
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/logging"
-	"github.com/infrahq/infra/internal/server/models"
 )
 
 type loginCmdOptions struct {
@@ -163,7 +162,7 @@ func login(cli *CLI, options loginCmdOptions) error {
 			return Error{Message: "Non-interactive login only supports access keys, set the INFRA_ACCESS_KEY environment variable and try again"}
 		}
 
-		if options.Provider == models.InternalInfraProviderName {
+		if options.Provider == "infra" {
 			loginReq.PasswordCredentials, err = promptLocalLogin(cli)
 			if err != nil {
 				return err

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -66,6 +66,11 @@ $ infra login --provider okta
 
 # Login with an access key
 $ export INFRA_ACCESS_KEY=1M4CWy9wF5.fAKeKEy5sMLH9ZZzAur0ZIjy
+$ infra login
+
+# Login with pre-set provider and server
+$ export INFRA_SERVER=example.infrahq.com
+$ export INFRA_PROVIDER=google
 $ infra login`,
 		Args:  MaxArgs(1),
 		Group: "Core commands:",
@@ -76,6 +81,10 @@ $ infra login`,
 
 			if len(args) == 1 {
 				options.Server = args[0]
+			}
+
+			if options.Provider == "infra" {
+				options.Provider = ""
 			}
 
 			return login(cli, options)
@@ -102,10 +111,13 @@ func login(cli *CLI, options loginCmdOptions) error {
 		if options.NonInteractive {
 			return Error{Message: "Non-interactive login requires the [SERVER] argument or environment variable INFRA_SERVER to be set"}
 		}
-
-		options.Server, err = promptServer(cli, config)
-		if err != nil {
-			return err
+		if len(config.Hosts) == 1 {
+			options.Server = config.Hosts[0].Host
+		} else {
+			options.Server, err = promptServer(cli, config)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -179,7 +191,6 @@ func login(cli *CLI, options loginCmdOptions) error {
 			}
 		}
 	}
-
 	return loginToInfra(cli, lc, loginReq, options.NoAgent)
 }
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->
Users have requested being able to run `infra login` and get logged in without the survey prompts. One could already set the `INFRA_SERVER` env var to skip server selection. This PR adds the `INFRA_PROVIDER` and cli docs to make it more clear. It also uses local login if the provider is `"infra"`

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2758 
