### PR TITLE
feat: login redirect

### DIFF
--- a/ui/__test__/login.test.js
+++ b/ui/__test__/login.test.js
@@ -23,6 +23,14 @@ jest.mock('swr', () => {
   }
 })
 
+jest.mock('next/router', () => ({
+  useRouter() {
+    return {
+      query: {},
+    }
+  },
+}))
+
 const providers = {
   data: {
     items: [

--- a/ui/components/auth-required.js
+++ b/ui/components/auth-required.js
@@ -4,15 +4,19 @@ import useSWR from 'swr'
 export default function AuthRequired({ children }) {
   const { data: auth, error } = useSWR('/api/users/self')
   const router = useRouter()
+  const { asPath } = router
 
   if (!auth && !error) {
-    return null
+    return undefined
   }
 
   if (!auth?.id) {
-    router.replace('/login')
-    return null
+    if (asPath !== '/destinations' && asPath !== '/') {
+      router.replace(`/login?next=${encodeURIComponent(asPath)}`)
+    } else {
+      router.replace('/login')
+    }
+    return undefined
   }
-
   return children
 }

--- a/ui/components/auth-required.js
+++ b/ui/components/auth-required.js
@@ -7,7 +7,7 @@ export default function AuthRequired({ children }) {
   const { asPath } = router
 
   if (!auth && !error) {
-    return undefined
+    return null
   }
 
   if (!auth?.id) {
@@ -16,7 +16,7 @@ export default function AuthRequired({ children }) {
     } else {
       router.replace('/login')
     }
-    return undefined
+    return null
   }
   return children
 }

--- a/ui/components/layouts/dashboard.js
+++ b/ui/components/layouts/dashboard.js
@@ -10,7 +10,7 @@ function Layout({ children }) {
   const { data: auth } = useSWR('/api/users/self')
   const { data: version } = useSWR('/api/version')
   const { admin, loading } = useAdmin()
-  const { mutate } = useSWRConfig()
+  const { cache } = useSWRConfig()
 
   const accessToSettingsPage = admin || auth?.providerNames?.includes('infra')
 
@@ -22,7 +22,7 @@ function Layout({ children }) {
     await fetch('/api/logout', {
       method: 'POST',
     })
-    await mutate('/api/users/self', async () => undefined)
+    cache.clear()
     router.replace('/login')
   }
 

--- a/ui/components/layouts/login.js
+++ b/ui/components/layouts/login.js
@@ -4,18 +4,21 @@ import { useRouter } from 'next/router'
 export default function Login({ children }) {
   const { data: auth, error } = useSWR('/api/users/self')
   const router = useRouter()
+  const { next } = router.query
 
   if (!auth && !error) {
     return null
   }
 
   if (auth?.id) {
-    // TODO (https://github.com/infrahq/infra/issues/1441): remove me when
-    // using an OTP doesn't trigger authentication
-    if (router.pathname !== '/login/finish') {
+    if (next) {
+      router.replace(decodeURIComponent(next))
+    } else if (router.pathname !== '/login/finish') {
+      // TODO (https://github.com/infrahq/infra/issues/1441): remove me when
+      // using an OTP doesn't trigger authentication
       router.replace('/')
-      return null
     }
+    return false
   }
 
   return (

--- a/ui/pages/login/callback.js
+++ b/ui/pages/login/callback.js
@@ -9,7 +9,7 @@ export default function Callback() {
   const { code, state } = router.query
 
   useEffect(() => {
-    async function login({ providerID, code, redirectURL }) {
+    async function login({ providerID, code, redirectURL, next }) {
       await fetch('/api/login', {
         method: 'POST',
         body: JSON.stringify({
@@ -22,11 +22,19 @@ export default function Callback() {
       })
 
       await mutate('/api/users/self')
-      router.replace('/')
+
+      if (next) {
+        router.replace(`/${next}`)
+      } else {
+        router.replace('/')
+      }
+
+      window.localStorage.removeItem('next')
     }
 
     const providerID = window.localStorage.getItem('providerID')
     const redirectURL = window.localStorage.getItem('redirectURL')
+    const next = window.localStorage.getItem('next')
 
     if (
       state === window.localStorage.getItem('state') &&
@@ -38,6 +46,7 @@ export default function Callback() {
         providerID,
         code,
         redirectURL,
+        next,
       })
       window.localStorage.removeItem('providerID')
       window.localStorage.removeItem('state')
@@ -50,7 +59,8 @@ export default function Callback() {
   }
 
   if (!state || !code) {
-    router.replace('/login')
+    const next = window.localStorage.getItem('next')
+    next ? router.replace(`/login?next=${next}`) : router.replace('/login')
     return null
   }
 

--- a/ui/pages/login/finish.js
+++ b/ui/pages/login/finish.js
@@ -16,10 +16,14 @@ export default function Finish() {
   const { mutate } = useSWRConfig()
 
   const { query } = router
-  const { user } = query
+  const { next, user } = query
 
   if (!user) {
-    router.replace('/login')
+    if (next) {
+      router.replace(`/login?next=${next}`)
+    } else {
+      router.replace('/login')
+    }
   }
 
   async function finish(e) {
@@ -44,7 +48,11 @@ export default function Finish() {
 
       await mutate('/api/users/self')
 
-      await router.replace('/')
+      if (next) {
+        router.replace(`/login?next=${next}`)
+      } else {
+        router.replace('/login')
+      }
     } catch (e) {
       if (e.fieldErrors) {
         const errors = {}

--- a/ui/pages/login/index.js
+++ b/ui/pages/login/index.js
@@ -103,11 +103,9 @@ export default function Login() {
       const data = await res.json()
 
       if (data.passwordUpdateRequired) {
-        const query = next ? { user: data.userID, next } : { user: data.userID }
-
         router.replace({
           pathname: '/login/finish',
-          query,
+          query: next ? { user: data.userID, next } : { user: data.userID },
         })
 
         return false

--- a/ui/pages/login/index.js
+++ b/ui/pages/login/index.js
@@ -9,8 +9,11 @@ import { providers as providersList } from '../../lib/providers'
 
 import LoginLayout from '../../components/layouts/login'
 
-function oidcLogin({ id, clientID, authURL, scopes }) {
+function oidcLogin({ id, clientID, authURL, scopes }, next) {
   window.localStorage.setItem('providerID', id)
+  if (next) {
+    window.localStorage.setItem('next', next)
+  }
 
   const state = [...Array(10)]
     .map(() => (~~(Math.random() * 36)).toString(36))
@@ -26,6 +29,8 @@ function oidcLogin({ id, clientID, authURL, scopes }) {
 }
 
 export function Providers({ providers }) {
+  const router = useRouter()
+  const { next } = router.query
   return (
     <>
       <div className='mt-2 w-full max-w-sm'>
@@ -33,7 +38,7 @@ export function Providers({ providers }) {
           p =>
             p.kind && (
               <button
-                onClick={() => oidcLogin(p)}
+                onClick={() => oidcLogin({ ...p }, next)}
                 key={p.id}
                 title={`${p.name} — ${p.url}`}
                 className='my-2 flex w-full items-center rounded-md border border-gray-700 px-4 py-3 hover:border-gray-600'
@@ -70,6 +75,7 @@ export default function Login() {
   )
   const { mutate } = useSWRConfig()
   const router = useRouter()
+  const { next } = router.query
 
   const [name, setName] = useState('')
   const [password, setPassword] = useState('')
@@ -97,9 +103,11 @@ export default function Login() {
       const data = await res.json()
 
       if (data.passwordUpdateRequired) {
+        const query = next ? { user: data.userID, next } : { user: data.userID }
+
         router.replace({
           pathname: '/login/finish',
-          query: { user: data.userID },
+          query,
         })
 
         return false


### PR DESCRIPTION
## Summary

Logged out users who are trying to access authenticated pages will now get redirected to the right destination page after logging in

EG)
original:
- `https://test.infrahq.com/users` -> user logs in -> `https://test.infrahq.com/destinations`

now:
- `https://test.infrahq.com/users` -> redirects to `https://test.infrahq.com/login?next=/users`
    -> users login -> `https://test.infrahq.com/users`

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #1670 
