### PR TITLE
fix: openapi doc generation command

### DIFF
--- a/internal/openapigen/main.go
+++ b/internal/openapigen/main.go
@@ -21,8 +21,6 @@ func run(args []string) error {
 	}
 	filename := args[0]
 
-	s := server.Server{}
-	routes := s.GenerateRoutes()
-
-	return server.WriteOpenAPIDocToFile(routes.OpenAPIDocument, internal.FullVersion(), filename)
+	doc := server.GenerateOpenAPIDoc()
+	return server.WriteOpenAPIDocToFile(doc, internal.FullVersion(), filename)
 }

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -13,11 +13,18 @@ import (
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/validate"
 )
+
+func GenerateOpenAPIDoc() openapi3.T {
+	srv := newServer(Options{})
+	srv.metricsRegistry = prometheus.NewRegistry()
+	return srv.GenerateRoutes().OpenAPIDocument
+}
 
 var pathIDReplacer = regexp.MustCompile(`:\w+`)
 


### PR DESCRIPTION
The metricsReigstry field is not exported, so we can't set it on the
server.

Instead expose a method that returns just the document, so that we can
call it from the command.