### PR TITLE
Refactor a test function and remove a test helper

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -30,8 +30,6 @@ func setupDB(t *testing.T) *gorm.DB {
 	patch.ModelsSymmetricKey(t)
 	db, err := data.NewDB(driver.Dialector, nil)
 	assert.NilError(t, err)
-	t.Cleanup(data.InvalidateCache)
-
 	return db.DB
 }
 

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/race"
 	"github.com/infrahq/infra/internal/server"
-	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/testing/database"
 	"github.com/infrahq/infra/uid"
 )
@@ -208,7 +207,6 @@ func setupEnv(t *testing.T) string {
 
 func setupServerOptions(t *testing.T, opts *server.Options) {
 	t.Helper()
-	t.Cleanup(data.InvalidateCache)
 
 	opts.Addr = server.ListenerOptions{HTTPS: "127.0.0.1:0", HTTP: "127.0.0.1:0"}
 

--- a/internal/openapigen/main.go
+++ b/internal/openapigen/main.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server"
 )
@@ -24,7 +22,7 @@ func run(args []string) error {
 	filename := args[0]
 
 	s := server.Server{}
-	routes := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes()
 
 	return server.WriteOpenAPIDocToFile(routes.OpenAPIDocument, internal.FullVersion(), filename)
 }

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -27,7 +26,7 @@ func TestAPI_CreateAccessKey(t *testing.T) {
 	}
 
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	userResp := createUser(t, srv, routes, "usera@example.com")
 
@@ -118,7 +117,7 @@ func TestAPI_CreateAccessKey(t *testing.T) {
 
 func TestAPI_ListAccessKeys_Success(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	run := func() api.ListResponse[api.AccessKey] {
 		req := httptest.NewRequest(http.MethodGet, "/api/access-keys", nil)
@@ -146,7 +145,7 @@ func TestAPI_ListAccessKeys_Success(t *testing.T) {
 
 func TestAPI_ListAccessKeys(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	db := srv.DB()
 

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -27,7 +27,6 @@ func setupDB(t *testing.T) *gorm.DB {
 	patch.ModelsSymmetricKey(t)
 	db, err := data.NewDB(driver.Dialector, nil)
 	assert.NilError(t, err)
-	t.Cleanup(data.InvalidateCache)
 
 	return db.DB
 }

--- a/internal/server/authn_test.go
+++ b/internal/server/authn_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -16,7 +15,7 @@ import (
 
 func TestServerLimitsAccessWithTemporaryPassword(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes((prometheus.NewRegistry()))
+	routes := srv.GenerateRoutes()
 
 	// create a user
 	resp := createUser(t, srv, routes, "hubert@example.com")

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -360,9 +360,8 @@ func GlobalCount[T models.Modelable](db *gorm.DB, selectors ...SelectorFunc) (in
 	return count, nil
 }
 
-// InfraProvider is a lazy-loaded cached reference to the infra provider. The
-// cache lasts for the entire lifetime of the process, so any test or test
-// helper that calls InfraProvider must call InvalidateCache to clean up.
+// InfraProvider returns the infra provider for the organization set in the db
+// context.
 func InfraProvider(db *gorm.DB) *models.Provider {
 	org := MustGetOrgFromContext(db.Statement.Context)
 	infra, err := get[models.Provider](db, ByProviderKind(models.ProviderKindInfra), ByOrgID(org.ID))
@@ -373,9 +372,8 @@ func InfraProvider(db *gorm.DB) *models.Provider {
 	return infra
 }
 
-// InfraConnectorIdentity is a lazy-loaded reference to the connector identity.
-// The cache lasts for the entire lifetime of the process, so any test or test
-// helper that calls InfraConnectorIdentity must call InvalidateCache to clean up.
+// InfraConnectorIdentity returns the connector identity for the organization set
+// in the db context.
 func InfraConnectorIdentity(db *gorm.DB) *models.Identity {
 	org := MustGetOrgFromContext(db.Statement.Context)
 	connector, err := GetIdentity(db, ByName(models.InternalInfraConnectorIdentityName), ByOrgID(org.ID))
@@ -383,10 +381,5 @@ func InfraConnectorIdentity(db *gorm.DB) *models.Identity {
 		logging.L.Panic().Err(err).Msg("failed to retrieve connector identity")
 		return nil // unreachable, the line above panics
 	}
-
 	return connector
-}
-
-// InvalidateCache is used to clear references to frequently used resources
-func InvalidateCache() {
 }

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -24,7 +24,6 @@ func setupDB(t *testing.T, driver gorm.Dialector) *gorm.DB {
 	assert.NilError(t, err)
 
 	logging.PatchLogger(t, zerolog.NewTestWriter(t))
-	t.Cleanup(InvalidateCache)
 
 	return db.DB
 }

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -26,7 +26,7 @@ func TestAPI_PProfHandler(t *testing.T) {
 		expectedResp func(t *testing.T, resp *httptest.ResponseRecorder)
 	}
 
-	s := &Server{db: setupDB(t)}
+	s := setupServer(t)
 	routes := s.GenerateRoutes(prometheus.NewRegistry())
 
 	run := func(t *testing.T, tc testCase) {

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -27,7 +26,7 @@ func TestAPI_PProfHandler(t *testing.T) {
 	}
 
 	s := setupServer(t)
-	routes := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes()
 
 	run := func(t *testing.T, tc testCase) {
 		// nolint:noctx

--- a/internal/server/destination_test.go
+++ b/internal/server/destination_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -17,7 +16,7 @@ import (
 
 func TestAPI_CreateDestination(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	type testCase struct {
 		name     string

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestAPI_ListGrants(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	createID := func(t *testing.T, name string) uid.ID {
 		t.Helper()
@@ -416,7 +416,7 @@ func TestAPI_ListGrants(t *testing.T) {
 
 func TestAPI_ListGrants_InheritedGrants(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	createID := func(t *testing.T, name string) uid.ID {
 		t.Helper()
@@ -615,7 +615,7 @@ var cmpAPIGrantJSON = gocmp.Options{
 
 func TestAPI_CreateGrant(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	accessKey, err := data.ValidateAccessKey(srv.DB(), adminAccessKey(srv))
 	assert.NilError(t, err)
@@ -776,7 +776,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 
 func TestAPI_DeleteGrant(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	user := &models.Identity{Name: "non-admin"}
 

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
@@ -37,7 +36,7 @@ func createGroups(t *testing.T, db *gorm.DB, groups ...*models.Group) {
 
 func TestAPI_ListGroups(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	var (
 		humans = models.Group{Name: "humans"}
@@ -193,7 +192,7 @@ func TestAPI_ListGroups(t *testing.T) {
 
 func TestAPI_CreateGroup(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	type testCase struct {
 		setup    func(t *testing.T, req *http.Request)
@@ -276,7 +275,7 @@ func TestAPI_CreateGroup(t *testing.T) {
 
 func TestAPI_DeleteGroup(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	var humans = models.Group{Name: "humans"}
 	createGroups(t, srv.DB(), &humans)
@@ -354,7 +353,7 @@ func TestAPI_DeleteGroup(t *testing.T) {
 
 func TestAPI_UpdateUsersInGroup(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	var humans = models.Group{Name: "humans"}
 	createGroups(t, srv.DB(), &humans)

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	gocmp "github.com/google/go-cmp/cmp"
-	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
@@ -165,7 +164,7 @@ var cmpAPIUserJSON = gocmp.Options{
 
 func TestWellKnownJWKs(t *testing.T) {
 	srv := setupServer(t, withAdminUser, withSupportAdminGrant)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	type testCase struct {
 		name     string

--- a/internal/server/login_test.go
+++ b/internal/server/login_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/bcrypt"
 	"gotest.tools/v3/assert"
 
@@ -18,7 +17,7 @@ import (
 
 func TestAPI_Login(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	// setup user to login as
 	user := &models.Identity{Name: "steve"}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -37,8 +37,6 @@ func setupDB(t *testing.T) *data.DB {
 	tpatch.ModelsSymmetricKey(t)
 	db, err := data.NewDB(driver.Dialector, nil)
 	assert.NilError(t, err)
-	t.Cleanup(data.InvalidateCache)
-
 	t.Cleanup(func() {
 		assert.NilError(t, db.Close())
 	})

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/opt"
@@ -265,7 +264,7 @@ func TestRequireAccessKey(t *testing.T) {
 
 func TestHandleInfraDestinationHeader(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 	db := srv.DB()
 
 	connector := models.Identity{Name: "connectorA"}

--- a/internal/server/openapi_test.go
+++ b/internal/server/openapi_test.go
@@ -19,7 +19,7 @@ import (
 func TestWriteOpenAPIDocToFile(t *testing.T) {
 	patchProductVersion(t, "0.0.0")
 	s := Server{metricsRegistry: prometheus.NewRegistry()}
-	routes := s.GenerateRoutes(nil)
+	routes := s.GenerateRoutes()
 
 	filename := filepath.Join(t.TempDir(), "openapi3.json")
 	err := WriteOpenAPIDocToFile(routes.OpenAPIDocument, "0.0.0", filename)

--- a/internal/server/openapi_test.go
+++ b/internal/server/openapi_test.go
@@ -18,8 +18,8 @@ import (
 //	go test ./internal/server -update
 func TestWriteOpenAPIDocToFile(t *testing.T) {
 	patchProductVersion(t, "0.0.0")
-	s := Server{}
-	routes := s.GenerateRoutes(prometheus.NewRegistry())
+	s := Server{metricsRegistry: prometheus.NewRegistry()}
+	routes := s.GenerateRoutes(nil)
 
 	filename := filepath.Join(t.TempDir(), "openapi3.json")
 	err := WriteOpenAPIDocToFile(routes.OpenAPIDocument, "0.0.0", filename)

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
@@ -31,7 +30,7 @@ func createOrgs(t *testing.T, db *gorm.DB, orgs ...*models.Organization) {
 
 func TestAPI_ListOrganizations(t *testing.T) {
 	srv := setupServer(t, withAdminUser, withSupportAdminGrant)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	var (
 		first  = models.Organization{Name: "first"}
@@ -111,7 +110,7 @@ func TestAPI_ListOrganizations(t *testing.T) {
 
 func TestAPI_CreateOrganization(t *testing.T) {
 	srv := setupServer(t, withAdminUser, withSupportAdminGrant)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	type testCase struct {
 		setup    func(t *testing.T, req *http.Request)
@@ -184,7 +183,7 @@ func TestAPI_CreateOrganization(t *testing.T) {
 
 func TestAPI_DeleteOrganization(t *testing.T) {
 	srv := setupServer(t, withAdminUser, withSupportAdminGrant)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	var first = models.Organization{Name: "first"}
 	createOrgs(t, srv.DB(), &first)

--- a/internal/server/passwordreset_test.go
+++ b/internal/server/passwordreset_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -18,7 +17,7 @@ import (
 
 func TestPasswordResetFlow(t *testing.T) {
 	s := setupServer(t)
-	routes := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes()
 
 	email.TestMode = true
 

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 	"k8s.io/utils/strings/slices"
 
@@ -21,7 +20,7 @@ import (
 
 func TestAPI_ListProviders(t *testing.T) {
 	s := setupServer(t, withAdminUser)
-	routes := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes()
 
 	testProvider := &models.Provider{
 		Name:    "mokta",
@@ -61,7 +60,7 @@ func TestAPI_ListProviders(t *testing.T) {
 
 func TestAPI_DeleteProvider(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	createProvider := func(t *testing.T) *models.Provider {
 		t.Helper()
@@ -137,7 +136,7 @@ func TestAPI_DeleteProvider(t *testing.T) {
 
 func TestAPI_CreateProvider(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	type testCase struct {
 		name     string
@@ -315,7 +314,7 @@ func TestAPI_CreateProvider(t *testing.T) {
 
 func TestAPI_UpdateProvider(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	provider := &models.Provider{
 		Name:    "private",

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
@@ -34,7 +33,7 @@ type Routes struct {
 // The order of routes in this function is important! Gin saves a route along
 // with all the middleware that will apply to the route when the
 // Router.{GET,POST,etc} method is called.
-func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
+func (s *Server) GenerateRoutes() Routes {
 	a := &API{t: s.tel, server: s}
 	a.addRewrites()
 	a.addRedirects()

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -52,7 +52,7 @@ func (s *Server) GenerateRoutes(promRegistry prometheus.Registerer) Routes {
 	)
 
 	// This group of middleware only applies to non-ui routes
-	apiGroup := router.Group("/", metrics.Middleware(promRegistry))
+	apiGroup := router.Group("/", metrics.Middleware(s.metricsRegistry))
 
 	// auth required, org required
 	authn := apiGroup.Group("/", setOrganizationInCtx(a.server), authenticatedMiddleware(a.server))

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -167,7 +166,7 @@ func TestTimestampAndDurationSerialization(t *testing.T) {
 
 func TestTrimWhitespace(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	userID := uid.New()
 	// nolint:noctx
@@ -209,7 +208,7 @@ func TestTrimWhitespace(t *testing.T) {
 
 func TestInfraVersionHeader(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	body := jsonBody(t, api.CreateUserRequest{Name: "usera@example.com"})
 	// nolint:noctx

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -220,7 +220,7 @@ func registerUIRoutes(router *gin.Engine, opts UIOptions) {
 
 func (s *Server) listen() error {
 	ginutil.SetMode()
-	router := s.GenerateRoutes(nil)
+	router := s.GenerateRoutes()
 
 	httpErrorLog := log.New(logging.NewFilteredHTTPLogger(), "", 0)
 	metricsServer := &http.Server{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -46,6 +46,8 @@ func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
 	err = s.loadConfig(s.options.Config)
 	assert.NilError(t, err)
 
+	s.metricsRegistry = prometheus.NewRegistry()
+
 	data.InvalidateCache()
 	t.Cleanup(data.InvalidateCache)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -270,7 +270,7 @@ func TestServer_GenerateRoutes_NoRoute(t *testing.T) {
 	}
 
 	s := setupServer(t)
-	router := s.GenerateRoutes(prometheus.NewRegistry())
+	router := s.GenerateRoutes()
 
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
@@ -335,7 +335,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 		opts.SessionDuration = time.Minute
 		opts.SessionExtensionDeadline = time.Minute
 	})
-	routes := s.GenerateRoutes(prometheus.NewRegistry())
+	routes := s.GenerateRoutes()
 
 	var buf bytes.Buffer
 	email := "admin@email.com"

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/logging"
-	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/testing/database"
 )
 
@@ -47,10 +46,6 @@ func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
 	assert.NilError(t, err)
 
 	s.metricsRegistry = prometheus.NewRegistry()
-
-	data.InvalidateCache()
-	t.Cleanup(data.InvalidateCache)
-
 	return s
 }
 

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -20,7 +19,7 @@ func TestAPI_Signup(t *testing.T) {
 	}
 
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	run := func(t *testing.T, tc testCase) {
 		body := tc.setup(t)

--- a/internal/server/tokens_test.go
+++ b/internal/server/tokens_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -20,7 +19,7 @@ import (
 
 func TestAPI_CreateToken(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	type testCase struct {
 		setup    func(t *testing.T, req *http.Request)

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"github.com/prometheus/client_golang/prometheus"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -23,7 +22,7 @@ import (
 
 func TestAPI_GetUser(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	createID := func(t *testing.T, name string) uid.ID {
 		t.Helper()
@@ -180,7 +179,7 @@ func TestAPI_GetUser(t *testing.T) {
 
 func TestAPI_ListUsers(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	// TODO: Convert the "humans" group and "AnotherUser" user to call the standard http endpoints
 	//       when the new endpoint to add a user to a group exists
@@ -442,7 +441,7 @@ var cmpAPIUserShallow = gocmp.Comparer(func(x, y api.User) bool {
 
 func TestAPI_CreateUser(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	existing := &models.Identity{Name: "existing@example.com"}
 	err := data.CreateIdentity(srv.DB(), existing)
@@ -695,7 +694,7 @@ func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 
 func TestAPI_DeleteUser(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	testUser := &models.Identity{Name: "test"}
 	err := data.CreateIdentity(srv.DB(), testUser)
@@ -766,7 +765,7 @@ func TestAPI_DeleteUser(t *testing.T) {
 
 func TestAPI_UpdateUser(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	routes := srv.GenerateRoutes(prometheus.NewRegistry())
+	routes := srv.GenerateRoutes()
 
 	user := &models.Identity{Name: "salsa@example.com"}
 	err := data.CreateIdentity(srv.DB(), user)


### PR DESCRIPTION
## Summary

Best viewed by individual commit.

This PR:
* refactors the `TestRequireAccessKey` test case to use a `testCase` struct, removing the need to cast the `interface{}` to a function
* removes the `prometheus.Registry` arg from `Server.GenerateRoutes`. We call this in many tests, and it can receive the registry from a field on the server
* remove `data.InvalidateCache`, which was used in tests, but we removed the caches in a previous commit, so we no longer need to invalidate them. In the future if we want to cache these references we can use the `data.DB` struct which is different for each test, so we shouldn't need to invalidate the cache.