### PR TITLE
fix(build): bad step name in ui build

### DIFF
--- a/.github/workflows/cd-containers.yaml
+++ b/.github/workflows/cd-containers.yaml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       component-name: ${{ steps.component-name.outputs.component-name }}
       container-image-name: ${{ steps.component-name.outputs.container-image-name }}
-      container-image-context: ${{ steps.component-context.outputs.container-image-context }}
+      container-image-context: ${{ steps.component-name.outputs.container-image-context }}
     steps:
       - id: component-name
         run: |


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The output references an unknown step which means the output is an empty string. TIt's a problem for the UI build because the context is not the root directory