### PR TITLE
feat: completions for `infra use`

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -158,7 +158,7 @@ func syncKubeConfig(ctx context.Context, cancel context.CancelFunc) {
 		logging.Errorf("agent failed to get user destination grants: %v\n", err)
 		cancel()
 	}
-	if err := writeKubeconfig(user, destinations.Items, grants.Items); err != nil {
+	if err := writeKubeconfig(user, destinations, grants); err != nil {
 		logging.Errorf("agent failed to update kube config: %v\n", err)
 		cancel()
 	}


### PR DESCRIPTION
## Summary

As part of #2875, this pr gets the resources that the user has access to as dynamic completion nouns. I've tested this myself, and it's a little slow because it has to make an api call, but it's convenient and it works.

I also update the list command to use `listAll()`

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->
