### PR TITLE
Replace NewTransaction with a real db transaction

### DIFF
--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -13,7 +13,7 @@ import (
 
 // TODO: replace calls to this function with GetRequestContext once the
 // data interface has stabilized.
-func getDB(c *gin.Context) data.GormTxn {
+func getDB(c *gin.Context) *data.Transaction {
 	return GetRequestContext(c).DBTxn
 }
 

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -1,6 +1,7 @@
 package access
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http/httptest"
@@ -32,16 +33,16 @@ func setupDB(t *testing.T) *data.DB {
 	return db
 }
 
-func setupAccessTestContext(t *testing.T) (*gin.Context, *data.DB, *models.Provider) {
+func setupAccessTestContext(t *testing.T) (*gin.Context, *data.Transaction, *models.Provider) {
 	// setup db and context
 	db := setupDB(t)
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	tx := data.NewTransaction(db.GormDB(), db.DefaultOrg.ID)
+	tx := txnForTestCase(t, db)
 	c.Set(RequestContextKey, RequestContext{DBTxn: tx})
 
 	admin := &models.Identity{Name: "admin@example.com"}
-	err := data.CreateIdentity(db, admin)
+	err := data.CreateIdentity(tx, admin)
 	assert.NilError(t, err)
 
 	c.Set("identity", admin)
@@ -51,12 +52,22 @@ func setupAccessTestContext(t *testing.T) (*gin.Context, *data.DB, *models.Provi
 		Privilege: models.InfraAdminRole,
 		Resource:  ResourceInfraAPI,
 	}
-	err = data.CreateGrant(db, adminGrant)
+	err = data.CreateGrant(tx, adminGrant)
 	assert.NilError(t, err)
 
-	provider := data.InfraProvider(db)
+	provider := data.InfraProvider(tx)
 
-	return c, db, provider
+	return c, tx, provider
+}
+
+func txnForTestCase(t *testing.T, db *data.DB) *data.Transaction {
+	t.Helper()
+	tx, err := db.Begin(context.Background())
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		assert.NilError(t, tx.Rollback())
+	})
+	return tx.WithOrgID(db.DefaultOrg.ID)
 }
 
 var (
@@ -107,7 +118,7 @@ func TestUsersGroupGrant(t *testing.T) {
 	assert.NilError(t, err)
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	tx := data.NewTransaction(db.GormDB(), db.DefaultOrg.ID)
+	tx := txnForTestCase(t, db)
 	c.Set(RequestContextKey, RequestContext{DBTxn: tx})
 	c.Set("identity", tom)
 
@@ -115,7 +126,7 @@ func TestUsersGroupGrant(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotAuthorized)
 	assert.Assert(t, authDB == nil)
 
-	grant(t, db, tom, tomsGroup.PolyID(), models.InfraAdminRole, "infra")
+	grant(t, tx, tom, tomsGroup.PolyID(), models.InfraAdminRole, "infra")
 
 	authDB, err = RequireInfraRole(c, models.InfraAdminRole)
 	assert.NilError(t, err)
@@ -135,7 +146,7 @@ func TestInfraRequireInfraRole(t *testing.T) {
 		assert.NilError(t, err)
 
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		tx := data.NewTransaction(db.GormDB(), db.DefaultOrg.ID)
+		tx := txnForTestCase(t, db)
 		c.Set(RequestContextKey, RequestContext{DBTxn: tx})
 		c.Set("identity", testIdentity)
 
@@ -175,7 +186,7 @@ func TestInfraRequireInfraRole(t *testing.T) {
 	})
 }
 
-func grant(t *testing.T, db *data.DB, currentUser *models.Identity, subject uid.PolymorphicID, privilege, resource string) {
+func grant(t *testing.T, db data.GormTxn, currentUser *models.Identity, subject uid.PolymorphicID, privilege, resource string) {
 	err := data.CreateGrant(db, &models.Grant{
 		Subject:   subject,
 		Privilege: privilege,

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -37,7 +37,8 @@ func setupAccessTestContext(t *testing.T) (*gin.Context, *data.DB, *models.Provi
 	db := setupDB(t)
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Set(RequestContextKey, RequestContext{DBTxn: db})
+	tx := data.NewTransaction(db.GormDB(), db.DefaultOrg.ID)
+	c.Set(RequestContextKey, RequestContext{DBTxn: tx})
 
 	admin := &models.Identity{Name: "admin@example.com"}
 	err := data.CreateIdentity(db, admin)
@@ -106,7 +107,8 @@ func TestUsersGroupGrant(t *testing.T) {
 	assert.NilError(t, err)
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
-	c.Set(RequestContextKey, RequestContext{DBTxn: db})
+	tx := data.NewTransaction(db.GormDB(), db.DefaultOrg.ID)
+	c.Set(RequestContextKey, RequestContext{DBTxn: tx})
 	c.Set("identity", tom)
 
 	authDB, err := RequireInfraRole(c, models.InfraAdminRole)
@@ -133,7 +135,8 @@ func TestInfraRequireInfraRole(t *testing.T) {
 		assert.NilError(t, err)
 
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
-		c.Set(RequestContextKey, RequestContext{DBTxn: db})
+		tx := data.NewTransaction(db.GormDB(), db.DefaultOrg.ID)
+		c.Set(RequestContextKey, RequestContext{DBTxn: tx})
 		c.Set("identity", testIdentity)
 
 		return c

--- a/internal/access/provideruser.go
+++ b/internal/access/provideruser.go
@@ -7,17 +7,10 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
+// TODO: remove this, it should be part of creating an identity
 func CreateProviderUser(c *gin.Context, provider *models.Provider, ident *models.Identity) (*models.ProviderUser, error) {
 	// does not need authorization check, this function should only be called internally
 	db := getDB(c)
 
 	return data.CreateProviderUser(db, provider, ident)
-}
-
-// UpdateProviderUser overwrites an existing set of provider tokens
-func UpdateProviderUser(c *gin.Context, providerToken *models.ProviderUser) error {
-	// does not need authorization check, this function should only be called internally
-	db := getDB(c)
-
-	return data.UpdateProviderUser(db, providerToken)
 }

--- a/internal/access/request.go
+++ b/internal/access/request.go
@@ -13,7 +13,7 @@ const RequestContextKey = "requestContext"
 // like the authenticated user. It also provides a database transaction.
 type RequestContext struct {
 	Request       *http.Request
-	DBTxn         data.GormTxn
+	DBTxn         *data.Transaction
 	Authenticated Authenticated
 }
 

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -31,8 +31,9 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 		return nil, "", fmt.Errorf("create org on sign-up: %w", err)
 	}
 
-	db = data.NewTransaction(db.GormDB(), details.Org.ID)
+	db = db.WithOrgID(details.Org.ID)
 	rCtx.DBTxn = db
+	rCtx.Authenticated.Organization = details.Org
 	c.Set(RequestContextKey, rCtx)
 
 	identity := &models.Identity{
@@ -48,7 +49,7 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 		return nil, "", fmt.Errorf("hash password on sign-up: %w", err)
 	}
 
-	_, err = CreateProviderUser(c, InfraProvider(c), identity)
+	_, err = data.CreateProviderUser(db, data.InfraProvider(db), identity)
 	if err != nil {
 		return nil, "", fmt.Errorf("create provider user on sign-up: %w", err)
 	}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/infrahq/secrets"
 	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
@@ -606,8 +605,8 @@ func (s Server) loadConfig(config Config) error {
 	}
 
 	org := s.db.DefaultOrg
-	return s.db.Transaction(func(db *gorm.DB) error {
-		tx := data.NewTransaction(db, org.ID)
+	return withDBTxn(context.Background(), s.db, func(tx *data.Transaction) error {
+		tx = tx.WithOrgID(org.ID)
 
 		if config.DefaultOrganizationDomain != org.Domain {
 			org.Domain = config.DefaultOrganizationDomain

--- a/internal/server/cookie_test.go
+++ b/internal/server/cookie_test.go
@@ -36,7 +36,6 @@ func TestResendAuthCookie(t *testing.T) {
 	c.Request = req
 	rCtx := access.RequestContext{
 		Request: c.Request,
-		DBTxn:   nil,
 		Authenticated: access.Authenticated{
 			AccessKey: &models.AccessKey{
 				ExpiresAt: time.Now().Add(5 * time.Minute),

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -155,6 +155,14 @@ func (t *Transaction) GormDB() *gorm.DB {
 	return t.DB
 }
 
+// WithOrgID returns a copy of the Transaction with the OrganizationID set to
+// orgID.
+func (t *Transaction) WithOrgID(orgID uid.ID) *Transaction {
+	newTxn := *t
+	newTxn.orgID = orgID
+	return &newTxn
+}
+
 func NewTransaction(db *gorm.DB, orgID uid.ID) *Transaction {
 	return &Transaction{DB: db, orgID: orgID}
 }

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -78,7 +78,8 @@ func createAdmin(t *testing.T, db data.GormTxn) *models.Identity {
 
 func loginAs(db data.GormTxn, user *models.Identity) *gin.Context {
 	ctx, _ := gin.CreateTestContext(nil)
-	ctx.Set(access.RequestContextKey, access.RequestContext{DBTxn: db})
+	tx := data.NewTransaction(db.GormDB(), db.OrganizationID())
+	ctx.Set(access.RequestContextKey, access.RequestContext{DBTxn: tx})
 	ctx.Set("identity", user)
 	return ctx
 }

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -109,9 +109,8 @@ func TestDBTimeout(t *testing.T) {
 	)
 	router.GET("/", func(c *gin.Context) {
 		rCtx := getRequestContext(c)
-		db := rCtx.DBTxn
 		cancel()
-		_, err := db.Exec("select 1;")
+		_, err := rCtx.DBTxn.Exec("select 1;")
 		assert.Error(t, err, "context canceled")
 
 		c.Status(200)
@@ -344,7 +343,8 @@ func TestRequireAccessKey(t *testing.T) {
 			c, _ := gin.CreateTestContext(httptest.NewRecorder())
 			c.Request = req
 
-			authned, err := requireAccessKey(c, db, srv)
+			tx := data.NewTransaction(db.GormDB(), 0)
+			authned, err := requireAccessKey(c, tx, srv)
 			tc.expected(t, authned, err)
 		})
 	}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -343,7 +343,7 @@ func TestRequireAccessKey(t *testing.T) {
 			c, _ := gin.CreateTestContext(httptest.NewRecorder())
 			c.Request = req
 
-			tx := data.NewTransaction(db.GormDB(), 0)
+			tx := txnForTestCase(t, db)
 			authned, err := requireAccessKey(c, tx, srv)
 			tc.expected(t, authned, err)
 		})
@@ -420,7 +420,6 @@ func TestHandleInfraDestinationHeader(t *testing.T) {
 
 func TestAuthenticatedMiddleware(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
-	db := srv.DB()
 	routes := srv.GenerateRoutes()
 
 	org := &models.Organization{
@@ -431,24 +430,29 @@ func TestAuthenticatedMiddleware(t *testing.T) {
 		Name:   "The Factory",
 		Domain: "the-factory-xyz8.infrahq.com",
 	}
-	createOrgs(t, db, otherOrg, org)
-	db = data.NewTransaction(db.GormDB(), org.ID)
+	createOrgs(t, srv.db, otherOrg, org)
+
+	tx, err := srv.db.Begin(context.Background())
+	assert.NilError(t, err)
+	tx = tx.WithOrgID(org.ID)
 
 	user := &models.Identity{
 		Name:               "userone@example.com",
 		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 	}
-	createIdentities(t, db, user)
+	createIdentities(t, tx, user)
 
 	token := &models.AccessKey{
 		IssuedFor:          user.ID,
-		ProviderID:         data.InfraProvider(db).ID,
+		ProviderID:         data.InfraProvider(tx).ID,
 		ExpiresAt:          time.Now().Add(10 * time.Second),
 		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 	}
 
-	key, err := data.CreateAccessKey(db, token)
+	key, err := data.CreateAccessKey(tx, token)
 	assert.NilError(t, err)
+
+	assert.NilError(t, tx.Commit())
 
 	httpSrv := httptest.NewServer(routes)
 	t.Cleanup(httpSrv.Close)
@@ -544,7 +548,6 @@ func TestAuthenticatedMiddleware(t *testing.T) {
 func TestUnauthenticatedMiddleware(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	srv.options.EnableSignup = true // multi-tenant environment
-	db := srv.DB()
 	routes := srv.GenerateRoutes()
 
 	org := &models.Organization{
@@ -555,31 +558,36 @@ func TestUnauthenticatedMiddleware(t *testing.T) {
 		Name:   "The Factory",
 		Domain: "the-factory-xyz8.infrahq.com",
 	}
-	createOrgs(t, db, otherOrg, org)
-	db = data.NewTransaction(db.GormDB(), org.ID)
+	createOrgs(t, srv.db, otherOrg, org)
+
+	tx, err := srv.db.Begin(context.Background())
+	assert.NilError(t, err)
+	tx = tx.WithOrgID(org.ID)
 
 	provider := &models.Provider{
 		Name:               "electric",
 		Kind:               models.ProviderKindGoogle,
 		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 	}
-	assert.NilError(t, data.CreateProvider(db, provider))
+	assert.NilError(t, data.CreateProvider(tx, provider))
 
 	user := &models.Identity{
 		Name:               "userone@example.com",
 		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 	}
-	createIdentities(t, db, user)
+	createIdentities(t, tx, user)
 
 	token := &models.AccessKey{
 		IssuedFor:          user.ID,
-		ProviderID:         data.InfraProvider(db).ID,
+		ProviderID:         data.InfraProvider(tx).ID,
 		ExpiresAt:          time.Now().Add(10 * time.Second),
 		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 	}
 
-	key, err := data.CreateAccessKey(db, token)
+	key, err := data.CreateAccessKey(tx, token)
 	assert.NilError(t, err)
+
+	assert.NilError(t, tx.Commit())
 
 	httpSrv := httptest.NewServer(routes)
 	t.Cleanup(httpSrv.Close)

--- a/internal/server/tokens_test.go
+++ b/internal/server/tokens_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +10,6 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/server/providers"
@@ -151,20 +149,7 @@ func TestAPI_CreateToken(t *testing.T) {
 				assert.NilError(t, err)
 
 				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{})
-				rCtx := access.RequestContext{
-					Request: req,
-					DBTxn:   srv.DB(),
-					Authenticated: access.Authenticated{
-						AccessKey: key,
-						User:      user,
-					},
-				}
-
-				// nolint: staticcheck
-				ctx = context.WithValue(ctx, access.RequestContextKey, rCtx)
-
 				*req = *req.WithContext(ctx)
-
 				req.Header.Set("Authorization", "Bearer "+accessKey)
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -203,20 +188,7 @@ func TestAPI_CreateToken(t *testing.T) {
 				assert.NilError(t, err)
 
 				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{UserInfoRevoked: true})
-				rCtx := access.RequestContext{
-					Request: req,
-					DBTxn:   srv.DB(),
-					Authenticated: access.Authenticated{
-						AccessKey: key,
-						User:      user,
-					},
-				}
-
-				// nolint: staticcheck
-				ctx = context.WithValue(ctx, access.RequestContextKey, rCtx)
-
 				*req = *req.WithContext(ctx)
-
 				req.Header.Set("Authorization", "Bearer "+accessKey)
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -573,7 +573,7 @@ func TestAPI_CreateUser(t *testing.T) {
 // Note this test is the result of a long conversation, don't change lightly.
 func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 	srv := &Server{db: setupDB(t)}
-	db := srv.DB()
+	db := txnForTestCase(t, srv.db)
 
 	a := &API{server: srv}
 	admin := createAdmin(t, db)


### PR DESCRIPTION
## Summary

The `data.NewTransaction` constructor is a bit misleading because it does not actually start a transaction. Instead it wraps a `gorm.DB` with our wrapper that implements the stdlib interface.

This PR removes the `NewTransaction` constructor and replaces it with two things:
* a `Transaction.WithOrgID` method for setting the OrgID metadata in the transaction
* a `DB.Begin` method for creating a new transaction.

This changes brings us much closer to the interface provided by the stdlib.

Also remove a couple places we were creating a `RequestContext` unnecessarily in tests.