### PR TITLE
fix: allow direct access key for idp user

### DIFF
--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -471,7 +472,9 @@ func TestAPI_UpdateProvider(t *testing.T) {
 }
 
 // mockOIDC is a fake oidc identity provider
-type fakeOIDCImplementation struct{}
+type fakeOIDCImplementation struct {
+	UserInfoRevoked bool // when true returns an error fromt the user info endpoint
+}
 
 func (m *fakeOIDCImplementation) Validate(_ context.Context) error {
 	return nil
@@ -491,5 +494,8 @@ func (m *fakeOIDCImplementation) RefreshAccessToken(_ context.Context, providerU
 }
 
 func (m *fakeOIDCImplementation) GetUserInfo(_ context.Context, _ *models.ProviderUser) (*providers.UserInfoClaims, error) {
+	if m.UserInfoRevoked {
+		return nil, fmt.Errorf("user revoked")
+	}
 	return &providers.UserInfoClaims{}, nil
 }

--- a/internal/server/tokens_test.go
+++ b/internal/server/tokens_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
+	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -19,9 +21,6 @@ import (
 func TestAPI_CreateToken(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
-
-	_, err := data.InitializeSettings(srv.db)
-	assert.NilError(t, err)
 
 	type testCase struct {
 		setup    func(t *testing.T, req *http.Request)
@@ -70,8 +69,12 @@ func TestAPI_CreateToken(t *testing.T) {
 				req.Header.Set("Authorization", "Bearer "+accessKey)
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.NilError(t, err)
 				assert.Equal(t, resp.Code, http.StatusCreated)
+
+				respBody := &api.CreateTokenResponse{}
+				err := json.Unmarshal(resp.Body.Bytes(), respBody)
+				assert.NilError(t, err)
+				assert.Assert(t, respBody.Token != "")
 			},
 		},
 		"access key directly created for user not in infra provider": {
@@ -93,7 +96,6 @@ func TestAPI_CreateToken(t *testing.T) {
 				req.Header.Set("Authorization", "Bearer "+accessKey)
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.NilError(t, err)
 				assert.Equal(t, resp.Code, http.StatusCreated)
 			},
 		},
@@ -141,8 +143,12 @@ func TestAPI_CreateToken(t *testing.T) {
 				req.Header.Set("Authorization", "Bearer "+accessKey)
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.NilError(t, err)
 				assert.Equal(t, resp.Code, http.StatusCreated)
+
+				respBody := &api.CreateTokenResponse{}
+				err := json.Unmarshal(resp.Body.Bytes(), respBody)
+				assert.NilError(t, err)
+				assert.Assert(t, respBody.Token != "")
 			},
 		},
 		"access key for revoked idp user": {

--- a/internal/server/tokens_test.go
+++ b/internal/server/tokens_test.go
@@ -1,0 +1,202 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/access"
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/server/providers"
+)
+
+func TestAPI_CreateToken(t *testing.T) {
+	srv := setupServer(t, withAdminUser)
+	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+
+	_, err := data.InitializeSettings(srv.db)
+	assert.NilError(t, err)
+
+	type testCase struct {
+		setup    func(t *testing.T, req *http.Request)
+		expected func(t *testing.T, resp *httptest.ResponseRecorder)
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		req, err := http.NewRequest(http.MethodPost, "/api/tokens", nil)
+		assert.NilError(t, err)
+		req.Header.Add("Infra-Version", apiVersionLatest)
+
+		if tc.setup != nil {
+			tc.setup(t, req)
+		}
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+
+		tc.expected(t, resp)
+	}
+
+	testCases := map[string]testCase{
+		"not authenticated": {
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusUnauthorized)
+			},
+		},
+		"infra provider user with valid access key": {
+			setup: func(t *testing.T, req *http.Request) {
+				user := &models.Identity{
+					Name: "spike@example.com",
+				}
+				err := data.CreateIdentity(srv.db, user)
+				assert.NilError(t, err)
+				_, err = data.CreateProviderUser(srv.db, data.InfraProvider(srv.db), user)
+				assert.NilError(t, err)
+
+				key := &models.AccessKey{
+					IssuedFor:  user.ID,
+					ProviderID: data.InfraProvider(srv.db).ID,
+					ExpiresAt:  time.Now().Add(10 * time.Second),
+				}
+				accessKey, err := data.CreateAccessKey(srv.db, key)
+				assert.NilError(t, err)
+
+				req.Header.Set("Authorization", "Bearer "+accessKey)
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.NilError(t, err)
+				assert.Equal(t, resp.Code, http.StatusCreated)
+			},
+		},
+		"access key directly created for user not in infra provider": {
+			setup: func(t *testing.T, req *http.Request) {
+				user := &models.Identity{
+					Name: "faye@example.com",
+				}
+				err := data.CreateIdentity(srv.db, user)
+				assert.NilError(t, err)
+
+				key := &models.AccessKey{
+					IssuedFor:  user.ID,
+					ProviderID: data.InfraProvider(srv.db).ID,
+					ExpiresAt:  time.Now().Add(10 * time.Second),
+				}
+				accessKey, err := data.CreateAccessKey(srv.db, key)
+				assert.NilError(t, err)
+
+				req.Header.Set("Authorization", "Bearer "+accessKey)
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.NilError(t, err)
+				assert.Equal(t, resp.Code, http.StatusCreated)
+			},
+		},
+		"access key for valid idp user": {
+			setup: func(t *testing.T, req *http.Request) {
+				user := &models.Identity{
+					Name: "jet@example.com",
+				}
+				err := data.CreateIdentity(srv.db, user)
+				assert.NilError(t, err)
+
+				provider := &models.Provider{
+					Name: "mockta",
+					Kind: models.ProviderKindOIDC,
+				}
+				err = data.CreateProvider(srv.db, provider)
+				assert.NilError(t, err)
+
+				_, err = data.CreateProviderUser(srv.db, provider, user)
+				assert.NilError(t, err)
+
+				key := &models.AccessKey{
+					IssuedFor:  user.ID,
+					ProviderID: provider.ID,
+					ExpiresAt:  time.Now().Add(10 * time.Second),
+				}
+				accessKey, err := data.CreateAccessKey(srv.db, key)
+				assert.NilError(t, err)
+
+				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{})
+				rCtx := access.RequestContext{
+					Request: req,
+					DBTxn:   srv.db,
+					Authenticated: access.Authenticated{
+						AccessKey: key,
+						User:      user,
+					},
+				}
+
+				// nolint: staticcheck
+				ctx = context.WithValue(ctx, access.RequestContextKey, rCtx)
+
+				*req = *req.WithContext(ctx)
+
+				req.Header.Set("Authorization", "Bearer "+accessKey)
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.NilError(t, err)
+				assert.Equal(t, resp.Code, http.StatusCreated)
+			},
+		},
+		"access key for revoked idp user": {
+			setup: func(t *testing.T, req *http.Request) {
+				user := &models.Identity{
+					Name: "ein@example.com",
+				}
+				err := data.CreateIdentity(srv.db, user)
+				assert.NilError(t, err)
+
+				provider := &models.Provider{
+					Name: "mockta-revoked-user",
+					Kind: models.ProviderKindOIDC,
+				}
+				err = data.CreateProvider(srv.db, provider)
+				assert.NilError(t, err)
+
+				_, err = data.CreateProviderUser(srv.db, provider, user)
+				assert.NilError(t, err)
+
+				key := &models.AccessKey{
+					IssuedFor:  user.ID,
+					ProviderID: provider.ID,
+					ExpiresAt:  time.Now().Add(10 * time.Second),
+				}
+				accessKey, err := data.CreateAccessKey(srv.db, key)
+				assert.NilError(t, err)
+
+				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{UserInfoRevoked: true})
+				rCtx := access.RequestContext{
+					Request: req,
+					DBTxn:   srv.db,
+					Authenticated: access.Authenticated{
+						AccessKey: key,
+						User:      user,
+					},
+				}
+
+				// nolint: staticcheck
+				ctx = context.WithValue(ctx, access.RequestContextKey, rCtx)
+
+				*req = *req.WithContext(ctx)
+
+				req.Header.Set("Authorization", "Bearer "+accessKey)
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusUnauthorized)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Moving this check for the provider sync fixes a bug where issuing an access key directly to a user from an identity provider did not work. Also added test coverage to the `/tokens` endpoint. 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2895 
