### PR TITLE
Make NewDB safer by not setting an org in the context

### DIFF
--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -86,11 +86,6 @@ func TestUpdateCredentials(t *testing.T) {
 	_, err = CreateCredential(c, *user)
 	assert.NilError(t, err)
 
-	err = data.SaveSettings(db, &models.Settings{
-		LengthMin: 8,
-	})
-	assert.NilError(t, err)
-
 	t.Run("Update user credentials IS single use password", func(t *testing.T) {
 		err := UpdateCredential(c, user, "newPassword")
 		assert.NilError(t, err)

--- a/internal/access/passwordreset_test.go
+++ b/internal/access/passwordreset_test.go
@@ -13,17 +13,10 @@ import (
 func TestPasswordResetFlow(t *testing.T) {
 	c, db, _ := setupAccessTestContext(t)
 
-	err := data.SaveSettings(db, &models.Settings{
-		LengthMin: 8,
-	})
-	assert.NilError(t, err)
-
-	user := &models.Identity{
-		Name: "joe@example.com",
-	}
+	user := &models.Identity{Name: "joe@example.com"}
 
 	// setup user
-	err = CreateIdentity(c, user)
+	err := CreateIdentity(c, user)
 	assert.NilError(t, err)
 
 	err = data.CreateCredential(db, &models.Credential{

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -142,29 +142,6 @@ func TestAPI_ListAccessKeys_Success(t *testing.T) {
 		assert.Assert(t, accessKeys.Count != 0)
 		assert.Assert(t, accessKeys.Items != nil)
 	})
-
-	t.Run("MissingIssuedFor", func(t *testing.T) {
-		if srv.DB().Dialector.Name() == "postgres" {
-			t.Skip("not possible with postgres because of FK constraint")
-		}
-		err := srv.DB().Create(&models.AccessKey{Name: "testing"}).Error
-		assert.NilError(t, err)
-
-		accessKeys := run()
-		assert.Assert(t, accessKeys.Count != 0)
-		assert.Assert(t, accessKeys.Items != nil)
-
-		var accessKey *api.AccessKey
-		for i := range accessKeys.Items {
-			if accessKeys.Items[i].Name == "testing" {
-				accessKey = &accessKeys.Items[i]
-			}
-		}
-
-		assert.Assert(t, accessKey.Name == "testing")
-		assert.Assert(t, accessKey.IssuedFor == 0)
-		assert.Assert(t, accessKey.IssuedForName == "")
-	})
 }
 
 func TestAPI_ListAccessKeys(t *testing.T) {

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -55,7 +55,8 @@ func NewDB(connection gorm.Dialector, loadDBKey func(db *gorm.DB) error) (*DB, e
 type DB struct {
 	*gorm.DB // embedded for now to minimize the diff
 
-	DefaultOrg         *models.Organization
+	DefaultOrg *models.Organization
+	// DefaultOrgSettings are the settings for DefaultOrg
 	DefaultOrgSettings *models.Settings
 }
 
@@ -111,9 +112,7 @@ func initialize(db *DB) error {
 	}
 
 	db.DefaultOrg = org
-
-	db.Statement.Context = WithOrg(db.Statement.Context, org)
-	db.DefaultOrgSettings, err = GetSettings(db.DB)
+	db.DefaultOrgSettings, err = getSettingsForOrg(db.DB, org.ID)
 	return err
 }
 

--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -10,6 +10,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func initializeSettings(db *gorm.DB) (*models.Settings, error) {
@@ -62,9 +63,12 @@ func initializeSettings(db *gorm.DB) (*models.Settings, error) {
 
 func GetSettings(db *gorm.DB) (*models.Settings, error) {
 	org := MustGetOrgFromContext(db.Statement.Context)
+	return getSettingsForOrg(db, org.ID)
+}
 
+func getSettingsForOrg(db *gorm.DB, orgID uid.ID) (*models.Settings, error) {
 	var settings models.Settings
-	if err := db.Where("organization_id = ?", org.ID).First(&settings).Error; err != nil {
+	if err := db.Where("organization_id = ?", orgID).First(&settings).Error; err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Cleanup a couple things from #2902

* We don't need these calls to `SaveSettings` anymore, it's always done by `NewDB`
* It's risky to set an org in the context in `NewDB` because of how gorm clones the context. So add a new function that lets us pass the org explicitly in this case.

## Related Issues

Related to #2903
