### PR TITLE
Fix reading the domain from the request

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -19,15 +19,16 @@ import (
 )
 
 func setupDB(t *testing.T) *gorm.DB {
+	t.Helper()
 	driver := database.PostgresDriver(t, "_access")
 	if driver == nil {
-		var err error
-		driver, err = data.NewSQLiteDriver("file::memory:")
+		lite, err := data.NewSQLiteDriver("file::memory:")
 		assert.NilError(t, err)
+		driver = &database.Driver{Dialector: lite}
 	}
 
 	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver, nil)
+	db, err := data.NewDB(driver.Dialector, nil)
 	assert.NilError(t, err)
 	t.Cleanup(data.InvalidateCache)
 

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -222,10 +222,8 @@ func setupServerOptions(t *testing.T, opts *server.Options) {
 
 	// TODO: why do tests fail when the same schemaSuffix is used?
 	suffix := "_cmd_" + t.Name()
-	pgDriver := database.PostgresDriver(t, suffix)
-	if pgDriver != nil {
-		dsn := os.Getenv("POSTGRESQL_CONNECTION") + " search_path=testing" + suffix
-		opts.DBConnectionString = dsn
+	if pgDriver := database.PostgresDriver(t, suffix); pgDriver != nil {
+		opts.DBConnectionString = pgDriver.DSN
 	}
 }
 

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -19,13 +19,13 @@ func setupDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	driver := database.PostgresDriver(t, "_authn")
 	if driver == nil {
-		var err error
-		driver, err = data.NewSQLiteDriver("file::memory:")
+		lite, err := data.NewSQLiteDriver("file::memory:")
 		assert.NilError(t, err)
+		driver = &database.Driver{Dialector: lite}
 	}
 
 	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver, nil)
+	db, err := data.NewDB(driver.Dialector, nil)
 	assert.NilError(t, err)
 	t.Cleanup(data.InvalidateCache)
 

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -41,7 +41,7 @@ func postgresDriver(t *testing.T) gorm.Dialector {
 	case driver == nil:
 		t.Skip("Set POSTGRESQL_CONNECTION to test against postgresql")
 	}
-	return driver
+	return driver.Dialector
 }
 
 // runDBTests against all supported databases. Defaults to only sqlite locally,

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -29,13 +29,13 @@ func setupDB(t *testing.T) *data.DB {
 	t.Helper()
 	driver := database.PostgresDriver(t, "_server")
 	if driver == nil {
-		var err error
-		driver, err = data.NewSQLiteDriver("file::memory:")
+		lite, err := data.NewSQLiteDriver("file::memory:")
 		assert.NilError(t, err)
+		driver = &database.Driver{Dialector: lite}
 	}
 
 	tpatch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver, nil)
+	db, err := data.NewDB(driver.Dialector, nil)
 	assert.NilError(t, err)
 	t.Cleanup(data.InvalidateCache)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -25,6 +24,7 @@ import (
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/testing/database"
 )
 
 func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
@@ -119,8 +119,8 @@ func TestServer_Run(t *testing.T) {
 		},
 	}
 
