### PR TITLE
fix: correct article based on table name

### DIFF
--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -347,6 +347,12 @@ type UniqueConstraintError struct {
 	Column string
 }
 
+// these are tables whose names need the 'an' article rather than 'a'
+var anArticleTableName = map[string]bool{
+	"access key":   true,
+	"organization": true,
+}
+
 func (e UniqueConstraintError) Error() string {
 	table := e.Table
 	switch table {
@@ -360,10 +366,15 @@ func (e UniqueConstraintError) Error() string {
 		table = strings.TrimSuffix(table, "s")
 	}
 
-	if e.Column == "" {
-		return fmt.Sprintf("a %v with that value already exists", table)
+	article := "a"
+	if anArticleTableName[table] {
+		article = "an"
 	}
-	return fmt.Sprintf("a %v with that %v already exists", table, e.Column)
+
+	if e.Column == "" {
+		return fmt.Sprintf("%s %v with that value already exists", article, table)
+	}
+	return fmt.Sprintf("%s %v with that %v already exists", article, table, e.Column)
 }
 
 // handleError looks for well known DB errors. If the error is recognized it


### PR DESCRIPTION
## Summary
Add a check in the error string builder for table names that require the 'an' article rather than 'a'.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3064 
