### PR TITLE
Migrations for RLS

### DIFF
--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -494,6 +494,23 @@ DELETE FROM settings WHERE id=24567;
 				// dropped indexes are tested by schema comparison
 			},
 		},
+		{
+			label: testCaseLine("2022-08-15T15:19"),
+			expected: func(t *testing.T, tx WriteTxn) {
+				stmt := `SELECT 1 FROM pg_roles WHERE rolname = 'infra_user'`
+				var val int
+				err := tx.QueryRow(stmt).Scan(&val)
+				assert.NilError(t, err)
+				assert.Equal(t, val, 1)
+
+			},
+		},
+		{
+			label: testCaseLine("2022-08-15T15:20"),
+			expected: func(t *testing.T, tx WriteTxn) {
+				// functions + schema changes are tested by schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -266,6 +266,10 @@ CREATE POLICY organization_policy ON identities USING ((EXISTS ( SELECT 1
    FROM identities identities_1
   WHERE (identities_1.organization_id = current_org()))));
 
+CREATE POLICY organization_policy ON password_reset_tokens USING ((EXISTS ( SELECT 1
+   FROM password_reset_tokens password_reset_tokens_1
+  WHERE (password_reset_tokens_1.organization_id = current_org()))));
+
 CREATE POLICY organization_policy ON providers USING ((EXISTS ( SELECT 1
    FROM providers providers_1
   WHERE (providers_1.organization_id = current_org()))));
@@ -273,6 +277,8 @@ CREATE POLICY organization_policy ON providers USING ((EXISTS ( SELECT 1
 CREATE POLICY organization_policy ON settings USING ((EXISTS ( SELECT 1
    FROM settings settings_1
   WHERE (settings_1.organization_id = current_org()))));
+
+ALTER TABLE password_reset_tokens ENABLE ROW LEVEL SECURITY;
 
 ALTER TABLE providers ENABLE ROW LEVEL SECURITY;
 

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -4,6 +4,10 @@
 --     go test -run TestMigrations ./internal/server/data -update
 --
 
+CREATE FUNCTION current_org() RETURNS bigint
+    LANGUAGE sql SECURITY DEFINER
+    AS $$ SELECT NULLIF(current_setting('app.current_org', TRUE), '')::BIGINT $$;
+
 CREATE TABLE access_keys (
     id bigint NOT NULL,
     created_at timestamp with time zone,
@@ -225,3 +229,51 @@ CREATE UNIQUE INDEX idx_password_reset_tokens_token ON password_reset_tokens USI
 CREATE UNIQUE INDEX idx_providers_name ON providers USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX settings_org_id ON settings USING btree (organization_id) WHERE (deleted_at IS NULL);
+
+ALTER TABLE access_keys ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE credentials ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE destinations ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE grants ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE groups ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE identities ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY organization_policy ON access_keys USING ((EXISTS ( SELECT 1
+   FROM access_keys access_keys_1
+  WHERE (access_keys_1.organization_id = current_org()))));
+
+CREATE POLICY organization_policy ON credentials USING ((EXISTS ( SELECT 1
+   FROM credentials credentials_1
+  WHERE (credentials_1.organization_id = current_org()))));
+
+CREATE POLICY organization_policy ON destinations USING ((EXISTS ( SELECT 1
+   FROM destinations destinations_1
+  WHERE (destinations_1.organization_id = current_org()))));
+
+CREATE POLICY organization_policy ON grants USING ((EXISTS ( SELECT 1
+   FROM grants grants_1
+  WHERE (grants_1.organization_id = current_org()))));
+
+CREATE POLICY organization_policy ON groups USING ((EXISTS ( SELECT 1
+   FROM groups groups_1
+  WHERE (groups_1.organization_id = current_org()))));
+
+CREATE POLICY organization_policy ON identities USING ((EXISTS ( SELECT 1
+   FROM identities identities_1
+  WHERE (identities_1.organization_id = current_org()))));
+
+CREATE POLICY organization_policy ON providers USING ((EXISTS ( SELECT 1
+   FROM providers providers_1
+  WHERE (providers_1.organization_id = current_org()))));
+
+CREATE POLICY organization_policy ON settings USING ((EXISTS ( SELECT 1
+   FROM settings settings_1
+  WHERE (settings_1.organization_id = current_org()))));
+
+ALTER TABLE providers ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE settings ENABLE ROW LEVEL SECURITY;

--- a/internal/server/data/schema/parse.go
+++ b/internal/server/data/schema/parse.go
@@ -107,6 +107,8 @@ func parseStatementLine(line string) (table, parsed string, err error) {
 	case strings.HasPrefix(line, "CREATE SEQUENCE"):
 	case strings.HasPrefix(line, "ALTER SEQUENCE"):
 	case strings.HasPrefix(line, "CREATE UNIQUE INDEX"):
+	case strings.HasPrefix(line, "CREATE FUNCTION"):
+	case strings.HasPrefix(line, "CREATE POLICY"):
 	default:
 		return "", "", fmt.Errorf("unexpected start of statement: %q", line)
 	}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -169,6 +169,11 @@ func unauthenticatedMiddleware(srv *Server) gin.HandlerFunc {
 			if org != nil {
 				c.Request = c.Request.WithContext(data.WithOrg(c.Request.Context(), org))
 				tx.Statement.Context = c.Request.Context() // TODO: remove with gorm
+				err = data.SetCurrentOrgRLS(srv.db.DB, org)
+				if err != nil {
+					logging.L.Warn().Err(err).Msg("couldn't set org for rls")
+					return
+				}
 			}
 
 			rCtx := access.RequestContext{


### PR DESCRIPTION
## Summary

This change includes the migrations for setting up RLS, and also sets the current organization in the middleware. It's not complete because it doesn't set up the unprivileged/privileged connections because we've been changing so much in the data layer.

There are also a few tests that are missing here, and some more work that needs to happen to de-privilege places in the code which should use the unprivileged connection.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

