### PR TITLE
fix: new signup session priority

### DIFF
--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -185,6 +185,40 @@ func TestRequireAccessKey(t *testing.T) {
 				assert.Equal(t, actual.User.Name, "existing@infrahq.com")
 			},
 		},
+		"SignupCookieIsUsedOverAuthCookie": {
+			setup: func(t *testing.T, db data.GormTxn) *http.Request {
+				authentication := issueToken(t, db, "existing@infrahq.com", time.Minute*1)
+
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+				r.AddCookie(&http.Cookie{
+					Name:     cookieSignupName,
+					Value:    authentication,
+					MaxAge:   int(time.Until(time.Now().Add(time.Minute * 1)).Seconds()),
+					Path:     cookiePath,
+					SameSite: http.SameSiteStrictMode,
+					Secure:   true,
+					HttpOnly: true,
+				})
+
+				r.AddCookie(&http.Cookie{
+					Name:     cookieSignupName,
+					Value:    "invalid.access.key",
+					MaxAge:   int(time.Until(time.Now().Add(time.Minute * 1)).Seconds()),
+					Path:     cookiePath,
+					SameSite: http.SameSiteStrictMode,
+					Secure:   true,
+					HttpOnly: true,
+				})
+
+				r.Header.Add("Authorization", " ")
+				return r
+			},
+			expected: func(t *testing.T, actual access.Authenticated, err error) {
+				assert.NilError(t, err)
+				assert.Equal(t, actual.User.Name, "existing@infrahq.com")
+			},
+		},
 		"AccessKeyExpired": {
 			setup: func(t *testing.T, db data.GormTxn) *http.Request {
 				authentication := issueToken(t, db, "existing@infrahq.com", time.Minute*-1)


### PR DESCRIPTION
## Summary
If a user has an `auth` cookie for the base Infra domain or an old org that had the same domain it will get sent to the server along with the `signup` cookie. The `signup` cookie should take priority over this `auth` cookie since it shows that the user is clearly being redirected after creating a new org and no previous auth should exist.

## Checklist
- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
