### PR TITLE
fix(helm): quote integer value

### DIFF
--- a/helm/charts/infra/templates/server/deployment.yaml
+++ b/helm/charts/infra/templates/server/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             - name: PGHOST
               value: {{ include "postgres.fullname" . }}
             - name: PGPORT
-              value: {{ .Values.postgres.service.port }}
+              value: {{ .Values.postgres.service.port | quote }}
             - name: PGDATABASE
               value: {{ .Values.postgres.dbName }}
             - name: PGUSER


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Fixing an issue with the Helm chart when server.persistence is enabled where the env value is not a string