### PR TITLE
fix(helm): default false to overriding old chart

### DIFF
--- a/.github/workflows/cd-helm.yaml
+++ b/.github/workflows/cd-helm.yaml
@@ -41,7 +41,7 @@ jobs:
           name: helm
       - run: |
           for chart in *.tgz; do
-            if aws s3 ls s3://${{ env.HELM_BUCKET }}/$chart && ! ${{ inputs.override-chart }} ; then
+            if aws s3 ls s3://${{ env.HELM_BUCKET }}/$chart && ! ${{ inputs.override-chart || false }} ; then
               echo "Skipping $chart which already exists."
               continue
             fi


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`inputs.override-chart` is empty if the workflow is invoked by something other than a `workflow_dispatch` which will erroneously override the previous chart