### PR TITLE
Remove regex replacement from org domain generation

### DIFF
--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -1,7 +1,6 @@
 package access
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -56,14 +55,6 @@ func DeleteOrganization(c *gin.Context, id uid.ID) error {
 	return data.DeleteOrganizations(db, data.ByID(id))
 }
 
-var domainNameReplacer = regexp.MustCompile(`[^\da-zA-Z-]`)
-
 func SanitizedDomain(subDomain, serverBaseDomain string) string {
-	sanitizedDomain := domainNameReplacer.ReplaceAllStringFunc(subDomain, func(s string) string {
-		if s == " " {
-			return "-"
-		}
-		return ""
-	})
-	return strings.ToLower(sanitizedDomain) + "." + serverBaseDomain
+	return strings.ToLower(subDomain) + "." + serverBaseDomain
 }

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -16,12 +16,7 @@ import (
 func createOrgs(t *testing.T, db data.GormTxn, orgs ...*models.Organization) {
 	t.Helper()
 	for i := range orgs {
-		o, err := data.GetOrganization(db, data.ByName(orgs[i].Name))
-		if err == nil {
-			*orgs[i] = *o
-			continue
-		}
-		err = data.CreateOrganization(db, orgs[i])
+		err := data.CreateOrganization(db, orgs[i])
 		assert.NilError(t, err, orgs[i].Name)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -57,6 +57,8 @@ type Options struct {
 	EmailFromName    string
 	SendgridApiKey   string
 
+	// BaseDomain of the server, which is appended to the organization slug to
+	// create a unique hostname for each organization.
 	BaseDomain string
 
 	Keys    []KeyProvider
@@ -113,9 +115,6 @@ type Addrs struct {
 
 // newServer creates a Server with base dependencies initialized to zero values.
 func newServer(options Options) *Server {
-	if options.BaseDomain == "" {
-		options.BaseDomain = "example.com"
-	}
 	return &Server{
 		options: options,
 		secrets: map[string]secrets.SecretStorage{},

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -21,6 +21,7 @@ func TestAPI_Signup(t *testing.T) {
 
 	srv := setupServer(t, withAdminUser)
 	srv.options.EnableSignup = true
+	srv.options.BaseDomain = "exampledomain.com"
 	routes := srv.GenerateRoutes()
 
 	run := func(t *testing.T, tc testCase) {
@@ -132,7 +133,7 @@ func TestAPI_Signup(t *testing.T) {
 				assert.Equal(t, respBody.Organization.Name, "acme")
 
 				// the organization exists
-				org, err := data.GetOrganization(srv.DB(), data.ByDomain("acme.example.com"))
+				org, err := data.GetOrganization(srv.DB(), data.ByDomain("acme.exampledomain.com"))
 				assert.NilError(t, err)
 				assert.Equal(t, org.ID, respBody.Organization.ID)
 


### PR DESCRIPTION
## Summary

With the changes in #3066, all we need to do here is lowercase the string. So we can remove the regex replacement.