### PR TITLE
feat: allow specified org domain on sign up

### DIFF
--- a/api/organization.go
+++ b/api/organization.go
@@ -25,12 +25,14 @@ func (r ListOrganizationsRequest) ValidationRules() []validate.ValidationRule {
 }
 
 type CreateOrganizationRequest struct {
-	Name string `json:"name"`
+	Name   string `json:"name"`
+	Domain string `json:"domain"`
 }
 
 func (r CreateOrganizationRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.Required("name", r.Name),
+		validate.Required("domain", r.Domain),
 		ValidateName(r.Name),
 	}
 }

--- a/api/signup.go
+++ b/api/signup.go
@@ -7,10 +7,15 @@ type SignupResponse struct {
 	Organization *Organization `json:"organization"`
 }
 
+type SignupOrg struct {
+	Name      string `json:"name"`
+	Subdomain string `json:"subDomain"`
+}
+
 type SignupRequest struct {
-	Name     string `json:"name"`
-	Password string `json:"password"`
-	Org      string `json:"org"`
+	Name     string    `json:"name"`
+	Password string    `json:"password"`
+	Org      SignupOrg `json:"org"`
 }
 
 func (r SignupRequest) ValidationRules() []validate.ValidationRule {
@@ -18,6 +23,7 @@ func (r SignupRequest) ValidationRules() []validate.ValidationRule {
 		validate.Required("name", r.Name),
 		validate.Email("name", r.Name),
 		validate.Required("password", r.Password),
-		validate.Required("org", r.Org),
+		validate.Required("org.name", r.Org.Name),
+		validate.Required("org.subDomain", r.Org.Subdomain),
 	}
 }

--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -1,6 +1,9 @@
 package access
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 
 	"github.com/infrahq/infra/internal/server/data"
@@ -51,4 +54,16 @@ func DeleteOrganization(c *gin.Context, id uid.ID) error {
 	}
 
 	return data.DeleteOrganizations(db, data.ByID(id))
+}
+
+var domainNameReplacer = regexp.MustCompile(`[^\da-zA-Z-]`)
+
+func SanitizedDomain(subDomain, serverBaseDomain string) string {
+	sanitizedDomain := domainNameReplacer.ReplaceAllStringFunc(subDomain, func(s string) string {
+		if s == " " {
+			return "-"
+		}
+		return ""
+	})
+	return strings.ToLower(sanitizedDomain) + "." + serverBaseDomain
 }

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -13,9 +13,10 @@ import (
 )
 
 type SignupDetails struct {
-	Name     string
-	Password string
-	Org      *models.Organization
+	Name      string
+	Password  string
+	Org       *models.Organization
+	SubDomain string
 }
 
 // Signup creates a user identity using the supplied name and password and
@@ -24,7 +25,7 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 	// no authorization is setup yet
 	db := getDB(c)
 
