### PR TITLE
Please review: error updates

### DIFF
--- a/internal/cmd/error.go
+++ b/internal/cmd/error.go
@@ -1,36 +1,51 @@
 package cmd
 
-import (
-	"fmt"
-	"strings"
-)
-
 // CLI Errors are user facing errors that are formatted.
 // Should be used for communication, rather than a stacktrace.
 type Error struct {
-	// OriginalError is an error that is caused by the system, used for logging/debugging
+	// Short redacted version of OriginalError, required if OriginalError is set
+	Cause string
+
+	// OriginalError is the error that bubbled up, used for logging/debugging
 	// Only set this if you need it to be printed as part of the user facing 'Message'.
 	OriginalError error
 
-	// Message is a human readable error message that user will read on the CLI.
-	// These should be full sentences, rather than a stack trace.
-	// Consider including suggestions to resolve the error.
-	Message string
+	// Human readable message to resolve the error. These should be full sentences.
+	Suggestion string
 }
 
+// Format is one of the three:
+// a) Error: Cause
+//    OriginalError
+//
+//    Suggestion
+//
+// b) Error: Cause
+//    Suggestion
+//
+// c) Suggestion
 func (e Error) Error() string {
-	if e.OriginalError != nil {
-		if len(e.Message) == 0 {
-			return fmt.Sprintf("Error: %v", e.OriginalError)
-		}
-
-		// Strip '.' at the end when message includes the original error
-		return fmt.Sprintf("%s: %v", strings.TrimSuffix(e.Message, "."), e.OriginalError)
+	if e.OriginalError == nil && len(e.Cause) == 0 {
+		return e.Suggestion
 	}
 
-	return e.Message
+	output := "Error: " + e.Cause
+	if e.OriginalError != nil {
+		output += "\n" + e.OriginalError.Error()
+	}
+
+	if len(e.Suggestion) > 0 {
+		output += "\n\n" + e.Suggestion
+	}
+
+	return output
 }
 
 func (e Error) Unwrap() error {
 	return e.OriginalError
+}
+
+var unauthorizedError = Error{
+	Cause:      "missing permissions to run this command",
+	Suggestion: "Please make sure you have the correct grants.",
 }


### PR DESCRIPTION
## Summary

1. The Error object was not being used in a consistent manner
2. Failed due to logical/user errors were missing the `Error:` in the front, which might be confusing with successes that outputted that nothing changed
3. API errors used terms unknown on the CLI - sync terms with UI/CLI: `identity_id` is known as `user name` in the CLI, `credential` is a complete server-side term, so `create credential: a credential with that identity_id already exists` is not useful for a CLI user 
4. Lacking suggestions on how to fix the error 
5. Right now, the error messages regarding permission errors are generic (but still able to be viewed with log levels). Before updating it to be very specific, these are the things that would need to be addressed before we work with the api errors: 
- org changes (these will change auth errors more than just requiring specific type of roles
- which api call failed (will need to decide if these are done on the client side, as it might be misleading to have a different error (eg. 'listuser' permission error for 'createuser') as it looks like a bug, even though it is a feature: 
```
$ infra users **add**
Error: you do not have permission to **list** users, requires role admin, view, or connector
```
- documentation on which roles grant which permissions OR which api calls (it is not possible for a user to find out which api calls needs what roles through documentation (for infra roles)) 
- split up which server-logic failed with which role is required rather than a single string, so ui/cli can parse each as needed (eg. a list of roles that are accepted `[admin, connector, view]`, and a separate var for which backend action it is trying to do `[listUsers]` -- *we should also consider not suggesting connector role as a solution for missing grants on the cli* 


## Preview

1. Format API errors: 
```
$ infra users add a@g
Error: create credential: a credential with that identity_id already exists
--> 
DEBUG call server: create user named "a@g"
DEBUG create credential: a credential with that identity_id already exists
Error: user a@g already exists
```
2. Add `Error:` whenever the exit status is failure
```
$infra users rm c@g
No user named "c@g"
-->
Error: no user named "c@g"
```
3. Contain enough information about the api for server admins to debug, but concise messages for an average cli user 
```
$ infra users add d@g 
Error: you do not have permission to list users, requires role admin, view, or connector
--> 
$ infra users add d@g 
Error: missing permissions to run this command

Please make sure you have the correct grants; requires role view or admin
---or---
$ infra users add d@g --log-level=debug
DEBUG call server: create user named "d@g"
DEBUG you do not have permission to list users, requires role admin, view, or connector
Error: missing permissions to run this command

Please make sure you have the correct grants; requires role view or admin
```
## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
