### PR TITLE
fix: set key expiry during exchance

### DIFF
--- a/internal/server/authn/authn_method.go
+++ b/internal/server/authn/authn_method.go
@@ -11,8 +11,15 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
+type AuthenticatedIdentity struct {
+	Identity      *models.Identity
+	Provider      *models.Provider
+	SessionExpiry time.Time
+	AuthScope     AuthScope
+}
+
 type LoginMethod interface {
-	Authenticate(ctx context.Context, db *gorm.DB) (*models.Identity, *models.Provider, AuthScope, error)
+	Authenticate(ctx context.Context, db *gorm.DB, requestedExpiry time.Time) (AuthenticatedIdentity, error)
 	Name() string                             // Name returns the name of the authentication method used
 	RequiresUpdate(db *gorm.DB) (bool, error) // Temporary way to check for one time password re-use, remove with #1441
 }
@@ -21,9 +28,9 @@ type AuthScope struct {
 	PasswordResetOnly bool
 }
 
-func Login(ctx context.Context, db *gorm.DB, loginMethod LoginMethod, keyExpiresAt time.Time, keyExtension time.Duration) (*models.AccessKey, string, error) {
+func Login(ctx context.Context, db *gorm.DB, loginMethod LoginMethod, requestedExpiry time.Time, keyExtension time.Duration) (*models.AccessKey, string, error) {
 	// challenge the user to authenticate
-	identity, provider, scope, err := loginMethod.Authenticate(ctx, db)
+	authenticated, err := loginMethod.Authenticate(ctx, db, requestedExpiry)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to login: %w", err)
 	}
@@ -31,15 +38,15 @@ func Login(ctx context.Context, db *gorm.DB, loginMethod LoginMethod, keyExpires
 	// login authentication was successful, create an access key for the user
 
 	accessKey := &models.AccessKey{
-		IssuedFor:         identity.ID,
-		IssuedForIdentity: identity,
-		ProviderID:        provider.ID,
-		ExpiresAt:         keyExpiresAt,
+		IssuedFor:         authenticated.Identity.ID,
+		IssuedForIdentity: authenticated.Identity,
+		ProviderID:        authenticated.Provider.ID,
+		ExpiresAt:         authenticated.SessionExpiry,
 		ExtensionDeadline: time.Now().UTC().Add(keyExtension),
 		Extension:         keyExtension,
 	}
 
-	if scope.PasswordResetOnly {
+	if authenticated.AuthScope.PasswordResetOnly {
 		accessKey.Scopes = append(accessKey.Scopes, models.ScopePasswordReset)
 	}
 
@@ -48,8 +55,8 @@ func Login(ctx context.Context, db *gorm.DB, loginMethod LoginMethod, keyExpires
 		return nil, "", fmt.Errorf("failed to create access key after login: %w", err)
 	}
 
-	identity.LastSeenAt = time.Now().UTC()
-	if err := data.SaveIdentity(db, identity); err != nil {
+	authenticated.Identity.LastSeenAt = time.Now().UTC()
+	if err := data.SaveIdentity(db, authenticated.Identity); err != nil {
 		return nil, "", fmt.Errorf("login failed to update last seen: %w", err)
 	}
 

--- a/internal/server/authn/key_exchange.go
+++ b/internal/server/authn/key_exchange.go
@@ -7,9 +7,8 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
-	"github.com/infrahq/infra/internal/server/models"
 )
 
 // keyExchangeAuthn allows exchanging a valid access key for new access key with a shorter lifetime
@@ -25,22 +24,29 @@ func NewKeyExchangeAuthentication(requestingAccessKey string, requestedExpiry ti
 	}
 }
 
-func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *gorm.DB) (*models.Identity, *models.Provider, AuthScope, error) {
+func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *gorm.DB, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
 	validatedRequestKey, err := data.ValidateAccessKey(db, a.RequestingAccessKey)
 	if err != nil {
-		return nil, nil, AuthScope{}, fmt.Errorf("invalid access key in exchange: %w", err)
+		return AuthenticatedIdentity{}, fmt.Errorf("invalid access key in exchange: %w", err)
 	}
 
-	if a.RequestedExpiry.After(validatedRequestKey.ExpiresAt) {
-		return nil, nil, AuthScope{}, fmt.Errorf("%w: cannot exchange an access key for another access key with a longer lifetime", internal.ErrBadRequest)
+	sessionExpiry := a.RequestedExpiry
+
+	if sessionExpiry.After(validatedRequestKey.ExpiresAt) {
+		logging.L.Trace().Msg("key exchanged with expiry before default, set exchanged key expiry to match requesting key")
+		sessionExpiry = validatedRequestKey.ExpiresAt
 	}
 
 	identity, err := data.GetIdentity(db, data.ByID(validatedRequestKey.IssuedFor))
 	if err != nil {
-		return nil, nil, AuthScope{}, fmt.Errorf("user is not valid: %w", err) // the user was probably deleted
+		return AuthenticatedIdentity{}, fmt.Errorf("user is not valid: %w", err) // the user was probably deleted
 	}
 
-	return identity, data.InfraProvider(db), AuthScope{}, nil
+	return AuthenticatedIdentity{
+		Identity:      identity,
+		Provider:      data.InfraProvider(db),
+		SessionExpiry: sessionExpiry,
+	}, nil
 }
 
 func (a *keyExchangeAuthn) Name() string {

--- a/internal/server/authn/key_exchange.go
+++ b/internal/server/authn/key_exchange.go
@@ -13,14 +13,12 @@ import (
 
 // keyExchangeAuthn allows exchanging a valid access key for new access key with a shorter lifetime
 type keyExchangeAuthn struct {
-	RequestingAccessKey string    // the access key being presented in the login request
-	RequestedExpiry     time.Time // the expiry of the new access key that would be issued on login
+	RequestingAccessKey string // the access key being presented in the login request
 }
 
-func NewKeyExchangeAuthentication(requestingAccessKey string, requestedExpiry time.Time) LoginMethod {
+func NewKeyExchangeAuthentication(requestingAccessKey string) LoginMethod {
 	return &keyExchangeAuthn{
 		RequestingAccessKey: requestingAccessKey,
-		RequestedExpiry:     requestedExpiry,
 	}
 }
 
@@ -30,7 +28,7 @@ func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *gorm.DB, requeste
 		return AuthenticatedIdentity{}, fmt.Errorf("invalid access key in exchange: %w", err)
 	}
 
-	sessionExpiry := a.RequestedExpiry
+	sessionExpiry := requestedExpiry
 
 	if sessionExpiry.After(validatedRequestKey.ExpiresAt) {
 		logging.L.Trace().Msg("key exchanged with expiry before default, set exchanged key expiry to match requesting key")

--- a/internal/server/authn/key_exchange_test.go
+++ b/internal/server/authn/key_exchange_test.go
@@ -2,6 +2,7 @@ package authn
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -21,8 +22,8 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 		expected    func(t *testing.T, authnIdentity AuthenticatedIdentity)
 	}
 
-	shortExpiry := time.Now().Add(1 * time.Minute)
-	longExpiry := time.Now().Add(30 * 24 * time.Hour)
+	shortExpiry := time.Now().UTC().Add(1 * time.Minute)
+	longExpiry := time.Now().UTC().Add(30 * 24 * time.Hour)
 
 	cases := map[string]testCase{
 		"InvalidAccessKeyCannotBeExchanged": {
@@ -100,7 +101,9 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 			expected: func(t *testing.T, authnIdentity AuthenticatedIdentity) {
 				assert.Equal(t, authnIdentity.Identity.Name, "krillin@example.com")
 				assert.Equal(t, data.InfraProvider(db).ID, authnIdentity.Provider.ID)
-				assert.Assert(t, authnIdentity.SessionExpiry.Equal(shortExpiry))
+				fmt.Println(authnIdentity.SessionExpiry)
+				fmt.Println(shortExpiry)
+				assert.Assert(t, authnIdentity.SessionExpiry.UTC().Equal(shortExpiry))
 			},
 		},
 		"ValidAccessKeySuccess": {

--- a/internal/server/authn/key_exchange_test.go
+++ b/internal/server/authn/key_exchange_test.go
@@ -24,7 +24,7 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 
 	shortExpiry := time.Now().UTC().Add(1 * time.Minute)
 	longExpiry := time.Now().UTC().Add(30 * 24 * time.Hour)
-	threshold := opt.DurationWithThreshold(time.Second)
+	threshold := opt.TimeWithThreshold(time.Second)
 
 	cases := map[string]testCase{
 		"InvalidAccessKeyCannotBeExchanged": {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -178,7 +178,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 
 	a.t.Event("login", key.IssuedFor.String(), Properties{"method": loginMethod.Name()})
 
-	return &api.LoginResponse{UserID: key.IssuedFor, Name: key.IssuedForIdentity.Name, AccessKey: bearer, Expires: api.Time(expires), PasswordUpdateRequired: requiresUpdate}, nil
+	return &api.LoginResponse{UserID: key.IssuedFor, Name: key.IssuedForIdentity.Name, AccessKey: bearer, Expires: api.Time(key.ExpiresAt), PasswordUpdateRequired: requiresUpdate}, nil
 }
 
 func (a *API) Logout(c *gin.Context, _ *api.EmptyRequest) (*api.EmptyResponse, error) {


### PR DESCRIPTION
- set key expiry to match exchanged key if exchanged key is valid for less than default session
- return AuthenticatedIdentity struct from authn rather than many separate values

## Summary
Fixing this now because our ArgoCD automation is using this flow.

This change fixes the key exchange login flow to work as long as your access key is valid. When the expiry time of the access key being passed in is less than the server's default session duration, set the new key to match the expiry of the one being exchanged rather than failing.

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2640