-	details.Org.GenerateDefaultDomain(baseDomain)
+	details.Org.Domain = SanitizedDomain(details.SubDomain, baseDomain)
 
 	if err := data.CreateOrganizationAndSetContext(db, details.Org); err != nil {
 		return nil, "", fmt.Errorf("create org on sign-up: %w", err)

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -52,9 +53,15 @@ func sendAPIError(c *gin.Context, err error) {
 	case errors.As(err, &uniqueConstraintError):
 		resp.Code = http.StatusConflict
 		resp.Message = err.Error()
+		// remove the error trace from field error message
+		errMsg := err.Error()
+		errTrace := strings.Split(err.Error(), ":")
+		if len(errTrace) > 0 {
+			errMsg = errTrace[len(errTrace)-1]
+		}
 		resp.FieldErrors = append(resp.FieldErrors, api.FieldError{
 			FieldName: uniqueConstraintError.Column,
-			Errors:    []string{err.Error()},
+			Errors:    []string{errMsg},
 		})
 
 	case errors.Is(err, internal.ErrNotFound):

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -114,9 +114,10 @@ func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.SignupResponse,
 	keyExpires := time.Now().UTC().Add(a.server.options.SessionDuration)
 
 	suDetails := access.SignupDetails{
-		Name:     r.Name,
-		Password: r.Password,
-		Org:      &models.Organization{Name: r.Org},
+		Name:      r.Name,
+		Password:  r.Password,
+		Org:       &models.Organization{Name: r.Org.Name},
+		SubDomain: r.Org.Subdomain,
 	}
 	identity, bearer, err := access.Signup(c, keyExpires, a.server.options.BaseDomain, suDetails)
 	if err != nil {

--- a/internal/server/models/organization.go
+++ b/internal/server/models/organization.go
@@ -1,11 +1,7 @@
 package models
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -25,26 +21,6 @@ func (o *Organization) ToAPI() *api.Organization {
 		Name:   o.Name,
 		Domain: o.Domain,
 	}
-}
-
-var domainNameReplacer = regexp.MustCompile(`[^\da-zA-Z-]`)
-
-// TODO: let's do this in data.CreateOrganization
-func (o *Organization) GenerateDefaultDomain(baseDomain string) {
-	if len(o.Domain) > 0 {
-		return
-	}
-	slug := domainNameReplacer.ReplaceAllStringFunc(o.Name, func(s string) string {
-		if s == " " {
-			return "-"
-		}
-		return ""
-	})
-	if len(slug) > 20 {
-		slug = slug[:20]
-	}
-	o.Domain = slug + "-" + generate.MathRandom(5, generate.CharsetAlphaNumeric)
-	o.Domain = strings.ToLower(o.Domain) + "." + baseDomain
 }
 
 type OrganizationMember struct {

--- a/internal/server/organizations.go
+++ b/internal/server/organizations.go
@@ -33,10 +33,9 @@ func (a *API) GetOrganization(c *gin.Context, r *api.Resource) (*api.Organizatio
 
 func (a *API) CreateOrganization(c *gin.Context, r *api.CreateOrganizationRequest) (*api.Organization, error) {
 	org := &models.Organization{
-		Name: r.Name,
+		Name:   r.Name,
+		Domain: r.Domain,
 	}
-
-	org.GenerateDefaultDomain(a.server.options.BaseDomain)
 
 	// TODO: This should be removed in the future in favour of setting CreatedBy automatically
 	authIdent := access.AuthenticatedIdentity(c)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -338,10 +338,16 @@ func TestServer_PersistSignupUser(t *testing.T) {
 	var buf bytes.Buffer
 	email := "admin@email.com"
 	passwd := "supersecretpassword"
-	org := "infrahq"
 
 	// run signup for "admin@email.com"
-	signupReq := api.SignupRequest{Name: email, Password: passwd, Org: org}
+	signupReq := api.SignupRequest{
+		Name:     email,
+		Password: passwd,
+		Org: api.SignupOrg{
+			Name:      "infrahq",
+			Subdomain: "infra",
+		},
+	}
 	err := json.NewEncoder(&buf).Encode(signupReq)
 	assert.NilError(t, err)
 

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -51,7 +51,8 @@ func TestAPI_Signup(t *testing.T) {
 
 				expected := []api.FieldError{
 					{FieldName: "name", Errors: []string{"is required"}},
-					{FieldName: "org", Errors: []string{"is required"}},
+					{FieldName: "org.name", Errors: []string{"is required"}},
+					{FieldName: "org.subDomain", Errors: []string{"is required"}},
 					{FieldName: "password", Errors: []string{"is required"}},
 				}
 				assert.DeepEqual(t, respBody.FieldErrors, expected)

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -3408,6 +3408,9 @@
             "application/json": {
               "schema": {
                 "properties": {
+                  "domain": {
+                    "type": "string"
+                  },
                   "name": {
                     "format": "[a-zA-Z0-9\\-_.]",
                     "maxLength": 256,
@@ -3416,7 +3419,8 @@
                   }
                 },
                 "required": [
-                  "name"
+                  "name",
+                  "domain"
                 ],
                 "type": "object"
               }
@@ -4815,7 +4819,15 @@
                     "type": "string"
                   },
                   "org": {
-                    "type": "string"
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "subDomain": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
                   },
                   "password": {
                     "type": "string"
@@ -4824,7 +4836,8 @@
                 "required": [
                   "name",
                   "password",
-                  "org"
+                  "org.name",
+                  "org.subDomain"
                 ],
                 "type": "object"
               }

--- a/ui/__test__/signup.test.js
+++ b/ui/__test__/signup.test.js
@@ -15,7 +15,7 @@ describe('Signup Component', () => {
     expect(screen.getByLabelText('Email')).toHaveValue('')
     expect(screen.getByLabelText('Password')).toHaveValue('')
     expect(screen.getByLabelText('Confirm Password')).toHaveValue('')
-    expect(screen.getByLabelText('Organization')).toHaveValue('')
+    expect(screen.getByLabelText('Name')).toHaveValue('')
     expect(screen.getByText('Get Started').closest('button')).toBeDisabled()
   })
 })

--- a/ui/pages/signup/index.js
+++ b/ui/pages/signup/index.js
@@ -7,17 +7,23 @@ export default function Signup() {
   const [name, setName] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
-  const [org, setOrg] = useState('')
+  const [orgName, setOrgName] = useState('')
+  const [subDomain, setSubDomain] = useState('')
+  const [automaticOrgDomain, setAutomaticOrgDomain] = useState(true) // track if the user has manually specified the org domain
+  const [submitted, setSubmitted] = useState(false)
   const [error, setError] = useState('')
   const [errors, setErrors] = useState({})
 
   async function onSubmit(e) {
     e.preventDefault()
 
+    setSubmitted(true)
+
     if (password !== confirmPassword) {
       setErrors({
         confirmPassword: 'passwords do not match',
       })
+      setSubmitted(false)
       return false
     }
 
@@ -28,7 +34,10 @@ export default function Signup() {
         body: JSON.stringify({
           name,
           password,
-          org,
+          org: {
+            name: orgName,
+            subDomain
+          }
         }),
       })
 
@@ -53,7 +62,19 @@ export default function Signup() {
       }
     }
 
+    setSubmitted(false)
+
     return false
+  }
+
+  const notURLSafePattern = /[^\da-zA-Z-]/g
+
+  function getURLSafeDomain(domain) {
+    // remove spaces
+    domain = domain.split(' ').join('-')
+    // remove unsafe characters
+    domain = domain.replace(notURLSafePattern, '')
+    return domain.toLowerCase()
   }
 
   return (
@@ -129,27 +150,62 @@ export default function Signup() {
             <ErrorMessage message={errors.confirmPassword} />
           )}
         </div>
+        <div className='my-2 w-full pt-6 text-2xs uppercase leading-none text-gray-400'>
+          Organization
+        </div>
         <div className='my-2 w-full'>
-          <label htmlFor='org' className='text-3xs uppercase text-gray-500'>
-            Organization
+          <label htmlFor='orgName' className='text-3xs uppercase text-gray-500'>
+            Name
           </label>
           <input
             required
-            id='org'
+            id='orgName'
             placeholder='name your organization'
             onChange={e => {
-              setOrg(e.target.value)
+              setOrgName(e.target.value)
               setErrors({})
               setError('')
+              if (automaticOrgDomain) {
+                setSubDomain(getURLSafeDomain(e.target.value))
+              }
             }}
             className={`mb-1 w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
-              errors.org ? 'border-pink-500/60' : ''
+              errors.org?.name ? 'border-pink-500/60' : ''
             }`}
           />
-          {errors.org && <ErrorMessage message={errors.org} />}
+        </div>
+        <div className='my-2 w-full'>
+          <label
+            htmlFor='orgDoman'
+            className='text-3xs uppercase text-gray-500'
+          >
+            Domain
+          </label>
+          <div className='flex flex-wrap'>
+            <input
+              required
+              name='orgDomain'
+              placeholder='your-domain'
+              value={subDomain}
+              onChange={e => {
+                setSubDomain(getURLSafeDomain(e.target.value))
+                setAutomaticOrgDomain(false) // do not set this automatically once it has been specified
+                setErrors({})
+                setError('')
+              }}
+              className={`mb-1 w-2/3 border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${errors.org?.subDomain ? 'border-pink-500/60' : ''
+                }`}
+            />
+            <div className='mb-1 w-1/3 text-2xs text-gray-500 border border-gray-800 py-2 text-center'>
+              .{window.location.host}
+            </div>
+            {errors.domain && (
+              <ErrorMessage message={errors.domain} />
+            )}
+          </div>
         </div>
         <button
-          disabled={!name || !password || !confirmPassword || !org}
+          disabled={!name || !password || !confirmPassword || !orgName || !subDomain || submitted}
           className='my-2 rounded-lg border border-violet-300 px-4 py-3 text-2xs text-violet-100 hover:border-violet-100 disabled:pointer-events-none disabled:opacity-30'
         >
           Get Started

--- a/ui/pages/signup/index.js
+++ b/ui/pages/signup/index.js
@@ -36,8 +36,8 @@ export default function Signup() {
           password,
           org: {
             name: orgName,
-            subDomain
-          }
+            subDomain,
+          },
         }),
       })
 