-	if pgConn := os.Getenv("POSTGRESQL_CONNECTION"); pgConn != "" {
-		opts.DBConnectionString = pgConn
+	if driver := database.PostgresDriver(t, "_server_run"); driver != nil {
+		opts.DBConnectionString = driver.DSN
 	} else {
 		opts.DBFile = filepath.Join(dir, "sqlite3.db")
 	}
@@ -220,8 +220,8 @@ func TestServer_Run_UIProxy(t *testing.T) {
 	}
 	assert.NilError(t, opts.UI.ProxyURL.Set(uiSrv.URL))
 
-	if pgConn := os.Getenv("POSTGRESQL_CONNECTION"); pgConn != "" {
-		opts.DBConnectionString = pgConn
+	if driver := database.PostgresDriver(t, "_server_run"); driver != nil {
+		opts.DBConnectionString = driver.DSN
 	} else {
 		opts.DBFile = filepath.Join(dir, "sqlite3.db")
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -112,11 +113,16 @@ func TestServer_Run(t *testing.T) {
 		DBEncryptionKeyProvider: "native",
 		DBEncryptionKey:         filepath.Join(dir, "sqlite3.db.key"),
 		TLSCache:                filepath.Join(dir, "tlscache"),
-		DBFile:                  filepath.Join(dir, "sqlite3.db"),
 		TLS: TLSOptions{
 			CA:           types.StringOrFile(golden.Get(t, "pki/ca.crt")),
 			CAPrivateKey: string(golden.Get(t, "pki/ca.key")),
 		},
+	}
+
+	if pgConn := os.Getenv("POSTGRESQL_CONNECTION"); pgConn != "" {
+		opts.DBConnectionString = pgConn
+	} else {
+		opts.DBFile = filepath.Join(dir, "sqlite3.db")
 	}
 
 	srv, err := New(opts)
@@ -206,7 +212,6 @@ func TestServer_Run_UIProxy(t *testing.T) {
 		DBEncryptionKeyProvider: "native",
 		DBEncryptionKey:         filepath.Join(dir, "sqlite3.db.key"),
 		TLSCache:                filepath.Join(dir, "tlscache"),
-		DBFile:                  filepath.Join(dir, "sqlite3.db"),
 		EnableSignup:            true,
 		TLS: TLSOptions{
 			CA:           types.StringOrFile(golden.Get(t, "pki/ca.crt")),
@@ -214,6 +219,12 @@ func TestServer_Run_UIProxy(t *testing.T) {
 		},
 	}
 	assert.NilError(t, opts.UI.ProxyURL.Set(uiSrv.URL))
+
+	if pgConn := os.Getenv("POSTGRESQL_CONNECTION"); pgConn != "" {
+		opts.DBConnectionString = pgConn
+	} else {
+		opts.DBFile = filepath.Join(dir, "sqlite3.db")
+	}
 
 	srv, err := New(opts)
 	assert.NilError(t, err)

--- a/internal/testing/database/postgres.go
+++ b/internal/testing/database/postgres.go
@@ -22,7 +22,7 @@ type TestingT interface {
 //
 // schemaSuffix is used to create a schema name to isolate the database from
 // other tests.
-func PostgresDriver(t TestingT, schemaSuffix string) gorm.Dialector {
+func PostgresDriver(t TestingT, schemaSuffix string) *Driver {
 	t.Helper()
 	pgConn, ok := os.LookupEnv("POSTGRESQL_CONNECTION")
 	if !ok {
@@ -44,6 +44,14 @@ func PostgresDriver(t TestingT, schemaSuffix string) gorm.Dialector {
 	assert.NilError(t, db.Exec("DROP SCHEMA IF EXISTS "+name+" CASCADE").Error)
 	assert.NilError(t, db.Exec("CREATE SCHEMA "+name).Error)
 
-	pgsql := postgres.Open(pgConn + " search_path=" + name)
-	return pgsql
+	dsn := pgConn + " search_path=" + name
+	pgsql := postgres.Open(dsn)
+	return &Driver{Dialector: pgsql, DSN: dsn}
+}
+
+type Driver struct {
+	Dialector gorm.Dialector
+	// DSN is the connection string that can be used to connect to this
+	// database.
+	DSN string
 }


### PR DESCRIPTION
## Summary

Best viewed by individual commit. I can remove any of these commits if there are concerns. I noticed a few other problems while working on this fix.

Fixes:
* permission required for the debug endpoint
* reading host header from the request, apparently some proxies remove the host header, so we have to use `req.Host`. The consequence of this change is that we no longer have a case where this is no host header. We plan on changing this later, and it is tracked in #2903 (second last item in the list currently).
* the postgres test helper so that `TestServerRun` uses postgres
* the wrong database connection was being used in the middleware

## Related Issues


Closes #2925
