### PR TITLE
improve: fixes docs for cli completion cmd

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -760,42 +760,40 @@ Generate shell auto-completion for the CLI
 
 To load completions:
 
-Bash:
+##### Bash:
 
-  $ source <(infra completion bash)
+`$ source <(infra completion bash)`
 
-  # To load completions for each session, execute once:
-  # Linux:
-  $ infra completion bash > /etc/bash_completion.d/infra
-  # macOS:
-  $ infra completion bash > /usr/local/etc/bash_completion.d/infra
+To load completions for each session, execute once:
+* Linux:
+  `$ infra completion bash > /etc/bash_completion.d/infra`
+* macOS:
+  `$ infra completion bash > /usr/local/etc/bash_completion.d/infra`
 
-Zsh:
+##### Zsh:
 
-  # If shell completion is not already enabled in your environment,
-  # you will need to enable it.  You can execute the following once:
+If shell completion is not already enabled in your environment, you will need to enable it. You can execute the following once:
+`$ echo "autoload -U compinit; compinit" >> ~/.zshrc`
 
-  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+To load completions for each session, execute once:
+`$ infra completion zsh > "${fpath[1]}/_infra"`
 
-  # To load completions for each session, execute once:
-  $ infra completion zsh > "${fpath[1]}/_infra"
+You will need to start a new shell for this setup to take effect.
 
-  # You will need to start a new shell for this setup to take effect.
+##### fish:
 
-fish:
+`$ infra completion fish | source`
 
-  $ infra completion fish | source
+To load completions for each session, execute once:
+`$ infra completion fish > ~/.config/fish/completions/infra.fish`
 
-  # To load completions for each session, execute once:
-  $ infra completion fish > ~/.config/fish/completions/infra.fish
+##### PowerShell:
 
-PowerShell:
+`PS> infra completion powershell | Out-String | Invoke-Expression`
 
-  PS> infra completion powershell | Out-String | Invoke-Expression
-
-  # To load completions for every new session, run:
-  PS> infra completion powershell > infra.ps1
-  # and source this file from your PowerShell profile.
+To load completions for every new session, run:
+`PS> infra completion powershell > infra.ps1`
+and source this file from your PowerShell profile.
 
 
 ```

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -14,42 +14,40 @@ func newCompletionsCmd() *cobra.Command {
 		Short: "Generate shell auto-completion for the CLI",
 		Long: fmt.Sprintf(`To load completions:
 
-Bash:
+##### Bash:
 
-  $ source <(%[1]s completion bash)
+`+"`"+`$ source <(%[1]s completion bash)`+"`"+`
 
-  # To load completions for each session, execute once:
-  # Linux:
-  $ %[1]s completion bash > /etc/bash_completion.d/%[1]s
-  # macOS:
-  $ %[1]s completion bash > /usr/local/etc/bash_completion.d/%[1]s
+To load completions for each session, execute once:
+* Linux:
+  `+"`"+`$ %[1]s completion bash > /etc/bash_completion.d/%[1]s`+"`"+`
+* macOS:
+  `+"`"+`$ %[1]s completion bash > /usr/local/etc/bash_completion.d/%[1]s`+"`"+`
 
-Zsh:
+##### Zsh:
 
-  # If shell completion is not already enabled in your environment,
-  # you will need to enable it.  You can execute the following once:
+If shell completion is not already enabled in your environment, you will need to enable it. You can execute the following once:
+`+"`"+`$ echo "autoload -U compinit; compinit" >> ~/.zshrc`+"`"+`
 
-  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+To load completions for each session, execute once:
+`+"`"+`$ %[1]s completion zsh > "${fpath[1]}/_%[1]s"`+"`"+`
 
-  # To load completions for each session, execute once:
-  $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
+You will need to start a new shell for this setup to take effect.
 
-  # You will need to start a new shell for this setup to take effect.
+##### fish:
 
-fish:
+`+"`"+`$ %[1]s completion fish | source`+"`"+`
 
-  $ %[1]s completion fish | source
+To load completions for each session, execute once:
+`+"`"+`$ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish`+"`"+`
 
-  # To load completions for each session, execute once:
-  $ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
+##### PowerShell:
 
-PowerShell:
+`+"`"+`PS> %[1]s completion powershell | Out-String | Invoke-Expression`+"`"+`
 
-  PS> %[1]s completion powershell | Out-String | Invoke-Expression
-
-  # To load completions for every new session, run:
-  PS> %[1]s completion powershell > %[1]s.ps1
-  # and source this file from your PowerShell profile.
+To load completions for every new session, run:
+`+"`"+`PS> %[1]s completion powershell > %[1]s.ps1`+"`"+`
+and source this file from your PowerShell profile.
 `, `infra`),
 		DisableFlagsInUseLine: true,
 		Group:                 "Other commands:",


### PR DESCRIPTION
## Summary

**CLI**
```% deb completion --help
To load completions:

Bash:

  $ source <(infra completion bash)

  # To load completions for each session, execute once:
  # Linux:
  $ infra completion bash > /etc/bash_completion.d/infra
  # macOS:
  $ infra completion bash > /usr/local/etc/bash_completion.d/infra

Zsh:

  # If shell completion is not already enabled in your environment,
  # you will need to enable it.  You can execute the following once:

  $ echo "autoload -U compinit; compinit" >> ~/.zshrc

  # To load completions for each session, execute once:
  $ infra completion zsh > "${fpath[1]}/_infra"

  # You will need to start a new shell for this setup to take effect.

fish:

  $ infra completion fish | source

  # To load completions for each session, execute once:
  $ infra completion fish > ~/.config/fish/completions/infra.fish

PowerShell:

  PS> infra completion powershell | Out-String | Invoke-Expression

  # To load completions for every new session, run:
  PS> infra completion powershell > infra.ps1
  # and source this file from your PowerShell profile.

Usage:
  infra completion

Global Flags:
      --help               Display help
      --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
```

Docs:
<img width="557" alt="image" src="https://user-images.githubusercontent.com/20054646/184676171-5529a9a4-0252-41c7-ada9-80f7a1e4b992.png">

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2927