@@ -193,19 +193,25 @@ export default function Signup() {
                 setErrors({})
                 setError('')
               }}
-              className={`mb-1 w-2/3 border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${errors.org?.subDomain ? 'border-pink-500/60' : ''
-                }`}
+              className={`mb-1 w-2/3 border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:outline-none focus:ring-gray-200 ${
+                errors.org?.subDomain ? 'border-pink-500/60' : ''
+              }`}
             />
-            <div className='mb-1 w-1/3 text-2xs text-gray-500 border border-gray-800 py-2 text-center'>
+            <div className='mb-1 w-1/3 border border-gray-800 py-2 text-center text-2xs text-gray-500'>
               .{window.location.host}
             </div>
-            {errors.domain && (
-              <ErrorMessage message={errors.domain} />
-            )}
+            {errors.domain && <ErrorMessage message={errors.domain} />}
           </div>
         </div>
         <button
-          disabled={!name || !password || !confirmPassword || !orgName || !subDomain || submitted}
+          disabled={
+            !name ||
+            !password ||
+            !confirmPassword ||
+            !orgName ||
+            !subDomain ||
+            submitted
+          }
           className='my-2 rounded-lg border border-violet-300 px-4 py-3 text-2xs text-violet-100 hover:border-violet-100 disabled:pointer-events-none disabled:opacity-30'
         >
           Get Started


### PR DESCRIPTION
## Summary
When a new organization signs up or is created by a support admin it should be possible to specify the org's subdomain or domain directly.
- Allow specifying your organization's sub-domain on sign-up.
- Allow support admins to directly specify an organization's full domain through the API. This may be useful as an admin workaround if we need a special domain. This is not a normal action.
- Update the UI for specified organization domains.
- Parse root errors from conflict error message trace for better error display.

<img width="815" alt="Screen Shot 2022-08-19 at 7 40 37 AM" src="https://user-images.githubusercontent.com/5853428/185605256-9005eb37-8f24-494b-ab5a-3984539f9502.png">

<img width="747" alt="Screen Shot 2022-08-19 at 7 40 59 AM" src="https://user-images.githubusercontent.com/5853428/185605278-b8048428-7d07-47b7-8fbf-16fc7afcf083.png">

<img width="429" alt="Screen Shot 2022-08-19 at 7 56 14 AM" src="https://user-images.githubusercontent.com/5853428/185605311-a46b69cc-3344-46a0-93bc-d8a6b2b9b6db.png">

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #2956 
