### PR TITLE
Remove db from gin context

### DIFF
--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -12,13 +12,10 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+// TODO: replace calls to this function with GetRequestContext once the
+// data interface has stabilized.
 func getDB(c *gin.Context) data.GormTxn {
-	db, ok := c.MustGet("db").(data.GormTxn)
-	if !ok {
-		return nil
-	}
-
-	return db
+	return GetRequestContext(c).DBTxn
 }
 
 // hasAuthorization checks if a caller is the owner of a resource before checking if they have an approprite role to access it

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -37,7 +37,7 @@ func setupAccessTestContext(t *testing.T) (*gin.Context, *data.DB, *models.Provi
 	db := setupDB(t)
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Set("db", db)
+	c.Set(RequestContextKey, RequestContext{DBTxn: db})
 
 	admin := &models.Identity{Name: "admin@example.com"}
 	err := data.CreateIdentity(db, admin)
@@ -106,7 +106,7 @@ func TestUsersGroupGrant(t *testing.T) {
 	assert.NilError(t, err)
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Set("db", db)
+	c.Set(RequestContextKey, RequestContext{DBTxn: db})
 	c.Set("identity", tom)
 
 	authDB, err := RequireInfraRole(c, models.InfraAdminRole)
@@ -133,7 +133,7 @@ func TestInfraRequireInfraRole(t *testing.T) {
 		assert.NilError(t, err)
 
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Set("db", db)
+		c.Set(RequestContextKey, RequestContext{DBTxn: db})
 		c.Set("identity", testIdentity)
 
 		return c

--- a/internal/access/signup_test.go
+++ b/internal/access/signup_test.go
@@ -21,7 +21,7 @@ func TestSignup(t *testing.T) {
 		db := setupDB(t)
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Request = (&http.Request{}).WithContext(context.Background())
-		c.Set("db", db)
+		c.Set(RequestContextKey, RequestContext{DBTxn: db})
 		return c, db
 	}
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -13,6 +13,7 @@ import (
 	gocmp "github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 
+	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/ginutil"
 	"github.com/infrahq/infra/internal/server/data"
@@ -77,7 +78,7 @@ func createAdmin(t *testing.T, db data.GormTxn) *models.Identity {
 
 func loginAs(db data.GormTxn, user *models.Identity) *gin.Context {
 	ctx, _ := gin.CreateTestContext(nil)
-	ctx.Set("db", db)
+	ctx.Set(access.RequestContextKey, access.RequestContext{DBTxn: db})
 	ctx.Set("identity", user)
 	return ctx
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -98,7 +98,6 @@ func authenticatedMiddleware(srv *Server) gin.HandlerFunc {
 
 			// TODO: remove once everything uses RequestContext
 			c.Set("identity", authned.User)
-			c.Set("db", tx)
 
 			if err := handleInfraDestinationHeader(c); err != nil {
 				sendAPIError(c, err)
@@ -179,8 +178,6 @@ func unauthenticatedMiddleware(srv *Server) gin.HandlerFunc {
 				Authenticated: authned,
 			}
 			c.Set(access.RequestContextKey, rCtx)
-			// TODO: remove once everything uses RequestContext
-			c.Set("db", tx)
 			c.Next()
 		})
 	}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -108,8 +108,8 @@ func TestDBTimeout(t *testing.T) {
 		unauthenticatedMiddleware(srv),
 	)
 	router.GET("/", func(c *gin.Context) {
-		db, ok := c.MustGet("db").(data.GormTxn)
-		assert.Check(t, ok)
+		rCtx := getRequestContext(c)
+		db := rCtx.DBTxn
 		cancel()
 		_, err := db.Exec("select 1;")
 		assert.Error(t, err, "context canceled")


### PR DESCRIPTION
Related to #3008, although merging this may cause some small conflicts with that PR.

This PR removes the `gorm.DB` reference from `gin.Context`, and ensures we always get the DB from our `RequestContext`. This will make it possible for us to add metadata to a Transaction struct directly, without having to use the gorm.DB context.