### PR TITLE
fix: avoid annoying mac port warning running tests

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -266,10 +266,14 @@ func (s *Server) listen() error {
 }
 
 func (s *Server) setupServer(server *http.Server) (net.Addr, error) {
+	if server.Addr == "" {
+		server.Addr = "127.0.0.1:"
+	}
 	l, err := net.Listen("tcp", server.Addr)
 	if err != nil {
 		return nil, err
 	}
+	logging.Infof("listening on %s", l.Addr().String())
 
 	s.routines = append(s.routines, routine{
 		run: func() error {


### PR DESCRIPTION
Avoids these annoying things by only binding to the local network device by default (tests use the default), not internet-facing ones.
<img width="265" alt="Screen Shot 2022-08-11 at 3 05 00 PM" src="https://user-images.githubusercontent.com/7130/184219402-0b1d4631-7435-4769-a25e-25fdc974a852.png">

