### PR TITLE
Accept Org ID from access key for unauthenticated endpoints

### DIFF
--- a/docs/dev/organization-request-flow.md
+++ b/docs/dev/organization-request-flow.md
@@ -1,6 +1,6 @@
 # Organization Request Flow
 
-The following diagram describes the process of loading the organization from the request, and how the various scenarios are handled with respect to authentication. Note that for "is org supplied?", the organization can come from a variety of places, (the request URL, `Infra-Organization` header, and access key) and that doesn't affect the rest of the flow.
+The following diagram describes the process of loading the organization from the request, and how the various scenarios are handled with respect to authentication. Note that for "is org supplied?", the organization can come from a variety of places, (the request URL, and access key) and that doesn't affect the rest of the flow.
 
 ```mermaid
 flowchart TD

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -347,7 +347,6 @@ func TestGetOrgFromRequest_FromRequestHost(t *testing.T) {
 	assert.NilError(t, err)
 
 	router.GET("/foo",
-		setOrganizationInCtx(srv),
 		unauthenticatedMiddleware(srv),
 		func(ctx *gin.Context) {
 			ctxOrg := data.OrgFromContext(ctx)
@@ -372,8 +371,9 @@ func TestGetOrgFromRequest_FromRequestHost(t *testing.T) {
 	assert.Equal(t, resp.StatusCode, 200)
 }
 
-func TestGetOrgFromRequest_MissingOrgErrors(t *testing.T) {
+func TestGetOrgFromRequest_MissingOrgErrorsInMultiTenantEnvironment(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
+	srv.options.EnableSignup = true // test multi-tenancy environment
 
 	router := gin.New()
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -333,42 +335,126 @@ func TestHandleInfraDestinationHeader(t *testing.T) {
 	})
 }
 
-func TestGetOrgFromRequest_FromRequestHost(t *testing.T) {
+func TestAuthenticatedMiddleware(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	db := srv.DB()
-
-	router := gin.New()
+	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
 	org := &models.Organization{
 		Name:   "The Umbrella Academy",
 		Domain: "umbrella.infrahq.com",
 	}
-	err := data.CreateOrganizationAndSetContext(db, org)
+	otherOrg := &models.Organization{
+		Name:   "The Factory",
+		Domain: "the-factory-xyz8.infrahq.com",
+	}
+	createOrgs(t, db, otherOrg, org)
+
+	user := &models.Identity{
+		Name:               "userone@example.com",
+		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+	}
+	createIdentities(t, db, user)
+
+	token := &models.AccessKey{
+		IssuedFor:          user.ID,
+		ProviderID:         data.InfraProvider(db).ID,
+		ExpiresAt:          time.Now().Add(10 * time.Second),
+		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+	}
+
+	key, err := data.CreateAccessKey(db, token)
 	assert.NilError(t, err)
 
-	router.GET("/foo",
-		unauthenticatedMiddleware(srv),
-		func(ctx *gin.Context) {
-			ctxOrg := data.OrgFromContext(ctx)
-
-			assert.Check(t, ctxOrg != nil)
-			assert.Check(t, ctxOrg.ID == org.ID, "got org %v", ctxOrg.Name)
-			ctx.JSON(200, api.EmptyResponse{})
-		})
-
-	httpSrv := httptest.NewServer(router)
+	httpSrv := httptest.NewServer(routes)
 	t.Cleanup(httpSrv.Close)
 
-	// nolint:noctx
-	req, err := http.NewRequest("GET", httpSrv.URL+"/foo", nil)
-	assert.NilError(t, err)
-	req.Host = org.Domain
+	type testCase struct {
+		name     string
+		setup    func(t *testing.T, req *http.Request)
+		expected func(t *testing.T, resp *http.Response)
+	}
 
-	client := httpSrv.Client()
-	resp, err := client.Do(req)
-	assert.NilError(t, err)
+	run := func(t *testing.T, tc testCase) {
+		// Any authenticated route will do
+		routeURL := httpSrv.URL + "/api/users/" + user.ID.String()
 
-	assert.Equal(t, resp.StatusCode, 200)
+		// nolint:noctx
+		req, err := http.NewRequest("GET", routeURL, nil)
+		assert.NilError(t, err)
+		req.Header.Set("Infra-Version", apiVersionLatest)
+
+		if tc.setup != nil {
+			tc.setup(t, req)
+		}
+
+		client := httpSrv.Client()
+		resp, err := client.Do(req)
+		assert.NilError(t, err)
+
+		tc.expected(t, resp)
+	}
+
+	testCases := []testCase{
+		{
+			name: "Org ID from access key",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+key)
+			},
+			expected: func(t *testing.T, resp *http.Response) {
+				body, err := io.ReadAll(resp.Body)
+				assert.NilError(t, err)
+
+				assert.Equal(t, resp.StatusCode, http.StatusOK, string(body))
+
+				respUser := &api.User{}
+				assert.NilError(t, json.Unmarshal(body, respUser))
+				assert.Equal(t, respUser.ID, user.ID)
+			},
+		},
+		{
+			name: "Missing access key",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Host = org.Domain
+			},
+			expected: func(t *testing.T, resp *http.Response) {
+				assert.Equal(t, resp.StatusCode, http.StatusUnauthorized)
+			},
+		},
+		{
+			name: "Org ID from access key and hostname match",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+key)
+				req.Host = org.Domain
+			},
+			expected: func(t *testing.T, resp *http.Response) {
+				body, err := io.ReadAll(resp.Body)
+				assert.NilError(t, err)
+
+				assert.Equal(t, resp.StatusCode, http.StatusOK, string(body))
+
+				respUser := &api.User{}
+				assert.NilError(t, json.Unmarshal(body, respUser))
+				assert.Equal(t, respUser.ID, user.ID)
+			},
+		},
+		{
+			name: "Org ID from access key and hostname conflict",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+key)
+				req.Host = otherOrg.Domain
+			},
+			expected: func(t *testing.T, resp *http.Response) {
+				assert.Equal(t, resp.StatusCode, http.StatusBadRequest)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
 }
 
 func TestGetOrgFromRequest_MissingOrgErrorsInMultiTenantEnvironment(t *testing.T) {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -595,9 +595,6 @@ func TestUnauthenticatedMiddleware(t *testing.T) {
 		},
 		{
 			name: "missing org with multi-tenancy, route returns error",
-			setup: func(t *testing.T, req *http.Request) {
-				t.Skip("TODO: currently this panics")
-			},
 			expected: func(t *testing.T, resp *http.Response) {
 				assert.Equal(t, resp.StatusCode, http.StatusBadRequest)
 			},

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -457,42 +457,176 @@ func TestAuthenticatedMiddleware(t *testing.T) {
 	}
 }
 
-func TestGetOrgFromRequest_MissingOrgErrorsInMultiTenantEnvironment(t *testing.T) {
+func TestUnauthenticatedMiddleware(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	srv.options.EnableSignup = true // test multi-tenancy environment
+	srv.options.EnableSignup = true // multi-tenant environment
+	db := srv.DB()
+	routes := srv.GenerateRoutes(prometheus.NewRegistry())
 
-	router := gin.New()
+	org := &models.Organization{
+		Name:   "The Umbrella Academy",
+		Domain: "umbrella.infrahq.com",
+	}
+	otherOrg := &models.Organization{
+		Name:   "The Factory",
+		Domain: "the-factory-xyz8.infrahq.com",
+	}
+	createOrgs(t, db, otherOrg, org)
 
-	router.GET("/foo",
-		unauthenticatedMiddleware(srv),
-		orgRequired(),
-		func(ctx *gin.Context) {
-			assert.Assert(t, false, "Shouldn't get here")
+	provider := &models.Provider{
+		Name:               "electric",
+		Kind:               models.ProviderKindGoogle,
+		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+	}
+	assert.NilError(t, data.CreateProvider(db, provider))
+
+	user := &models.Identity{
+		Name:               "userone@example.com",
+		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+	}
+	createIdentities(t, db, user)
+
+	token := &models.AccessKey{
+		IssuedFor:          user.ID,
+		ProviderID:         data.InfraProvider(db).ID,
+		ExpiresAt:          time.Now().Add(10 * time.Second),
+		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+	}
+
+	key, err := data.CreateAccessKey(db, token)
+	assert.NilError(t, err)
+
+	httpSrv := httptest.NewServer(routes)
+	t.Cleanup(httpSrv.Close)
+
+	type testCase struct {
+		name     string
+		route    string
+		setup    func(t *testing.T, req *http.Request)
+		expected func(t *testing.T, resp *http.Response)
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		// Any unauthenticated route will do
+		routeURL := httpSrv.URL + "/api/providers"
+		if tc.route != "" {
+			routeURL = httpSrv.URL + tc.route
+		}
+
+		// nolint:noctx
+		req, err := http.NewRequest("GET", routeURL, nil)
+		assert.NilError(t, err)
+		req.Header.Set("Infra-Version", apiVersionLatest)
+
+		if tc.setup != nil {
+			tc.setup(t, req)
+		}
+
+		client := httpSrv.Client()
+		resp, err := client.Do(req)
+		assert.NilError(t, err)
+
+		tc.expected(t, resp)
+	}
+
+	expectSuccess := func(t *testing.T, resp *http.Response) {
+		body, err := io.ReadAll(resp.Body)
+		assert.NilError(t, err)
+
+		assert.Equal(t, resp.StatusCode, http.StatusOK, string(body))
+
+		respProviders := &api.ListResponse[api.Provider]{}
+		assert.NilError(t, json.Unmarshal(body, respProviders))
+		assert.Equal(t, len(respProviders.Items), 1)
+		assert.Equal(t, respProviders.Items[0].ID, provider.ID)
+	}
+
+	testCases := []testCase{
+		{
+			name: "Org ID from access key",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+key)
+			},
+			expected: expectSuccess,
+		},
+		{
+			name: "Org ID from hostname",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Host = org.Domain
+			},
+			expected: expectSuccess,
+		},
+		{
+			name: "Org ID from access key and hostname match",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+key)
+				req.Host = org.Domain
+			},
+			expected: expectSuccess,
+		},
+		{
+			name: "Org ID from access key and hostname conflict",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+key)
+				req.Host = otherOrg.Domain
+			},
+			expected: func(t *testing.T, resp *http.Response) {
+				assert.Equal(t, resp.StatusCode, http.StatusBadRequest)
+			},
+		},
+		{
+			name: "missing org with single-tenancy returns default",
+			setup: func(t *testing.T, req *http.Request) {
+				srv.options.EnableSignup = false
+				t.Cleanup(func() {
+					srv.options.EnableSignup = true
+				})
+			},
+			expected: func(t *testing.T, resp *http.Response) {
+				assert.Equal(t, resp.StatusCode, http.StatusOK)
+			},
+		},
+		{
+			name:  "missing org with multi-tenancy, route ignores org",
+			route: "/api/version",
+			expected: func(t *testing.T, resp *http.Response) {
+				assert.Equal(t, resp.StatusCode, http.StatusOK)
+			},
+		},
+		{
+			name: "missing org with multi-tenancy, route returns error",
+			setup: func(t *testing.T, req *http.Request) {
+				t.Skip("TODO: currently this panics")
+			},
+			expected: func(t *testing.T, resp *http.Response) {
+				assert.Equal(t, resp.StatusCode, http.StatusBadRequest)
+			},
+		},
+		{
+			name: "missing org with multi-tenancy, route returns fake data",
+			setup: func(t *testing.T, req *http.Request) {
+				t.Skip("TODO: not yet implemented")
+			},
+			expected: func(t *testing.T, resp *http.Response) {
+				assert.Equal(t, resp.StatusCode, http.StatusOK)
+				// TODO: check fake data
+			},
+		},
+		{
+			name:  "unknown hostname works like missing org",
+			route: "/api/version",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Host = "http://notadomainweknowabout.org/foo"
+			},
+			expected: func(t *testing.T, resp *http.Response) {
+				assert.Equal(t, resp.StatusCode, http.StatusOK)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
 		})
-
-	req := httptest.NewRequest("GET", "http://notadomainweknowabout.org/foo", nil)
-
-	resp := httptest.NewRecorder()
-	router.ServeHTTP(resp, req)
-
-	assert.Equal(t, resp.Code, http.StatusBadRequest)
-}
-
-func TestGetOrgFromRequest_UsesDefaultWhenDomainDoesNotMatchAnyOrg(t *testing.T) {
-	srv := setupServer(t, withAdminUser)
-
-	router := gin.New()
-
-	router.GET("/foo",
-		unauthenticatedMiddleware(srv),
-		func(ctx *gin.Context) {
-			ctx.JSON(200, nil)
-		})
-
-	req := httptest.NewRequest("GET", "/foo", nil)
-
-	resp := httptest.NewRecorder()
-	router.ServeHTTP(resp, req)
-
-	assert.Equal(t, resp.Code, http.StatusOK)
+	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -108,7 +108,6 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 
 	// while an org is required for these endpoints, they return fake data when the org is not supplied
 	noAuthnOptOrg := apiGroup.Group("/",
-		setOrganizationInCtx(a.server),
 		unauthenticatedMiddleware(a.server),
 		// Until we're ready to return fake data, require the org.
 		orgRequired(),
@@ -117,7 +116,7 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	get(a, noAuthnOptOrg, "/api/settings", a.GetSettings)
 
 	// no auth required, org required
-	noAuthnWithOrg := apiGroup.Group("/", setOrganizationInCtx(a.server), unauthenticatedMiddleware(a.server), orgRequired())
+	noAuthnWithOrg := apiGroup.Group("/", unauthenticatedMiddleware(a.server), orgRequired())
 
 	post(a, noAuthnWithOrg, "/api/login", a.Login)
 	post(a, noAuthnWithOrg, "/api/password-reset-request", a.RequestPasswordReset)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -55,7 +55,7 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	apiGroup := router.Group("/", metrics.Middleware(promRegistry))
 
 	// auth required, org required
-	authn := apiGroup.Group("/", setOrganizationInCtx(a.server), authenticatedMiddleware(a.server))
+	authn := apiGroup.Group("/", authenticatedMiddleware(a.server))
 
 	get(a, authn, "/api/users", a.ListUsers)
 	post(a, authn, "/api/users", a.CreateUser)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -106,15 +106,6 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	get(a, noAuthnNoOrg, "/api/version", a.Version)
 	get(a, noAuthnNoOrg, "/api/server-configuration", a.GetServerConfiguration)
 
-	// while an org is required for these endpoints, they return fake data when the org is not supplied
-	noAuthnOptOrg := apiGroup.Group("/",
-		unauthenticatedMiddleware(a.server),
-		// Until we're ready to return fake data, require the org.
-		orgRequired(),
-	)
-	get(a, noAuthnOptOrg, "/api/providers", a.ListProviders)
-	get(a, noAuthnOptOrg, "/api/settings", a.GetSettings)
-
 	// no auth required, org required
 	noAuthnWithOrg := apiGroup.Group("/", unauthenticatedMiddleware(a.server), orgRequired())
 
@@ -123,6 +114,8 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	post(a, noAuthnWithOrg, "/api/password-reset", a.VerifiedPasswordReset)
 
 	get(a, noAuthnWithOrg, "/api/providers/:id", a.GetProvider)
+	get(a, noAuthnWithOrg, "/api/providers", a.ListProviders)
+	get(a, noAuthnWithOrg, "/api/settings", a.GetSettings)
 
 	add(a, noAuthnWithOrg, route[api.EmptyRequest, WellKnownJWKResponse]{
 		method:              http.MethodGet,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,9 +29,13 @@ import (
 )
 
 type Options struct {
-	Version                  float64
-	TLSCache                 string // TODO: move this to TLS.CacheDir
-	EnableTelemetry          bool
+	Version         float64
+	TLSCache        string // TODO: move this to TLS.CacheDir
+	EnableTelemetry bool
+	// EnableSignup indicates that anyone can signup and create an org. When
+	// true this implies multi-tenancy, but false does not necessarily indicate
+	// a single tenancy environment (because orgs could have been created by a
+	// support admin).
 	EnableSignup             bool
 	SessionDuration          time.Duration
 	SessionExtensionDeadline time.Duration

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -368,7 +368,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 
 	req = httptest.NewRequest(http.MethodPost, "/api/login", &buf)
 	req.Header.Set("Infra-Version", apiVersionLatest)
-	req.Header.Set("Infra-Organization", signupResp.Organization.Name)
+	req.Host = signupResp.Organization.Domain
 	resp = httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
 	assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())


### PR DESCRIPTION
## Summary

Implemented the linked proposal by allowing access key to specify the org ID for unauthenticated endpoints.

Also:
* removes the unused `Infra-Organization` header, which is no longer safe now that org name is not unique
* fixes a TODO about using a transaction for a db query
* adds some godoc for the `SignupEnabled` server option

Best viewed by individual commit.

Making this a draft until I have written tests to cover all the cases.

Resolves https://github.com/infrahq/internal/issues/23
