### PR TITLE
Remove gorm from the migrator

### DIFF
--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"net/url"
@@ -31,17 +33,23 @@ func NewDB(connection gorm.Dialector, loadDBKey func(db *gorm.DB) error) (*DB, e
 	if err != nil {
 		return nil, fmt.Errorf("db conn: %w", err)
 	}
+	dataDB := &DB{DB: db}
 
 	opts := migrator.Options{
 		InitSchema: initializeSchema,
-		LoadKey:    loadDBKey,
+		LoadKey: func(tx migrator.DB) error {
+			if loadDBKey == nil {
+				return nil
+			}
+			// TODO: use the passed in tx instead of dataDB once the queries
+			// used by loadDBKey are ported to sql
+			return loadDBKey(dataDB.DB)
+		},
 	}
-	m := migrator.New(db, opts, migrations())
+	m := migrator.New(dataDB, opts, migrations())
 	if err := m.Migrate(); err != nil {
 		return nil, fmt.Errorf("migration failed: %w", err)
 	}
-
-	dataDB := &DB{DB: db}
 	if err := initialize(dataDB); err != nil {
 		return nil, fmt.Errorf("initialize database: %w", err)
 	}
@@ -59,12 +67,29 @@ type DB struct {
 	DefaultOrgSettings *models.Settings
 }
 
-func (db *DB) Close() error {
-	sqlDB, err := db.DB.DB()
+func (d *DB) Close() error {
+	sqlDB, err := d.DB.DB()
 	if err != nil {
 		return fmt.Errorf("failed to get database conn to close: %w", err)
 	}
 	return sqlDB.Close()
+}
+
+func (d *DB) DriverName() string {
+	return d.Dialector.Name()
+}
+
+func (d *DB) Exec(query string, args ...any) (sql.Result, error) {
+	db := d.DB.Exec(query, args...)
+	return driver.RowsAffected(db.RowsAffected), db.Error
+}
+
+func (d *DB) Query(query string, args ...any) (*sql.Rows, error) {
+	return d.DB.Raw(query, args...).Rows()
+}
+
+func (d *DB) QueryRow(query string, args ...any) *sql.Row {
+	return d.DB.Raw(query, args...).Row()
 }
 
 // newRawDB creates a new database connection without running migrations.

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -92,6 +92,17 @@ func (d *DB) QueryRow(query string, args ...any) *sql.Row {
 	return d.DB.Raw(query, args...).Row()
 }
 
+type WriteTxn interface {
+	ReadTxn
+	Exec(sql string, values ...interface{}) (sql.Result, error)
+}
+
+type ReadTxn interface {
+	DriverName() string
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
 // newRawDB creates a new database connection without running migrations.
 func newRawDB(connection gorm.Dialector) (*gorm.DB, error) {
 	db, err := gorm.Open(connection, &gorm.Config{

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -124,11 +124,11 @@ func addKindToProviders() *migrator.Migration {
 				return err
 			}
 
-			stmt = `UPDATE providers WHERE kind IS NULL AND name = ? SET kind = ?`
-			if _, err := tx.Exec(stmt, "infra", models.ProviderKindInfra); err != nil {
+			stmt = `UPDATE providers SET kind = ? WHERE kind IS NULL AND name = ?`
+			if _, err := tx.Exec(stmt, models.ProviderKindInfra, "infra"); err != nil {
 				return err
 			}
-			stmt = `UPDATE providers WHERE kind IS NULL SET kind = ?`
+			stmt = `UPDATE providers SET kind = ? WHERE kind IS NULL`
 			if _, err := tx.Exec(stmt, models.ProviderKindOkta); err != nil {
 				return err
 			}
@@ -196,8 +196,9 @@ func addAuthURLAndScopeToProviders() *migrator.Migration {
 						return fmt.Errorf("could not get provider info: %w", err)
 					}
 
+					scopes := models.CommaSeparatedStrings(authServerInfo.ScopesSupported)
 					stmt := `UPDATE providers SET auth_url = ?, scopes = ? WHERE id = ?`
-					_, err = tx.Exec(stmt, authServerInfo.AuthURL, authServerInfo.ScopesSupported, provider.ID)
+					_, err = tx.Exec(stmt, authServerInfo.AuthURL, scopes, provider.ID)
 					if err != nil {
 						return err
 					}

--- a/internal/server/data/migrator/helpers_test.go
+++ b/internal/server/data/migrator/helpers_test.go
@@ -12,7 +12,7 @@ func setupExampleTable(t *testing.T, db DB) {
 		t.Skip("does not work with sqlite")
 	}
 
-	db.Exec("DROP TABLE example")
+	_, _ = db.Exec("DROP TABLE example")
 
 	var exampleTable = `
 CREATE TABLE example (
@@ -24,7 +24,7 @@ ALTER TABLE example ADD CONSTRAINT example_pkey PRIMARY KEY (id);
 	_, err := db.Exec(exampleTable)
 	assert.NilError(t, err)
 	t.Cleanup(func() {
-		db.Exec("DROP TABLE example")
+		_, _ = db.Exec("DROP TABLE example")
 	})
 }
 

--- a/internal/server/data/migrator/helpers_test.go
+++ b/internal/server/data/migrator/helpers_test.go
@@ -3,13 +3,12 @@ package migrator
 import (
 	"testing"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 )
 
-func setupExampleTable(t *testing.T, db *gorm.DB) {
+func setupExampleTable(t *testing.T, db DB) {
 	t.Helper()
-	if db.Dialector.Name() == "sqlite" {
+	if db.DriverName() == "sqlite" {
 		t.Skip("does not work with sqlite")
 	}
 
@@ -22,7 +21,7 @@ CREATE TABLE example (
 );
 ALTER TABLE example ADD CONSTRAINT example_pkey PRIMARY KEY (id);
 `
-	err := db.Exec(exampleTable).Error
+	_, err := db.Exec(exampleTable)
 	assert.NilError(t, err)
 	t.Cleanup(func() {
 		db.Exec("DROP TABLE example")
@@ -30,7 +29,7 @@ ALTER TABLE example ADD CONSTRAINT example_pkey PRIMARY KEY (id);
 }
 
 func TestHasTable(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db DB) {
 		setupExampleTable(t, db)
 
 		assert.Assert(t, HasTable(db, "example"))
@@ -39,7 +38,7 @@ func TestHasTable(t *testing.T) {
 }
 
 func TestHasColumn(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db DB) {
 		setupExampleTable(t, db)
 
 		assert.Assert(t, HasColumn(db, "example", "id"))
@@ -50,7 +49,7 @@ func TestHasColumn(t *testing.T) {
 }
 
 func TestHasConstraint(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db DB) {
 		setupExampleTable(t, db)
 
 		assert.Assert(t, HasConstraint(db, "example", "example_pkey"))

--- a/internal/server/data/migrator/migrator_test.go
+++ b/internal/server/data/migrator/migrator_test.go
@@ -3,7 +3,6 @@ package migrator
 import (
 	"database/sql"
 	"database/sql/driver"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,21 +54,6 @@ var extendedMigrations = append(migrations, &Migration{
 		return err
 	},
 })
-
-var failingMigration = []*Migration{
-	{
-		ID: "201904231300",
-		Migrate: func(tx DB) error {
-			if _, err := tx.Exec(Book{}.Schema()); err != nil {
-				return err
-			}
-			return errors.New("this transaction should be rolled back")
-		},
-		Rollback: func(tx DB) error {
-			return nil
-		},
-	},
-}
 
 type Person struct {
 	gorm.Model

--- a/internal/server/models/encryption_test.go
+++ b/internal/server/models/encryption_test.go
@@ -34,7 +34,8 @@ func TestEncryptedAtRest(t *testing.T) {
 	db, err := data.NewDB(driver, nil)
 	assert.NilError(t, err)
 
-	assert.NilError(t, db.Exec(StructForTesting{}.Schema()).Error)
+	_, err = db.Exec(StructForTesting{}.Schema())
+	assert.NilError(t, err)
 
 	id := uid.New()
 


### PR DESCRIPTION
## Summary

Previously the `data/migrator` used `gorm.DB` to perform queries. This PR changes it to accept an interface that closely resembles the interface provided by the stdlib. The only difference from the stdlib is a `DriverName` method. That extra method should be easy to implement by checking the type of the driver, or we may decide to remove sqlite support and remove the need for that method.

This change is done first before converting the query functions because `migrator` is a separate package which `data` depends on. So it has to be converted first.

This PR also removes the `UseTransaction` option from the migrator. We were not using this option, and it made it more difficult to accept an interface. In the future if we want to use a transaction for applying migrations we can manage the transaction from `data.NewDB` and it will behave the same as the transaction managed by the migrator itself.

Best viewed by individual commit.

Related to #2415