### PR TITLE
fix(dev): force set Helm string value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ dev:
 	docker buildx build ui --load -t infrahq/ui:dev
 	kubectl config use-context docker-desktop
 	helm upgrade --install --wait  \
-		--set global.image.pullPolicy=Never \
-		--set global.image.tag=dev \
-		--set server.podAnnotations.checksum=$$(docker images -q infrahq/infra:dev) \
-		--set connector.podAnnotations.checksum=$$(docker images -q infrahq/infra:dev) \
-		--set ui.podAnnotations.checksum=$$(docker images -q infrahq/ui:dev) \
+		--set-string global.image.pullPolicy=Never \
+		--set-string global.image.tag=dev \
+		--set-string server.podAnnotations.checksum=$$(docker images -q infrahq/infra:dev) \
+		--set-string connector.podAnnotations.checksum=$$(docker images -q infrahq/infra:dev) \
+		--set-string ui.podAnnotations.checksum=$$(docker images -q infrahq/ui:dev) \
 		infra ./helm/charts/infra \
 		$(flags)
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

It's possible some values in `make dev` are interpreted by Helm as numbers rather than string which will break Helm since fields such as annotations require a string value. Use `--set-string` instead of just `--set` so the value passed to Helm will always be interpreted as a string.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3061
