### PR TITLE
maintain(dev): individual image checksums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ dev:
 	helm upgrade --install --wait  \
 		--set global.image.pullPolicy=Never \
 		--set global.image.tag=dev \
-		--set global.podAnnotations.checksum=$$(docker images -q infrahq/infra:dev)$$(docker images -q infrahq/ui:dev) \
+		--set server.podAnnotations.checksum=$$(docker images -q infrahq/infra:dev) \
+		--set connector.podAnnotations.checksum=$$(docker images -q infrahq/infra:dev) \
+		--set ui.podAnnotations.checksum=$$(docker images -q infrahq/ui:dev) \
 		infra ./helm/charts/infra \
 		$(flags)
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

individually set image checksums otherwise a server change will trigger a new ui pod or vice versa. global.podAnnotations also applies to the postgres pod which incorrectly causes it to restart
