### PR TITLE
fix: create connector identity for org

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -58,10 +58,6 @@ func setupAccessTestContext(t *testing.T) (*gin.Context, *gorm.DB, *models.Provi
 
 	provider := data.InfraProvider(db)
 
-	identity := &models.Identity{Name: models.InternalInfraConnectorIdentityName}
-	err = data.CreateIdentity(db, identity)
-	assert.NilError(t, err)
-
 	return c, db, provider
 }
 

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -348,7 +348,7 @@ func updateUser(cli *CLI, name string) error {
 }
 
 func getUserByNameOrID(client *api.Client, name string) (*api.User, error) {
-	users, err := client.ListUsers(api.ListUsersRequest{Name: name})
+	users, err := client.ListUsers(api.ListUsersRequest{Name: name, ShowSystem: true})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -348,7 +348,13 @@ func updateUser(cli *CLI, name string) error {
 }
 
 func getUserByNameOrID(client *api.Client, name string) (*api.User, error) {
-	users, err := client.ListUsers(api.ListUsersRequest{Name: name, ShowSystem: true})
+	showSystem := false
+
+	if name == "connector" {
+		showSystem = true
+	}
+
+	users, err := client.ListUsers(api.ListUsersRequest{Name: name, ShowSystem: showSystem})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -3,7 +3,6 @@ package data
 import (
 	"context"
 	"os"
-	"sort"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -145,13 +144,9 @@ func TestPaginationSelector(t *testing.T) {
 			assert.NilError(t, CreateIdentity(db, g))
 		}
 
-		alphabeticalIdentities = append(alphabeticalIdentities, models.InternalInfraConnectorIdentityName)
-
-		sort.Strings(alphabeticalIdentities)
-
 		p := models.Pagination{Page: 1, Limit: 10}
 
-		actual, err := ListIdentities(db, &p)
+		actual, err := ListIdentities(db, &p, NotName(models.InternalInfraConnectorIdentityName))
 		assert.NilError(t, err)
 		assert.Equal(t, len(actual), 10)
 		for i := 0; i < p.Limit; i++ {
@@ -162,7 +157,7 @@ func TestPaginationSelector(t *testing.T) {
 		}
 
 		p.Page = 2
-		actual, err = ListIdentities(db, &p)
+		actual, err = ListIdentities(db, &p, NotName(models.InternalInfraConnectorIdentityName))
 		assert.NilError(t, err)
 		assert.Equal(t, len(actual), 10)
 		for i := 0; i < p.Limit; i++ {
@@ -170,16 +165,16 @@ func TestPaginationSelector(t *testing.T) {
 		}
 
 		p.Page = 3
-		actual, err = ListIdentities(db, &p)
+		actual, err = ListIdentities(db, &p, NotName(models.InternalInfraConnectorIdentityName))
 		assert.NilError(t, err)
-		assert.Equal(t, len(actual), 7)
+		assert.Equal(t, len(actual), 6)
 
 		for i := 0; i < 6; i++ {
 			assert.Equal(t, alphabeticalIdentities[i+(p.Page-1)*p.Limit], actual[i].Name)
 		}
 
 		p.Page, p.Limit = 1, 26
-		actual, err = ListIdentities(db, &p)
+		actual, err = ListIdentities(db, &p, NotName(models.InternalInfraConnectorIdentityName))
 		assert.NilError(t, err)
 		for i, user := range actual {
 			assert.Equal(t, user.Name, alphabeticalIdentities[i])

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -79,7 +80,6 @@ func TestSnowflakeIDSerialization(t *testing.T) {
 
 func TestDatabaseSelectors(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
-
 		// assert.NilError(t, initializeSchema(db))
 
 		org := OrgFromContext(db.Statement.Context)
@@ -138,12 +138,16 @@ func TestDatabaseSelectors(t *testing.T) {
 
 func TestPaginationSelector(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *gorm.DB) {
-		letters := make([]string, 0, 26)
+		alphabeticalIdentities := []string{}
 		for r := 'a'; r < 'a'+26; r++ {
-			letters = append(letters, string(r))
+			alphabeticalIdentities = append(alphabeticalIdentities, string(r))
 			g := &models.Identity{Name: string(r)}
 			assert.NilError(t, CreateIdentity(db, g))
 		}
+
+		alphabeticalIdentities = append(alphabeticalIdentities, models.InternalInfraConnectorIdentityName)
+
+		sort.Strings(alphabeticalIdentities)
 
 		p := models.Pagination{Page: 1, Limit: 10}
 
@@ -151,7 +155,10 @@ func TestPaginationSelector(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, len(actual), 10)
 		for i := 0; i < p.Limit; i++ {
-			assert.Equal(t, letters[i+(p.Page-1)*p.Limit], actual[i].Name)
+			if actual[i].Name == models.InternalInfraConnectorIdentityName {
+				continue
+			}
+			assert.Equal(t, alphabeticalIdentities[i+(p.Page-1)*p.Limit], actual[i].Name)
 		}
 
 		p.Page = 2
@@ -159,23 +166,23 @@ func TestPaginationSelector(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, len(actual), 10)
 		for i := 0; i < p.Limit; i++ {
-			assert.Equal(t, letters[i+(p.Page-1)*p.Limit], actual[i].Name)
+			assert.Equal(t, alphabeticalIdentities[i+(p.Page-1)*p.Limit], actual[i].Name)
 		}
 
 		p.Page = 3
 		actual, err = ListIdentities(db, &p)
 		assert.NilError(t, err)
-		assert.Equal(t, len(actual), 6)
+		assert.Equal(t, len(actual), 7)
 
 		for i := 0; i < 6; i++ {
-			assert.Equal(t, letters[i+(p.Page-1)*p.Limit], actual[i].Name)
+			assert.Equal(t, alphabeticalIdentities[i+(p.Page-1)*p.Limit], actual[i].Name)
 		}
 
 		p.Page, p.Limit = 1, 26
 		actual, err = ListIdentities(db, &p)
 		assert.NilError(t, err)
 		for i, user := range actual {
-			assert.Equal(t, user.Name, letters[i])
+			assert.Equal(t, user.Name, alphabeticalIdentities[i])
 		}
 	})
 }

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -96,10 +96,12 @@ func TestListIdentities(t *testing.T) {
 		)
 		createIdentities(t, db, &bond, &bourne, &bauer)
 
+		connector := InfraConnectorIdentity(db)
+
 		t.Run("list all", func(t *testing.T) {
 			identities, err := ListIdentities(db, nil)
 			assert.NilError(t, err)
-			expected := []models.Identity{bauer, bond, bourne}
+			expected := []models.Identity{*connector, bauer, bond, bourne}
 			assert.DeepEqual(t, identities, expected, cmpModelsIdentityShallow)
 		})
 
@@ -188,7 +190,6 @@ func TestDeleteIdentityWithGroups(t *testing.T) {
 		group, err = GetGroup(db, ByID(group.ID))
 		assert.NilError(t, err)
 		assert.Equal(t, group.TotalUsers, 2)
-
 	})
 }
 

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -55,7 +55,9 @@ func CreateOrganization(db *gorm.DB, org *models.Organization) error {
 	if err := CreateProvider(db, infraProvider); err != nil {
 		return fmt.Errorf("failed to create infra provider: %w", err)
 	}
-	return nil
+
+	// this identity is used to create access keys for connectors
+	return CreateIdentity(db, &models.Identity{Name: models.InternalInfraConnectorIdentityName})
 }
 
 func GetOrganization(db *gorm.DB, selectors ...SelectorFunc) (*models.Organization, error) {

--- a/internal/server/testdata/TestMetrics/infra_users
+++ b/internal/server/testdata/TestMetrics/infra_users
@@ -1,1 +1,1 @@
-infra_users 3
+infra_users 4


### PR DESCRIPTION
## Summary
When an org signs up they need a connector identity to start adding destinations. Create it by default.

Tests dependent on #2952 

## Checklist

- [x] Considered security implications of the change
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2946 
