### PR TITLE
maintain: clean up org db context setting

### DIFF
--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ListOrganizations(c *gin.Context, name string, pg *models.Pagination) ([]models.Organization, error) {
-	var selectors = []data.SelectorFunc{}
+	selectors := []data.SelectorFunc{}
 	if name != "" {
 		selectors = append(selectors, data.ByName(name))
 	}
@@ -41,7 +41,7 @@ func CreateOrganization(c *gin.Context, org *models.Organization) error {
 		return HandleAuthErr(err, "organizations", "create", models.InfraSupportAdminRole)
 	}
 
-	return data.CreateOrganization(db, org)
+	return data.CreateOrganizationAndSetContext(db, org)
 }
 
 func DeleteOrganization(c *gin.Context, id uid.ID) error {

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -26,10 +26,9 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 
 	details.Org.GenerateDefaultDomain(baseDomain)
 
-	if err := data.CreateOrganization(db, details.Org); err != nil {
+	if err := data.CreateOrganizationAndSetContext(db, details.Org); err != nil {
 		return nil, "", fmt.Errorf("create org on sign-up: %w", err)
 	}
-	db.Statement.Context = data.WithOrg(db.Statement.Context, details.Org)
 
 	// check the admin user's password requirements against our basic password requirements
 	err := checkPasswordRequirements(db, details.Password)

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -41,7 +41,6 @@ func NewDB(connection gorm.Dialector, loadDBKey func(db *gorm.DB) error) (*DB, e
 		return nil, fmt.Errorf("migration failed: %w", err)
 	}
 
-	// TODO: initialize, and populate settings and org on DB
 	dataDB := &DB{DB: db}
 	if err := initialize(dataDB); err != nil {
 		return nil, fmt.Errorf("initialize database: %w", err)
@@ -104,7 +103,7 @@ func initialize(db *DB) error {
 			Name:      models.DefaultOrganizationName,
 			CreatedBy: models.CreatedBySystem,
 		}
-		if err := CreateOrganization(db.DB, org); err != nil {
+		if err := CreateOrganizationAndSetContext(db.DB, org); err != nil {
 			return fmt.Errorf("failed to create default organization: %w", err)
 		}
 	case err != nil:

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -30,13 +30,14 @@ func MustGetOrgFromContext(ctx context.Context) *models.Organization {
 }
 
 // WithOrg sets an Organization in the context. The Organization will be used
-// by all query functions to insert,select, and modify entities within that
+// by all query functions to insert, select, and modify entities within that
 // organization.
 func WithOrg(ctx context.Context, org *models.Organization) context.Context {
 	return context.WithValue(ctx, orgCtxKey{}, org)
 }
 
-func CreateOrganization(db *gorm.DB, org *models.Organization) error {
+// CreateOrganizationAndSetContext creates a new organization and sets the current db context to execute on this org
+func CreateOrganizationAndSetContext(db *gorm.DB, org *models.Organization) error {
 	err := add(db, org)
 	if err != nil {
 		return fmt.Errorf("creating org: %w", err)
@@ -49,9 +50,8 @@ func CreateOrganization(db *gorm.DB, org *models.Organization) error {
 	}
 
 	infraProvider := &models.Provider{
-		Name:               models.InternalInfraProviderName,
-		Kind:               models.ProviderKindInfra,
-		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+		Name: models.InternalInfraProviderName,
+		Kind: models.ProviderKindInfra,
 	}
 	if err := CreateProvider(db, infraProvider); err != nil {
 		return fmt.Errorf("failed to create infra provider: %w", err)

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -50,14 +50,18 @@ func CreateOrganizationAndSetContext(db *gorm.DB, org *models.Organization) erro
 	}
 
 	infraProvider := &models.Provider{
-		Name: models.InternalInfraProviderName,
-		Kind: models.ProviderKindInfra,
+		Name:      models.InternalInfraProviderName,
+		Kind:      models.ProviderKindInfra,
+		CreatedBy: models.CreatedBySystem,
 	}
 	if err := CreateProvider(db, infraProvider); err != nil {
 		return fmt.Errorf("failed to create infra provider: %w", err)
 	}
 
-	connector := &models.Identity{Name: models.InternalInfraConnectorIdentityName}
+	connector := &models.Identity{
+		Name:      models.InternalInfraConnectorIdentityName,
+		CreatedBy: models.CreatedBySystem,
+	}
 	// this identity is used to create access keys for connectors
 	if err := CreateIdentity(db, connector); err != nil {
 		return fmt.Errorf("failed to create connector identity while creating org: %w", err)

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // PostgreSQL only has microsecond precision
-var cmpTimeWithDBPrecision = cmpopts.EquateApproxTime(time.Microsecond)
+var cmpTimeWithDBPrecision = cmpopts.EquateApproxTime(time.Millisecond)
 
 func TestCreateOrganizationAndSetContext(t *testing.T) {
 	pgsql := postgresDriver(t)

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -3,8 +3,9 @@ package data
 import (
 	"testing"
 
-	"github.com/infrahq/infra/internal/server/models"
 	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/server/models"
 )
 
 func TestCreateOrganizationAndSetContext(t *testing.T) {

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // PostgreSQL only has microsecond precision
-var cmpTimeWithDBPrecision = cmpopts.EquateApproxTime(time.Millisecond)
+var cmpTimeWithDBPrecision = cmpopts.EquateApproxTime(time.Microsecond)
 
 func TestCreateOrganizationAndSetContext(t *testing.T) {
 	pgsql := postgresDriver(t)
@@ -29,7 +29,7 @@ func TestCreateOrganizationAndSetContext(t *testing.T) {
 	// org is created
 	readOrg, err := GetOrganization(db, ByID(org.ID))
 	assert.NilError(t, err)
-	assert.DeepEqual(t, org, readOrg)
+	assert.DeepEqual(t, org, readOrg, cmpTimeWithDBPrecision)
 
 	// infra provider is created
 	orgInfraIDP := InfraProvider(db)

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -1,12 +1,28 @@
 package data
 
 import (
+	"reflect"
 	"testing"
 
+	gocmp "github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/models"
 )
+
+var cmpOrgShallow = gocmp.Comparer(func(x, y models.Organization) bool {
+	return x.Model.ID == y.Model.ID &&
+		x.Name == y.Name &&
+		x.Domain == y.Domain
+})
+
+var cmpProviderShallow = gocmp.Comparer(func(x, y models.Provider) bool {
+	return x.Model.ID == y.Model.ID &&
+		x.Name == y.Name &&
+		reflect.DeepEqual(x.Scopes, y.Scopes) &&
+		x.Kind == y.Kind &&
+		x.OrganizationID == y.OrganizationID
+})
 
 func TestCreateOrganizationAndSetContext(t *testing.T) {
 	pgsql := postgresDriver(t)
@@ -19,7 +35,7 @@ func TestCreateOrganizationAndSetContext(t *testing.T) {
 
 	// db context is set
 	ctxOrg := OrgFromContext(db.Statement.Context)
-	assert.DeepEqual(t, org, ctxOrg)
+	assert.DeepEqual(t, org, ctxOrg, cmpOrgShallow)
 
 	// org is created
 	readOrg, err := GetOrganization(db, ByID(org.ID))
@@ -31,11 +47,11 @@ func TestCreateOrganizationAndSetContext(t *testing.T) {
 	assert.NilError(t, err)
 
 	expectedOrgInfraProviderIDP := &models.Provider{
-		Model:              orgInfraIDP.Model, // does not matter
+		Model:              models.Model{ID: orgInfraIDP.Model.ID}, // does not matter
 		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 		Scopes:             models.CommaSeparatedStrings{},
 		Name:               models.InternalInfraProviderName,
 		Kind:               models.ProviderKindInfra,
 	}
-	assert.DeepEqual(t, orgInfraIDP, expectedOrgInfraProviderIDP)
+	assert.DeepEqual(t, orgInfraIDP, expectedOrgInfraProviderIDP, cmpProviderShallow)
 }

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/infrahq/infra/internal/server/models"
 )
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -233,7 +233,9 @@ func requireAccessKey(db *gorm.DB, req *http.Request) (access.Authenticated, err
 		return u, fmt.Errorf("access kye org lookup: %w", err)
 	}
 
+	// now that the org is loaded scope all db calls to that org
 	db.Statement.Context = data.WithOrg(db.Statement.Context, org)
+
 	identity, err := data.GetIdentity(db, data.ByID(accessKey.IssuedFor))
 	if err != nil {
 		return u, fmt.Errorf("identity for access key: %w", err)

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -43,7 +43,6 @@ func setupDB(t *testing.T) *data.DB {
 		assert.NilError(t, db.Close())
 	})
 
-	db.Statement.Context = data.WithOrg(db.Statement.Context, db.DefaultOrg)
 	return db
 }
 
@@ -344,7 +343,7 @@ func TestGetOrgFromRequest_FromRequestHost(t *testing.T) {
 		Name:   "The Umbrella Academy",
 		Domain: "umbrella.infrahq.com",
 	}
-	err := data.CreateOrganization(db, org)
+	err := data.CreateOrganizationAndSetContext(db, org)
 	assert.NilError(t, err)
 
 	router.GET("/foo",

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -24,8 +24,9 @@ func createOrgs(t *testing.T, db *gorm.DB, orgs ...*models.Organization) {
 			continue
 		}
 		orgs[i].GenerateDefaultDomain("example.com")
-		err = data.CreateOrganization(db, orgs[i])
+		err = data.CreateOrganizationAndSetContext(db, orgs[i])
 		assert.NilError(t, err, orgs[i].Name)
+		assert.DeepEqual(t, data.OrgFromContext(db.Statement.Context), orgs[i])
 	}
 }
 
@@ -186,7 +187,7 @@ func TestAPI_DeleteOrganization(t *testing.T) {
 	srv := setupServer(t, withAdminUser, withSupportAdminGrant)
 	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	var first = models.Organization{Name: "first"}
+	first := models.Organization{Name: "first"}
 	createOrgs(t, srv.DB(), &first)
 
 	type testCase struct {


### PR DESCRIPTION
- rename CreateOrganization to reflect its functionality
- remove unneeded db statement context setting
- do not set db context in middleware test
- remove the "set default org" from setupDB in server (and other) packages

## Summary
Cleaning up some org creation and context setting. 

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

Part of #2903
