### PR TITLE
demo: alternative to the access package

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -199,7 +199,7 @@ func can(t *testing.T, db *data.DB, subject string, privilege string) {
 	assert.NilError(t, err)
 	rCtx := RequestContext{DBTxn: txnForTestCase(t, db)}
 	rCtx.Authenticated.User = &models.Identity{Model: models.Model{ID: id}}
-	err = IsAuthorized(rCtx, privilege)
+	_, err = IsAuthorized(rCtx, privilege)
 	assert.NilError(t, err)
 }
 
@@ -208,7 +208,7 @@ func cant(t *testing.T, db *data.DB, subject string, privilege string) {
 	assert.NilError(t, err)
 	rCtx := RequestContext{DBTxn: txnForTestCase(t, db)}
 	rCtx.Authenticated.User = &models.Identity{Model: models.Model{ID: id}}
-	err = IsAuthorized(rCtx, privilege)
+	_, err = IsAuthorized(rCtx, privilege)
 	assert.ErrorIs(t, err, ErrNotAuthorized)
 }
 

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -57,7 +57,7 @@ func UpdateCredential(c *gin.Context, user *models.Identity, oldPassword, newPas
 
 	// anyone can update their own credentials, so check authorization when not self
 	if !isSelf {
-		err := IsAuthorized(rCtx, models.InfraAdminRole)
+		_, err := IsAuthorized(rCtx, models.InfraAdminRole)
 		if err != nil {
 			return HandleAuthErr(err, "user", "update", models.InfraAdminRole)
 		}

--- a/internal/access/destination.go
+++ b/internal/access/destination.go
@@ -20,7 +20,7 @@ func CreateDestination(c *gin.Context, destination *models.Destination) error {
 
 func SaveDestination(rCtx RequestContext, destination *models.Destination) error {
 	roles := []string{models.InfraAdminRole, models.InfraConnectorRole}
-	if err := IsAuthorized(rCtx, roles...); err != nil {
+	if _, err := IsAuthorized(rCtx, roles...); err != nil {
 		return HandleAuthErr(err, "destination", "update", roles...)
 	}
 

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -25,7 +25,7 @@ func GetIdentity(c *gin.Context, id uid.ID) (*models.Identity, error) {
 	// anyone can get their own user data
 	if !isIdentitySelf(rCtx, id) {
 		roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
-		err := IsAuthorized(rCtx, roles...)
+		_, err := IsAuthorized(rCtx, roles...)
 		if err != nil {
 			return nil, HandleAuthErr(err, "user", "get", roles...)
 		}

--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -32,7 +32,7 @@ func GetOrganization(c *gin.Context, id uid.ID) (*models.Organization, error) {
 		// request is authorized because the user is a member of the org
 	} else {
 		roles := []string{models.InfraSupportAdminRole}
-		err := IsAuthorized(rCtx, roles...)
+		_, err := IsAuthorized(rCtx, roles...)
 		if err != nil {
 			return nil, HandleAuthErr(err, "organizations", "get", roles...)
 		}

--- a/internal/access/request.go
+++ b/internal/access/request.go
@@ -3,6 +3,7 @@ package access
 import (
 	"net/http"
 
+	"github.com/infrahq/infra/internal/server/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
@@ -20,6 +21,8 @@ type RequestContext struct {
 	// start transactions. Most routes should use DBTxn and should not use
 	// DataDB directly.
 	DataDB *data.DB
+
+	Permissions access.PermissionSet
 }
 
 // Authenticated stores data about the authenticated user. If the AccessKey or

--- a/internal/server/access/permissions.go
+++ b/internal/server/access/permissions.go
@@ -98,7 +98,7 @@ func (p PermissionSet) Allows(access Access) error {
 	return nil
 }
 
-var RolePermissions = map[string]PermissionSet{
+var rolePermissions = map[string]PermissionSet{
 	RoleView: toSet(
 		perm(ResourceAccessKeys, OperationRead),
 		perm(ResourceGrants, OperationRead),
@@ -136,4 +136,14 @@ var RolePermissions = map[string]PermissionSet{
 		perm(ResourceOrganizations, OperationWrite),
 		perm(ResourceSystem, OperationRead),
 	),
+}
+
+func PermissionsForRoles(roles ...string) PermissionSet {
+	result := make(PermissionSet, len(roles)*3) // every role has at least 3 permissions
+	for _, role := range roles {
+		for key, v := range rolePermissions[role] {
+			result[key] = v
+		}
+	}
+	return result
 }

--- a/internal/server/access/permissions.go
+++ b/internal/server/access/permissions.go
@@ -1,0 +1,137 @@
+package access
+
+import "fmt"
+
+type Role string
+
+const (
+	RoleSupportAdmin = "support-admin"
+	RoleAdmin        = "admin"
+	RoleView         = "view"
+	RoleConnector    = "connector"
+)
+
+type Resource int
+
+const (
+	ResourceSystem        Resource = 0
+	ResourceGrants        Resource = 1
+	ResourceProviders     Resource = 2
+	ResourceOrganizations Resource = 3
+	ResourceDestinations  Resource = 4
+	ResourceUsers         Resource = 5
+	ResourceGroups        Resource = 6
+	ResourceAccessKeys    Resource = 7
+	ResourceCredentials   Resource = 8
+	ResourceSettings      Resource = 9
+)
+
+func (r Resource) String() string {
+	switch r {
+	case ResourceSystem:
+		return "system"
+	case ResourceGrants:
+		return "grants"
+	case ResourceProviders:
+		return "providers"
+	case ResourceOrganizations:
+		return "organizations"
+	case ResourceDestinations:
+		return "destinations"
+	case ResourceUsers:
+		return "users"
+	case ResourceGroups:
+		return "groups"
+	case ResourceAccessKeys:
+		return "access keys"
+	case ResourceCredentials:
+		return "credentials"
+	default:
+		return ""
+	}
+}
+
+type Operation int
+
+const (
+	OperationRead  Operation = 0
+	OperationWrite Operation = 1
+)
+
+func (p Operation) String() string {
+	switch p {
+	case OperationRead:
+		return "read"
+	case OperationWrite:
+		return "write"
+	default:
+		return ""
+	}
+}
+
+type Access struct {
+	Resource  Resource
+	Operation Operation
+}
+
+func perm(r Resource, o Operation) Access {
+	return Access{Resource: r, Operation: o}
+}
+
+type PermissionSet map[Access]struct{}
+
+func toSet(access ...Access) PermissionSet {
+	result := make(PermissionSet, len(access))
+	for _, a := range access {
+		result[a] = struct{}{}
+	}
+	return result
+}
+
+func (p PermissionSet) Allows(access Access) error {
+	if _, ok := p[access]; !ok {
+		return fmt.Errorf("missing permission to %v the %v resource",
+			access.Operation, access.Resource)
+	}
+	return nil
+}
+
+var RolePermissions = map[string]PermissionSet{
+	RoleView: toSet(
+		perm(ResourceAccessKeys, OperationRead),
+		perm(ResourceGrants, OperationRead),
+		perm(ResourceGroups, OperationRead),
+		perm(ResourceUsers, OperationRead),
+	),
+
+	RoleAdmin: toSet(
+		perm(ResourceAccessKeys, OperationRead),
+		perm(ResourceAccessKeys, OperationWrite),
+		perm(ResourceCredentials, OperationWrite),
+		perm(ResourceDestinations, OperationRead),
+		perm(ResourceDestinations, OperationWrite),
+		perm(ResourceGrants, OperationRead),
+		perm(ResourceGrants, OperationWrite),
+		perm(ResourceGroups, OperationRead),
+		perm(ResourceGroups, OperationWrite),
+		perm(ResourceUsers, OperationRead),
+		perm(ResourceUsers, OperationWrite),
+		perm(ResourceProviders, OperationRead),
+		perm(ResourceProviders, OperationWrite),
+		perm(ResourceSettings, OperationWrite),
+	),
+
+	RoleConnector: toSet(
+		perm(ResourceDestinations, OperationRead),
+		perm(ResourceDestinations, OperationWrite),
+		perm(ResourceGrants, OperationRead),
+		perm(ResourceUsers, OperationRead),
+		perm(ResourceGroups, OperationRead),
+	),
+
+	RoleSupportAdmin: toSet(
+		perm(ResourceOrganizations, OperationRead),
+		perm(ResourceOrganizations, OperationWrite),
+		perm(ResourceSystem, OperationRead),
+	),
+}

--- a/internal/server/access/permissions.go
+++ b/internal/server/access/permissions.go
@@ -46,6 +46,8 @@ func (r Resource) String() string {
 		return "access keys"
 	case ResourceCredentials:
 		return "credentials"
+	case ResourceSettings:
+		return "settings"
 	default:
 		return ""
 	}

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/access"
 	"github.com/infrahq/infra/internal/server/data/migrator"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -80,6 +81,8 @@ func NewDB(dbOpts NewDBOptions) (*DB, error) {
 // and settings.
 type DB struct {
 	*gorm.DB // embedded for now to minimize the diff
+
+	access.PermissionSet
 
 	DefaultOrg *models.Organization
 	// DefaultOrgSettings are the settings for DefaultOrg
@@ -149,6 +152,7 @@ type GormTxn interface {
 
 type Transaction struct {
 	*gorm.DB
+	access.PermissionSet
 	orgID     uid.ID
 	completed *atomic.Bool
 }

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -152,9 +152,13 @@ type GormTxn interface {
 
 type Transaction struct {
 	*gorm.DB
-	access.PermissionSet
+	PermissionSet
 	orgID     uid.ID
 	completed *atomic.Bool
+}
+
+type PermissionSet interface {
+	Allows(access.Access, any) error
 }
 
 func (t *Transaction) DriverName() string {

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -42,9 +42,9 @@ func (g *grantsTable) ScanFields() []any {
 var grantWrite = access.Access{Resource: access.ResourceGrants, Operation: access.OperationWrite}
 
 func CreateGrant(tx WriteTxn, grant *models.Grant) error {
-	if err := tx.Allows(grantWrite); err != nil {
-		return err
-	}
+	// if err := tx.Allows(grantWrite); err != nil {
+	//	return err
+	//}
 
 	switch {
 	case grant.Subject == "":

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -15,6 +15,7 @@ import (
 	pgxstdlib "github.com/jackc/pgx/v4/stdlib"
 
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/access"
 	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -38,7 +39,13 @@ func (g *grantsTable) ScanFields() []any {
 	return []any{&g.CreatedAt, &g.CreatedBy, &g.DeletedAt, &g.ID, &g.OrganizationID, &g.Privilege, &g.Resource, &g.Subject, &g.UpdatedAt}
 }
 
+var grantWrite = access.Access{Resource: access.ResourceGrants, Operation: access.OperationWrite}
+
 func CreateGrant(tx WriteTxn, grant *models.Grant) error {
+	if err := tx.Allows(grantWrite); err != nil {
+		return err
+	}
+
 	switch {
 	case grant.Subject == "":
 		return fmt.Errorf("subject is required")

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -17,7 +17,7 @@ type ReadTxn interface {
 
 	OrganizationID() uid.ID
 
-	Allows(access.Access) error
+	Allows(access.Access, any) error
 }
 
 // WriteTxn extends ReadTxn by adding write queries.

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/infrahq/infra/internal/server/access"
 	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/uid"
 )
@@ -15,6 +16,8 @@ type ReadTxn interface {
 	QueryRow(query string, args ...any) *sql.Row
 
 	OrganizationID() uid.ID
+
+	Allows(access.Access) error
 }
 
 // WriteTxn extends ReadTxn by adding write queries.

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -2,14 +2,15 @@ package models
 
 import (
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/server/access"
 	"github.com/infrahq/infra/uid"
 )
 
 const (
-	InfraSupportAdminRole = "support-admin"
-	InfraAdminRole        = "admin"
-	InfraViewRole         = "view"
-	InfraConnectorRole    = "connector"
+	InfraSupportAdminRole = access.RoleSupportAdmin
+	InfraAdminRole        = access.RoleAdmin
+	InfraViewRole         = access.RoleView
+	InfraConnectorRole    = access.RoleConnector
 )
 
 // BasePermissionConnect is the first-principle permission that all other permissions are defined from.

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -251,11 +251,14 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 		}
 		c.Set(access.RequestContextKey, rCtx)
 
-		perms, err := route.authorization(rCtx, req)
-		if err != nil {
-			return err
+		// TODO: make this required
+		if route.authorization != nil {
+			perms, err := route.authorization(rCtx, req)
+			if err != nil {
+				return err
+			}
+			rCtx.Permissions = perms
 		}
-		rCtx.Permissions = perms
 
 		resp, err := route.handler(c, req)
 		if err != nil {


### PR DESCRIPTION
Update: many of the changes from the original draft were merged as part of #3103

This PR is a demonstration / proof-of-concept, that shows a different approach to our API authorization. I am **not** looking to merge this any time soon. I am opening this to demonstrate an approach that I've mentioned a few times in a number of discussions. This PR should only act as a demonstration of the possible approach. It will need more work before it's anywhere close to mergeable.

By moving authorization checks to be immediately after authn in the request flow can allow us to remove the `access` package without losing the benefits that the `access` package is supposed to provide.  By checking permissions at the data layer (where the operation is actually being performed) we end up with better safeguards than the `access` package can provide, while also fixing the problems we have now (misleading error message, and unnecessary application layers that cause confusion and slow us down).