### PR TITLE
maintain: log real client IP

### DIFF
--- a/internal/logging/middleware.go
+++ b/internal/logging/middleware.go
@@ -44,7 +44,7 @@ func Middleware() gin.HandlerFunc {
 			Str("method", method).
 			Str("path", c.Request.URL.Path).
 			Str("localAddr", c.Request.Host).
-			Str("remoteAddr", c.Request.RemoteAddr).
+			Str("remoteAddr", c.ClientIP()).
 			Str("userAgent", c.Request.UserAgent()).
 			Int64("contentLength", c.Request.ContentLength).
 			Logger()

--- a/internal/logging/middleware.go
+++ b/internal/logging/middleware.go
@@ -40,28 +40,29 @@ func Middleware() gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		method := c.Request.Method
-		log := L.With().
+		event := L.With().
 			Str("method", method).
 			Str("path", c.Request.URL.Path).
 			Str("localAddr", c.Request.Host).
 			Str("remoteAddr", c.ClientIP()).
-			Str("userAgent", c.Request.UserAgent()).
-			Int64("contentLength", c.Request.ContentLength).
-			Logger()
+			Str("userAgent", c.Request.UserAgent())
 
+		if c.Request.ContentLength > 0 {
+			event = event.Int64("contentLength", c.Request.ContentLength)
+		}
+
+		logger := event.Logger()
 		begin := time.Now()
 
 		c.Next()
 
 		status := c.Writer.Status()
-
 		// sample logs for successful GET request if the log level is INFO or above
 		if status < 400 && method == http.MethodGet && zerolog.GlobalLevel() >= zerolog.InfoLevel {
-			log = log.Sample(sampler.Get(c.Request.Method, c.FullPath()))
+			logger = logger.Sample(sampler.Get(c.Request.Method, c.FullPath()))
 		}
 
-		log.Info().
-			Dur("elapsed", time.Since(begin)).
+		logger.Info().Dur("elapsed", time.Since(begin)).
 			Int("statusCode", status).
 			Int("size", c.Writer.Size()).
 			Msg("")


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

When the server is behind a load balancer or ingress, the remote addr is
often an intermediate address instead of the real address. It can be
tedious to get the real address since there's multiple values to
check. Fortunately, gin has `c.ClientIP()` which does the work for us.