### PR TITLE
Replace gorm.DB with an interface

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -17,12 +17,16 @@ func ListAccessKeys(c *gin.Context, identityID uid.ID, name string, showExpired 
 		return nil, HandleAuthErr(err, "access keys", "list", roles...)
 	}
 
-	s := []data.SelectorFunc{data.ByOptionalIssuedFor(identityID), data.ByOptionalName(name)}
+	s := []data.SelectorFunc{
+		data.Preload("IssuedForIdentity"),
+		data.ByOptionalIssuedFor(identityID),
+		data.ByOptionalName(name),
+	}
 	if !showExpired {
 		s = append(s, data.ByNotExpiredOrExtended())
 	}
 
-	return data.ListAccessKeys(db.Preload("IssuedForIdentity"), p, s...)
+	return data.ListAccessKeys(db, p, s...)
 }
 
 func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey) (body string, err error) {

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/data"
@@ -18,7 +17,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func setupDB(t *testing.T) *gorm.DB {
+func setupDB(t *testing.T) *data.DB {
 	t.Helper()
 	driver := database.PostgresDriver(t, "_access")
 	if driver == nil {
@@ -30,10 +29,10 @@ func setupDB(t *testing.T) *gorm.DB {
 	patch.ModelsSymmetricKey(t)
 	db, err := data.NewDB(driver.Dialector, nil)
 	assert.NilError(t, err)
-	return db.DB
+	return db
 }
 
-func setupAccessTestContext(t *testing.T) (*gin.Context, *gorm.DB, *models.Provider) {
+func setupAccessTestContext(t *testing.T) (*gin.Context, *data.DB, *models.Provider) {
 	// setup db and context
 	db := setupDB(t)
 
@@ -173,7 +172,7 @@ func TestInfraRequireInfraRole(t *testing.T) {
 	})
 }
 
-func grant(t *testing.T, db *gorm.DB, currentUser *models.Identity, subject uid.PolymorphicID, privilege, resource string) {
+func grant(t *testing.T, db *data.DB, currentUser *models.Identity, subject uid.PolymorphicID, privilege, resource string) {
 	err := data.CreateGrant(db, &models.Grant{
 		Subject:   subject,
 		Privilege: privilege,
@@ -183,13 +182,13 @@ func grant(t *testing.T, db *gorm.DB, currentUser *models.Identity, subject uid.
 	assert.NilError(t, err)
 }
 
-func can(t *testing.T, db *gorm.DB, subject uid.PolymorphicID, privilege, resource string) {
+func can(t *testing.T, db *data.DB, subject uid.PolymorphicID, privilege, resource string) {
 	canAccess, err := Can(db, subject, privilege, resource)
 	assert.NilError(t, err)
 	assert.Assert(t, canAccess)
 }
 
-func cant(t *testing.T, db *gorm.DB, subject uid.PolymorphicID, privilege, resource string) {
+func cant(t *testing.T, db *data.DB, subject uid.PolymorphicID, privilege, resource string) {
 	canAccess, err := Can(db, subject, privilege, resource)
 	assert.NilError(t, err)
 	assert.Assert(t, !canAccess)

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -111,13 +111,13 @@ func updateCredential(c *gin.Context, user *models.Identity, newPassword string,
 	return nil
 }
 
-func GetRequestContext(c *gin.Context) *RequestContext {
+func GetRequestContext(c *gin.Context) RequestContext {
 	if raw, ok := c.Get(RequestContextKey); ok {
 		if rCtx, ok := raw.(RequestContext); ok {
-			return &rCtx
+			return rCtx
 		}
 	}
-	return nil
+	return RequestContext{}
 }
 
 // list of valid special chars is from OWASP, wikipedia

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -7,12 +7,13 @@ import (
 	"unicode"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/validate"
-	"golang.org/x/crypto/bcrypt"
 )
 
 func CreateCredential(c *gin.Context, user models.Identity) (string, error) {

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -7,14 +7,12 @@ import (
 	"unicode"
 
 	"github.com/gin-gonic/gin"
-	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
-
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/validate"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func CreateCredential(c *gin.Context, user models.Identity) (string, error) {
@@ -137,7 +135,7 @@ func hasMinimumCount(min int, password string, check func(rune) bool) bool {
 	return count >= min
 }
 
-func checkPasswordRequirements(db *gorm.DB, password string) error {
+func checkPasswordRequirements(db data.GormTxn, password string) error {
 	settings, err := data.GetSettings(db)
 	if err != nil {
 		return err

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -75,7 +74,7 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 	return data.ListGrants(db, p, selectors...)
 }
 
-func userInGroup(db *gorm.DB, authnUserID uid.ID, groupID uid.ID) bool {
+func userInGroup(db data.GormTxn, authnUserID uid.ID, groupID uid.ID) bool {
 	groups, err := data.ListGroups(db, &models.Pagination{Limit: 1}, data.ByGroupMember(authnUserID), data.ByID(groupID))
 	if err != nil {
 		return false
@@ -90,7 +89,7 @@ func userInGroup(db *gorm.DB, authnUserID uid.ID, groupID uid.ID) bool {
 }
 
 func CreateGrant(c *gin.Context, grant *models.Grant) error {
-	var db *gorm.DB
+	var db data.GormTxn
 	var err error
 
 	if grant.Privilege == models.InfraSupportAdminRole && grant.Resource == ResourceInfraAPI {

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/data"
@@ -88,7 +87,7 @@ func DeleteGroup(c *gin.Context, id uid.ID) error {
 	return data.DeleteGroups(db, selectors...)
 }
 
-func checkIdentitiesInList(db *gorm.DB, ids []uid.ID) ([]uid.ID, error) {
+func checkIdentitiesInList(db data.GormTxn, ids []uid.ID) ([]uid.ID, error) {
 	identities, err := data.ListIdentities(db, nil, data.ByIDs(ids))
 	if err != nil {
 		return nil, err

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -43,7 +43,7 @@ func GetIdentity(c *gin.Context, id uid.ID) (*models.Identity, error) {
 		return nil, HandleAuthErr(err, "user", "get", roles...)
 	}
 
-	return data.GetIdentity(db.Preload("Providers"), data.ByID(id))
+	return data.GetIdentity(db, data.Preload("Providers"), data.ByID(id))
 }
 
 func CreateIdentity(c *gin.Context, identity *models.Identity) error {
@@ -122,6 +122,7 @@ func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID, s
 	}
 
 	selectors := []data.SelectorFunc{
+		data.Preload("Providers"),
 		data.ByOptionalName(name),
 		data.ByOptionalIDs(ids),
 		data.ByOptionalIdentityGroupID(groupID),
@@ -131,7 +132,7 @@ func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID, s
 		selectors = append(selectors, data.NotName(models.InternalInfraConnectorIdentityName))
 	}
 
-	return data.ListIdentities(db.Preload("Providers"), p, selectors...)
+	return data.ListIdentities(db, p, selectors...)
 }
 
 func GetContextProviderIdentity(c RequestContext) (*models.Provider, string, error) {

--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -44,7 +44,7 @@ func CreateOrganization(c *gin.Context, org *models.Organization) error {
 		return HandleAuthErr(err, "organizations", "create", models.InfraSupportAdminRole)
 	}
 
-	return data.CreateOrganizationAndSetContext(db, org)
+	return data.CreateOrganization(db, org)
 }
 
 func DeleteOrganization(c *gin.Context, id uid.ID) error {

--- a/internal/access/request.go
+++ b/internal/access/request.go
@@ -3,8 +3,7 @@ package access
 import (
 	"net/http"
 
-	"gorm.io/gorm"
-
+	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -14,7 +13,7 @@ const RequestContextKey = "requestContext"
 // like the authenticated user. It also provides a database transaction.
 type RequestContext struct {
 	Request       *http.Request
-	DBTxn         *gorm.DB
+	DBTxn         data.GormTxn
 	Authenticated Authenticated
 }
 

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -27,7 +27,7 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 
 	details.Org.Domain = SanitizedDomain(details.SubDomain, baseDomain)
 
-	if err := data.CreateOrganizationAndSetContext(db, details.Org); err != nil {
+	if err := data.CreateOrganization(db, details.Org); err != nil {
 		return nil, "", fmt.Errorf("create org on sign-up: %w", err)
 	}
 

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -31,6 +31,8 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 		return nil, "", fmt.Errorf("create org on sign-up: %w", err)
 	}
 
+	db = data.NewTransaction(db.GormDB(), details.Org.ID)
+
 	// check the admin user's password requirements against our basic password requirements
 	err := checkPasswordRequirements(db, details.Password)
 	if err != nil {

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -32,6 +32,10 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 	}
 
 	db = data.NewTransaction(db.GormDB(), details.Org.ID)
+	c.Set("db", db)
+	rCtx := GetRequestContext(c)
+	rCtx.DBTxn = db
+	c.Set(RequestContextKey, rCtx)
 
 	// check the admin user's password requirements against our basic password requirements
 	err := checkPasswordRequirements(db, details.Password)

--- a/internal/access/signup_test.go
+++ b/internal/access/signup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
+// TODO: move this test coverage to the API handler
 func TestSignup(t *testing.T) {
 	setup := func(t *testing.T) (*gin.Context, data.GormTxn) {
 		db := setupDB(t)
@@ -42,6 +43,10 @@ func TestSignup(t *testing.T) {
 		assert.Equal(t, identity.Name, user)
 		assert.Equal(t, identity.OrganizationID, org.ID)
 
+		// simulate a request
+		tx := data.NewTransaction(db.GormDB(), org.ID)
+		c.Set("db", tx)
+
 		// check "admin" user can login
 		userPassLogin := authn.NewPasswordCredentialAuthentication(user, pass)
 		key, _, requiresUpdate, err := Login(c, userPassLogin, time.Now().Add(time.Hour), time.Hour)
@@ -52,7 +57,7 @@ func TestSignup(t *testing.T) {
 
 		rCtx := RequestContext{
 			Authenticated: Authenticated{User: identity},
-			DBTxn:         db,
+			DBTxn:         tx,
 		}
 
 		// check "admin" can create token

--- a/internal/access/signup_test.go
+++ b/internal/access/signup_test.go
@@ -8,15 +8,15 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/authn"
+	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
 func TestSignup(t *testing.T) {
-	setup := func(t *testing.T) (*gin.Context, *gorm.DB) {
+	setup := func(t *testing.T) (*gin.Context, data.GormTxn) {
 		db := setupDB(t)
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Request = (&http.Request{}).WithContext(context.Background())

--- a/internal/server/authn/authn_method.go
+++ b/internal/server/authn/authn_method.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"gorm.io/gorm"
-
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
@@ -19,16 +17,16 @@ type AuthenticatedIdentity struct {
 }
 
 type LoginMethod interface {
-	Authenticate(ctx context.Context, db *gorm.DB, requestedExpiry time.Time) (AuthenticatedIdentity, error)
-	Name() string                             // Name returns the name of the authentication method used
-	RequiresUpdate(db *gorm.DB) (bool, error) // Temporary way to check for one time password re-use, remove with #1441
+	Authenticate(ctx context.Context, db data.GormTxn, requestedExpiry time.Time) (AuthenticatedIdentity, error)
+	Name() string                                 // Name returns the name of the authentication method used
+	RequiresUpdate(db data.GormTxn) (bool, error) // Temporary way to check for one time password re-use, remove with #1441
 }
 
 type AuthScope struct {
 	PasswordResetOnly bool
 }
 
-func Login(ctx context.Context, db *gorm.DB, loginMethod LoginMethod, requestedExpiry time.Time, keyExtension time.Duration) (*models.AccessKey, string, error) {
+func Login(ctx context.Context, db data.GormTxn, loginMethod LoginMethod, requestedExpiry time.Time, keyExtension time.Duration) (*models.AccessKey, string, error) {
 	// challenge the user to authenticate
 	authenticated, err := loginMethod.Authenticate(ctx, db, requestedExpiry)
 	if err != nil {

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/data"
@@ -15,7 +14,7 @@ import (
 	"github.com/infrahq/infra/internal/testing/patch"
 )
 
-func setupDB(t *testing.T) *gorm.DB {
+func setupDB(t *testing.T) *data.DB {
 	t.Helper()
 	driver := database.PostgresDriver(t, "_authn")
 	if driver == nil {
@@ -28,7 +27,7 @@ func setupDB(t *testing.T) *gorm.DB {
 	db, err := data.NewDB(driver.Dialector, nil)
 	assert.NilError(t, err)
 
-	return db.DB
+	return db
 }
 
 func TestLogin(t *testing.T) {

--- a/internal/server/authn/key_exchange.go
+++ b/internal/server/authn/key_exchange.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"gorm.io/gorm"
-
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 )
@@ -22,7 +20,7 @@ func NewKeyExchangeAuthentication(requestingAccessKey string) LoginMethod {
 	}
 }
 
-func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *gorm.DB, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
+func (a *keyExchangeAuthn) Authenticate(_ context.Context, db data.GormTxn, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
 	validatedRequestKey, err := data.ValidateAccessKey(db, a.RequestingAccessKey)
 	if err != nil {
 		return AuthenticatedIdentity{}, fmt.Errorf("invalid access key in exchange: %w", err)
@@ -51,6 +49,6 @@ func (a *keyExchangeAuthn) Name() string {
 	return "exchange"
 }
 
-func (a *keyExchangeAuthn) RequiresUpdate(db *gorm.DB) (bool, error) {
+func (a *keyExchangeAuthn) RequiresUpdate(db data.GormTxn) (bool, error) {
 	return false, nil // not applicable to key exchange
 }

--- a/internal/server/authn/key_exchange_test.go
+++ b/internal/server/authn/key_exchange_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/opt"
 
@@ -17,7 +16,7 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 	db := setupDB(t)
 
 	type testCase struct {
-		setup       func(t *testing.T, db *gorm.DB) (LoginMethod, time.Time)
+		setup       func(t *testing.T, db data.GormTxn) (LoginMethod, time.Time)
 		expectedErr string
 		expected    func(t *testing.T, authnIdentity AuthenticatedIdentity)
 	}
@@ -28,7 +27,7 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 
 	cases := map[string]testCase{
 		"InvalidAccessKeyCannotBeExchanged": {
-			setup: func(t *testing.T, db *gorm.DB) (LoginMethod, time.Time) {
+			setup: func(t *testing.T, db data.GormTxn) (LoginMethod, time.Time) {
 				user := &models.Identity{Name: "goku@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
@@ -40,7 +39,7 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 			expectedErr: "could not get access key from database",
 		},
 		"ExpiredAccessKeyCannotBeExchanged": {
-			setup: func(t *testing.T, db *gorm.DB) (LoginMethod, time.Time) {
+			setup: func(t *testing.T, db data.GormTxn) (LoginMethod, time.Time) {
 				user := &models.Identity{Name: "bulma@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
@@ -60,7 +59,7 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 			expectedErr: data.ErrAccessKeyExpired.Error(),
 		},
 		"AccessKeyCannotBeExchangedWhenUserNoLongerExists": {
-			setup: func(t *testing.T, db *gorm.DB) (LoginMethod, time.Time) {
+			setup: func(t *testing.T, db data.GormTxn) (LoginMethod, time.Time) {
 				user := &models.Identity{Name: "notforlong@example.com"}
 				user.DeletedAt.Time = time.Now()
 				user.DeletedAt.Valid = true
@@ -82,7 +81,7 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 			expectedErr: "user is not valid",
 		},
 		"AccessKeyCannotBeExchangedForLongerLived": {
-			setup: func(t *testing.T, db *gorm.DB) (LoginMethod, time.Time) {
+			setup: func(t *testing.T, db data.GormTxn) (LoginMethod, time.Time) {
 				user := &models.Identity{Name: "krillin@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)
@@ -106,7 +105,7 @@ func TestKeyExchangeAuthentication(t *testing.T) {
 			},
 		},
 		"ValidAccessKeySuccess": {
-			setup: func(t *testing.T, db *gorm.DB) (LoginMethod, time.Time) {
+			setup: func(t *testing.T, db data.GormTxn) (LoginMethod, time.Time) {
 				user := &models.Identity{Name: "cell@example.com"}
 				err := data.CreateIdentity(db, user)
 				assert.NilError(t, err)

--- a/internal/server/authn/password_credentials.go
+++ b/internal/server/authn/password_credentials.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/data"
 )
@@ -24,7 +23,7 @@ func NewPasswordCredentialAuthentication(username, password string) LoginMethod 
 	}
 }
 
-func (a *passwordCredentialAuthn) Authenticate(_ context.Context, db *gorm.DB, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
+func (a *passwordCredentialAuthn) Authenticate(_ context.Context, db data.GormTxn, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
 	identity, err := data.GetIdentity(db, data.ByName(a.Username))
 	if err != nil {
 		return AuthenticatedIdentity{}, fmt.Errorf("could not get identity for username: %w", err)
@@ -62,7 +61,7 @@ func (a *passwordCredentialAuthn) Name() string {
 	return "credentials"
 }
 
-func (a *passwordCredentialAuthn) RequiresUpdate(db *gorm.DB) (bool, error) {
+func (a *passwordCredentialAuthn) RequiresUpdate(db data.GormTxn) (bool, error) {
 	identity, err := data.GetIdentity(db, data.ByName(a.Username))
 	if err != nil {
 		return false, fmt.Errorf("could not get identity for username: %w", err)

--- a/internal/server/authn/password_credentials_test.go
+++ b/internal/server/authn/password_credentials_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/data"
@@ -17,14 +16,14 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 	db := setupDB(t)
 
 	type testCase struct {
-		setup       func(t *testing.T, db *gorm.DB) LoginMethod
+		setup       func(t *testing.T, db data.GormTxn) LoginMethod
 		expectedErr string
 		expected    func(t *testing.T, authnIdentity AuthenticatedIdentity)
 	}
 
 	cases := map[string]testCase{
 		"UsernameAndOneTimePasswordFirstUse": {
-			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
 				username := "goku@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -52,7 +51,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			},
 		},
 		"UsernameAndPassword": {
-			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
 				username := "bulma@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -80,7 +79,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			},
 		},
 		"UsernameAndPasswordReuse": {
-			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
 				username := "cell@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -113,7 +112,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			},
 		},
 		"ValidUsernameAndNoPasswordFails": {
-			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
 				username := "krillin@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -124,7 +123,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			expectedErr: "record not found",
 		},
 		"UsernameAndInvalidPasswordFails": {
-			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
 				username := "po@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -148,7 +147,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			expectedErr: "hashedPassword is not the hash of the given password",
 		},
 		"UsernameAndEmptyPasswordFails": {
-			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
 				username := "gohan@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -172,7 +171,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			expectedErr: "hashedPassword is not the hash of the given password",
 		},
 		"EmptyUsernameAndPasswordFails": {
-			setup: func(t *testing.T, db *gorm.DB) LoginMethod {
+			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
 				return NewPasswordCredentialAuthentication("", "whatever")
 			},
 			expectedErr: "record not found",

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -435,7 +435,7 @@ func TestLoadConfigWithProviders(t *testing.T) {
 	err = s.db.Where("name = ?", "okta").First(&okta).Error
 	assert.NilError(t, err)
 
-	defaultOrg := data.MustGetOrgFromContext(s.DB().Statement.Context)
+	defaultOrg := s.db.DefaultOrg
 	expected := models.Provider{
 		Model:              okta.Model,     // not relevant
 		CreatedBy:          okta.CreatedBy, // not relevant
@@ -848,7 +848,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 	err = s.db.Where("name = ?", "atko").First(&provider).Error
 	assert.NilError(t, err)
 
-	defaultOrg := data.MustGetOrgFromContext(s.DB().Statement.Context)
+	defaultOrg := s.db.DefaultOrg
 	expected := models.Provider{
 		Model:              provider.Model,     // not relevant
 		CreatedBy:          provider.CreatedBy, // not relevant
@@ -939,11 +939,12 @@ func TestLoadAccessKey(t *testing.T) {
 }
 
 // getTestUserDetails gets the attributes of a user created from a config file
-func getTestUserDetails(db *gorm.DB, name string) (*models.Identity, *models.Credential, *models.AccessKey, error) {
+func getTestUserDetails(tx data.GormTxn, name string) (*models.Identity, *models.Credential, *models.AccessKey, error) {
 	var user models.Identity
 	var credential models.Credential
 	var accessKey models.AccessKey
 
+	db := tx.GormDB()
 	err := db.Where("name = ?", name).First(&user).Error
 	if err != nil {
 		return nil, nil, nil, err

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -157,8 +157,7 @@ func ValidateAccessKey(tx GormTxn, authnKey string) (*models.AccessKey, error) {
 
 		t.ExtensionDeadline = time.Now().UTC().Add(t.Extension)
 
-		// TODO: constructor
-		tx = &Transaction{DB: tx.GormDB(), orgID: t.OrganizationID}
+		tx = NewTransaction(tx.GormDB(), t.OrganizationID)
 		if err := SaveAccessKey(tx, t); err != nil {
 			return nil, err
 		}

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -157,6 +157,9 @@ func ValidateAccessKey(tx GormTxn, authnKey string) (*models.AccessKey, error) {
 
 		t.ExtensionDeadline = time.Now().UTC().Add(t.Extension)
 
+		// Set the orgID in the tx. This is only necessary because our data
+		// layer requires an orgID be set in the transaction. If we remove
+		// that requirement, we can remove this line as well.
 		tx = NewTransaction(tx.GormDB(), t.OrganizationID)
 		if err := SaveAccessKey(tx, t); err != nil {
 			return nil, err

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCreateAccessKey(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		jerry := &models.Identity{Name: "jseinfeld@infrahq.com"}
 
 		err := CreateIdentity(db, jerry)
@@ -103,7 +103,7 @@ func createAccessKeyWithExtensionDeadline(t *testing.T, db *gorm.DB, ttl, exensi
 }
 
 func TestCheckAccessKeySecret(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		body, _ := createTestAccessKey(t, db, time.Hour*5)
 
 		_, err := ValidateAccessKey(db, body)
@@ -118,7 +118,7 @@ func TestCheckAccessKeySecret(t *testing.T) {
 }
 
 func TestDeleteAccessKey(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		_, token := createTestAccessKey(t, db, time.Minute*5)
 
 		_, err := GetAccessKey(db, ByID(token.ID))
@@ -136,7 +136,7 @@ func TestDeleteAccessKey(t *testing.T) {
 }
 
 func TestCheckAccessKeyExpired(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		body, _ := createTestAccessKey(t, db, -1*time.Hour)
 
 		_, err := ValidateAccessKey(db, body)
@@ -145,7 +145,7 @@ func TestCheckAccessKeyExpired(t *testing.T) {
 }
 
 func TestCheckAccessKeyPastExtensionDeadline(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		body, _ := createAccessKeyWithExtensionDeadline(t, db, 1*time.Hour, -1*time.Hour)
 
 		_, err := ValidateAccessKey(db, body)
@@ -154,7 +154,7 @@ func TestCheckAccessKeyPastExtensionDeadline(t *testing.T) {
 }
 
 func TestListAccessKeys(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		user := &models.Identity{Name: "tmp@infrahq.com"}
 		err := CreateIdentity(db, user)
 		assert.NilError(t, err)

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/generate"
@@ -84,7 +83,7 @@ func TestCreateAccessKey(t *testing.T) {
 	})
 }
 
-func createAccessKeyWithExtensionDeadline(t *testing.T, db *gorm.DB, ttl, exensionDeadline time.Duration) (string, *models.AccessKey) {
+func createAccessKeyWithExtensionDeadline(t *testing.T, db GormTxn, ttl, exensionDeadline time.Duration) (string, *models.AccessKey) {
 	identity := &models.Identity{Name: "Wall-E"}
 	err := CreateIdentity(db, identity)
 	assert.NilError(t, err)
@@ -203,7 +202,7 @@ func TestListAccessKeys(t *testing.T) {
 	})
 }
 
-func createTestAccessKey(t *testing.T, db *gorm.DB, sessionDuration time.Duration) (string, *models.AccessKey) {
+func createTestAccessKey(t *testing.T, db GormTxn, sessionDuration time.Duration) (string, *models.AccessKey) {
 	user := &models.Identity{Name: "tmp@infrahq.com"}
 	err := CreateIdentity(db, user)
 	assert.NilError(t, err)

--- a/internal/server/data/credential.go
+++ b/internal/server/data/credential.go
@@ -3,8 +3,6 @@ package data
 import (
 	"fmt"
 
-	"gorm.io/gorm"
-
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -30,10 +28,10 @@ func SaveCredential(db GormTxn, credential *models.Credential) error {
 	return save(db, credential)
 }
 
-func GetCredential(db *gorm.DB, selectors ...SelectorFunc) (*models.Credential, error) {
+func GetCredential(db GormTxn, selectors ...SelectorFunc) (*models.Credential, error) {
 	return get[models.Credential](db, selectors...)
 }
 
-func DeleteCredential(db *gorm.DB, id uid.ID) error {
+func DeleteCredential(db GormTxn, id uid.ID) error {
 	return delete[models.Credential](db, id)
 }

--- a/internal/server/data/credential.go
+++ b/internal/server/data/credential.go
@@ -16,14 +16,14 @@ func validateCredential(c *models.Credential) error {
 	return nil
 }
 
-func CreateCredential(db *gorm.DB, credential *models.Credential) error {
+func CreateCredential(db GormTxn, credential *models.Credential) error {
 	if err := validateCredential(credential); err != nil {
 		return err
 	}
 	return add(db, credential)
 }
 
-func SaveCredential(db *gorm.DB, credential *models.Credential) error {
+func SaveCredential(db GormTxn, credential *models.Credential) error {
 	if err := validateCredential(credential); err != nil {
 		return err
 	}

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -152,6 +152,10 @@ func (t *Transaction) GormDB() *gorm.DB {
 	return t.DB
 }
 
+func NewTransaction(db *gorm.DB, orgID uid.ID) *Transaction {
+	return &Transaction{DB: db, orgID: orgID}
+}
+
 // newRawDB creates a new database connection without running migrations.
 func newRawDB(connection gorm.Dialector) (*gorm.DB, error) {
 	db, err := gorm.Open(connection, &gorm.Config{

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -132,6 +132,9 @@ func (t Transaction) DriverName() string {
 }
 
 func (t *Transaction) OrganizationID() uid.ID {
+	if t.orgID == 0 {
+		panic("OrganizationID was not set")
+	}
 	return t.orgID
 }
 

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -192,7 +192,7 @@ func initialize(db *DB) error {
 			Name:      models.DefaultOrganizationName,
 			CreatedBy: models.CreatedBySystem,
 		}
-		if err := CreateOrganizationAndSetContext(db, org); err != nil {
+		if err := CreateOrganization(db, org); err != nil {
 			return fmt.Errorf("failed to create default organization: %w", err)
 		}
 	case err != nil:

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -119,6 +119,9 @@ type ReadTxn interface {
 type GormTxn interface {
 	WriteTxn
 
+	// GormDB returns the underlying reference to the gorm.DB struct.
+	// Do not use this in new code! Instead, write SQL using the stdlib\
+	// interface of Query, QueryRow, and Exec.
 	GormDB() *gorm.DB
 }
 
@@ -264,6 +267,8 @@ func get[T models.Modelable](tx GormTxn, selectors ...SelectorFunc) (*T, error) 
 	return result, nil
 }
 
+// setOrg checks if model is an organization member, and sets the organizationID
+// from the transaction when it is an organization member.
 func setOrg(tx ReadTxn, model any) {
 	member, ok := model.(orgMember)
 	if !ok {

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -92,9 +92,10 @@ func (d *DB) QueryRow(query string, args ...any) *sql.Row {
 	return d.DB.Raw(query, args...).Row()
 }
 
-// OrganizationID returns 0, a whole DB should not be scoped to an org.
 func (d *DB) OrganizationID() uid.ID {
-	return 0
+	// FIXME: this is a hack to keep our tests passing. The db should not
+	// be scoped to an org ID.
+	return d.DefaultOrg.ID
 }
 
 func (d *DB) GormDB() *gorm.DB {

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -135,7 +135,7 @@ func TestCreateTransactionError(t *testing.T) {
 	// on creation error (such as conflict) the database transaction should still be usable
 	runDBTests(t, func(t *testing.T, db *DB) {
 		err := db.Transaction(func(txDB *gorm.DB) error {
-			tx := &Transaction{DB: txDB}
+			tx := &Transaction{DB: txDB, orgID: 12345}
 
 			g := &models.Grant{}
 			err := add(tx, g)

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -135,7 +134,9 @@ func TestDefaultSortFromType(t *testing.T) {
 func TestCreateTransactionError(t *testing.T) {
 	// on creation error (such as conflict) the database transaction should still be usable
 	runDBTests(t, func(t *testing.T, db *DB) {
-		err := db.Transaction(func(tx *gorm.DB) error {
+		err := db.Transaction(func(txDB *gorm.DB) error {
+			tx := &Transaction{DB: txDB}
+
 			g := &models.Grant{}
 			err := add(tx, g)
 			if err != nil {
@@ -157,13 +158,8 @@ func TestCreateTransactionError(t *testing.T) {
 
 func TestSetOrg(t *testing.T) {
 	model := &models.AccessKey{}
-	org := &models.Organization{}
-	org.ID = 123456
 
-	db := &gorm.DB{}
-	db.Statement = &gorm.Statement{
-		Context: WithOrg(context.Background(), org),
-	}
-	setOrg(db, model)
+	tx := &Transaction{orgID: 123456}
+	setOrg(tx, model)
 	assert.Equal(t, model.OrganizationID, uid.ID(123456))
 }

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -18,14 +18,14 @@ func validateDestination(dest *models.Destination) error {
 	return nil
 }
 
-func CreateDestination(db *gorm.DB, destination *models.Destination) error {
+func CreateDestination(db GormTxn, destination *models.Destination) error {
 	if err := validateDestination(destination); err != nil {
 		return err
 	}
 	return add(db, destination)
 }
 
-func SaveDestination(db *gorm.DB, destination *models.Destination) error {
+func SaveDestination(db GormTxn, destination *models.Destination) error {
 	if err := validateDestination(destination); err != nil {
 		return err
 	}

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 	"time"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/models"
 )
 
 func TestDestinationSaveCreatedPersists(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		destination := &models.Destination{
 			Name: "example-cluster-1",
 		}
@@ -33,7 +32,7 @@ func TestDestinationSaveCreatedPersists(t *testing.T) {
 }
 
 func TestCountDestinationsByConnectedVersion(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		assert.NilError(t, CreateDestination(db, &models.Destination{Name: "1", UniqueID: "1", LastSeenAt: time.Now()}))
 		assert.NilError(t, CreateDestination(db, &models.Destination{Name: "2", UniqueID: "2", Version: "", LastSeenAt: time.Now().Add(-10 * time.Minute)}))
 		assert.NilError(t, CreateDestination(db, &models.Destination{Name: "3", UniqueID: "3", Version: "0.1.0", LastSeenAt: time.Now()}))

--- a/internal/server/data/encryption_key.go
+++ b/internal/server/data/encryption_key.go
@@ -21,7 +21,7 @@ func CreateEncryptionKey(db GormTxn, key *models.EncryptionKey) (*models.Encrypt
 	return key, nil
 }
 
-func GetEncryptionKey(db *gorm.DB, selector SelectorFunc) (result *models.EncryptionKey, err error) {
+func GetEncryptionKey(db GormTxn, selector SelectorFunc) (result *models.EncryptionKey, err error) {
 	return get[models.EncryptionKey](db, selector)
 }
 

--- a/internal/server/data/encryption_key.go
+++ b/internal/server/data/encryption_key.go
@@ -8,7 +8,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func CreateEncryptionKey(db *gorm.DB, key *models.EncryptionKey) (*models.EncryptionKey, error) {
+func CreateEncryptionKey(db GormTxn, key *models.EncryptionKey) (*models.EncryptionKey, error) {
 	if key.KeyID == 0 {
 		// not a security issue; just an identifier
 		key.KeyID = mathrand.Int31() // nolint:gosec

--- a/internal/server/data/encryption_key_test.go
+++ b/internal/server/data/encryption_key_test.go
@@ -3,14 +3,13 @@ package data
 import (
 	"testing"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/models"
 )
 
 func TestEncryptionKeys(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		k, err := CreateEncryptionKey(db, &models.EncryptionKey{
 			Name:      "foo",
 			Encrypted: []byte{0x00},

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -10,7 +10,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func CreateGrant(db *gorm.DB, grant *models.Grant) error {
+func CreateGrant(db GormTxn, grant *models.Grant) error {
 	switch {
 	case grant.Subject == "":
 		return fmt.Errorf("subject is required")

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -22,15 +22,15 @@ func CreateGrant(db GormTxn, grant *models.Grant) error {
 	return add(db, grant)
 }
 
-func GetGrant(db *gorm.DB, selectors ...SelectorFunc) (*models.Grant, error) {
+func GetGrant(db GormTxn, selectors ...SelectorFunc) (*models.Grant, error) {
 	return get[models.Grant](db, selectors...)
 }
 
-func ListGrants(db *gorm.DB, p *models.Pagination, selectors ...SelectorFunc) ([]models.Grant, error) {
+func ListGrants(db GormTxn, p *models.Pagination, selectors ...SelectorFunc) ([]models.Grant, error) {
 	return list[models.Grant](db, p, selectors...)
 }
 
-func DeleteGrants(db *gorm.DB, selectors ...SelectorFunc) error {
+func DeleteGrants(db GormTxn, selectors ...SelectorFunc) error {
 	toDelete, err := list[models.Grant](db, nil, selectors...)
 	if err != nil {
 		return err

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -3,7 +3,6 @@ package data
 import (
 	"testing"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func TestDuplicateGrant(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		g := models.Grant{
 			Model:     models.Model{ID: 1},
 			Subject:   "i:1234567",

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -7,7 +7,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func CreateGroup(db *gorm.DB, group *models.Group) error {
+func CreateGroup(db GormTxn, group *models.Group) error {
 	return add(db, group)
 }
 

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -11,7 +11,7 @@ func CreateGroup(db GormTxn, group *models.Group) error {
 	return add(db, group)
 }
 
-func GetGroup(db *gorm.DB, selectors ...SelectorFunc) (*models.Group, error) {
+func GetGroup(db GormTxn, selectors ...SelectorFunc) (*models.Group, error) {
 	group, err := get[models.Group](db, selectors...)
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func GetGroup(db *gorm.DB, selectors ...SelectorFunc) (*models.Group, error) {
 	return group, nil
 }
 
-func ListGroups(db *gorm.DB, p *models.Pagination, selectors ...SelectorFunc) ([]models.Group, error) {
+func ListGroups(db GormTxn, p *models.Pagination, selectors ...SelectorFunc) ([]models.Group, error) {
 	groups, err := list[models.Group](db, p, selectors...)
 
 	if err != nil {
@@ -52,7 +52,7 @@ func ByGroupMember(id uid.ID) SelectorFunc {
 	}
 }
 
-func DeleteGroups(db *gorm.DB, selectors ...SelectorFunc) error {
+func DeleteGroups(db GormTxn, selectors ...SelectorFunc) error {
 	toDelete, err := ListGroups(db, nil, selectors...)
 	if err != nil {
 		return err
@@ -85,11 +85,11 @@ func DeleteGroups(db *gorm.DB, selectors ...SelectorFunc) error {
 	return deleteAll[models.Group](db, ByIDs(ids))
 }
 
-func AddUsersToGroup(db *gorm.DB, groupID uid.ID, idsToAdd []uid.ID) error {
+func AddUsersToGroup(db GormTxn, groupID uid.ID, idsToAdd []uid.ID) error {
 	for _, id := range idsToAdd {
 		// This is effectively an "INSERT OR IGNORE" or "INSERT ... ON CONFLICT ... DO NOTHING" statement which
 		// works across both sqlite and postgres
-		err := db.Exec("INSERT INTO identities_groups (group_id, identity_id) SELECT ?, ? WHERE NOT EXISTS (SELECT 1 FROM identities_groups WHERE group_id = ? AND identity_id = ?)", groupID, id, groupID, id).Error
+		_, err := db.Exec("INSERT INTO identities_groups (group_id, identity_id) SELECT ?, ? WHERE NOT EXISTS (SELECT 1 FROM identities_groups WHERE group_id = ? AND identity_id = ?)", groupID, id, groupID, id)
 		if err != nil {
 			return err
 		}
@@ -97,9 +97,9 @@ func AddUsersToGroup(db *gorm.DB, groupID uid.ID, idsToAdd []uid.ID) error {
 	return nil
 }
 
-func RemoveUsersFromGroup(db *gorm.DB, groupID uid.ID, idsToRemove []uid.ID) error {
+func RemoveUsersFromGroup(db GormTxn, groupID uid.ID, idsToRemove []uid.ID) error {
 	for _, id := range idsToRemove {
-		err := db.Exec("DELETE FROM identities_groups WHERE identity_id = ? AND group_id = ?", id, groupID).Error
+		_, err := db.Exec("DELETE FROM identities_groups WHERE identity_id = ? AND group_id = ?", id, groupID)
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,8 @@ func RemoveUsersFromGroup(db *gorm.DB, groupID uid.ID, idsToRemove []uid.ID) err
 	return nil
 }
 
-func CountUsersInGroup(db *gorm.DB, groupID uid.ID) (int64, error) {
+func CountUsersInGroup(tx GormTxn, groupID uid.ID) (int64, error) {
+	db := tx.GormDB()
 	var count int64
 	err := db.Table("identities_groups").Where("group_id = ?", groupID).Count(&count).Error
 	if err != nil {

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/models"
@@ -39,7 +38,7 @@ func TestCreateGroup(t *testing.T) {
 	})
 }
 
-func createGroups(t *testing.T, db *gorm.DB, groups ...*models.Group) {
+func createGroups(t *testing.T, db GormTxn, groups ...*models.Group) {
 	t.Helper()
 	for i := range groups {
 		err := CreateGroup(db, groups[i])

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGroup(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		everyone := models.Group{Name: "Everyone"}
 
 		err := db.Create(&everyone).Error
@@ -27,7 +27,7 @@ func TestGroup(t *testing.T) {
 }
 
 func TestCreateGroup(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		everyone := models.Group{Name: "Everyone"}
 
 		err := CreateGroup(db, &everyone)
@@ -48,7 +48,7 @@ func createGroups(t *testing.T, db *gorm.DB, groups ...*models.Group) {
 }
 
 func TestCreateGroupDuplicate(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			everyone  = models.Group{Name: "Everyone"}
 			engineers = models.Group{Name: "Engineering"}
@@ -63,7 +63,7 @@ func TestCreateGroupDuplicate(t *testing.T) {
 }
 
 func TestGetGroup(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			everyone  = models.Group{Name: "Everyone"}
 			engineers = models.Group{Name: "Engineering"}
@@ -79,7 +79,7 @@ func TestGetGroup(t *testing.T) {
 }
 
 func TestListGroups(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			everyone  = models.Group{Name: "Everyone"}
 			engineers = models.Group{Name: "Engineering"}
@@ -135,7 +135,7 @@ var cmpGroupShallow = gocmp.Comparer(func(x, y models.Group) bool {
 })
 
 func TestDeleteGroup(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			everyone  = models.Group{Name: "Everyone"}
 			engineers = models.Group{Name: "Engineering"}
@@ -164,7 +164,7 @@ func TestDeleteGroup(t *testing.T) {
 }
 
 func TestRecreateGroupSameName(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			everyone  = models.Group{Name: "Everyone"}
 			engineers = models.Group{Name: "Engineering"}
@@ -182,7 +182,7 @@ func TestRecreateGroupSameName(t *testing.T) {
 }
 
 func TestAddUsersToGroup(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var everyone = models.Group{Name: "Everyone"}
 		createGroups(t, db, &everyone)
 

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -11,7 +11,8 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func AssignIdentityToGroups(db *gorm.DB, user *models.Identity, provider *models.Provider, newGroups []string) error {
+func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.Provider, newGroups []string) error {
+	db := tx.GormDB()
 	pu, err := GetProviderUser(db, provider.ID, user.ID)
 	if err != nil {
 		return err
@@ -23,7 +24,7 @@ func AssignIdentityToGroups(db *gorm.DB, user *models.Identity, provider *models
 
 	pu.Groups = newGroups
 	pu.LastUpdate = time.Now().UTC()
-	if err := save(db, pu); err != nil {
+	if err := save(tx, pu); err != nil {
 		return fmt.Errorf("save: %w", err)
 	}
 
@@ -69,7 +70,7 @@ func AssignIdentityToGroups(db *gorm.DB, user *models.Identity, provider *models
 				CreatedByProvider: provider.ID,
 			}
 
-			if err = CreateGroup(db, group); err != nil {
+			if err = CreateGroup(tx, group); err != nil {
 				return fmt.Errorf("create group: %w", err)
 			}
 			groupID = group.ID
@@ -94,7 +95,7 @@ func AssignIdentityToGroups(db *gorm.DB, user *models.Identity, provider *models
 	return nil
 }
 
-func CreateIdentity(db *gorm.DB, identity *models.Identity) error {
+func CreateIdentity(db GormTxn, identity *models.Identity) error {
 	return add(db, identity)
 }
 
@@ -141,6 +142,6 @@ func DeleteIdentities(db *gorm.DB, selectors ...SelectorFunc) error {
 	return deleteAll[models.Identity](db, ByIDs(ids))
 }
 
-func SaveIdentity(db *gorm.DB, identity *models.Identity) error {
+func SaveIdentity(db GormTxn, identity *models.Identity) error {
 	return save(db, identity)
 }

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ssoroka/slice"
+	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -111,8 +112,11 @@ func DeleteIdentity(db GormTxn, id uid.ID) error {
 }
 
 func DeleteIdentities(tx GormTxn, selectors ...SelectorFunc) error {
-	db := tx.GormDB()
-	toDelete, err := ListIdentities(db.Select("id"), nil, selectors...)
+	selectID := func(db *gorm.DB) *gorm.DB {
+		return db.Select("id")
+	}
+	selectors = append([]SelectorFunc{selectID}, selectors...)
+	toDelete, err := ListIdentities(tx, nil, selectors...)
 	if err != nil {
 		return err
 	}

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/ssoroka/slice"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal"
@@ -30,7 +29,7 @@ func TestIdentity(t *testing.T) {
 	})
 }
 
-func createIdentities(t *testing.T, db *gorm.DB, identities ...*models.Identity) {
+func createIdentities(t *testing.T, db GormTxn, identities ...*models.Identity) {
 	t.Helper()
 	for i := range identities {
 		err := CreateIdentity(db, identities[i])

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -268,7 +268,7 @@ func TestAssignIdentityToGroups(t *testing.T) {
 				assert.NilError(t, err)
 
 				// reload identity and check groups
-				id, err := GetIdentity(db.Preload("Groups"), ByID(identity.ID))
+				id, err := GetIdentity(db, Preload("Groups"), ByID(identity.ID))
 				assert.NilError(t, err)
 				groupNames := slice.Map[models.Group, string](id.Groups, func(g models.Group) string {
 					return g.Name

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestIdentity(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		bond := models.Identity{Name: "jbond@infrahq.com"}
 
 		err := db.Create(&bond).Error
@@ -39,7 +39,7 @@ func createIdentities(t *testing.T, db *gorm.DB, identities ...*models.Identity)
 }
 
 func TestCreateDuplicateUser(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			bond   = models.Identity{Name: "jbond@infrahq.com"}
 			bourne = models.Identity{Name: "jbourne@infrahq.com"}
@@ -56,7 +56,7 @@ func TestCreateDuplicateUser(t *testing.T) {
 }
 
 func TestGetIdentity(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			bond   = models.Identity{Name: "jbond@infrahq.com"}
 			bourne = models.Identity{Name: "jbourne@infrahq.com"}
@@ -72,7 +72,7 @@ func TestGetIdentity(t *testing.T) {
 }
 
 func TestListIdentities(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			everyone  = models.Group{Name: "Everyone"}
 			engineers = models.Group{Name: "Engineering"}
@@ -140,7 +140,7 @@ var cmpModelsIdentityShallow = cmp.Comparer(func(x, y models.Identity) bool {
 })
 
 func TestDeleteIdentity(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			bond   = models.Identity{Name: "jbond@infrahq.com"}
 			bourne = models.Identity{Name: "jbourne@infrahq.com"}
@@ -169,7 +169,7 @@ func TestDeleteIdentity(t *testing.T) {
 }
 
 func TestDeleteIdentityWithGroups(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			bond   = models.Identity{Name: "jbond@infrahq.com"}
 			bourne = models.Identity{Name: "jbourne@infrahq.com"}
@@ -194,7 +194,7 @@ func TestDeleteIdentityWithGroups(t *testing.T) {
 }
 
 func TestReCreateIdentitySameName(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			bond   = models.Identity{Name: "jbond@infrahq.com"}
 			bourne = models.Identity{Name: "jbourne@infrahq.com"}
@@ -235,7 +235,7 @@ func TestAssignIdentityToGroups(t *testing.T) {
 		},
 	}
 
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		for i, test := range tests {
 			t.Run(test.Name, func(t *testing.T) {
 				// setup identity

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -510,16 +510,18 @@ DELETE FROM settings WHERE id=24567;
 	var initialSchema string
 	runStep(t, "initial schema", func(t *testing.T) {
 		patch.ModelsSymmetricKey(t)
-		db, err := newRawDB(postgresDriver(t))
+		rawDB, err := newRawDB(postgresDriver(t))
 		assert.NilError(t, err)
 
+		db := &DB{DB: rawDB}
 		opts := migrator.Options{InitSchema: initializeSchema}
-		m := migrator.New(&DB{DB: db}, opts, nil)
+		m := migrator.New(db, opts, nil)
 		assert.NilError(t, m.Migrate())
 
 		initialSchema = dumpSchema(t, os.Getenv("POSTGRESQL_CONNECTION"))
 
-		assert.NilError(t, db.Exec("DROP SCHEMA IF EXISTS testing CASCADE").Error)
+		_, err = db.Exec("DROP SCHEMA IF EXISTS testing CASCADE")
+		assert.NilError(t, err)
 	})
 
 	db, err := newRawDB(postgresDriver(t))

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"gorm.io/gorm"
-
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -49,7 +47,7 @@ func CreateOrganizationAndSetContext(tx GormTxn, org *models.Organization) error
 	// TODO: constructor?
 	tx = &Transaction{DB: db, orgID: org.ID}
 
-	_, err = initializeSettings(db)
+	_, err = initializeSettings(tx)
 	if err != nil {
 		return fmt.Errorf("initializing org settings: %w", err)
 	}
@@ -85,15 +83,15 @@ func CreateOrganizationAndSetContext(tx GormTxn, org *models.Organization) error
 	return nil
 }
 
-func GetOrganization(db *gorm.DB, selectors ...SelectorFunc) (*models.Organization, error) {
+func GetOrganization(db GormTxn, selectors ...SelectorFunc) (*models.Organization, error) {
 	return get[models.Organization](db, selectors...)
 }
 
-func ListOrganizations(db *gorm.DB, p *models.Pagination, selectors ...SelectorFunc) ([]models.Organization, error) {
+func ListOrganizations(db GormTxn, p *models.Pagination, selectors ...SelectorFunc) ([]models.Organization, error) {
 	return list[models.Organization](db, p, selectors...)
 }
 
-func DeleteOrganizations(db *gorm.DB, selectors ...SelectorFunc) error {
+func DeleteOrganizations(db GormTxn, selectors ...SelectorFunc) error {
 	toDelete, err := GetOrganization(db, selectors...)
 	if err != nil {
 		return err

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/models"
@@ -14,59 +15,59 @@ import (
 var cmpTimeWithDBPrecision = cmpopts.EquateApproxTime(time.Microsecond)
 
 func TestCreateOrganizationAndSetContext(t *testing.T) {
-	pgsql := postgresDriver(t)
-	db := setupDB(t, pgsql)
+	runDBTests(t, func(t *testing.T, db *gorm.DB) {
 
-	org := &models.Organization{Name: "syndicate", Domain: "syndicate-123"}
+		org := &models.Organization{Name: "syndicate", Domain: "syndicate-123"}
 
-	err := CreateOrganizationAndSetContext(db, org)
-	assert.NilError(t, err)
+		err := CreateOrganizationAndSetContext(db, org)
+		assert.NilError(t, err)
 
-	// db context is set
-	ctxOrg := OrgFromContext(db.Statement.Context)
-	assert.DeepEqual(t, org, ctxOrg, cmpTimeWithDBPrecision)
+		// db context is set
+		ctxOrg := OrgFromContext(db.Statement.Context)
+		assert.DeepEqual(t, org, ctxOrg, cmpTimeWithDBPrecision)
 
-	// org is created
-	readOrg, err := GetOrganization(db, ByID(org.ID))
-	assert.NilError(t, err)
-	assert.DeepEqual(t, org, readOrg, cmpTimeWithDBPrecision)
+		// org is created
+		readOrg, err := GetOrganization(db, ByID(org.ID))
+		assert.NilError(t, err)
+		assert.DeepEqual(t, org, readOrg, cmpTimeWithDBPrecision)
 
-	// infra provider is created
-	orgInfraIDP := InfraProvider(db)
-	assert.NilError(t, err)
+		// infra provider is created
+		orgInfraIDP := InfraProvider(db)
+		assert.NilError(t, err)
 
-	expectedOrgInfraProviderIDP := &models.Provider{
-		Model:              orgInfraIDP.Model, // does not matter
-		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
-		Scopes:             models.CommaSeparatedStrings{},
-		Name:               models.InternalInfraProviderName,
-		Kind:               models.ProviderKindInfra,
-		CreatedBy:          models.CreatedBySystem,
-	}
-	assert.DeepEqual(t, orgInfraIDP, expectedOrgInfraProviderIDP, cmpTimeWithDBPrecision)
+		expectedOrgInfraProviderIDP := &models.Provider{
+			Model:              orgInfraIDP.Model, // does not matter
+			OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+			Scopes:             models.CommaSeparatedStrings{},
+			Name:               models.InternalInfraProviderName,
+			Kind:               models.ProviderKindInfra,
+			CreatedBy:          models.CreatedBySystem,
+		}
+		assert.DeepEqual(t, orgInfraIDP, expectedOrgInfraProviderIDP, cmpTimeWithDBPrecision)
 
-	// the org connector is created and granted approprite access
-	connector, err := GetIdentity(db, ByName(models.InternalInfraConnectorIdentityName))
-	assert.NilError(t, err)
+		// the org connector is created and granted approprite access
+		connector, err := GetIdentity(db, ByName(models.InternalInfraConnectorIdentityName))
+		assert.NilError(t, err)
 
-	expectedConnector := &models.Identity{
-		Model:              connector.Model,
-		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
-		Name:               models.InternalInfraConnectorIdentityName,
-		CreatedBy:          models.CreatedBySystem,
-	}
-	assert.DeepEqual(t, connector, expectedConnector)
+		expectedConnector := &models.Identity{
+			Model:              connector.Model,
+			OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+			Name:               models.InternalInfraConnectorIdentityName,
+			CreatedBy:          models.CreatedBySystem,
+		}
+		assert.DeepEqual(t, connector, expectedConnector)
 
-	connectorGrant, err := GetGrant(db, BySubject(connector.PolyID()), ByPrivilege(models.InfraAdminRole), ByResource("infra"))
-	assert.NilError(t, err)
+		connectorGrant, err := GetGrant(db, BySubject(connector.PolyID()), ByPrivilege(models.InfraAdminRole), ByResource("infra"))
+		assert.NilError(t, err)
 
-	expectedConnectorGrant := &models.Grant{
-		Model:              connectorGrant.Model,
-		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
-		Subject:            connector.PolyID(),
-		Privilege:          models.InfraAdminRole,
-		Resource:           "infra",
-		CreatedBy:          models.CreatedBySystem,
-	}
-	assert.DeepEqual(t, connectorGrant, expectedConnectorGrant)
+		expectedConnectorGrant := &models.Grant{
+			Model:              connectorGrant.Model,
+			OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+			Subject:            connector.PolyID(),
+			Privilege:          models.InfraAdminRole,
+			Resource:           "infra",
+			CreatedBy:          models.CreatedBySystem,
+		}
+		assert.DeepEqual(t, connectorGrant, expectedConnectorGrant)
+	})
 }

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -21,6 +21,8 @@ func TestCreateOrganizationAndSetContext(t *testing.T) {
 		err := CreateOrganizationAndSetContext(db, org)
 		assert.NilError(t, err)
 
+		tx := &Transaction{DB: db.DB, orgID: org.ID}
+
 		// db context is set
 		ctxOrg := OrgFromContext(db.Statement.Context)
 		assert.DeepEqual(t, org, ctxOrg, cmpTimeWithDBPrecision)
@@ -31,7 +33,7 @@ func TestCreateOrganizationAndSetContext(t *testing.T) {
 		assert.DeepEqual(t, org, readOrg, cmpTimeWithDBPrecision)
 
 		// infra provider is created
-		orgInfraIDP := InfraProvider(db)
+		orgInfraIDP := InfraProvider(tx)
 		assert.NilError(t, err)
 
 		expectedOrgInfraProviderIDP := &models.Provider{
@@ -45,7 +47,7 @@ func TestCreateOrganizationAndSetContext(t *testing.T) {
 		assert.DeepEqual(t, orgInfraIDP, expectedOrgInfraProviderIDP, cmpTimeWithDBPrecision)
 
 		// the org connector is created and granted approprite access
-		connector, err := GetIdentity(db, ByName(models.InternalInfraConnectorIdentityName))
+		connector, err := GetIdentity(tx, ByName(models.InternalInfraConnectorIdentityName))
 		assert.NilError(t, err)
 
 		expectedConnector := &models.Identity{
@@ -56,7 +58,7 @@ func TestCreateOrganizationAndSetContext(t *testing.T) {
 		}
 		assert.DeepEqual(t, connector, expectedConnector)
 
-		connectorGrant, err := GetGrant(db, BySubject(connector.PolyID()), ByPrivilege(models.InfraAdminRole), ByResource("infra"))
+		connectorGrant, err := GetGrant(tx, BySubject(connector.PolyID()), ByPrivilege(models.InfraAdminRole), ByResource("infra"))
 		assert.NilError(t, err)
 
 		expectedConnectorGrant := &models.Grant{

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/models"
@@ -15,7 +14,7 @@ import (
 var cmpTimeWithDBPrecision = cmpopts.EquateApproxTime(time.Microsecond)
 
 func TestCreateOrganizationAndSetContext(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 
 		org := &models.Organization{Name: "syndicate", Domain: "syndicate-123"}
 

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -13,19 +13,15 @@ import (
 // PostgreSQL only has microsecond precision
 var cmpTimeWithDBPrecision = cmpopts.EquateApproxTime(time.Microsecond)
 
-func TestCreateOrganizationAndSetContext(t *testing.T) {
+func TestCreateOrganization(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 
 		org := &models.Organization{Name: "syndicate", Domain: "syndicate-123"}
 
-		err := CreateOrganizationAndSetContext(db, org)
+		err := CreateOrganization(db, org)
 		assert.NilError(t, err)
 
 		tx := &Transaction{DB: db.DB, orgID: org.ID}
-
-		// db context is set
-		ctxOrg := OrgFromContext(db.Statement.Context)
-		assert.DeepEqual(t, org, ctxOrg, cmpTimeWithDBPrecision)
 
 		// org is created
 		readOrg, err := GetOrganization(db, ByID(org.ID))

--- a/internal/server/data/passwordresettoken.go
+++ b/internal/server/data/passwordresettoken.go
@@ -13,7 +13,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func CreatePasswordResetToken(db *gorm.DB, user *models.Identity, ttl time.Duration) (*models.PasswordResetToken, error) {
+func CreatePasswordResetToken(db GormTxn, user *models.Identity, ttl time.Duration) (*models.PasswordResetToken, error) {
 	tries := 0
 retry:
 	token, err := generate.CryptoRandom(10, generate.CharsetAlphaNumeric)

--- a/internal/server/data/passwordresettoken.go
+++ b/internal/server/data/passwordresettoken.go
@@ -40,7 +40,7 @@ retry:
 	return prt, nil
 }
 
-func GetPasswordResetTokenByToken(db *gorm.DB, token string) (*models.PasswordResetToken, error) {
+func GetPasswordResetTokenByToken(db GormTxn, token string) (*models.PasswordResetToken, error) {
 	prts, err := list[models.PasswordResetToken](db, &models.Pagination{Limit: 1}, func(db *gorm.DB) *gorm.DB {
 		return db.Where("token = ?", token)
 	})
@@ -60,6 +60,6 @@ func GetPasswordResetTokenByToken(db *gorm.DB, token string) (*models.PasswordRe
 	return &prts[0], nil
 }
 
-func DeletePasswordResetToken(db *gorm.DB, prt *models.PasswordResetToken) error {
+func DeletePasswordResetToken(db GormTxn, prt *models.PasswordResetToken) error {
 	return delete[models.PasswordResetToken](db, prt.ID)
 }

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -60,7 +60,7 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 		// if a user has no other providers, we need to remove the user.
 		userIDsToDelete := []uid.ID{}
 		for _, providerUser := range providerUsers {
-			user, err := GetIdentity(db.Preload("Providers"), ByID(providerUser.IdentityID))
+			user, err := GetIdentity(db, Preload("Providers"), ByID(providerUser.IdentityID))
 			if err != nil {
 				if errors.Is(err, internal.ErrNotFound) {
 					continue

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"gorm.io/gorm"
-
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -29,11 +27,11 @@ func CreateProvider(db GormTxn, provider *models.Provider) error {
 	return add(db, provider)
 }
 
-func GetProvider(db *gorm.DB, selectors ...SelectorFunc) (*models.Provider, error) {
+func GetProvider(db GormTxn, selectors ...SelectorFunc) (*models.Provider, error) {
 	return get[models.Provider](db, selectors...)
 }
 
-func ListProviders(db *gorm.DB, p *models.Pagination, selectors ...SelectorFunc) ([]models.Provider, error) {
+func ListProviders(db GormTxn, p *models.Pagination, selectors ...SelectorFunc) ([]models.Provider, error) {
 	return list[models.Provider](db, p, selectors...)
 }
 
@@ -44,7 +42,7 @@ func SaveProvider(db GormTxn, provider *models.Provider) error {
 	return save(db, provider)
 }
 
-func DeleteProviders(db *gorm.DB, selectors ...SelectorFunc) error {
+func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 	toDelete, err := ListProviders(db, nil, selectors...)
 	if err != nil {
 		return fmt.Errorf("listing providers: %w", err)
@@ -98,7 +96,8 @@ type providersCount struct {
 	Count float64
 }
 
-func CountProvidersByKind(db *gorm.DB) ([]providersCount, error) {
+func CountProvidersByKind(tx GormTxn) ([]providersCount, error) {
+	db := tx.GormDB()
 	var results []providersCount
 	if err := db.Raw("SELECT kind, COUNT(*) as count FROM providers WHERE kind <> 'infra' AND deleted_at IS NULL GROUP BY kind").Scan(&results).Error; err != nil {
 		return nil, err

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -22,7 +22,7 @@ func validateProvider(p *models.Provider) error {
 	}
 }
 
-func CreateProvider(db *gorm.DB, provider *models.Provider) error {
+func CreateProvider(db GormTxn, provider *models.Provider) error {
 	if err := validateProvider(provider); err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func ListProviders(db *gorm.DB, p *models.Pagination, selectors ...SelectorFunc)
 	return list[models.Provider](db, p, selectors...)
 }
 
-func SaveProvider(db *gorm.DB, provider *models.Provider) error {
+func SaveProvider(db GormTxn, provider *models.Provider) error {
 	if err := validateProvider(provider); err != nil {
 		return err
 	}

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -25,7 +25,7 @@ func TestProvider(t *testing.T) {
 	})
 }
 
-func createProviders(t *testing.T, db *gorm.DB, providers ...models.Provider) {
+func createProviders(t *testing.T, db GormTxn, providers ...models.Provider) {
 	for i := range providers {
 		err := CreateProvider(db, &providers[i])
 		assert.NilError(t, err)

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestProvider(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		providerDevelop := models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 
 		err := db.Create(&providerDevelop).Error
@@ -33,7 +33,7 @@ func createProviders(t *testing.T, db *gorm.DB, providers ...models.Provider) {
 }
 
 func TestCreateProviderDuplicate(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			providerDevelop    = models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 			providerProduction = models.Provider{Name: "okta-production", URL: "prod.okta.com", Kind: models.ProviderKindOkta}
@@ -51,7 +51,7 @@ func TestCreateProviderDuplicate(t *testing.T) {
 }
 
 func TestGetProvider(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			providerDevelop    = models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 			providerProduction = models.Provider{Name: "okta-production", URL: "prod.okta.com", Kind: models.ProviderKindOkta}
@@ -67,7 +67,7 @@ func TestGetProvider(t *testing.T) {
 }
 
 func TestListProviders(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			providerDevelop    = models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 			providerProduction = models.Provider{Name: "okta-production", URL: "prod.okta.com", Kind: models.ProviderKindOkta}
@@ -86,7 +86,7 @@ func TestListProviders(t *testing.T) {
 }
 
 func TestDeleteProviders(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			providerDevelop    = models.Provider{}
 			providerProduction = models.Provider{}
@@ -150,7 +150,7 @@ func TestDeleteProviders(t *testing.T) {
 }
 
 func TestRecreateProviderSameDomain(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var (
 			providerDevelop    = models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 			providerProduction = models.Provider{Name: "okta-production", URL: "prod.okta.com", Kind: models.ProviderKindOkta}
@@ -169,7 +169,7 @@ func TestRecreateProviderSameDomain(t *testing.T) {
 }
 
 func TestCountProvidersByKind(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "oidc", Kind: "oidc"}))
 		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "okta", Kind: "okta"}))
 		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "okta2", Kind: "okta"}))

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"gorm.io/gorm"
-
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/models"
@@ -31,7 +29,7 @@ func validateProviderUser(u *models.ProviderUser) error {
 }
 
 func CreateProviderUser(db GormTxn, provider *models.Provider, ident *models.Identity) (*models.ProviderUser, error) {
-	pu, err := get[models.ProviderUser](db.GormDB(), ByIdentityID(ident.ID), ByProviderID(provider.ID))
+	pu, err := get[models.ProviderUser](db, ByIdentityID(ident.ID), ByProviderID(provider.ID))
 	if err != nil && !errors.Is(err, internal.ErrNotFound) {
 		return nil, err
 	}
@@ -59,20 +57,20 @@ func UpdateProviderUser(db GormTxn, providerUser *models.ProviderUser) error {
 	return save(db, providerUser)
 }
 
-func ListProviderUsers(db *gorm.DB, p *models.Pagination, selectors ...SelectorFunc) ([]models.ProviderUser, error) {
+func ListProviderUsers(db GormTxn, p *models.Pagination, selectors ...SelectorFunc) ([]models.ProviderUser, error) {
 	return list[models.ProviderUser](db, p, selectors...)
 }
 
-func DeleteProviderUsers(db *gorm.DB, selectors ...SelectorFunc) error {
+func DeleteProviderUsers(db GormTxn, selectors ...SelectorFunc) error {
 	return deleteAll[models.ProviderUser](db, selectors...)
 }
 
-func GetProviderUser(db *gorm.DB, providerID, userID uid.ID) (*models.ProviderUser, error) {
+func GetProviderUser(db GormTxn, providerID, userID uid.ID) (*models.ProviderUser, error) {
 	return get[models.ProviderUser](db, ByProviderID(providerID), ByIdentityID(userID))
 }
 
 func SyncProviderUser(ctx context.Context, tx GormTxn, user *models.Identity, provider *models.Provider, oidcClient providers.OIDCClient) error {
-	providerUser, err := GetProviderUser(tx.GormDB(), provider.ID, user.ID)
+	providerUser, err := GetProviderUser(tx, provider.ID, user.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/opt"
 
@@ -49,7 +48,7 @@ var cmpEncryptedAtRestNotZero = cmp.Comparer(func(x, y models.EncryptedAtRest) b
 })
 
 func TestSyncProviderUser(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		provider := &models.Provider{
 			Name: "mockta",
 			Kind: models.ProviderKindOkta,
@@ -228,7 +227,7 @@ func TestSyncProviderUser(t *testing.T) {
 }
 
 func TestDeleteProviderUser(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		provider := &models.Provider{
 			Name: "mockta",
 			Kind: models.ProviderKindOkta,

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -195,6 +195,12 @@ func ByOptionalIdentityGroupID(groupID uid.ID) SelectorFunc {
 	}
 }
 
+func Preload(name string) SelectorFunc {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Preload(name)
+	}
+}
+
 func ByDomain(host string) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("domain = ?", host)

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -122,12 +122,6 @@ func ByIdentityID(identityID uid.ID) SelectorFunc {
 	}
 }
 
-func ByUserID(userID uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("user_id = ?", userID)
-	}
-}
-
 func ByNotExpiredOrExtended() SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		query := strings.Builder{}
@@ -154,23 +148,9 @@ func CreatedBy(id uid.ID) SelectorFunc {
 	}
 }
 
-func OrderBy(order string) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Order(order)
-	}
-}
-
 func Limit(limit int) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Limit(limit)
-	}
-}
-
-// NotCreatedBy filters out entities not created by the passed in ID
-func NotCreatedBy(id uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		// the created_by field is default 0 when not set by default
-		return db.Where("created_by != ?", id)
 	}
 }
 

--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -75,10 +75,10 @@ func getSettingsForOrg(db *gorm.DB, orgID uid.ID) (*models.Settings, error) {
 	return &settings, nil
 }
 
-func SaveSettings(db *gorm.DB, settings *models.Settings) error {
+func SaveSettings(db GormTxn, settings *models.Settings) error {
 	// TODO: clean this up by having the query use the organization_id instead of the
 	// primary key in the WHERE.
-	existing, err := GetSettings(db)
+	existing, err := GetSettings(db.GormDB())
 	if err != nil {
 		return err
 	}

--- a/internal/server/data/settings_test.go
+++ b/internal/server/data/settings_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/opt"
 
@@ -14,7 +13,7 @@ import (
 )
 
 func TestInitializeSettings(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *gorm.DB) {
+	runDBTests(t, func(t *testing.T, db *DB) {
 		var settings *models.Settings
 		runStep(t, "first call creates new settings", func(t *testing.T) {
 			var err error

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -6,7 +6,6 @@ import (
 
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
-	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/claims"
 	"github.com/infrahq/infra/internal/generate"
@@ -18,7 +17,7 @@ var signatureAlgorithmFromKeyAlgorithm = map[string]string{
 	"ED25519": "EdDSA", // elliptic curve 25519
 }
 
-func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires time.Time) (string, error) {
+func createJWT(db GormTxn, identity *models.Identity, groups []string, expires time.Time) (string, error) {
 	settings, err := GetSettings(db)
 	if err != nil {
 		return "", err
@@ -63,7 +62,7 @@ func createJWT(db *gorm.DB, identity *models.Identity, groups []string, expires 
 	return raw, nil
 }
 
-func CreateIdentityToken(db *gorm.DB, identityID uid.ID) (token *models.Token, err error) {
+func CreateIdentityToken(db GormTxn, identityID uid.ID) (token *models.Token, err error) {
 	identity, err := GetIdentity(db, ByID(identityID))
 	if err != nil {
 		return nil, err

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
@@ -103,7 +102,7 @@ func responseBodyAPIErrorWithCode(code int32) func(t *testing.T, resp *httptest.
 	}
 }
 
-func createAccessKey(t *testing.T, db *gorm.DB, email string) (string, *models.Identity) {
+func createAccessKey(t *testing.T, db data.GormTxn, email string) (string, *models.Identity) {
 	t.Helper()
 	user := &models.Identity{Name: email}
 	err := data.CreateIdentity(db, user)

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -18,7 +17,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func createIdentities(t *testing.T, db *gorm.DB, identities ...*models.Identity) {
+func createIdentities(t *testing.T, db data.GormTxn, identities ...*models.Identity) {
 	t.Helper()
 	for i := range identities {
 		err := data.CreateIdentity(db, identities[i])
@@ -26,7 +25,7 @@ func createIdentities(t *testing.T, db *gorm.DB, identities ...*models.Identity)
 	}
 }
 
-func createGroups(t *testing.T, db *gorm.DB, groups ...*models.Group) {
+func createGroups(t *testing.T, db data.GormTxn, groups ...*models.Group) {
 	t.Helper()
 	for i := range groups {
 		err := data.CreateGroup(db, groups[i])

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	gocmp "github.com/google/go-cmp/cmp"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/generate"
@@ -59,7 +58,7 @@ func withSupportAdminGrant(_ *testing.T, opts *Options) {
 	})
 }
 
-func createAdmin(t *testing.T, db *gorm.DB) *models.Identity {
+func createAdmin(t *testing.T, db data.GormTxn) *models.Identity {
 	user := &models.Identity{
 		Name: "admin+" + generate.MathRandom(10, generate.CharsetAlphaNumeric),
 	}
@@ -76,7 +75,7 @@ func createAdmin(t *testing.T, db *gorm.DB) *models.Identity {
 	return user
 }
 
-func loginAs(db *gorm.DB, user *models.Identity) *gin.Context {
+func loginAs(db data.GormTxn, user *models.Identity) *gin.Context {
 	ctx, _ := gin.CreateTestContext(nil)
 	ctx.Set("db", db)
 	ctx.Set("identity", user)

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -3,7 +3,6 @@ package server
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
@@ -11,11 +10,11 @@ import (
 	"github.com/infrahq/infra/metrics"
 )
 
-func setupMetrics(db *gorm.DB) *prometheus.Registry {
+func setupMetrics(db data.GormTxn) *prometheus.Registry {
 	registry := metrics.NewRegistry(productVersion())
 
-	if rawDB, err := db.DB(); err == nil {
-		registry.MustRegister(collectors.NewDBStatsCollector(rawDB, db.Dialector.Name()))
+	if sqlDB, err := db.GormDB().DB(); err == nil {
+		registry.MustRegister(collectors.NewDBStatsCollector(sqlDB, db.DriverName()))
 	}
 
 	registry.MustRegister(metrics.NewCollector(prometheus.Opts{

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 
@@ -17,7 +16,7 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	run := func(db *gorm.DB, s string) []byte {
+	run := func(db data.GormTxn, s string) []byte {
 		patchProductVersion(t, "9.9.9")
 		registry := setupMetrics(db)
 
@@ -36,14 +35,14 @@ func TestMetrics(t *testing.T) {
 	}
 
 	t.Run("build info", func(t *testing.T) {
-		db := setupDB(t).DB
+		db := setupDB(t)
 		actual := run(db, `build_info({.*})? \d+`)
 		expected := `build_info{branch="main",commit="",date="",version="9.9.9"} 1`
 		assert.Equal(t, string(actual), expected)
 	})
 
 	t.Run("infra users", func(t *testing.T) {
-		db := setupDB(t).DB
+		db := setupDB(t)
 
 		assert.NilError(t, data.CreateIdentity(db, &models.Identity{Name: "1"}))
 		assert.NilError(t, data.CreateIdentity(db, &models.Identity{Name: "2"}))
@@ -54,7 +53,7 @@ func TestMetrics(t *testing.T) {
 	})
 
 	t.Run("infra groups", func(t *testing.T) {
-		db := setupDB(t).DB
+		db := setupDB(t)
 
 		assert.NilError(t, data.CreateGroup(db, &models.Group{Name: "heroes"}))
 		assert.NilError(t, data.CreateGroup(db, &models.Group{Name: "villains"}))
@@ -64,14 +63,14 @@ func TestMetrics(t *testing.T) {
 	})
 
 	t.Run("infra grants", func(t *testing.T) {
-		db := setupDB(t).DB
+		db := setupDB(t)
 
 		actual := run(db, `infra_grants({.*})? \d+`)
 		golden.Assert(t, string(actual), t.Name())
 	})
 
 	t.Run("infra providers", func(t *testing.T) {
-		db := setupDB(t).DB
+		db := setupDB(t)
 
 		assert.NilError(t, data.CreateProvider(db, &models.Provider{Name: "oidc", Kind: "oidc"}))
 		assert.NilError(t, data.CreateProvider(db, &models.Provider{Name: "okta", Kind: "okta"}))
@@ -84,7 +83,7 @@ func TestMetrics(t *testing.T) {
 	})
 
 	t.Run("infra destinations", func(t *testing.T) {
-		db := setupDB(t).DB
+		db := setupDB(t)
 
 		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "1", UniqueID: "1", LastSeenAt: time.Now()}))
 		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "2", UniqueID: "2", Version: "", LastSeenAt: time.Now().Add(-10 * time.Minute)}))

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -196,7 +196,7 @@ func orgRequired() gin.HandlerFunc {
 }
 
 // requireAccessKey checks the bearer token is present and valid
-func requireAccessKey(c *gin.Context, db *gorm.DB, srv *Server) (access.Authenticated, error) {
+func requireAccessKey(c *gin.Context, db data.GormTxn, srv *Server) (access.Authenticated, error) {
 	var u access.Authenticated
 
 	bearer, err := reqBearerToken(c, srv.options.BaseDomain)
@@ -225,7 +225,7 @@ func requireAccessKey(c *gin.Context, db *gorm.DB, srv *Server) (access.Authenti
 	}
 
 	// now that the org is loaded scope all db calls to that org
-	db.Statement.Context = data.WithOrg(db.Statement.Context, org)
+	db = data.NewTransaction(db.GormDB(), org.ID)
 
 	identity, err := data.GetIdentity(db, data.ByID(accessKey.IssuedFor))
 	if err != nil {
@@ -263,7 +263,7 @@ func getRequestContext(c *gin.Context) access.RequestContext {
 	return rCtx
 }
 
-func getOrgFromRequest(req *http.Request, tx *gorm.DB) (*models.Organization, error) {
+func getOrgFromRequest(req *http.Request, tx data.GormTxn) (*models.Organization, error) {
 	host := req.Host
 
 	logging.Debugf("Host: %s", host)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -73,7 +73,9 @@ func handleInfraDestinationHeader(c *gin.Context) error {
 // possibly also of the destination.
 func authenticatedMiddleware(srv *Server) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		withDBTxn(c.Request.Context(), srv.DB(), func(tx *gorm.DB) {
+		withDBTxn(c.Request.Context(), srv.DB().GormDB(), func(db *gorm.DB) {
+
+			tx := data.NewTransaction(db, 0)
 			authned, err := requireAccessKey(c, tx, srv)
 			if err != nil {
 				sendAPIError(c, err)
@@ -86,9 +88,7 @@ func authenticatedMiddleware(srv *Server) gin.HandlerFunc {
 				return
 			}
 
-			c.Request = c.Request.WithContext(data.WithOrg(c.Request.Context(), authned.Organization))
-			tx.Statement.Context = c.Request.Context() // TODO: remove with gorm
-
+			tx = data.NewTransaction(db, authned.Organization.ID)
 			rCtx := access.RequestContext{
 				Request:       c.Request,
 				DBTxn:         tx,
@@ -115,7 +115,7 @@ func authenticatedMiddleware(srv *Server) gin.HandlerFunc {
 //
 // Returns the organization from any source that is not nil, or an error if the
 // two sources do not match.
-func validateOrgMatchesRequest(req *http.Request, tx *gorm.DB, accessKeyOrg *models.Organization) (*models.Organization, error) {
+func validateOrgMatchesRequest(req *http.Request, tx data.GormTxn, accessKeyOrg *models.Organization) (*models.Organization, error) {
 	orgFromRequest, err := getOrgFromRequest(req, tx)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,8 @@ func withDBTxn(ctx context.Context, db *gorm.DB, fn func(tx *gorm.DB)) {
 
 func unauthenticatedMiddleware(srv *Server) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		withDBTxn(c.Request.Context(), srv.DB(), func(tx *gorm.DB) {
+		withDBTxn(c.Request.Context(), srv.DB().GormDB(), func(db *gorm.DB) {
+			tx := data.NewTransaction(db, 0)
 			// ignore errors, access key is not required
 			authned, _ := requireAccessKey(c, tx, srv)
 
@@ -157,6 +158,7 @@ func unauthenticatedMiddleware(srv *Server) gin.HandlerFunc {
 				sendAPIError(c, internal.ErrBadRequest)
 				return
 			}
+			authned.Organization = org
 
 			// See this diagram for more details about this request flow
 			// when an org is not specified.
@@ -167,13 +169,14 @@ func unauthenticatedMiddleware(srv *Server) gin.HandlerFunc {
 				org = srv.db.DefaultOrg
 			}
 			if org != nil {
-				c.Request = c.Request.WithContext(data.WithOrg(c.Request.Context(), org))
-				tx.Statement.Context = c.Request.Context() // TODO: remove with gorm
+				authned.Organization = org
+				tx = data.NewTransaction(db, org.ID)
 			}
 
 			rCtx := access.RequestContext{
-				Request: c.Request,
-				DBTxn:   tx,
+				Request:       c.Request,
+				DBTxn:         tx,
+				Authenticated: authned,
 			}
 			c.Set(access.RequestContextKey, rCtx)
 			// TODO: remove once everything uses RequestContext
@@ -185,9 +188,9 @@ func unauthenticatedMiddleware(srv *Server) gin.HandlerFunc {
 
 func orgRequired() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		org := data.OrgFromContext(c.Request.Context())
+		rCtx := getRequestContext(c)
 
-		if org == nil {
+		if rCtx.Authenticated.Organization == nil {
 			sendAPIError(c, internal.ErrBadRequest)
 			return
 		}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -138,7 +138,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"ValidAuthCookie": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				authentication := issueToken(t, db, "existing@infrahq.com", time.Minute*1)
 
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -162,7 +162,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"ValidSignupCookie": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				authentication := issueToken(t, db, "existing@infrahq.com", time.Minute*1)
 
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -398,6 +398,7 @@ func TestAuthenticatedMiddleware(t *testing.T) {
 		Domain: "the-factory-xyz8.infrahq.com",
 	}
 	createOrgs(t, db, otherOrg, org)
+	db = data.NewTransaction(db.GormDB(), org.ID)
 
 	user := &models.Identity{
 		Name:               "userone@example.com",
@@ -521,6 +522,7 @@ func TestUnauthenticatedMiddleware(t *testing.T) {
 		Domain: "the-factory-xyz8.infrahq.com",
 	}
 	createOrgs(t, db, otherOrg, org)
+	db = data.NewTransaction(db.GormDB(), org.ID)
 
 	provider := &models.Provider{
 		Name:               "electric",

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/opt"
 
@@ -46,7 +45,7 @@ func setupDB(t *testing.T) *data.DB {
 	return db
 }
 
-func issueToken(t *testing.T, db *gorm.DB, identityName string, sessionDuration time.Duration) string {
+func issueToken(t *testing.T, db data.GormTxn, identityName string, sessionDuration time.Duration) string {
 	user := &models.Identity{Name: identityName}
 
 	err := data.CreateIdentity(db, user)
@@ -109,10 +108,10 @@ func TestDBTimeout(t *testing.T) {
 		unauthenticatedMiddleware(srv),
 	)
 	router.GET("/", func(c *gin.Context) {
-		db, ok := c.MustGet("db").(*gorm.DB)
+		db, ok := c.MustGet("db").(data.GormTxn)
 		assert.Check(t, ok)
 		cancel()
-		err := db.Exec("select 1;").Error
+		_, err := db.Exec("select 1;")
 		assert.Error(t, err, "context canceled")
 
 		c.Status(200)
@@ -122,12 +121,12 @@ func TestDBTimeout(t *testing.T) {
 
 func TestRequireAccessKey(t *testing.T) {
 	type testCase struct {
-		setup    func(t *testing.T, db *gorm.DB) *http.Request
+		setup    func(t *testing.T, db data.GormTxn) *http.Request
 		expected func(t *testing.T, authned access.Authenticated, err error)
 	}
 	cases := map[string]testCase{
 		"AccessKeyValid": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				authentication := issueToken(t, db, "existing@infrahq.com", time.Minute*1)
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.Header.Add("Authorization", "Bearer "+authentication)
@@ -187,7 +186,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"AccessKeyExpired": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				authentication := issueToken(t, db, "existing@infrahq.com", time.Minute*-1)
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.Header.Add("Authorization", "Bearer "+authentication)
@@ -198,7 +197,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"AccessKeyInvalidKey": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				token := issueToken(t, db, "existing@infrahq.com", time.Minute*1)
 				secret := token[:models.AccessKeySecretLength]
 				authentication := fmt.Sprintf("%s.%s", uid.New().String(), secret)
@@ -211,7 +210,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"AccessKeyNoMatch": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				authentication := fmt.Sprintf("%s.%s", uid.New().String(), generate.MathRandom(models.AccessKeySecretLength, generate.CharsetAlphaNumeric))
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.Header.Add("Authorization", "Bearer "+authentication)
@@ -222,7 +221,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"AccessKeyInvalidSecret": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				token := issueToken(t, db, "existing@infrahq.com", time.Minute*1)
 				authentication := fmt.Sprintf("%s.%s", strings.Split(token, ".")[0], generate.MathRandom(models.AccessKeySecretLength, generate.CharsetAlphaNumeric))
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -234,7 +233,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"UnknownAuthenticationMethod": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				authentication, err := generate.CryptoRandom(32, generate.CharsetAlphaNumeric)
 				assert.NilError(t, err)
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -246,7 +245,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"NoAuthentication": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				// nil pointer if we don't seup the request header here
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				return r
@@ -256,7 +255,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"EmptyAuthentication": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.Header.Add("Authorization", "")
 				return r
@@ -266,7 +265,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"EmptySpaceAuthentication": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 				r.Header.Add("Authorization", " ")
 				return r
@@ -276,7 +275,7 @@ func TestRequireAccessKey(t *testing.T) {
 			},
 		},
 		"EmptyCookieAuthentication": {
-			setup: func(t *testing.T, db *gorm.DB) *http.Request {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				r := httptest.NewRequest(http.MethodGet, "/", nil)
 
 				r.AddCookie(&http.Cookie{
@@ -299,7 +298,7 @@ func TestRequireAccessKey(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			db := setupDB(t).DB
+			db := setupDB(t)
 
 			srv := &Server{
 				options: Options{

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -21,7 +21,7 @@ func createOrgs(t *testing.T, db data.GormTxn, orgs ...*models.Organization) {
 			*orgs[i] = *o
 			continue
 		}
-		err = data.CreateOrganizationAndSetContext(db, orgs[i])
+		err = data.CreateOrganization(db, orgs[i])
 		assert.NilError(t, err, orgs[i].Name)
 	}
 }

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -14,7 +13,7 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func createOrgs(t *testing.T, db *gorm.DB, orgs ...*models.Organization) {
+func createOrgs(t *testing.T, db data.GormTxn, orgs ...*models.Organization) {
 	t.Helper()
 	for i := range orgs {
 		o, err := data.GetOrganization(db, data.ByName(orgs[i].Name))
@@ -24,7 +23,6 @@ func createOrgs(t *testing.T, db *gorm.DB, orgs ...*models.Organization) {
 		}
 		err = data.CreateOrganizationAndSetContext(db, orgs[i])
 		assert.NilError(t, err, orgs[i].Name)
-		assert.DeepEqual(t, data.OrgFromContext(db.Statement.Context), orgs[i])
 	}
 }
 

--- a/internal/server/passwordreset.go
+++ b/internal/server/passwordreset.go
@@ -10,7 +10,6 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
-	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/email"
 )
 
@@ -25,7 +24,7 @@ func (a *API) RequestPasswordReset(c *gin.Context, r *api.PasswordResetRequest) 
 		return nil, err
 	}
 
-	org := data.MustGetOrgFromContext(c)
+	org := access.GetRequestContext(c).Authenticated.Organization
 
 	// send email
 	err = email.SendPasswordReset("", r.Email, email.PasswordResetData{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -166,8 +166,8 @@ func New(options Options) (*Server, error) {
 
 // DB returns an instance of a database connection pool that is used by the server.
 // It is primarily used by tests to create fixture data.
-func (s *Server) DB() *gorm.DB {
-	return s.db.DB
+func (s *Server) DB() data.GormTxn {
+	return s.db
 }
 
 func (s *Server) Run(ctx context.Context) error {
@@ -362,7 +362,7 @@ func (s *Server) getPostgresConnectionString() (string, error) {
 var dbKeyName = "dbkey"
 
 // load encrypted db key from database
-func (s *Server) loadDBKey(db *gorm.DB) error {
+func (s *Server) loadDBKey(db data.GormTxn) error {
 	provider, ok := s.keys[s.options.DBEncryptionKeyProvider]
 	if !ok {
 		return fmt.Errorf("key provider %s not configured", s.options.DBEncryptionKeyProvider)
@@ -388,7 +388,7 @@ func (s *Server) loadDBKey(db *gorm.DB) error {
 }
 
 // creates db key
-func createDBKey(db *gorm.DB, provider secrets.SymmetricKeyProvider, rootKeyId string) error {
+func createDBKey(db data.GormTxn, provider secrets.SymmetricKeyProvider, rootKeyId string) error {
 	sKey, err := provider.GenerateDataKey(rootKeyId)
 	if err != nil {
 		return err

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gopkg.in/segmentio/analytics-go.v3"
-	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
@@ -19,11 +18,11 @@ type Properties = analytics.Properties
 
 type Telemetry struct {
 	client  analytics.Client
-	db      *gorm.DB
+	db      data.GormTxn
 	infraID uid.ID
 }
 
-func NewTelemetry(db *gorm.DB, infraID uid.ID) *Telemetry {
+func NewTelemetry(db data.GormTxn, infraID uid.ID) *Telemetry {
 	return &Telemetry{
 		client:  analytics.New(internal.TelemetryWriteKey),
 		db:      db,

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -12,7 +12,6 @@ import (
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
-	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/email"
 	"github.com/infrahq/infra/internal/server/models"
 )
@@ -87,8 +86,9 @@ func (a *API) CreateUser(c *gin.Context, r *api.CreateUserRequest) (*api.CreateU
 	}
 
 	if email.IsConfigured() {
-		org := data.MustGetOrgFromContext(c)
-		currentUser := access.GetRequestContext(c).Authenticated.User
+		rCtx := access.GetRequestContext(c)
+		org := rCtx.Authenticated.Organization
+		currentUser := rCtx.Authenticated.User
 
 		// hack because we don't have names.
 		fromName := buildNameFromEmail(currentUser.Name)


### PR DESCRIPTION
## Summary

Branched from #3006, that will need to merge first.

This is a rather large PR because it was hard to split this change into smaller pieces. Introducing the interface should be the largest part of the change. After this everything should be easily broken up into much smaller changes.

This PR does the following:
* introduces a `GormTxn` interface that is accepted by all the `data` query functions
* adds methods to that interface to pass the Organization ID
* updates the middleware to set the orgID on this transaction, and all functions to read from this value.

This approach makes our code much safer, because we are no longer defaulting to the default orgID.  I'll call out some places where I had to explicitly do this in tests to prevent breaking many tests. I'll go through in a follow up to fix these places.

There are many commits, and a lot of them are very mechanism find/replace. I'll try to call out the most interesting bits with inline comments.

Related to https://github.com/infrahq/infra/issues/2415