### PR TITLE
Remove the second DB field from server

### DIFF
--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -144,10 +144,10 @@ func TestAPI_ListAccessKeys_Success(t *testing.T) {
 	})
 
 	t.Run("MissingIssuedFor", func(t *testing.T) {
-		if srv.db.Dialector.Name() == "postgres" {
+		if srv.DB().Dialector.Name() == "postgres" {
 			t.Skip("not possible with postgres because of FK constraint")
 		}
-		err := srv.db.Create(&models.AccessKey{Name: "testing"}).Error
+		err := srv.DB().Create(&models.AccessKey{Name: "testing"}).Error
 		assert.NilError(t, err)
 
 		accessKeys := run()
@@ -171,7 +171,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	db := srv.db
+	db := srv.DB()
 
 	user := &models.Identity{Model: models.Model{ID: uid.New()}, Name: "foo@example.com"}
 	err := data.CreateIdentity(db, user)

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -429,7 +429,7 @@ func TestLoadConfigWithProviders(t *testing.T) {
 	err = s.db.Where("name = ?", "okta").First(&okta).Error
 	assert.NilError(t, err)
 
-	defaultOrg := data.MustGetOrgFromContext(s.db.Statement.Context)
+	defaultOrg := data.MustGetOrgFromContext(s.DB().Statement.Context)
 	expected := models.Provider{
 		Model:              okta.Model,     // not relevant
 		CreatedBy:          okta.CreatedBy, // not relevant
@@ -523,24 +523,24 @@ func TestLoadConfigWithUsers(t *testing.T) {
 	err := s.loadConfig(config)
 	assert.NilError(t, err)
 
-	user, _, _, err := getTestUserDetails(s.db, "bob")
+	user, _, _, err := getTestUserDetails(s.DB(), "bob")
 	assert.NilError(t, err)
 	assert.Equal(t, "bob", user.Name)
 
-	user, creds, _, err := getTestUserDetails(s.db, "alice")
+	user, creds, _, err := getTestUserDetails(s.DB(), "alice")
 	assert.NilError(t, err)
 	assert.Equal(t, "alice", user.Name)
 	err = bcrypt.CompareHashAndPassword(creds.PasswordHash, []byte("password"))
 	assert.NilError(t, err)
 
-	user, _, key, err := getTestUserDetails(s.db, "sue")
+	user, _, key, err := getTestUserDetails(s.DB(), "sue")
 	assert.NilError(t, err)
 	assert.Equal(t, "sue", user.Name)
 	assert.Equal(t, key.KeyID, "aaaaaaaaaa")
 	chksm := sha256.Sum256([]byte("bbbbbbbbbbbbbbbbbbbbbbbb"))
 	assert.Equal(t, bytes.Compare(key.SecretChecksum, chksm[:]), 0) // 0 means the byte slices are equal
 
-	user, creds, key, err = getTestUserDetails(s.db, "jim")
+	user, creds, key, err = getTestUserDetails(s.DB(), "jim")
 	assert.NilError(t, err)
 	assert.Equal(t, "jim", user.Name)
 	err = bcrypt.CompareHashAndPassword(creds.PasswordHash, []byte("password"))
@@ -674,7 +674,7 @@ func TestLoadConfigPruneConfig(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, int64(3), grants) // 2 from config, 1 internal connector
 
-	identities, err := data.ListIdentities(s.db, nil)
+	identities, err := data.ListIdentities(s.DB(), nil)
 	assert.NilError(t, err)
 	assert.Equal(t, 2, len(identities))
 
@@ -709,7 +709,7 @@ func TestLoadConfigPruneConfig(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, int64(1), grants) // connector
 
-	identities, err = data.ListIdentities(s.db, nil)
+	identities, err = data.ListIdentities(s.DB(), nil)
 	assert.NilError(t, err)
 	assert.Equal(t, 1, len(identities))
 
@@ -787,7 +787,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 	assert.Equal(t, privileges["view"], 0)
 	assert.Equal(t, privileges["connector"], 1)
 
-	identities, err := data.ListIdentities(s.db, nil)
+	identities, err := data.ListIdentities(s.DB(), nil)
 	assert.NilError(t, err)
 	assert.Equal(t, 5, len(identities)) // john@example.com, sarah@example.com, test@example.com, connector, r2d2, c3po
 
@@ -839,7 +839,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 	err = s.db.Where("name = ?", "atko").First(&provider).Error
 	assert.NilError(t, err)
 
-	defaultOrg := data.MustGetOrgFromContext(s.db.Statement.Context)
+	defaultOrg := data.MustGetOrgFromContext(s.DB().Statement.Context)
 	expected := models.Provider{
 		Model:              provider.Model,     // not relevant
 		CreatedBy:          provider.CreatedBy, // not relevant
@@ -883,7 +883,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 	assert.Equal(t, privileges["view"], 2)
 	assert.Equal(t, privileges["connector"], 1)
 
-	identities, err = data.ListIdentities(s.db, nil)
+	identities, err = data.ListIdentities(s.DB(), nil)
 	assert.NilError(t, err)
 	assert.Equal(t, 2, len(identities))
 
@@ -908,23 +908,23 @@ func TestLoadAccessKey(t *testing.T) {
 
 	// create a user and assign them an access key
 	bob := &models.Identity{Name: "bob"}
-	err := data.CreateIdentity(s.db, bob)
+	err := data.CreateIdentity(s.DB(), bob)
 	assert.NilError(t, err)
 
-	err = s.loadAccessKey(s.db, bob, testAccessKey)
+	err = s.loadAccessKey(s.DB(), bob, testAccessKey)
 	assert.NilError(t, err)
 
 	t.Run("access key can be reloaded for the same identity it was issued for", func(t *testing.T) {
-		err = s.loadAccessKey(s.db, bob, testAccessKey)
+		err = s.loadAccessKey(s.DB(), bob, testAccessKey)
 		assert.NilError(t, err)
 	})
 
 	t.Run("duplicate access key ID is rejected", func(t *testing.T) {
 		alice := &models.Identity{Name: "alice"}
-		err = data.CreateIdentity(s.db, alice)
+		err = data.CreateIdentity(s.DB(), alice)
 		assert.NilError(t, err)
 
-		err = s.loadAccessKey(s.db, alice, testAccessKey)
+		err = s.loadAccessKey(s.DB(), alice, testAccessKey)
 		assert.Error(t, err, "access key assigned to \"alice\" is already assigned to another user, a user's access key must have a unique ID")
 	})
 }

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -26,8 +26,7 @@ func TestAPI_PProfHandler(t *testing.T) {
 		expectedResp func(t *testing.T, resp *httptest.ResponseRecorder)
 	}
 
-	dataDB := setupDB(t)
-	s := &Server{db: dataDB.DB, dataDB: dataDB}
+	s := &Server{db: setupDB(t)}
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
 	run := func(t *testing.T, tc testCase) {
@@ -59,7 +58,7 @@ func TestAPI_PProfHandler(t *testing.T) {
 			name:         "missing admin role",
 			expectedCode: http.StatusForbidden,
 			setupRequest: func(_ *testing.T, req *http.Request) {
-				key, _ := createAccessKey(t, s.db, "user1@example.com")
+				key, _ := createAccessKey(t, s.DB(), "user1@example.com")
 				req.Header.Add("Authorization", "Bearer "+key)
 			},
 			expectedResp: responseBodyAPIErrorWithCode(http.StatusForbidden),
@@ -68,8 +67,8 @@ func TestAPI_PProfHandler(t *testing.T) {
 			name:         "successful profile",
 			expectedCode: http.StatusOK,
 			setupRequest: func(t *testing.T, req *http.Request) {
-				key, user := createAccessKey(t, s.db, "user2@example.com")
-				err := data.CreateGrant(s.db, &models.Grant{
+				key, user := createAccessKey(t, s.DB(), "user2@example.com")
+				err := data.CreateGrant(s.DB(), &models.Grant{
 					Subject:   user.PolyID(),
 					Privilege: models.InfraSupportAdminRole,
 					Resource:  access.ResourceInfraAPI,

--- a/internal/server/login_test.go
+++ b/internal/server/login_test.go
@@ -22,12 +22,12 @@ func TestAPI_Login(t *testing.T) {
 
 	// setup user to login as
 	user := &models.Identity{Name: "steve"}
-	err := data.CreateIdentity(srv.db, user)
+	err := data.CreateIdentity(srv.DB(), user)
 	assert.NilError(t, err)
 
-	p := data.InfraProvider(srv.db)
+	p := data.InfraProvider(srv.DB())
 
-	_, err = data.CreateProviderUser(srv.db, p, user)
+	_, err = data.CreateProviderUser(srv.DB(), p, user)
 	assert.NilError(t, err)
 
 	hash, err := bcrypt.GenerateFromPassword([]byte("hunter2"), bcrypt.MinCost)
@@ -38,7 +38,7 @@ func TestAPI_Login(t *testing.T) {
 		PasswordHash: hash,
 	}
 
-	err = data.CreateCredential(srv.db, userCredential)
+	err = data.CreateCredential(srv.DB(), userCredential)
 	assert.NilError(t, err)
 
 	type testCase struct {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -91,13 +91,11 @@ func TestRequestTimeoutSuccess(t *testing.T) {
 }
 
 func TestDBTimeout(t *testing.T) {
-	dataDB := setupDB(t)
 	var ctx context.Context
 	var cancel context.CancelFunc
 
 	srv := newServer(Options{})
-	srv.dataDB = dataDB
-	srv.db = dataDB.DB
+	srv.db = setupDB(t)
 
 	router := gin.New()
 	router.Use(
@@ -271,7 +269,7 @@ func TestRequireAccessKey(t *testing.T) {
 func TestHandleInfraDestinationHeader(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
-	db := srv.db
+	db := srv.DB()
 
 	connector := models.Identity{Name: "connectorA"}
 	err := data.CreateIdentity(db, &connector)
@@ -338,7 +336,7 @@ func TestHandleInfraDestinationHeader(t *testing.T) {
 
 func TestGetOrgFromRequest_FromRequestHost(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	db := srv.db
+	db := srv.DB()
 
 	router := gin.New()
 

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -39,7 +39,7 @@ func TestAPI_ListOrganizations(t *testing.T) {
 		third  = models.Organization{Name: "third"}
 	)
 
-	createOrgs(t, srv.db, &first, &second, &third)
+	createOrgs(t, srv.DB(), &first, &second, &third)
 
 	type testCase struct {
 		urlPath  string
@@ -187,7 +187,7 @@ func TestAPI_DeleteOrganization(t *testing.T) {
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
 	var first = models.Organization{Name: "first"}
-	createOrgs(t, srv.db, &first)
+	createOrgs(t, srv.DB(), &first)
 
 	type testCase struct {
 		urlPath  string
@@ -228,7 +228,7 @@ func TestAPI_DeleteOrganization(t *testing.T) {
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusNoContent, resp.Body.String())
-				actual, err := data.ListOrganizations(srv.db, &models.Pagination{}, data.ByID(first.ID))
+				actual, err := data.ListOrganizations(srv.DB(), &models.Pagination{}, data.ByID(first.ID))
 				assert.NilError(t, err)
 				assert.Equal(t, len(actual), 0)
 			},

--- a/internal/server/passwordreset_test.go
+++ b/internal/server/passwordreset_test.go
@@ -26,10 +26,10 @@ func TestPasswordResetFlow(t *testing.T) {
 		Name: "skeletor@example.com",
 	}
 
-	err := data.CreateIdentity(s.db, user)
+	err := data.CreateIdentity(s.DB(), user)
 	assert.NilError(t, err)
 
-	err = data.CreateCredential(s.db, &models.Credential{
+	err = data.CreateCredential(s.DB(), &models.Credential{
 		IdentityID:   user.ID,
 		PasswordHash: []byte("foo"),
 	})

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -30,10 +30,10 @@ func TestAPI_ListProviders(t *testing.T) {
 		Scopes:  []string{"openid", "email"},
 	}
 
-	err := data.CreateProvider(s.db, testProvider)
+	err := data.CreateProvider(s.DB(), testProvider)
 	assert.NilError(t, err)
 
-	dbProviders, err := data.ListProviders(s.db, nil)
+	dbProviders, err := data.ListProviders(s.DB(), nil)
 	assert.NilError(t, err)
 	assert.Equal(t, len(dbProviders), 2)
 
@@ -66,7 +66,7 @@ func TestAPI_DeleteProvider(t *testing.T) {
 	createProvider := func(t *testing.T) *models.Provider {
 		t.Helper()
 		p := &models.Provider{Name: "mokta", Kind: models.ProviderKindOkta}
-		err := data.CreateProvider(srv.db, p)
+		err := data.CreateProvider(srv.DB(), p)
 		assert.NilError(t, err)
 		return p
 	}
@@ -107,7 +107,7 @@ func TestAPI_DeleteProvider(t *testing.T) {
 		"not authorized": {
 			urlPath: "/api/providers/2341",
 			setup: func(t *testing.T, req *http.Request) {
-				key, _ := createAccessKey(t, srv.db, "someonenew@example.com")
+				key, _ := createAccessKey(t, srv.DB(), "someonenew@example.com")
 				req.Header.Set("Authorization", "Bearer "+key)
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -121,7 +121,7 @@ func TestAPI_DeleteProvider(t *testing.T) {
 			},
 		},
 		"infra provider can not be deleted": {
-			urlPath: "/api/providers/" + data.InfraProvider(srv.db).ID.String(),
+			urlPath: "/api/providers/" + data.InfraProvider(srv.DB()).ID.String(),
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
 			},
@@ -183,7 +183,7 @@ func TestAPI_CreateProvider(t *testing.T) {
 				ClientSecret: "client-secret",
 			},
 			setup: func(t *testing.T, req *http.Request) {
-				accessKey, _ := createAccessKey(t, srv.db, "usera@example.com")
+				accessKey, _ := createAccessKey(t, srv.DB(), "usera@example.com")
 				req.Header.Set("Authorization", "Bearer "+accessKey)
 
 				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{})
@@ -324,7 +324,7 @@ func TestAPI_UpdateProvider(t *testing.T) {
 		Scopes:  []string{"openid", "email"},
 	}
 
-	err := data.CreateProvider(srv.db, provider)
+	err := data.CreateProvider(srv.DB(), provider)
 	assert.NilError(t, err)
 
 	type testCase struct {
@@ -372,7 +372,7 @@ func TestAPI_UpdateProvider(t *testing.T) {
 				ClientSecret: "client-secret",
 			},
 			setup: func(t *testing.T, req *http.Request) {
-				accessKey, _ := createAccessKey(t, srv.db, "usera@example.com")
+				accessKey, _ := createAccessKey(t, srv.DB(), "usera@example.com")
 				req.Header.Set("Authorization", "Bearer "+accessKey)
 
 				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -37,8 +37,7 @@ func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
 		op(t, &options)
 	}
 	s := newServer(options)
-	s.dataDB = setupDB(t)
-	s.db = s.dataDB.DB
+	s.db = setupDB(t)
 
 	// TODO: share more of this with Server.New
 	err := loadDefaultSecretConfig(s.secrets)

--- a/internal/server/tokens_test.go
+++ b/internal/server/tokens_test.go
@@ -54,17 +54,17 @@ func TestAPI_CreateToken(t *testing.T) {
 				user := &models.Identity{
 					Name: "spike@example.com",
 				}
-				err := data.CreateIdentity(srv.db, user)
+				err := data.CreateIdentity(srv.DB(), user)
 				assert.NilError(t, err)
-				_, err = data.CreateProviderUser(srv.db, data.InfraProvider(srv.db), user)
+				_, err = data.CreateProviderUser(srv.DB(), data.InfraProvider(srv.DB()), user)
 				assert.NilError(t, err)
 
 				key := &models.AccessKey{
 					IssuedFor:  user.ID,
-					ProviderID: data.InfraProvider(srv.db).ID,
+					ProviderID: data.InfraProvider(srv.DB()).ID,
 					ExpiresAt:  time.Now().Add(10 * time.Second),
 				}
-				accessKey, err := data.CreateAccessKey(srv.db, key)
+				accessKey, err := data.CreateAccessKey(srv.DB(), key)
 				assert.NilError(t, err)
 
 				req.Header.Set("Authorization", "Bearer "+accessKey)
@@ -83,15 +83,15 @@ func TestAPI_CreateToken(t *testing.T) {
 				user := &models.Identity{
 					Name: "faye@example.com",
 				}
-				err := data.CreateIdentity(srv.db, user)
+				err := data.CreateIdentity(srv.DB(), user)
 				assert.NilError(t, err)
 
 				key := &models.AccessKey{
 					IssuedFor:  user.ID,
-					ProviderID: data.InfraProvider(srv.db).ID,
+					ProviderID: data.InfraProvider(srv.DB()).ID,
 					ExpiresAt:  time.Now().Add(10 * time.Second),
 				}
-				accessKey, err := data.CreateAccessKey(srv.db, key)
+				accessKey, err := data.CreateAccessKey(srv.DB(), key)
 				assert.NilError(t, err)
 
 				req.Header.Set("Authorization", "Bearer "+accessKey)
@@ -105,17 +105,17 @@ func TestAPI_CreateToken(t *testing.T) {
 				user := &models.Identity{
 					Name: "jet@example.com",
 				}
-				err := data.CreateIdentity(srv.db, user)
+				err := data.CreateIdentity(srv.DB(), user)
 				assert.NilError(t, err)
 
 				provider := &models.Provider{
 					Name: "mockta",
 					Kind: models.ProviderKindOIDC,
 				}
-				err = data.CreateProvider(srv.db, provider)
+				err = data.CreateProvider(srv.DB(), provider)
 				assert.NilError(t, err)
 
-				_, err = data.CreateProviderUser(srv.db, provider, user)
+				_, err = data.CreateProviderUser(srv.DB(), provider, user)
 				assert.NilError(t, err)
 
 				key := &models.AccessKey{
@@ -123,13 +123,13 @@ func TestAPI_CreateToken(t *testing.T) {
 					ProviderID: provider.ID,
 					ExpiresAt:  time.Now().Add(10 * time.Second),
 				}
-				accessKey, err := data.CreateAccessKey(srv.db, key)
+				accessKey, err := data.CreateAccessKey(srv.DB(), key)
 				assert.NilError(t, err)
 
 				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{})
 				rCtx := access.RequestContext{
 					Request: req,
-					DBTxn:   srv.db,
+					DBTxn:   srv.DB(),
 					Authenticated: access.Authenticated{
 						AccessKey: key,
 						User:      user,
@@ -157,17 +157,17 @@ func TestAPI_CreateToken(t *testing.T) {
 				user := &models.Identity{
 					Name: "ein@example.com",
 				}
-				err := data.CreateIdentity(srv.db, user)
+				err := data.CreateIdentity(srv.DB(), user)
 				assert.NilError(t, err)
 
 				provider := &models.Provider{
 					Name: "mockta-revoked-user",
 					Kind: models.ProviderKindOIDC,
 				}
-				err = data.CreateProvider(srv.db, provider)
+				err = data.CreateProvider(srv.DB(), provider)
 				assert.NilError(t, err)
 
-				_, err = data.CreateProviderUser(srv.db, provider, user)
+				_, err = data.CreateProviderUser(srv.DB(), provider, user)
 				assert.NilError(t, err)
 
 				key := &models.AccessKey{
@@ -175,13 +175,13 @@ func TestAPI_CreateToken(t *testing.T) {
 					ProviderID: provider.ID,
 					ExpiresAt:  time.Now().Add(10 * time.Second),
 				}
-				accessKey, err := data.CreateAccessKey(srv.db, key)
+				accessKey, err := data.CreateAccessKey(srv.DB(), key)
 				assert.NilError(t, err)
 
 				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{UserInfoRevoked: true})
 				rCtx := access.RequestContext{
 					Request: req,
-					DBTxn:   srv.db,
+					DBTxn:   srv.DB(),
 					Authenticated: access.Authenticated{
 						AccessKey: key,
 						User:      user,


### PR DESCRIPTION
`dataDB` was added temporarily to expose more data from NewDB. This commit replaces most access of Server.db with a call to `Server.DB()`. A function should make it easier to migrate code away from gorm without having to change all of these call sites again.

Resolves [this TODO](https://github.com/infrahq/infra/pull/2911#discussion_r943752984) from #2911