### PR TITLE
Replace delete and insert access key functions with sql

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -49,7 +49,7 @@ func DeleteAccessKey(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "access key", "delete", models.InfraAdminRole)
 	}
 
-	return data.DeleteAccessKeys(db, data.ByID(id))
+	return data.DeleteAccessKey(db, id)
 }
 
 func DeleteRequestAccessKey(c RequestContext) error {

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -49,10 +49,12 @@ func DeleteAccessKey(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "access key", "delete", models.InfraAdminRole)
 	}
 
-	return data.DeleteAccessKey(db, id)
+	return data.DeleteAccessKeys(db, data.DeleteAccessKeysOptions{ByID: id})
 }
 
 func DeleteRequestAccessKey(c RequestContext) error {
 	// does not need authorization check, this action is limited to the calling key
-	return data.DeleteAccessKey(c.DBTxn, c.Authenticated.AccessKey.ID)
+
+	id := c.Authenticated.AccessKey.ID
+	return data.DeleteAccessKeys(c.DBTxn, data.DeleteAccessKeysOptions{ByID: id})
 }

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -79,7 +79,7 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "user", "delete", models.InfraAdminRole)
 	}
 
-	if err := data.DeleteAccessKeys(db, data.DeleteAccessKeysOptions{ByUserID: id}); err != nil {
+	if err := data.DeleteAccessKeys(db, data.DeleteAccessKeysOptions{ByIssuedForID: id}); err != nil {
 		return fmt.Errorf("delete identity access keys: %w", err)
 	}
 
@@ -179,7 +179,7 @@ func UpdateIdentityInfoFromProvider(c RequestContext, oidc providers.OIDCClient)
 			return err
 		}
 
-		if nestedErr := data.DeleteAccessKeys(db, data.DeleteAccessKeysOptions{ByUserID: identity.ID}); nestedErr != nil {
+		if nestedErr := data.DeleteAccessKeys(db, data.DeleteAccessKeysOptions{ByIssuedForID: identity.ID}); nestedErr != nil {
 			logging.Errorf("failed to revoke invalid user session: %s", nestedErr)
 		}
 

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -79,7 +79,7 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "user", "delete", models.InfraAdminRole)
 	}
 
-	if err := data.DeleteAccessKeys(db, data.ByIssuedFor(id)); err != nil {
+	if err := data.DeleteAccessKeys(db, data.DeleteAccessKeysOptions{ByUserID: id}); err != nil {
 		return fmt.Errorf("delete identity access keys: %w", err)
 	}
 
@@ -179,7 +179,7 @@ func UpdateIdentityInfoFromProvider(c RequestContext, oidc providers.OIDCClient)
 			return err
 		}
 
