### PR TITLE
feat: add welcome signup email

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ issues:
 linters:
   enable:
     - asciicheck
-    - deadcode
     - durationcheck
     - errcheck
     - errorlint
@@ -47,10 +46,8 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - wastedassign
   disable:
     - scopelint

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2
 	github.com/pdevine/go-asciisprite v0.1.6
 	github.com/rs/zerolog v1.27.0
-	github.com/sendgrid/sendgrid-go v3.11.1+incompatible
 	github.com/spf13/pflag v1.0.5
 	github.com/ssoroka/slice v0.0.0-20220402005549-78f0cea3df8b
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
@@ -72,7 +71,6 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/sendgrid/rest v2.6.9+incompatible // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -678,10 +678,6 @@ github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIH
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 h1:ZuhckGJ10ulaKkdvJtiAqsLTiPrLaXSdnVgXJKJkTxE=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
-github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
-github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
-github.com/sendgrid/sendgrid-go v3.11.1+incompatible h1:ai0+woZ3r/+tKLQExznak5XerOFoD6S7ePO0lMV8WXo=
-github.com/sendgrid/sendgrid-go v3.11.1+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/shirou/gopsutil/v3 v3.22.7 h1:flKnuCMfUUrO+oAvwAd6GKZgnPzr098VA/UJ14nhJd4=
 github.com/shirou/gopsutil/v3 v3.22.7/go.mod h1:s648gW4IywYzUfE/KjXxUsqrqx/T2xO5VqOXxONeRfI=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -25,6 +25,8 @@ func CryptoRandom(n int, charset string) (string, error) {
 
 	bytes := make([]byte, n)
 	for i := range bytes {
+		// linter is mistaken about which package this is
+		// nolint: gosec
 		bigint, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
 		if err != nil {
 			return "", fmt.Errorf("couldn't generate random string of len %d: %w", n, err)

--- a/internal/server/email/passwordreset.go
+++ b/internal/server/email/passwordreset.go
@@ -5,7 +5,5 @@ type PasswordResetData struct {
 }
 
 func SendPasswordReset(name, address string, data PasswordResetData) error {
-	return SendTemplate(name, address, EmailTemplatePasswordReset, map[string]interface{}{
-		"link": data.Link,
-	})
+	return SendTemplate(name, address, EmailTemplatePasswordReset, data)
 }

--- a/internal/server/email/sendgrid.go
+++ b/internal/server/email/sendgrid.go
@@ -1,11 +1,11 @@
 package email
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"os"
-
-	"github.com/sendgrid/sendgrid-go"
-	"github.com/sendgrid/sendgrid-go/helpers/mail"
+	texttemplate "text/template"
 
 	"github.com/infrahq/infra/internal/logging"
 )
@@ -13,15 +13,29 @@ import (
 type EmailTemplate int8
 
 const (
-	EmailTemplateAccountCreated EmailTemplate = iota
+	EmailTemplateSignup EmailTemplate = iota
 	EmailTemplatePasswordReset
 	EmailTemplateUserInvite
 )
 
-var emailTemplateIDs = map[EmailTemplate]string{
-	EmailTemplateAccountCreated: "",
-	EmailTemplatePasswordReset:  "d-d87873d2f11b4055befbd7064cda44d6", // transactional-password-reset
-	EmailTemplateUserInvite:     "d-ac6bcb2a7f02463c8b7fc8caffc35f2d", // transactional-user-invite
+type TemplateDetail struct {
+	TemplateName string
+	Subject      string
+}
+
+var emailTemplates = map[EmailTemplate]TemplateDetail{
+	EmailTemplateSignup: {
+		TemplateName: "signup",
+		Subject:      "Welcome to Infra!",
+	},
+	EmailTemplatePasswordReset: {
+		TemplateName: "password-reset",
+		Subject:      "Password Reset",
+	},
+	EmailTemplateUserInvite: {
+		TemplateName: "user-invite",
+		Subject:      "{{.FromUserName}} has invited you to Infra",
+	},
 }
 
 var (
@@ -29,8 +43,9 @@ var (
 	FromAddress        = "noreply@infrahq.com"
 	FromName           = "Infra"
 	SendgridAPIKey     = os.Getenv("SENDGRID_API_KEY")
+	SMTPServer         = "smtp.sendgrid.net:465"
 	TestMode           = false
-	TestDataSent       = []map[string]interface{}{}
+	TestDataSent       = []any{}
 	ErrUnknownTemplate = errors.New("unknown template")
 	ErrNotConfigured   = errors.New("email sending not configured")
 )
@@ -39,7 +54,7 @@ func IsConfigured() bool {
 	return len(SendgridAPIKey) > 0
 }
 
-func SendTemplate(name, address string, template EmailTemplate, data map[string]interface{}) error {
+func SendTemplate(name, address string, template EmailTemplate, data any) error {
 	if TestMode {
 		logging.Debugf("sent email to %q: %+v\n", address, data)
 		TestDataSent = append(TestDataSent, data)
@@ -50,34 +65,49 @@ func SendTemplate(name, address string, template EmailTemplate, data map[string]
 		return ErrNotConfigured
 	}
 
-	m := mail.NewV3Mail()
-
-	m.SetFrom(mail.NewEmail(FromName, FromAddress))
-
-	templateID, ok := emailTemplateIDs[template]
-	if !ok || len(templateID) == 0 {
+	details, ok := emailTemplates[template]
+	if !ok {
 		return ErrUnknownTemplate
 	}
 
-	m.SetTemplateID(templateID)
-
-	p := mail.NewPersonalization()
-	p.AddTos([]*mail.Email{mail.NewEmail(name, address)}...)
-
-	for k, v := range data {
-		p.SetDynamicTemplateData(k, v)
+	t, err := texttemplate.New("subject").Parse(details.Subject)
+	if err != nil {
+		return fmt.Errorf("parsing subject: %w", err)
 	}
 
-	m.AddPersonalizations(p)
-
-	request := sendgrid.GetRequest(SendgridAPIKey, "/v3/mail/send", "https://api.sendgrid.com")
-	request.Method = "POST"
-	var Body = mail.GetRequestBody(m)
-	request.Body = Body
-	response, err := sendgrid.API(request)
-	if response.StatusCode != 200 {
-		logging.Debugf("sendgrid api responded with status code %d", response.StatusCode)
+	w := &bytes.Buffer{}
+	if err := t.Execute(w, data); err != nil {
+		return fmt.Errorf("rendering subject: %w", err)
 	}
-	// TODO: handle rate limiting and send retries
-	return err
+
+	msg := Message{
+		FromName:    FromName,
+		FromAddress: FromAddress,
+		ToName:      name,
+		ToAddress:   address,
+		Subject:     w.String(),
+	}
+
+	// render template with "data"
+	w.Reset()
+	err = textTemplateList.ExecuteTemplate(w, details.TemplateName+".text.plain", data)
+	if err != nil {
+		return err
+	}
+	msg.PlainBody = w.Bytes()
+
+	w = &bytes.Buffer{}
+	err = htmlTemplateList.ExecuteTemplate(w, details.TemplateName+".text.html", data)
+	if err != nil {
+		return err
+	}
+	msg.HTMLBody = w.Bytes()
+
+	// TODO: handle rate limiting, retries, understanding which errors are retryable, send queues, whatever
+	if err := SendSMTP(msg); err != nil {
+		logging.Errorf("SMTP mail delivery error: %s", err)
+		return err
+	}
+
+	return nil
 }

--- a/internal/server/email/signup.go
+++ b/internal/server/email/signup.go
@@ -1,0 +1,9 @@
+package email
+
+type SignupData struct {
+	Link string
+}
+
+func SendSignupEmail(name, address string, data SignupData) error {
+	return SendTemplate(name, address, EmailTemplateSignup, data)
+}

--- a/internal/server/email/smtp.go
+++ b/internal/server/email/smtp.go
@@ -1,0 +1,238 @@
+package email
+
+import (
+	"bufio"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Client struct {
+	*tls.Conn
+	reader *bufio.Reader
+	sync.Mutex
+	skipTLSVerify bool
+}
+
+type Message struct {
+	FromName    string
+	FromAddress string
+	ToName      string
+	ToAddress   string
+	Subject     string
+	PlainBody   []byte
+	HTMLBody    []byte
+}
+
+var client = &Client{}
+
+func (c *Client) connect() (err error) {
+	if c.Conn != nil {
+		return nil
+	}
+
+	if SendgridAPIKey == "" {
+		return fmt.Errorf("Sendgrid API key is not set")
+	}
+
+	conn, err := tls.Dial("tcp", SMTPServer, &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		MaxVersion: tls.VersionTLS13,
+		// nolint:gosec
+		InsecureSkipVerify: c.skipTLSVerify, // only used by tests
+	})
+	if err != nil {
+		return err
+	}
+
+	err = conn.SetDeadline(time.Now().Add(30 * time.Second))
+	if err != nil {
+		return fmt.Errorf("set deadline: %w", err)
+	}
+	c.Conn = conn
+
+	defer func() {
+		if err != nil {
+			c.Conn = nil
+		}
+	}()
+
+	c.reader = bufio.NewReader(c.Conn)
+	var b []byte
+	b, err = c.reader.Peek(3)
+	if err != nil {
+		return fmt.Errorf("peek: %w", err)
+	}
+	if string(b) == "220" { // 220 server ready
+		// read line and throw away
+		if _, err = c.readln(""); err != nil {
+			return err
+		}
+	}
+	if err = c.writeln("AUTH LOGIN"); err != nil {
+		return err
+	}
+	if _, err = c.readln("334 " + base64encode("Username:")); err != nil {
+		return err
+	}
+	if err = c.writeln(base64encode("apikey")); err != nil {
+		return err
+	}
+	if _, err = c.readln("334 " + base64encode("Password:")); err != nil {
+		return err
+	}
+	if err = c.writeln(base64encode(SendgridAPIKey)); err != nil {
+		return err
+	}
+	if _, err = c.readln("235 Authentication successful"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func base64encode(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+// readln reads a line of text ending in \n. if expected is empty it returns the result.
+// if expected is not empty, the read string must match or start with the expected string
+func (c *Client) readln(expected string) (result string, err error) {
+	defer func() {
+		if err != nil {
+			c.Conn = nil
+		}
+	}()
+
+	if err := c.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		return "", fmt.Errorf("set deadline: %w", err)
+	}
+
+	s, err := c.reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	s = strings.TrimRight(s, "\r\n")
+
+	if expected != "" && !strings.HasPrefix(s, expected) {
+		return s, fmt.Errorf("Unexpected value read: %q while waiting for %q", s, expected)
+	}
+
+	return s, nil
+}
+
+func (c *Client) writeln(s string) (err error) {
+	defer func() {
+		if err != nil {
+			c.Conn = nil
+		}
+	}()
+
+	s += "\r\n"
+	if err = c.SetWriteDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		return fmt.Errorf("set write deadline: %w", err)
+	}
+	written, err := c.Write([]byte(s))
+	if err != nil {
+		return fmt.Errorf("write auth login: %w", err)
+	}
+	if written != len(s) {
+		return fmt.Errorf("partial write %d bytes of %d", written, len(s))
+	}
+
+	return nil
+}
+
+// SendSMTP sends an email message
+func SendSMTP(msg Message) error {
+	client.Lock()
+	defer client.Unlock()
+
+	if err := client.connect(); err != nil {
+		return err
+	}
+
+	if err := client.writeln(fmt.Sprintf("MAIL FROM: %s", msg.FromAddress)); err != nil {
+		return fmt.Errorf("write mail from: %w", err)
+	}
+	if _, err := client.readln("250 Sender address accepted"); err != nil {
+		return err
+	}
+
+	if err := client.writeln(fmt.Sprintf("RCPT TO: %s", msg.ToAddress)); err != nil {
+		return fmt.Errorf("write rcpt to: %w", err)
+	}
+	if _, err := client.readln("250 Recipient address accepted"); err != nil {
+		return err
+	}
+
+	if err := client.writeln("DATA"); err != nil {
+		return err
+	}
+	if _, err := client.readln("354 "); err != nil {
+		return err
+	}
+
+	if len(msg.ToName) > 0 {
+		if err := client.writeln(fmt.Sprintf("To: %q <%s>", msg.ToName, msg.ToAddress)); err != nil {
+			return fmt.Errorf("write to: %w", err)
+		}
+	}
+	if len(msg.FromName) > 0 {
+		if err := client.writeln(fmt.Sprintf("From: %q <%s>", msg.FromName, msg.FromAddress)); err != nil {
+			return fmt.Errorf("write from: %w", err)
+		}
+	}
+	if len(msg.Subject) > 0 {
+		if err := client.writeln(fmt.Sprintf("Subject: %s", msg.Subject)); err != nil {
+			return fmt.Errorf("write subject: %w", err)
+		}
+	}
+
+	// mime multipart
+	if err := client.writeln("MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=c3VwYWhpbmZyYQ\r\n"); err != nil {
+		return err
+	}
+
+	// plain
+	if len(msg.PlainBody) > 0 {
+		if err := client.writeln("--c3VwYWhpbmZyYQ\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\n"); err != nil {
+			return err
+		}
+		if err := client.writeln(base64encode(string(msg.PlainBody))); err != nil {
+			return err
+		}
+	}
+
+	// html
+	if len(msg.HTMLBody) > 0 {
+		if err := client.writeln("--c3VwYWhpbmZyYQ\r\nContent-Type: text/html\r\nContent-Transfer-Encoding: base64\r\n"); err != nil {
+			return err
+		}
+		if err := client.writeln(base64encode(string(msg.HTMLBody))); err != nil {
+			return err
+		}
+	}
+
+	// end mime
+	if err := client.writeln("--c3VwYWhpbmZyYQ--\r\n"); err != nil {
+		return err
+	}
+
+	if err := client.writeln("."); err != nil {
+		return fmt.Errorf("write send line: %w", err)
+	}
+
+	result, err := client.readln("")
+	if err != nil {
+		return fmt.Errorf("reading send result: %w", err)
+	}
+	if !strings.HasPrefix(result, "250 Ok") {
+		return fmt.Errorf("expected 250 Ok result, but got %q", result)
+	}
+	return nil
+}

--- a/internal/server/email/smtp_test.go
+++ b/internal/server/email/smtp_test.go
@@ -66,7 +66,7 @@ var (
 func successCase(t *testing.T, c net.Conn) {
 	reader := bufio.NewReader(c)
 	read := func(msg string) string {
-		c.SetDeadline(time.Now().Add(5 * time.Second))
+		_ = c.SetDeadline(time.Now().Add(5 * time.Second))
 		s, err := reader.ReadString('\n')
 		assert.NilError(t, err, fmt.Sprintf("waiting for read %q", msg))
 		s = strings.TrimRight(s, "\r\n")
@@ -76,7 +76,7 @@ func successCase(t *testing.T, c net.Conn) {
 		return s
 	}
 	write := func(s string) {
-		c.SetDeadline(time.Now().Add(5 * time.Second))
+		_ = c.SetDeadline(time.Now().Add(5 * time.Second))
 		_, err := c.Write([]byte(s + "\r\n"))
 		assert.NilError(t, err, fmt.Sprintf("waiting for write %q", s))
 	}

--- a/internal/server/email/smtp_test.go
+++ b/internal/server/email/smtp_test.go
@@ -1,0 +1,181 @@
+package email
+
+import (
+	"bufio"
+	"crypto/tls"
+	"encoding/base64"
+	"net"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func setupClient(srv net.Listener) {
+	SendgridAPIKey = "api-key"
+	SMTPServer = srv.Addr().String()
+	client = &Client{skipTLSVerify: true}
+}
+
+func setupSMTPServer(t *testing.T, handler func(t *testing.T, c net.Conn)) net.Listener {
+	certPem := []byte(`-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----`)
+	keyPem := []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+-----END EC PRIVATE KEY-----`)
+	cert, err := tls.X509KeyPair(certPem, keyPem)
+	if err != nil {
+		assert.NilError(t, err)
+	}
+	cfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+	listener, err := tls.Listen("tcp", "127.0.0.1:", cfg)
+	if err != nil {
+		assert.NilError(t, err)
+	}
+	go func() {
+		// wait for one connection and then close.
+		c, err := listener.Accept()
+		assert.NilError(t, err)
+		handler(t, c)
+		c.Close()
+	}()
+	return listener
+}
+
+var (
+	to      string
+	from    string
+	subject string
+	plain   string
+	html    string
+)
+
+func successCase(t *testing.T, c net.Conn) {
+	reader := bufio.NewReader(c)
+	read := func(msg string) string {
+		s, err := reader.ReadString('\n')
+		s = strings.TrimRight(s, "\r\n")
+		assert.NilError(t, err)
+		if msg != "" {
+			assert.Equal(t, s, msg)
+		}
+		return s
+	}
+	write := func(s string) {
+		_, err := c.Write([]byte(s + "\r\n"))
+		assert.NilError(t, err)
+	}
+	write("220 server ready")
+	read("AUTH LOGIN")
+	write("334 VXNlcm5hbWU6")
+	read("YXBpa2V5")
+	write("334 UGFzc3dvcmQ6")
+	read("YXBpLWtleQ==")
+	write("235 Authentication successful")
+	assert.Assert(t, strings.HasPrefix(read(""), "MAIL FROM: "))
+	write("250 Sender address accepted")
+	assert.Assert(t, strings.HasPrefix(read(""), "RCPT TO: "))
+	write("250 Recipient address accepted")
+	read("DATA")
+	write("354 Ready")
+	for s := read(""); s != "."; s = read("") {
+		switch {
+		case strings.HasPrefix(s, "To: "):
+			to = strings.SplitN(s, ": ", 2)[1]
+		case strings.HasPrefix(s, "From: "):
+			from = strings.SplitN(s, ": ", 2)[1]
+		case strings.HasPrefix(s, "Subject: "):
+			subject = strings.SplitN(s, ": ", 2)[1]
+		case strings.HasPrefix(s, "MIME-Version: "):
+			// read until end of mime block
+			isPlain := true
+			for s = read(""); s != "--c3VwYWhpbmZyYQ--"; s = read("") {
+				switch s {
+				case "Content-Type: multipart/alternative; boundary=c3VwYWhpbmZyYQ":
+				case "--c3VwYWhpbmZyYQ":
+				case "Content-Transfer-Encoding: base64":
+				case "Content-Type: text/plain":
+					isPlain = true
+				case "Content-Type: text/html":
+					isPlain = false
+				case "--c3VwYWhpbmZyYQ--":
+					break
+				case "":
+				default:
+					b, err := base64.StdEncoding.DecodeString(s)
+					assert.NilError(t, err)
+					if isPlain {
+						plain = string(b)
+					} else {
+						html = string(b)
+					}
+				}
+			}
+			read("") // blank line at the end
+		default:
+			t.Error("unexpected message: ", s)
+		}
+	}
+	write("250 Ok")
+}
+
+func TestSendEmail(t *testing.T) {
+	srv := setupSMTPServer(t, successCase)
+	setupClient(srv)
+
+	err := SendSMTP(Message{
+		ToName:      "Steven",
+		ToAddress:   "steven@example.com",
+		FromName:    "Also Steven",
+		FromAddress: "steven@example.com",
+		Subject:     "The art of emails",
+		PlainBody:   []byte("Hello world\n.\n."),
+		HTMLBody:    []byte("<h2> HELLO WORLD <h2>"),
+	})
+	assert.NilError(t, err)
+
+	assert.Equal(t, plain, "Hello world\n.\n.")
+	assert.Equal(t, html, "<h2> HELLO WORLD <h2>")
+}
+
+func TestSendPasswordReset(t *testing.T) {
+	srv := setupSMTPServer(t, successCase)
+	setupClient(srv)
+
+	err := SendTemplate("steven", "steven@example.com", EmailTemplatePasswordReset, PasswordResetData{
+		Link: "https://example.com?himom=1",
+	})
+	assert.NilError(t, err)
+}
+
+func TestSendUserInvite(t *testing.T) {
+	srv := setupSMTPServer(t, successCase)
+	setupClient(srv)
+
+	err := SendTemplate("steven", "steven@example.com", EmailTemplateUserInvite, UserInviteData{
+		FromUserName: "joe bill",
+		Link:         "https://example.com?himom=1",
+	})
+	assert.NilError(t, err)
+}
+
+func TestSendSignup(t *testing.T) {
+	srv := setupSMTPServer(t, successCase)
+	setupClient(srv)
+
+	err := SendTemplate("steven", "steven@example.com", EmailTemplateSignup, SignupData{
+		Link: "https://supahdomain.example.com/login",
+	})
+	assert.NilError(t, err)
+}

--- a/internal/server/email/templates.go
+++ b/internal/server/email/templates.go
@@ -1,0 +1,26 @@
+package email
+
+import (
+	"embed"
+	htmltemplate "html/template"
+	texttemplate "text/template"
+)
+
+//go:embed templates/*
+var templateFiles embed.FS
+
+var textTemplateList *texttemplate.Template
+var htmlTemplateList *htmltemplate.Template
+
+func init() {
+	var err error
+	textTemplateList, err = texttemplate.ParseFS(templateFiles, "**/*.text.plain")
+	if err != nil {
+		panic("can't read text templates: " + err.Error())
+	}
+
+	htmlTemplateList, err = htmltemplate.ParseFS(templateFiles, "**/*.text.html")
+	if err != nil {
+		panic("can't read html templates: " + err.Error())
+	}
+}

--- a/internal/server/email/templates/password-reset.text.html
+++ b/internal/server/email/templates/password-reset.text.html
@@ -1,0 +1,6 @@
+
+<p>Someone has requested a password reset for your Infra account. If this was not you, you can safely ignore this email.</p>
+
+<p>
+  <a href="{{.Link}}">Click here to reset your password</a>
+</p>

--- a/internal/server/email/templates/password-reset.text.plain
+++ b/internal/server/email/templates/password-reset.text.plain
@@ -1,0 +1,4 @@
+Someone has requested a password reset for your Infra account. If this was not you, you can safely ignore this email.
+
+Click here to reset your password:
+  {{.Link}}

--- a/internal/server/email/templates/signup.text.html
+++ b/internal/server/email/templates/signup.text.html
@@ -1,0 +1,6 @@
+<h3>Welcome to Infra!</h3>
+
+<p>
+  You can sign into your account any time from 
+  <a href="{{.Link}}">{{.Link}}</a>.
+</p>

--- a/internal/server/email/templates/signup.text.plain
+++ b/internal/server/email/templates/signup.text.plain
@@ -1,0 +1,3 @@
+Welcome to Infra!
+
+You can sign into your account any time from {{.Link}}

--- a/internal/server/email/templates/user-invite.text.html
+++ b/internal/server/email/templates/user-invite.text.html
@@ -1,0 +1,7 @@
+<p>{{.FromUserName}} has invited you to Infra!</p>
+
+<p>Infra is the simplest way to manage infrastructure access.</p>
+
+<p>
+  <a href="{{.Link}}">Login to access your infrastructure</a>
+</p>

--- a/internal/server/email/templates/user-invite.text.plain
+++ b/internal/server/email/templates/user-invite.text.plain
@@ -1,0 +1,6 @@
+{{.FromUserName}} has invited you to Infra!
+
+Infra is the simplest way to manage infrastructure access.
+
+Log in to access your infrastructure:
+  {{.Link}}

--- a/internal/server/email/userinvite.go
+++ b/internal/server/email/userinvite.go
@@ -6,8 +6,5 @@ type UserInviteData struct {
 }
 
 func SendUserInvite(name, address string, data UserInviteData) error {
-	return SendTemplate(name, address, EmailTemplateUserInvite, map[string]interface{}{
-		"fromName": data.FromUserName,
-		"link":     data.Link,
-	})
+	return SendTemplate(name, address, EmailTemplateUserInvite, data)
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/authn"
+	"github.com/infrahq/infra/internal/server/email"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/server/providers"
 )
@@ -129,6 +130,14 @@ func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.SignupResponse,
 	a.t.User(identity.ID.String(), r.Name)
 	a.t.Alias(identity.ID.String())
 	a.t.Event("signup", identity.ID.String(), Properties{})
+
+	err = email.SendSignupEmail("", r.Name, email.SignupData{
+		Link: fmt.Sprintf("https://%s/login", r.Org.Subdomain),
+	})
+	if err != nil {
+		// if email failed, continue on anyway.
+		logging.L.Error().Err(err).Msg("could not send signup email")
+	}
 
 	return &api.SignupResponse{
 		User:         identity.ToAPI(),

--- a/internal/server/passwordreset_test.go
+++ b/internal/server/passwordreset_test.go
@@ -61,8 +61,10 @@ func TestPasswordResetFlow(t *testing.T) {
 	assert.Assert(t, len(tokens) > 0)
 	token := tokens[len(tokens)-1]
 
+	resetData, ok := email.TestDataSent[0].(email.PasswordResetData)
+	assert.Assert(t, ok)
 	// TODO: fix test so that we can verify the domain; default org has blank domain
-	assert.Equal(t, email.TestDataSent[0]["link"], "https:///password-reset?token="+token)
+	assert.Equal(t, resetData.Link, "https:///password-reset?token="+token)
 
 	// reset the password with the token
 	body, err = json.Marshal(&api.VerifiedResetPasswordRequest{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,6 +56,7 @@ type Options struct {
 	EmailFromAddress string
 	EmailFromName    string
 	SendgridApiKey   string
+	SMTPServer       string
 
 	BaseDomain string
 
@@ -423,5 +424,8 @@ func configureEmail(options Options) {
 	}
 	if len(options.SendgridApiKey) > 0 {
 		email.SendgridAPIKey = options.SendgridApiKey
+	}
+	if len(options.SMTPServer) > 0 {
+		email.SMTPServer = options.SMTPServer
 	}
 }


### PR DESCRIPTION
## Summary

- switches to SMTP for email delivery instead of sendgrid api
- renders email templates locally instead of depending on remote service
- switches existing emails over to new templates
- adds welcome/signup email

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

also..
Resolves #2971
