### PR TITLE
fix: grant the org connector role

### DIFF
--- a/internal/server/testdata/TestMetrics/infra_grants
+++ b/internal/server/testdata/TestMetrics/infra_grants
@@ -1,1 +1,1 @@
-infra_grants 0
+infra_grants 1


### PR DESCRIPTION
## Summary
When creating a connector for a new org that connector identity also needs to be given a connector grant to be able to add destinations.

I'll add a test for this in #2952 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2946 