-		if nestedErr := data.DeleteAccessKeys(db, data.ByIssuedFor(identity.ID)); nestedErr != nil {
+		if nestedErr := data.DeleteAccessKeys(db, data.DeleteAccessKeysOptions{ByUserID: identity.ID}); nestedErr != nil {
 			logging.Errorf("failed to revoke invalid user session: %s", nestedErr)
 		}
 

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -129,11 +129,9 @@ func GetAccessKey(tx GormTxn, selectors ...SelectorFunc) (*models.AccessKey, err
 	return result, nil
 }
 
-func DeleteAccessKey(db GormTxn, id uid.ID) error {
-	return delete[models.AccessKey](db, id)
-}
-
 type DeleteAccessKeysOptions struct {
+	// ByID instructs DeleteAccessKeys to delete the key with this ID.
+	ByID uid.ID
 	// ByUserID instructs DeleteAccessKeys to delete keys issued for this user.
 	ByUserID uid.ID
 	// ByProviderID instructs DeleteAccessKeys to delete keys issued by this
@@ -145,6 +143,8 @@ func DeleteAccessKeys(tx WriteTxn, opts DeleteAccessKeysOptions) error {
 	query := Query("UPDATE access_keys")
 	query.B("SET deleted_at = ? WHERE", time.Now())
 	switch {
+	case opts.ByID != 0:
+		query.B("id = ?", opts.ByID)
 	case opts.ByUserID != 0:
 		query.B("issued_for = ?", opts.ByUserID)
 	case opts.ByProviderID != 0:

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -132,8 +132,8 @@ func GetAccessKey(tx GormTxn, selectors ...SelectorFunc) (*models.AccessKey, err
 type DeleteAccessKeysOptions struct {
 	// ByID instructs DeleteAccessKeys to delete the key with this ID.
 	ByID uid.ID
-	// ByUserID instructs DeleteAccessKeys to delete keys issued for this user.
-	ByUserID uid.ID
+	// ByIssuedForID instructs DeleteAccessKeys to delete keys issued for this user.
+	ByIssuedForID uid.ID
 	// ByProviderID instructs DeleteAccessKeys to delete keys issued by this
 	// provider.
 	ByProviderID uid.ID
@@ -145,8 +145,8 @@ func DeleteAccessKeys(tx WriteTxn, opts DeleteAccessKeysOptions) error {
 	switch {
 	case opts.ByID != 0:
 		query.B("id = ?", opts.ByID)
-	case opts.ByUserID != 0:
-		query.B("issued_for = ?", opts.ByUserID)
+	case opts.ByIssuedForID != 0:
+		query.B("issued_for = ?", opts.ByIssuedForID)
 	case opts.ByProviderID != 0:
 		query.B("provider_id = ?", opts.ByProviderID)
 	default:

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -17,6 +17,24 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+type accessKeyTable models.AccessKey
+
+func (a accessKeyTable) Table() string {
+	return "access_keys"
+}
+
+func (a accessKeyTable) Columns() []string {
+	return []string{"created_at", "deleted_at", "expires_at", "extension", "extension_deadline", "id", "issued_for", "key_id", "name", "provider_id", "scopes", "secret_checksum", "updated_at"}
+}
+
+func (a accessKeyTable) Values() []any {
+	return []any{a.CreatedAt, a.DeletedAt, a.ExpiresAt, a.Extension, a.ExtensionDeadline, a.ID, a.IssuedFor, a.KeyID, a.Name, a.ProviderID, a.Scopes, a.SecretChecksum, a.UpdatedAt}
+}
+
+func (a *accessKeyTable) ScanFields() []any {
+	return []any{&a.CreatedAt, &a.DeletedAt, &a.ExpiresAt, &a.Extension, &a.ExtensionDeadline, &a.ID, &a.IssuedFor, &a.KeyID, &a.Name, &a.ProviderID, &a.Scopes, &a.SecretChecksum, &a.UpdatedAt}
+}
+
 var (
 	ErrAccessKeyExpired          = fmt.Errorf("access key expired")
 	ErrAccessKeyDeadlineExceeded = fmt.Errorf("%w: extension deadline exceeded", ErrAccessKeyExpired)

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -23,15 +23,15 @@ func (a accessKeyTable) Table() string {
 }
 
 func (a accessKeyTable) Columns() []string {
-	return []string{"created_at", "deleted_at", "expires_at", "extension", "extension_deadline", "id", "issued_for", "key_id", "name", "provider_id", "scopes", "secret_checksum", "updated_at"}
+	return []string{"created_at", "deleted_at", "expires_at", "extension", "extension_deadline", "id", "issued_for", "key_id", "name", "organization_id", "provider_id", "scopes", "secret_checksum", "updated_at"}
 }
 
 func (a accessKeyTable) Values() []any {
-	return []any{a.CreatedAt, a.DeletedAt, a.ExpiresAt, a.Extension, a.ExtensionDeadline, a.ID, a.IssuedFor, a.KeyID, a.Name, a.ProviderID, a.Scopes, a.SecretChecksum, a.UpdatedAt}
+	return []any{a.CreatedAt, a.DeletedAt, a.ExpiresAt, a.Extension, a.ExtensionDeadline, a.ID, a.IssuedFor, a.KeyID, a.Name, a.OrganizationID, a.ProviderID, a.Scopes, a.SecretChecksum, a.UpdatedAt}
 }
 
 func (a *accessKeyTable) ScanFields() []any {
-	return []any{&a.CreatedAt, &a.DeletedAt, &a.ExpiresAt, &a.Extension, &a.ExtensionDeadline, &a.ID, &a.IssuedFor, &a.KeyID, &a.Name, &a.ProviderID, &a.Scopes, &a.SecretChecksum, &a.UpdatedAt}
+	return []any{&a.CreatedAt, &a.DeletedAt, &a.ExpiresAt, &a.Extension, &a.ExtensionDeadline, &a.ID, &a.IssuedFor, &a.KeyID, &a.Name, &a.OrganizationID, &a.ProviderID, &a.Scopes, &a.SecretChecksum, &a.UpdatedAt}
 }
 
 var (
@@ -152,6 +152,7 @@ func DeleteAccessKeys(tx WriteTxn, opts DeleteAccessKeysOptions) error {
 	default:
 		return fmt.Errorf("DeleteAccessKeys requires an ID to delete")
 	}
+	query.B("AND organization_id = ?", tx.OrganizationID())
 
 	_, err := tx.Exec(query.String(), query.Args...)
 	return err

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ssoroka/slice"
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
@@ -134,17 +133,28 @@ func DeleteAccessKey(db GormTxn, id uid.ID) error {
 	return delete[models.AccessKey](db, id)
 }
 
-func DeleteAccessKeys(db GormTxn, selectors ...SelectorFunc) error {
-	toDelete, err := list[models.AccessKey](db, nil, selectors...)
-	if err != nil {
-		return err
+type DeleteAccessKeysOptions struct {
+	// ByUserID instructs DeleteAccessKeys to delete keys issued for this user.
+	ByUserID uid.ID
+	// ByProviderID instructs DeleteAccessKeys to delete keys issued by this
+	// provider.
+	ByProviderID uid.ID
+}
+
+func DeleteAccessKeys(tx WriteTxn, opts DeleteAccessKeysOptions) error {
+	query := Query("UPDATE access_keys")
+	query.B("SET deleted_at = ? WHERE", time.Now())
+	switch {
+	case opts.ByUserID != 0:
+		query.B("issued_for = ?", opts.ByUserID)
+	case opts.ByProviderID != 0:
+		query.B("provider_id = ?", opts.ByProviderID)
+	default:
+		return fmt.Errorf("DeleteAccessKeys requires an ID to delete")
 	}
 
-	ids := slice.Map[models.AccessKey, uid.ID](toDelete, func(k models.AccessKey) uid.ID {
-		return k.ID
-	})
-
-	return deleteAll[models.AccessKey](db, ByIDs(ids))
+	_, err := tx.Exec(query.String(), query.Args...)
+	return err
 }
 
 func ValidateAccessKey(tx GormTxn, authnKey string) (*models.AccessKey, error) {

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -94,7 +94,7 @@ func CreateAccessKey(db GormTxn, accessKey *models.AccessKey) (body string, err 
 		accessKey.Name = fmt.Sprintf("%s-%s", identityIssuedFor.Name, accessKey.ID.String())
 	}
 
-	if err := add(db, accessKey); err != nil {
+	if err := insert(db, (*accessKeyTable)(accessKey)); err != nil {
 		return "", err
 	}
 

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -201,7 +201,7 @@ func TestDeleteAccessKeys(t *testing.T) {
 			toKeep := &models.AccessKey{IssuedFor: otherUser.ID, ProviderID: otherProvider.ID}
 			createAccessKeys(t, tx, key1, key2, toKeep)
 
-			err := DeleteAccessKeys(tx, DeleteAccessKeysOptions{ByUserID: user.ID})
+			err := DeleteAccessKeys(tx, DeleteAccessKeysOptions{ByIssuedForID: user.ID})
 			assert.NilError(t, err)
 
 			remaining, err := ListAccessKeys(tx, nil)

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -11,10 +11,9 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/opt"
 
-	"github.com/infrahq/infra/uid"
-
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func TestCreateAccessKey(t *testing.T) {
@@ -186,11 +185,77 @@ func TestDeleteAccessKey(t *testing.T) {
 
 		_, err = GetAccessKey(db, ByID(token.ID))
 		assert.Error(t, err, "record not found")
-
-		err = DeleteAccessKeys(db, ByID(token.ID))
-		assert.NilError(t, err)
 	})
 }
+
+func TestDeleteAccessKeys(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		provider := &models.Provider{Name: "azure", Kind: models.ProviderKindAzure}
+		otherProvider := &models.Provider{Name: "other", Kind: models.ProviderKindGoogle}
+		createProviders(t, db, provider, otherProvider)
+
+		user := &models.Identity{Name: "main@example.com"}
+		otherUser := &models.Identity{Name: "other@example.com"}
+		createIdentities(t, db, user, otherUser)
+
+		t.Run("empty options", func(t *testing.T) {
+			err := DeleteAccessKeys(db, DeleteAccessKeysOptions{})
+			assert.ErrorContains(t, err, "requires an ID to delete")
+		})
+
+		t.Run("by user id", func(t *testing.T) {
+			tx := txnForTestCase(t, db)
+			key1 := &models.AccessKey{IssuedFor: user.ID, ProviderID: provider.ID}
+			key2 := &models.AccessKey{IssuedFor: user.ID, ProviderID: otherProvider.ID}
+			toKeep := &models.AccessKey{IssuedFor: otherUser.ID, ProviderID: otherProvider.ID}
+			createAccessKeys(t, tx, key1, key2, toKeep)
+
+			err := DeleteAccessKeys(tx, DeleteAccessKeysOptions{ByUserID: user.ID})
+			assert.NilError(t, err)
+
+			remaining, err := ListAccessKeys(tx, nil)
+			assert.NilError(t, err)
+			expected := []models.AccessKey{
+				{Model: models.Model{ID: toKeep.ID}},
+			}
+			assert.DeepEqual(t, remaining, expected, cmpModelByID)
+		})
+
+		t.Run("by provider id", func(t *testing.T) {
+			tx := txnForTestCase(t, db)
+			key1 := &models.AccessKey{IssuedFor: user.ID, ProviderID: provider.ID}
+			key2 := &models.AccessKey{IssuedFor: otherUser.ID, ProviderID: provider.ID}
+			toKeep := &models.AccessKey{IssuedFor: user.ID, ProviderID: otherProvider.ID}
+			createAccessKeys(t, tx, key1, key2, toKeep)
+
+			err := DeleteAccessKeys(tx, DeleteAccessKeysOptions{ByProviderID: provider.ID})
+			assert.NilError(t, err)
+
+			remaining, err := ListAccessKeys(tx, nil)
+			assert.NilError(t, err)
+			expected := []models.AccessKey{
+				{Model: models.Model{ID: toKeep.ID}},
+			}
+			assert.DeepEqual(t, remaining, expected, cmpModelByID)
+		})
+	})
+}
+
+func createAccessKeys(t *testing.T, db GormTxn, keys ...*models.AccessKey) {
+	t.Helper()
+	for i := range keys {
+		_, err := CreateAccessKey(db, keys[i])
+		assert.NilError(t, err)
+	}
+}
+
+type primaryKeyable interface {
+	Primary() uid.ID
+}
+
+var cmpModelByID = cmp.Comparer(func(x, y primaryKeyable) bool {
+	return x.Primary() == y.Primary()
+})
 
 func TestCheckAccessKeyExpired(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
@@ -252,11 +317,11 @@ func TestListAccessKeys(t *testing.T) {
 
 		keys, err := ListAccessKeys(db, nil, ByNotExpiredOrExtended())
 		assert.NilError(t, err)
-		assert.Assert(t, len(keys) == 1)
+		assert.Equal(t, len(keys), 1)
 
 		keys, err = ListAccessKeys(db, nil)
 		assert.NilError(t, err)
-		assert.Assert(t, len(keys) == 3)
+		assert.Equal(t, len(keys), 3)
 	})
 }
 

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -6,7 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/opt"
+
+	"github.com/infrahq/infra/uid"
 
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/models"
@@ -19,46 +24,69 @@ func TestCreateAccessKey(t *testing.T) {
 		err := CreateIdentity(db, jerry)
 		assert.NilError(t, err)
 
-		t.Run("no key id set", func(t *testing.T) {
+		infraProviderID := InfraProvider(db).ID
+
+		t.Run("all default values", func(t *testing.T) {
 			key := &models.AccessKey{
 				IssuedFor:  jerry.ID,
-				ProviderID: InfraProvider(db).ID,
+				ProviderID: infraProviderID,
 			}
-			_, err := CreateAccessKey(db, key)
+			pair, err := CreateAccessKey(db, key)
 			assert.NilError(t, err)
-			assert.Assert(t, key.KeyID != "")
+
+			expected := &models.AccessKey{
+				Model: models.Model{
+					ID:        uid.ID(12345),
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				IssuedFor:      jerry.ID,
+				ProviderID:     infraProviderID,
+				KeyID:          "<any-string>",
+				Secret:         "<any-string>",
+				ExpiresAt:      time.Now().Add(12 * time.Hour),
+				Name:           fmt.Sprintf("%s-%s", jerry.Name, key.ID.String()),
+				SecretChecksum: secretChecksum(key.Secret),
+			}
+			assert.DeepEqual(t, key, expected, cmpAccessKey)
+			assert.Equal(t, pair, key.KeyID+"."+key.Secret)
+
+			// check that we can fetch the same value from the db
+			fromDB, err := GetAccessKey(db, ByID(key.ID))
+			assert.NilError(t, err)
+
+			// fromDB should not have the secret value
+			key.Secret = ""
+			assert.DeepEqual(t, fromDB, key, cmpopts.EquateEmpty(), cmpTimeWithDBPrecision)
 		})
 
-		t.Run("no key secret set", func(t *testing.T) {
+		t.Run("all values", func(t *testing.T) {
 			key := &models.AccessKey{
-				IssuedFor:  jerry.ID,
-				ProviderID: InfraProvider(db).ID,
+				Model: models.Model{
+					ID:        uid.ID(512512),
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				Name:              "the-key",
+				IssuedFor:         jerry.ID,
+				ProviderID:        infraProviderID,
+				ExpiresAt:         time.Now().Add(time.Hour),
+				Extension:         3 * time.Hour,
+				ExtensionDeadline: time.Now().Add(time.Minute),
+				KeyID:             "0123456789",
+				Secret:            "012345678901234567890123",
+				Scopes:            []string{"first", "third"},
 			}
-			_, err := CreateAccessKey(db, key)
+			pair, err := CreateAccessKey(db, key)
 			assert.NilError(t, err)
-			assert.Assert(t, key.Secret != "")
-		})
+			assert.Equal(t, pair, key.KeyID+"."+key.Secret)
 
-		t.Run("no expiry set", func(t *testing.T) {
-			key := &models.AccessKey{
-				IssuedFor:  jerry.ID,
-				ProviderID: InfraProvider(db).ID,
-			}
-			_, err := CreateAccessKey(db, key)
+			// check that we can fetch the same value from the db
+			fromDB, err := GetAccessKey(db, ByID(key.ID))
 			assert.NilError(t, err)
-			assert.Assert(t, !key.ExpiresAt.IsZero())
-		})
-
-		t.Run("no name set", func(t *testing.T) {
-			key := &models.AccessKey{
-				IssuedFor:  jerry.ID,
-				ProviderID: InfraProvider(db).ID,
-			}
-			_, err := CreateAccessKey(db, key)
-			assert.NilError(t, err)
-
-			expected := fmt.Sprintf("%s-%s", jerry.Name, key.ID.String())
-			assert.Equal(t, key.Name, expected)
+			// fromDB should not have the secret value
+			key.Secret = ""
+			assert.DeepEqual(t, fromDB, key, cmpTimeWithDBPrecision)
 		})
 
 		t.Run("invalid specified key id length", func(t *testing.T) {
@@ -82,6 +110,36 @@ func TestCreateAccessKey(t *testing.T) {
 		})
 	})
 }
+
+var cmpModel = cmp.Options{
+	cmp.FilterPath(opt.PathField(models.Model{}, "ID"), anyValidUID),
+	cmp.FilterPath(opt.PathField(models.Model{}, "CreatedAt"), opt.TimeWithThreshold(2*time.Second)),
+	cmp.FilterPath(opt.PathField(models.Model{}, "UpdatedAt"), opt.TimeWithThreshold(2*time.Second)),
+}
+
+var cmpAccessKey = cmp.Options{
+	cmpModel,
+	cmp.FilterPath(opt.PathField(models.AccessKey{}, "KeyID"), nonZeroString),
+	cmp.FilterPath(opt.PathField(models.AccessKey{}, "Secret"), nonZeroString),
+	cmp.FilterPath(opt.PathField(models.AccessKey{}, "ExpiresAt"), opt.TimeWithThreshold(time.Second)),
+}
+
+var nonZeroString = cmp.Comparer(func(x, y string) bool {
+	if x == "" || y == "" {
+		return false
+	}
+	if x == "<any-string>" || y == "<any-string>" {
+		return true
+	}
+	return false
+})
+
+var anyValidUID = cmp.Comparer(func(x, y uid.ID) bool {
+	return x > 0 && y > 0
+})
+
+// PostgreSQL only has microsecond precision
+var cmpTimeWithDBPrecision = cmpopts.EquateApproxTime(time.Microsecond)
 
 func createAccessKeyWithExtensionDeadline(t *testing.T, db GormTxn, ttl, extensionDeadline time.Duration) (string, *models.AccessKey) {
 	identity := &models.Identity{Name: "Wall-E"}

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -28,6 +28,14 @@ func setupDB(t *testing.T, driver gorm.Dialector) *DB {
 	return db
 }
 
+func txnForTestCase(t *testing.T, db *DB) *Transaction {
+	t.Helper()
+	tx, err := db.Begin(context.Background())
+	assert.NilError(t, err)
+	t.Cleanup(func() { tx.Rollback() })
+	return tx.WithOrgID(db.DefaultOrg.ID)
+}
+
 // runDBTests against all supported databases.
 // Set POSTGRESQL_CONNECTION to a postgresql connection string to run tests
 // against postgresql.

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -28,12 +28,14 @@ func setupDB(t *testing.T, driver gorm.Dialector) *DB {
 	return db
 }
 
-func txnForTestCase(t *testing.T, db *DB) *Transaction {
+func txnForTestCase(t *testing.T, db *DB, orgID uid.ID) *Transaction {
 	t.Helper()
 	tx, err := db.Begin(context.Background())
 	assert.NilError(t, err)
-	t.Cleanup(func() { tx.Rollback() })
-	return tx.WithOrgID(db.DefaultOrg.ID)
+	t.Cleanup(func() {
+		_ = tx.Rollback()
+	})
+	return tx.WithOrgID(orgID)
 }
 
 // runDBTests against all supported databases.

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -2,16 +2,11 @@ package data
 
 import (
 	"testing"
-	"time"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/models"
 )
-
-// PostgreSQL only has microsecond precision
-var cmpTimeWithDBPrecision = cmpopts.EquateApproxTime(time.Microsecond)
 
 func TestCreateOrganization(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -83,7 +83,7 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 			return fmt.Errorf("delete provider users: %w", err)
 		}
 
-		if err := DeleteAccessKeys(db, ByProviderID(p.ID)); err != nil {
+		if err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByProviderID: p.ID}); err != nil {
 			return fmt.Errorf("delete access keys: %w", err)
 		}
 	}

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -77,6 +77,7 @@ func insert(tx WriteTxn, item Insertable) error {
 	if err := item.OnInsert(); err != nil {
 		return err
 	}
+	setOrg(tx, item)
 
 	query := Query("INSERT INTO")
 	query.B(item.Table())

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -3,8 +3,6 @@ package data
 import (
 	"strings"
 
-	"gorm.io/gorm"
-
 	"github.com/infrahq/infra/uid"
 )
 
@@ -36,14 +34,6 @@ func (q *queryBuilder) B(clause string, args ...interface{}) {
 // WriteTxn.Exec, or ReadTxn.Query. You must also pass q.Args as the varargs.
 func (q *queryBuilder) String() string {
 	return q.query.String()
-}
-
-type WriteTxn interface {
-	Exec(query string, args ...any) *gorm.DB
-}
-
-type ReadTxn interface {
-	Raw(query string, args ...any) *gorm.DB
 }
 
 type Table interface {
@@ -95,7 +85,7 @@ func insert(tx WriteTxn, item Insertable) error {
 	query.B(") VALUES (")
 	query.B(placeholderForColumns(item.Columns()), item.Values()...)
 	query.B(");")
-	err := tx.Exec(query.String(), query.Args...).Error
+	_, err := tx.Exec(query.String(), query.Args...)
 	return err
 }
 
@@ -120,7 +110,7 @@ func update(tx WriteTxn, item Updatable) error {
 	query.B("SET")
 	query.B(columnsForUpdate(item.Columns()), item.Values()...)
 	query.B("WHERE id = ?;", item.Primary())
-	err := tx.Exec(query.String(), query.Args...).Error
+	_, err := tx.Exec(query.String(), query.Args...)
 	return err
 }
 

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -1,0 +1,118 @@
+package data
+
+import (
+	"strings"
+
+	"gorm.io/gorm"
+
+	"github.com/infrahq/infra/uid"
+)
+
+type queryBuilder struct {
+	query strings.Builder
+	Args  []interface{}
+}
+
+// Query initializes a queryBuilder and returns it populated with stmt.
+// The stmt string can generally contain any SELECT, FROM, or JOIN
+// clauses, and may contain the entire query as long as there are no
+// query parameters.
+// Use queryBuilder.B to add sections of a query with parameters.
+func Query(stmt string) *queryBuilder {
+	q := &queryBuilder{}
+	q.query.WriteString(stmt + " ")
+	return q
+}
+
+// B adds clause and args to the query. The clause must be a trusted string
+// literal. Any arguments must be passed as args so that they are properly
+// escaped by the database driver.
+func (q *queryBuilder) B(clause string, args ...interface{}) {
+	q.query.WriteString(clause + " ")
+	q.Args = append(q.Args, args...)
+}
+
+// String returns the query string, which is used as the first parameter to
+// WriteTxn.Exec, or ReadTxn.Query. You must also pass q.Args as the varargs.
+func (q *queryBuilder) String() string {
+	return q.query.String()
+}
+
+type WriteTxn interface {
+	Exec(query string, args ...any) *gorm.DB
+}
+
+type ReadTxn interface {
+	Raw(query string, args ...any) *gorm.DB
+}
+
+type Table interface {
+	Table() string
+	// Columns returns the names of the tables columns.
+	Columns() []string
+}
+
+type Insertable interface {
+	Table
+	// Values returns the values for all fields. The values must be in the same
+	// order as the column names returned by Columns.
+	Values() []any
+}
+
+type Updatable interface {
+	Insertable
+	// Primary returns the value for the field that is mapped to the primary key
+	// of the table.
+	Primary() uid.ID
+}
+
+type Deletable interface {
+	Table() string
+	Primary() uid.ID
+}
+
+type Selectable interface {
+	Table
+	// ScanFields returns pointers to all the fields, which should be used in
+	// sql.Rows.Scan. The fields must be in the same order as the column names
+	// returned by Columns.
+	ScanFields() []any
+}
+
+func insert(tx WriteTxn, item Insertable) error {
+	query := Query("INSERT INTO")
+	query.B(item.Table())
+	query.B("(")
+	query.B(columnsForInsert(item.Columns()))
+	query.B(") VALUES (")
+	query.B(placeholderForColumns(item.Columns()), item.Values()...)
+	query.B(");")
+	err := tx.Exec(query.String(), query.Args...).Error
+	return err
+}
+
+func columnsForInsert(columns []string) string {
+	return strings.Join(columns, ", ")
+}
+
+func placeholderForColumns(columns []string) string {
+	result := make([]string, len(columns))
+	for i := range columns {
+		result[i] = "?"
+	}
+	return strings.Join(result, ", ")
+}
+
+func update(tx WriteTxn, item Updatable) error {
+	query := Query("UPDATE")
+	query.B(item.Table())
+	query.B("SET")
+	query.B(columnsForUpdate(item.Columns()), item.Values()...)
+	query.B("WHERE id = ?;", item.Primary())
+	err := tx.Exec(query.String(), query.Args...).Error
+	return err
+}
+
+func columnsForUpdate(columns []string) string {
+	return strings.Join(columns, " = ?, ") + " = ?"
+}

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -106,6 +106,8 @@ func update(tx WriteTxn, item Updatable) error {
 	if err := item.OnUpdate(); err != nil {
 		return err
 	}
+	setOrg(tx, item)
+
 	query := Query("UPDATE")
 	query.B(item.Table())
 	query.B("SET")

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -57,6 +57,8 @@ type Insertable interface {
 	// Values returns the values for all fields. The values must be in the same
 	// order as the column names returned by Columns.
 	Values() []any
+	// OnInsert is called by insert to initialize values before inserting.
+	OnInsert() error
 }
 
 type Updatable interface {
@@ -64,6 +66,8 @@ type Updatable interface {
 	// Primary returns the value for the field that is mapped to the primary key
 	// of the table.
 	Primary() uid.ID
+	// OnUpdate is called by update to initialize values before updating.
+	OnUpdate() error
 }
 
 type Deletable interface {
@@ -80,6 +84,10 @@ type Selectable interface {
 }
 
 func insert(tx WriteTxn, item Insertable) error {
+	if err := item.OnInsert(); err != nil {
+		return err
+	}
+
 	query := Query("INSERT INTO")
 	query.B(item.Table())
 	query.B("(")
@@ -104,6 +112,9 @@ func placeholderForColumns(columns []string) string {
 }
 
 func update(tx WriteTxn, item Updatable) error {
+	if err := item.OnUpdate(); err != nil {
+		return err
+	}
 	query := Query("UPDATE")
 	query.B(item.Table())
 	query.B("SET")

--- a/internal/server/data/query_test.go
+++ b/internal/server/data/query_test.go
@@ -1,0 +1,65 @@
+package data
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/uid"
+)
+
+type example struct {
+	ID    uid.ID
+	First string
+	Age   int
+}
+
+func (e example) Primary() uid.ID {
+	return e.ID
+}
+
+func (e example) Table() string {
+	return "examples"
+}
+
+func (e example) Columns() []string {
+	return []string{"id", "first", "age"}
+}
+
+func (e example) Values() []any {
+	return []any{e.ID, e.First, e.Age}
+}
+
+func TestInsert(t *testing.T) {
+	e := example{ID: 123, First: "first", Age: 111}
+	tx := &txnCapture{}
+	err := insert(tx, e)
+	assert.NilError(t, err)
+	expected := `INSERT INTO examples ( id, first, age ) VALUES ( ?, ?, ? ); `
+	assert.Equal(t, tx.query, expected)
+	expectedArgs := []any{uid.ID(123), "first", 111}
+	assert.DeepEqual(t, tx.args, expectedArgs)
+}
+
+type txnCapture struct {
+	query string
+	args  []any
+}
+
+func (t *txnCapture) Exec(query string, args ...any) *gorm.DB {
+	t.query = query
+	t.args = args
+	return &gorm.DB{}
+}
+
+func TestUpdate(t *testing.T) {
+	e := example{ID: 123, First: "first", Age: 111}
+	tx := &txnCapture{}
+	err := update(tx, e)
+	assert.NilError(t, err)
+	expected := `UPDATE examples SET id = ?, first = ?, age = ? WHERE id = ?; `
+	assert.Equal(t, tx.query, expected)
+	expectedArgs := []any{uid.ID(123), "first", 111, uid.ID(123)}
+	assert.DeepEqual(t, tx.args, expectedArgs)
+}

--- a/internal/server/data/query_test.go
+++ b/internal/server/data/query_test.go
@@ -31,6 +31,14 @@ func (e example) Values() []any {
 	return []any{e.ID, e.First, e.Age}
 }
 
+func (e example) OnInsert() error {
+	return nil
+}
+
+func (e example) OnUpdate() error {
+	return nil
+}
+
 func TestInsert(t *testing.T) {
 	e := example{ID: 123, First: "first", Age: 111}
 	tx := &txnCapture{}

--- a/internal/server/data/query_test.go
+++ b/internal/server/data/query_test.go
@@ -1,9 +1,9 @@
 package data
 
 import (
+	"database/sql"
 	"testing"
 
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/uid"
@@ -51,14 +51,15 @@ func TestInsert(t *testing.T) {
 }
 
 type txnCapture struct {
+	ReadTxn
 	query string
 	args  []any
 }
 
-func (t *txnCapture) Exec(query string, args ...any) *gorm.DB {
+func (t *txnCapture) Exec(query string, args ...any) (sql.Result, error) {
 	t.query = query
 	t.args = args
-	return &gorm.DB{}
+	return nil, nil
 }
 
 func TestUpdate(t *testing.T) {

--- a/internal/server/data/settings_test.go
+++ b/internal/server/data/settings_test.go
@@ -2,14 +2,10 @@ package data
 
 import (
 	"testing"
-	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/opt"
 
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/uid"
 )
 
 func TestInitializeSettings(t *testing.T) {
@@ -32,16 +28,6 @@ func TestInitializeSettings(t *testing.T) {
 		})
 	})
 }
-
-var cmpModel = cmp.Options{
-	cmp.FilterPath(opt.PathField(models.Model{}, "ID"), anyValidUID),
-	cmp.FilterPath(opt.PathField(models.Model{}, "CreatedAt"), opt.TimeWithThreshold(2*time.Second)),
-	cmp.FilterPath(opt.PathField(models.Model{}, "UpdatedAt"), opt.TimeWithThreshold(2*time.Second)),
-}
-
-var anyValidUID = cmp.Comparer(func(x, y uid.ID) bool {
-	return x > 0 && y > 0
-})
 
 func runStep(t *testing.T, name string, fn func(t *testing.T)) {
 	if !t.Run(name, fn) {

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -21,7 +21,7 @@ type AccessKey struct {
 	Name string `gorm:"uniqueIndex:idx_access_keys_name,where:deleted_at is NULL"`
 	// IssuedFor is the ID of the user that this access key was created for
 	IssuedFor         uid.ID
-	IssuedForIdentity *Identity `gorm:"foreignKey:IssuedFor"`
+	IssuedForIdentity *Identity `gorm:"foreignKey:IssuedFor" db:"-"`
 	ProviderID        uid.ID
 
 	ExpiresAt         time.Time
@@ -29,7 +29,7 @@ type AccessKey struct {
 	ExtensionDeadline time.Time
 
 	KeyID          string `gorm:"<-;uniqueIndex:idx_access_keys_key_id,where:deleted_at is NULL"`
-	Secret         string `gorm:"-"`
+	Secret         string `gorm:"-" db:"-"`
 	SecretChecksum []byte
 
 	Scopes CommaSeparatedStrings // if set, scopes limit what the key can be used for

--- a/internal/server/models/model.go
+++ b/internal/server/models/model.go
@@ -39,3 +39,7 @@ func (m *Model) BeforeCreate(_ *gorm.DB) error {
 
 	return nil
 }
+
+func (m Model) Primary() uid.ID {
+	return m.ID
+}

--- a/internal/server/models/model.go
+++ b/internal/server/models/model.go
@@ -43,3 +43,19 @@ func (m *Model) BeforeCreate(_ *gorm.DB) error {
 func (m Model) Primary() uid.ID {
 	return m.ID
 }
+
+func (m *Model) OnInsert() error {
+	if m.ID == 0 {
+		m.ID = uid.New()
+	}
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = time.Now()
+	}
+	m.UpdatedAt = m.CreatedAt
+	return nil
+}
+
+func (m *Model) OnUpdate() error {
+	m.UpdatedAt = time.Now()
+	return nil
+}


### PR DESCRIPTION
## Summary

Related to #2415, this PR adds the building blocks for creating regular sql queries, and replaces insert and delete access keys with regular sql queries.