### PR TITLE
fix: exclude builtin users and providers from metrics

### DIFF
--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -100,7 +100,7 @@ type providersCount struct {
 
 func CountProvidersByKind(db *gorm.DB) ([]providersCount, error) {
 	var results []providersCount
-	if err := db.Raw("SELECT kind, COUNT(*) as count FROM providers WHERE deleted_at IS NULL GROUP BY kind").Scan(&results).Error; err != nil {
+	if err := db.Raw("SELECT kind, COUNT(*) as count FROM providers WHERE kind <> 'infra' AND deleted_at IS NULL GROUP BY kind").Scan(&results).Error; err != nil {
 		return nil, err
 	}
 

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -182,7 +182,6 @@ func TestCountProvidersByKind(t *testing.T) {
 		expected := []providersCount{
 			{Kind: "azure", Count: 1},
 			{Kind: "google", Count: 1},
-			{Kind: "infra", Count: 1},
 			{Kind: "oidc", Count: 1},
 			{Kind: "okta", Count: 2},
 		}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -23,7 +23,7 @@ func setupMetrics(db *gorm.DB) *prometheus.Registry {
 		Name:      "users",
 		Help:      "The total number of users",
 	}, []string{}, func() []metrics.Metric {
-		count, err := data.GlobalCount[models.Identity](db)
+		count, err := data.GlobalCount[models.Identity](db, data.NotName("connector"))
 		if err != nil {
 			logging.L.Warn().Err(err).Msg("users")
 			return []metrics.Metric{}
@@ -55,7 +55,7 @@ func setupMetrics(db *gorm.DB) *prometheus.Registry {
 		Name:      "grants",
 		Help:      "The total number of grants",
 	}, []string{}, func() []metrics.Metric {
-		count, err := data.GlobalCount[models.Grant](db)
+		count, err := data.GlobalCount[models.Grant](db, data.NotPrivilege("connector"))
 		if err != nil {
 			logging.L.Warn().Err(err).Msg("grants")
 			return []metrics.Metric{}

--- a/internal/server/testdata/TestMetrics/infra_providers
+++ b/internal/server/testdata/TestMetrics/infra_providers
@@ -1,5 +1,4 @@
 infra_providers{kind="azure"} 1
 infra_providers{kind="google"} 1
-infra_providers{kind="infra"} 1
 infra_providers{kind="oidc"} 1
 infra_providers{kind="okta"} 2

--- a/internal/server/testdata/TestMetrics/infra_users
+++ b/internal/server/testdata/TestMetrics/infra_users
@@ -1,1 +1,1 @@
-infra_users 4
+infra_users 3


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Exclude internal resources like the connector identity and privilege from metrics