### PR TITLE
improve: extend invite expiry time

### DIFF
--- a/internal/access/passwordreset.go
+++ b/internal/access/passwordreset.go
@@ -1,6 +1,8 @@
 package access
 
 import (
+	"time"
+
 	"github.com/gin-gonic/gin"
 
 	"github.com/infrahq/infra/internal"
@@ -9,7 +11,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func PasswordResetRequest(c *gin.Context, email string) (token string, err error) {
+func PasswordResetRequest(c *gin.Context, email string, ttl time.Duration) (token string, err error) {
 	// no auth required
 	db := getDB(c)
 
@@ -28,7 +30,7 @@ func PasswordResetRequest(c *gin.Context, email string) (token string, err error
 		return "", err
 	}
 
-	prt, err := data.CreatePasswordResetToken(db, &users[0])
+	prt, err := data.CreatePasswordResetToken(db, &users[0], ttl)
 	if err != nil {
 		return "", err
 	}

--- a/internal/access/passwordreset_test.go
+++ b/internal/access/passwordreset_test.go
@@ -2,6 +2,7 @@ package access
 
 import (
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 	"gotest.tools/v3/assert"
@@ -26,7 +27,7 @@ func TestPasswordResetFlow(t *testing.T) {
 	assert.NilError(t, err)
 
 	// request password reset
-	token, err := PasswordResetRequest(c, "joe@example.com")
+	token, err := PasswordResetRequest(c, "joe@example.com", 1*time.Minute)
 	assert.NilError(t, err)
 
 	// verify with token and set new password

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrNotFound       = fmt.Errorf("record not found")
 	ErrBadRequest     = fmt.Errorf("bad request")
 	ErrNotImplemented = fmt.Errorf("not implemented")
+	ErrExpired        = fmt.Errorf("expired")
 )

--- a/internal/server/data/passwordresettoken.go
+++ b/internal/server/data/passwordresettoken.go
@@ -1,17 +1,21 @@
 package data
 
 import (
+	"errors"
 	"time"
 
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/generate"
+	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
 func CreatePasswordResetToken(db *gorm.DB, user *models.Identity) (*models.PasswordResetToken, error) {
+	tries := 0
+retry:
 	token, err := generate.CryptoRandom(10, generate.CharsetAlphaNumeric)
 	if err != nil {
 		return nil, err
@@ -21,10 +25,15 @@ func CreatePasswordResetToken(db *gorm.DB, user *models.Identity) (*models.Passw
 		ID:         uid.New(),
 		Token:      token,
 		IdentityID: user.ID,
-		ExpiresAt:  time.Now().Add(10 * time.Minute).UTC(),
+		ExpiresAt:  time.Now().Add(72 * time.Hour).UTC(),
 	}
 
+	tries++
 	if err = save(db, prt); err != nil {
+		if tries <= 3 && errors.Is(err, UniqueConstraintError{}) {
+			logging.Warnf("generated random token %q already exists in the database", token)
+			goto retry // on the off chance the token exists.
+		}
 		return nil, err
 	}
 
@@ -33,7 +42,7 @@ func CreatePasswordResetToken(db *gorm.DB, user *models.Identity) (*models.Passw
 
 func GetPasswordResetTokenByToken(db *gorm.DB, token string) (*models.PasswordResetToken, error) {
 	prts, err := list[models.PasswordResetToken](db, &models.Pagination{Limit: 1}, func(db *gorm.DB) *gorm.DB {
-		return db.Where("token = ? and expires_at > ?", token, time.Now().UTC())
+		return db.Where("token = ?", token)
 	})
 	if err != nil {
 		return nil, err
@@ -45,7 +54,7 @@ func GetPasswordResetTokenByToken(db *gorm.DB, token string) (*models.PasswordRe
 
 	if prts[0].ExpiresAt.Before(time.Now()) {
 		_ = DeletePasswordResetToken(db, &prts[0])
-		return nil, internal.ErrNotFound
+		return nil, internal.ErrExpired
 	}
 
 	return &prts[0], nil

--- a/internal/server/data/passwordresettoken.go
+++ b/internal/server/data/passwordresettoken.go
@@ -13,7 +13,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func CreatePasswordResetToken(db *gorm.DB, user *models.Identity) (*models.PasswordResetToken, error) {
+func CreatePasswordResetToken(db *gorm.DB, user *models.Identity, ttl time.Duration) (*models.PasswordResetToken, error) {
 	tries := 0
 retry:
 	token, err := generate.CryptoRandom(10, generate.CharsetAlphaNumeric)
@@ -25,7 +25,7 @@ retry:
 		ID:         uid.New(),
 		Token:      token,
 		IdentityID: user.ID,
-		ExpiresAt:  time.Now().Add(72 * time.Hour).UTC(),
+		ExpiresAt:  time.Now().Add(ttl).UTC(),
 	}
 
 	tries++

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -74,6 +74,10 @@ func sendAPIError(c *gin.Context, err error) {
 			return resp.FieldErrors[i].FieldName < resp.FieldErrors[j].FieldName
 		})
 
+	case errors.Is(err, internal.ErrExpired):
+		resp.Code = http.StatusGone
+		resp.Message = "requested resource has expired"
+
 	case errors.Is(err, internal.ErrBadRequest):
 		resp.Code = http.StatusBadRequest
 		resp.Message = err.Error()

--- a/internal/server/passwordreset.go
+++ b/internal/server/passwordreset.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -16,7 +17,7 @@ import (
 func (a *API) RequestPasswordReset(c *gin.Context, r *api.PasswordResetRequest) (*api.EmptyResponse, error) {
 	// TODO: rate-limit
 
-	token, err := access.PasswordResetRequest(c, r.Email)
+	token, err := access.PasswordResetRequest(c, r.Email, 15*time.Minute)
 	if err != nil {
 		if errors.Is(err, internal.ErrNotFound) {
 			return nil, nil // This is okay. we don't notify the user if we failed to find the email.

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ssoroka/slice"
@@ -93,7 +94,7 @@ func (a *API) CreateUser(c *gin.Context, r *api.CreateUserRequest) (*api.CreateU
 		fromName := buildNameFromEmail(currentUser.Name)
 		toName := buildNameFromEmail(user.Name)
 
-		token, err := access.PasswordResetRequest(c, user.Name)
+		token, err := access.PasswordResetRequest(c, user.Name, 72*time.Hour)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- extend invite expiry time
- better error message on expired invite token
- retry on generated token existing already (super unlikely)
