### PR TITLE
fix: do not make external API calls in tests

### DIFF
--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -316,9 +316,11 @@ func TestLoadConfigInvalid(t *testing.T) {
 		"MissingProviderName": {
 			Providers: []Provider{
 				{
-					URL:          "demo.okta.com",
+					URL:          "example.com",
 					ClientID:     "client-id",
 					ClientSecret: "client-secret",
+					AuthURL:      "example.com/auth",
+					Scopes:       []string{"openid", "email"},
 				},
 			},
 		},
@@ -335,8 +337,10 @@ func TestLoadConfigInvalid(t *testing.T) {
 			Providers: []Provider{
 				{
 					Name:         "okta",
-					URL:          "demo.okta.com",
+					URL:          "example.com",
 					ClientSecret: "client-secret",
+					AuthURL:      "example.com/auth",
+					Scopes:       []string{"openid", "email"},
 				},
 			},
 		},
@@ -344,8 +348,10 @@ func TestLoadConfigInvalid(t *testing.T) {
 			Providers: []Provider{
 				{
 					Name:     "okta",
-					URL:      "demo.okta.com",
+					URL:      "example.com",
 					ClientID: "client-id",
+					AuthURL:  "example.com/auth",
+					Scopes:   []string{"openid", "email"},
 				},
 			},
 		},
@@ -353,9 +359,9 @@ func TestLoadConfigInvalid(t *testing.T) {
 			Providers: []Provider{
 				{
 					Name:     "okta",
-					URL:      "demo.okta.com",
+					URL:      "example.com",
 					ClientID: "client-id",
-					AuthURL:  "example.com",
+					AuthURL:  "example.com/auth",
 					Scopes:   []string{"offline_access"},
 				},
 			},
@@ -392,10 +398,10 @@ func TestLoadConfigWithProviders(t *testing.T) {
 		Providers: []Provider{
 			{
 				Name:         "okta",
-				URL:          "demo.okta.com",
+				URL:          "example.com",
 				ClientID:     "client-id",
 				ClientSecret: "client-secret",
-				AuthURL:      "dev.okta.com/oauth2/default/v1/token",
+				AuthURL:      "example.com/oauth2/default/v1/token",
 				Scopes:       []string{"openid", "email"},
 			},
 			{
@@ -434,11 +440,11 @@ func TestLoadConfigWithProviders(t *testing.T) {
 		Model:              okta.Model,     // not relevant
 		CreatedBy:          okta.CreatedBy, // not relevant
 		Name:               "okta",
-		URL:                "demo.okta.com",
+		URL:                "example.com",
 		ClientID:           "client-id",
 		ClientSecret:       "client-secret",
 		Kind:               models.ProviderKindOIDC, // the kind gets the default value
-		AuthURL:            "dev.okta.com/oauth2/default/v1/token",
+		AuthURL:            "example.com/oauth2/default/v1/token",
 		Scopes:             []string{"openid", "email"},
 		OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrg.ID},
 	}
@@ -642,9 +648,11 @@ func TestLoadConfigPruneConfig(t *testing.T) {
 		Providers: []Provider{
 			{
 				Name:         "okta",
-				URL:          "demo.okta.com",
+				URL:          "example.com",
 				ClientID:     "client-id",
 				ClientSecret: "client-secret",
+				AuthURL:      "example.com/auth",
+				Scopes:       []string{"openid", "email"},
 			},
 		},
 		Grants: []Grant{
@@ -691,9 +699,11 @@ func TestLoadConfigPruneConfig(t *testing.T) {
 		Providers: []Provider{
 			{
 				Name:         "okta",
-				URL:          "new-demo.okta.com",
+				URL:          "new.example.com",
 				ClientID:     "new-client-id",
 				ClientSecret: "new-client-secret",
+				AuthURL:      "new.example.com/auth",
+				Scopes:       []string{"openid", "email"},
 			},
 		},
 	}
@@ -725,10 +735,10 @@ func TestLoadConfigUpdate(t *testing.T) {
 		Providers: []Provider{
 			{
 				Name:         "okta",
-				URL:          "demo.okta.com",
+				URL:          "example.okta.com",
 				ClientID:     "client-id",
 				ClientSecret: "client-secret",
-				AuthURL:      "demo.okta.com/auth",
+				AuthURL:      "example.com/auth",
 				Scopes:       []string{"openid", "email"},
 			},
 		},
@@ -807,10 +817,10 @@ func TestLoadConfigUpdate(t *testing.T) {
 		Providers: []Provider{
 			{
 				Name:         "atko",
-				URL:          "demo.atko.com",
+				URL:          "new.example.com",
 				ClientID:     "client-id-2",
 				ClientSecret: "client-secret-2",
-				AuthURL:      "demo.okta.com/v1/auth",
+				AuthURL:      "new.example.com/v1/auth",
 				Scopes:       []string{"openid", "email", "groups"},
 			},
 		},
@@ -844,11 +854,11 @@ func TestLoadConfigUpdate(t *testing.T) {
 		Model:              provider.Model,     // not relevant
 		CreatedBy:          provider.CreatedBy, // not relevant
 		Name:               "atko",
-		URL:                "demo.atko.com",
+		URL:                "new.example.com",
 		ClientID:           "client-id-2",
 		ClientSecret:       "client-secret-2",
 		Kind:               models.ProviderKindOIDC, // the kind gets the default value
-		AuthURL:            "demo.okta.com/v1/auth",
+		AuthURL:            "new.example.com/v1/auth",
 		Scopes:             []string{"openid", "email", "groups"},
 		OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrg.ID},
 	}

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -641,7 +641,6 @@ func TestLoadConfigWithGroupGrants(t *testing.T) {
 }
 
 func TestLoadConfigPruneConfig(t *testing.T) {
-	t.Skip("do not hit external urls") // this test needs to not hit https://demo.okta.com/.well-known/openid-configuration
 	s := setupServer(t)
 
 	config := Config{

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -154,6 +154,7 @@ func TestMigrations(t *testing.T) {
 			setup: func(t *testing.T, db *gorm.DB) {
 				stmt := `
 INSERT INTO providers (id, created_at, updated_at, deleted_at, name, url, client_id, client_secret, kind, created_by) VALUES (67301777540980736, '2022-07-05 17:13:14.172568+00', '2022-07-05 17:13:14.172568+00', NULL, 'infra', '', '', 'AAAAEIRG2/PYF2erJG6cYHTybucGYWVzZ2NtBDjJTEEbL3Jvb3QvLmluZnJhL3NxbGl0ZTMuZGIua2V5DGt4MdtlZuxOUhZQTw', 'infra', 1);
+INSERT INTO providers (id, created_at, updated_at, deleted_at, name, url, client_id, client_secret, kind, created_by) VALUES (67301777540980737, '2022-07-05 17:13:14.172568+00', '2022-07-05 17:13:14.172568+00', NULL, 'okta', 'example.okta.com', 'client-id', 'AAAAEIRG2/PYF2erJG6cYHTybucGYWVzZ2NtBDjJTEEbL3Jvb3QvLmluZnJhL3NxbGl0ZTMuZGIua2V5DGt4MdtlZuxOUhZQTw', 'okta', 1);
 `
 				err := db.Exec(stmt).Error
 				assert.NilError(t, err)
@@ -176,12 +177,16 @@ INSERT INTO providers (id, created_at, updated_at, deleted_at, name, url, client
 					actual = append(actual, p)
 				}
 
-				// updated := parseTime(t, "2022-07-05 17:13:14.172568+00")
 				expected := []models.Provider{
 					{
 						Name:    "infra",
 						AuthURL: "",
 						Scopes:  nil,
+					},
+					{
+						Name:    "okta",
+						AuthURL: "https://example.okta.com/oauth2/v1/authorize", // set from external endpoint
+						Scopes:  models.CommaSeparatedStrings{"openid", "email", "offline_access", "groups"},
 					},
 				}
 				assert.DeepEqual(t, actual, expected)

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestProvider(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
-		providerDevelop := models.Provider{Name: "okta-development", URL: "dev.okta.com", Kind: models.ProviderKindOkta}
+		providerDevelop := models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 
 		err := db.Create(&providerDevelop).Error
 		assert.NilError(t, err)
@@ -21,7 +21,7 @@ func TestProvider(t *testing.T) {
 		var provider models.Provider
 		err = db.Not("name = ?", models.InternalInfraProviderName).First(&provider).Error
 		assert.NilError(t, err)
-		assert.Equal(t, "dev.okta.com", provider.URL)
+		assert.Equal(t, "example.com", provider.URL)
 	})
 }
 
@@ -35,7 +35,7 @@ func createProviders(t *testing.T, db *gorm.DB, providers ...models.Provider) {
 func TestCreateProviderDuplicate(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
 		var (
-			providerDevelop    = models.Provider{Name: "okta-development", URL: "dev.okta.com", Kind: models.ProviderKindOkta}
+			providerDevelop    = models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 			providerProduction = models.Provider{Name: "okta-production", URL: "prod.okta.com", Kind: models.ProviderKindOkta}
 		)
 
@@ -53,7 +53,7 @@ func TestCreateProviderDuplicate(t *testing.T) {
 func TestGetProvider(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
 		var (
-			providerDevelop    = models.Provider{Name: "okta-development", URL: "dev.okta.com", Kind: models.ProviderKindOkta}
+			providerDevelop    = models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 			providerProduction = models.Provider{Name: "okta-production", URL: "prod.okta.com", Kind: models.ProviderKindOkta}
 		)
 
@@ -69,7 +69,7 @@ func TestGetProvider(t *testing.T) {
 func TestListProviders(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
 		var (
-			providerDevelop    = models.Provider{Name: "okta-development", URL: "dev.okta.com", Kind: models.ProviderKindOkta}
+			providerDevelop    = models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 			providerProduction = models.Provider{Name: "okta-production", URL: "prod.okta.com", Kind: models.ProviderKindOkta}
 		)
 
@@ -95,7 +95,7 @@ func TestDeleteProviders(t *testing.T) {
 			i                  = 0
 		)
 		setup := func() {
-			providerDevelop = models.Provider{Name: fmt.Sprintf("okta-development-%d", i), URL: "dev.okta.com", Kind: models.ProviderKindOkta}
+			providerDevelop = models.Provider{Name: fmt.Sprintf("okta-development-%d", i), URL: "example.com", Kind: models.ProviderKindOkta}
 			providerProduction = models.Provider{Name: fmt.Sprintf("okta-production-%d", i+1), URL: "prod.okta.com", Kind: models.ProviderKindOkta}
 			i += 2
 
@@ -146,25 +146,24 @@ func TestDeleteProviders(t *testing.T) {
 			_, err = GetIdentity(db, ByID(pu.IdentityID))
 			assert.NilError(t, err)
 		})
-
 	})
 }
 
 func TestRecreateProviderSameDomain(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
 		var (
-			providerDevelop    = models.Provider{Name: "okta-development", URL: "dev.okta.com", Kind: models.ProviderKindOkta}
+			providerDevelop    = models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 			providerProduction = models.Provider{Name: "okta-production", URL: "prod.okta.com", Kind: models.ProviderKindOkta}
 		)
 
 		createProviders(t, db, providerDevelop, providerProduction)
 
 		err := DeleteProviders(db, func(db *gorm.DB) *gorm.DB {
-			return db.Where(&models.Provider{Name: "okta-development", URL: "dev.okta.com", Kind: models.ProviderKindOkta})
+			return db.Where(&models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta})
 		})
 		assert.NilError(t, err)
 
-		err = CreateProvider(db, &models.Provider{Name: "okta-development", URL: "dev.okta.com", Kind: models.ProviderKindOkta})
+		err = CreateProvider(db, &models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta})
 		assert.NilError(t, err)
 	})
 }


### PR DESCRIPTION
## Summary
- Remove domains that may be called externally in the case of a bad test configuration
- Remove migration test that makes external call

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2949
