### PR TITLE
fix: hide connector grants

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -265,6 +265,7 @@ func (c Client) ListGrants(req ListGrantsRequest) (*ListResponse[Grant], error) 
 		"resource":      {req.Resource},
 		"privilege":     {req.Privilege},
 		"showInherited": {strconv.FormatBool(req.ShowInherited)},
+		"showSystem":    {strconv.FormatBool(req.ShowSystem)},
 		"page":          {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
 	})
 }

--- a/api/grant.go
+++ b/api/grant.go
@@ -38,7 +38,7 @@ type ListGrantsRequest struct {
 	Resource      string `form:"resource" example:"production"`
 	Privilege     string `form:"privilege" example:"view"`
 	ShowInherited bool   `form:"showInherited" note:"if true, this field includes grants that the user inherits through groups"`
-	ShowSystem    bool   `form:"showSystem"`
+	ShowSystem    bool   `form:"showSystem" note:"if true, this shows the connector and other internal grants"`
 	PaginationRequest
 }
 

--- a/api/grant.go
+++ b/api/grant.go
@@ -38,6 +38,7 @@ type ListGrantsRequest struct {
 	Resource      string `form:"resource" example:"production"`
 	Privilege     string `form:"privilege" example:"view"`
 	ShowInherited bool   `form:"showInherited" note:"if true, this field includes grants that the user inherits through groups"`
+	ShowSystem    bool   `form:"showSystem"`
 	PaginationRequest
 }
 

--- a/api/user.go
+++ b/api/user.go
@@ -28,7 +28,7 @@ type ListUsersRequest struct {
 	Name       string   `form:"name"`
 	Group      uid.ID   `form:"group"`
 	IDs        []uid.ID `form:"ids"`
-	ShowSystem bool     `form:"showSystem"`
+	ShowSystem bool     `form:"showSystem" note:"if true, this shows the connector and other internal users"`
 	PaginationRequest
 }
 

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -69,7 +69,7 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 	}
 
 	if !showSystem {
-		selectors = append(selectors, data.NotPrivilege(models.InfraConnectorRole))
+		selectors = append(selectors, data.NotInfraConnector())
 	}
 
 	return data.ListGrants(db, p, selectors...)

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -20,7 +20,7 @@ func GetGrant(c *gin.Context, id uid.ID) (*models.Grant, error) {
 	return data.GetGrant(db, data.ByID(id))
 }
 
-func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, privilege string, inherited bool, p *models.Pagination) ([]models.Grant, error) {
+func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, privilege string, inherited bool, showSystem bool, p *models.Pagination) ([]models.Grant, error) {
 	selectors := []data.SelectorFunc{
 		data.ByOptionalResource(resource),
 		data.ByOptionalPrivilege(privilege),
@@ -66,6 +66,10 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 		selectors = append(selectors, data.GrantsInheritedBySubject(subject))
 	} else {
 		selectors = append(selectors, data.ByOptionalSubject(subject))
+	}
+
+	if !showSystem {
+		selectors = append(selectors, data.NotPrivilege(models.InfraConnectorRole))
 	}
 
 	return data.ListGrants(db, p, selectors...)

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -192,6 +192,12 @@ func NotPrivilege(privilege string) SelectorFunc {
 	}
 }
 
+func NotInfraConnector() SelectorFunc {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where(`NOT (privilege = 'connector' AND resource = 'infra')`)
+	}
+}
+
 func ByOptionalIdentityGroupID(groupID uid.ID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		if groupID == 0 {

--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -24,7 +24,7 @@ func (a *API) ListGrants(c *gin.Context, r *api.ListGrantsRequest) (*api.ListRes
 		subject = uid.NewGroupPolymorphicID(r.Group)
 	}
 
-	grants, err := access.ListGrants(c, subject, r.Resource, r.Privilege, r.ShowInherited, &p)
+	grants, err := access.ListGrants(c, subject, r.Resource, r.Privilege, r.ShowInherited, r.ShowSystem, &p)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (a *API) CreateGrant(c *gin.Context, r *api.CreateGrantRequest) (*api.Creat
 	var ucerr data.UniqueConstraintError
 
 	if errors.As(err, &ucerr) {
-		grants, err := access.ListGrants(c, grant.Subject, grant.Resource, grant.Privilege, false, nil)
+		grants, err := access.ListGrants(c, grant.Subject, grant.Resource, grant.Privilege, false, false, nil)
 
 		if err != nil {
 			return nil, err
@@ -93,7 +93,7 @@ func (a *API) DeleteGrant(c *gin.Context, r *api.Resource) (*api.EmptyResponse, 
 	}
 
 	if grant.Resource == access.ResourceInfraAPI && grant.Privilege == models.InfraAdminRole {
-		infraAdminGrants, err := access.ListGrants(c, "", grant.Resource, grant.Privilege, false, nil)
+		infraAdminGrants, err := access.ListGrants(c, "", grant.Resource, grant.Privilege, false, false, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -2005,6 +2005,13 @@
           },
           {
             "in": "query",
+            "name": "showSystem",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
             "name": "page",
             "schema": {
               "format": "int",

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -2004,9 +2004,11 @@
             }
           },
           {
+            "description": "if true, this shows the connector and other internal grants",
             "in": "query",
             "name": "showSystem",
             "schema": {
+              "description": "if true, this shows the connector and other internal grants",
               "type": "boolean"
             }
           },
@@ -4943,9 +4945,11 @@
             }
           },
           {
+            "description": "if true, this shows the connector and other internal users",
             "in": "query",
             "name": "showSystem",
             "schema": {
+              "description": "if true, this shows the connector and other internal users",
               "type": "boolean"
             }
           },


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->
This is a natural continuation of this issue https://github.com/infrahq/infra/pull/2892, which was also causing a bug with the `infra grants list` command.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2909 
