### PR TITLE
fix: reuse connections with a properly-sized connection pool

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -30,6 +30,7 @@ services:
 
   db:
     image: postgres:alpine
+    command: postgres -c log_connections=on -c log_min_messages=INFO
     restart: always
     user: postgres
     environment:

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -148,7 +148,8 @@ func Run(ctx context.Context, options Options) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	repeat.Start(ctx, 5*time.Second, syncWithServer(k8s, client, destination, certCache, caCertPEM))
+	// TODO: make polling time configurable
+	repeat.Start(ctx, 30*time.Second, syncWithServer(k8s, client, destination, certCache, caCertPEM))
 
 	ginutil.SetMode()
 	router := gin.New()


### PR DESCRIPTION
## Summary

- under load of more than one parallel connection, gorm is not reusing db connections and closing them immediately after each query, The `SetMaxIdleConns` value defaults to 2, so after 2 connections it starts closing idle connections immediately. This creates a lot of overhead. 
- also increases the connector poll time to 30s instead of 5s

tested manually and resolves the issue.