### PR TITLE
maintain: tune prometheus latency rule

### DIFF
--- a/helm/charts/infra/templates/server/prometheusrule.yaml
+++ b/helm/charts/infra/templates/server/prometheusrule.yaml
@@ -101,7 +101,7 @@ spec:
             summary: HTTP requests are taking too long.
           expr: |
             sum by (method, path) (rate(http_request_duration_seconds_sum{ {{ $commonLabels }} }[5m])) /
-            sum by (method, path) (rate(http_request_duration_seconds_count{ {{ $commonLabels }} }[5m])) > 0.3
+            sum by (method, path) (rate(http_request_duration_seconds_count{ {{ $commonLabels }} }[5m])) > 5
           for: 5m
           labels:
 {{- with .Values.server.metrics.prometheusRule.additionalRuleLabels }}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Increase the threshold where alerts fire to 5s instead of 300ms.