### PR TITLE
Add validation to org subdomain during signup, and add a list of reserved subdomains.

### DIFF
--- a/api/passwordreset.go
+++ b/api/passwordreset.go
@@ -21,8 +21,13 @@ type VerifiedResetPasswordRequest struct {
 func (r VerifiedResetPasswordRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.Required("token", r.Token),
-		validate.String("token", r.Token, 10, 10, validate.AlphaNumeric...),
+		validate.StringRule{
+			Name:            "token",
+			Value:           r.Token,
+			MinLength:       10,
+			MaxLength:       10,
+			CharacterRanges: validate.AlphaNumeric,
+		},
 		validate.Required("password", r.Password),
-		// todo: validate password meets org's criteria
 	}
 }

--- a/api/signup.go
+++ b/api/signup.go
@@ -12,10 +12,30 @@ type SignupOrg struct {
 	Subdomain string `json:"subDomain"`
 }
 
+var reservedSubDomains = []string{
+	"infra", "infrahq", "auth", "authz", "authn",
+	"api", "www", "ftp", "ssh", "info", "help", "about",
+	"grants", "connector", "login", "signup",
+	"system", "admin", "email", "bastion",
+}
+
 func (r SignupOrg) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.Required("name", r.Name),
 		validate.Required("subDomain", r.Subdomain),
+		validate.ReservedStrings("subDomain", r.Subdomain, reservedSubDomains),
+		validate.StringRule{
+			Name:      "subDomain",
+			Value:     r.Subdomain,
+			MinLength: 3,
+			MaxLength: 63,
+			CharacterRanges: []validate.CharRange{
+				validate.AlphabetLower,
+				validate.AlphabetUpper,
+				validate.Numbers,
+				validate.Dash,
+			},
+		},
 	}
 }
 

--- a/api/signup.go
+++ b/api/signup.go
@@ -12,6 +12,13 @@ type SignupOrg struct {
 	Subdomain string `json:"subDomain"`
 }
 
+func (r SignupOrg) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.Required("name", r.Name),
+		validate.Required("subDomain", r.Subdomain),
+	}
+}
+
 type SignupRequest struct {
 	Name     string    `json:"name"`
 	Password string    `json:"password"`
@@ -23,7 +30,5 @@ func (r SignupRequest) ValidationRules() []validate.ValidationRule {
 		validate.Required("name", r.Name),
 		validate.Email("name", r.Name),
 		validate.Required("password", r.Password),
-		validate.Required("org.name", r.Org.Name),
-		validate.Required("org.subDomain", r.Org.Subdomain),
 	}
 }

--- a/api/signup.go
+++ b/api/signup.go
@@ -35,6 +35,11 @@ func (r SignupOrg) ValidationRules() []validate.ValidationRule {
 				validate.Numbers,
 				validate.Dash,
 			},
+			FirstCharacterRange: []validate.CharRange{
+				validate.AlphabetLower,
+				validate.AlphabetUpper,
+				validate.Numbers,
+			},
 		},
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -342,7 +342,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 		Password: passwd,
 		Org: api.SignupOrg{
 			Name:      "infrahq",
-			Subdomain: "infra",
+			Subdomain: "myorg",
 		},
 	}
 	err := json.NewEncoder(&buf).Encode(signupReq)

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -4827,6 +4827,9 @@
                         "type": "string"
                       },
                       "subDomain": {
+                        "format": "[a-zA-Z0-9\\-]",
+                        "maxLength": 63,
+                        "minLength": 3,
                         "type": "string"
                       }
                     },

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -4830,6 +4830,10 @@
                         "type": "string"
                       }
                     },
+                    "required": [
+                      "name",
+                      "subDomain"
+                    ],
                     "type": "object"
                   },
                   "password": {
@@ -4838,9 +4842,7 @@
                 },
                 "required": [
                   "name",
-                  "password",
-                  "org.name",
-                  "org.subDomain"
+                  "password"
                 ],
                 "type": "object"
               }

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -24,16 +24,6 @@ type StringRule struct {
 	CharacterRanges []CharRange
 }
 
-func String(name, value string, min, max int, charset ...CharRange) StringRule {
-	return StringRule{
-		Name:            name,
-		Value:           value,
-		MinLength:       min,
-		MaxLength:       max,
-		CharacterRanges: charset,
-	}
-}
-
 type CharRange struct {
 	Low  rune
 	High rune

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -141,3 +141,30 @@ func (e enum) DescribeSchema(parent *openapi3.Schema) {
 		schema.Enum = append(schema.Enum, v)
 	}
 }
+
+// ReservedStrings returns a validation that checks that value does not match
+// any of the strings in values.
+func ReservedStrings(name string, value string, values []string) ValidationRule {
+	return reserved{Name: name, Value: value, Reserved: values}
+}
+
+type reserved struct {
+	Name     string
+	Value    string
+	Reserved []string
+}
+
+func (r reserved) Validate() *Failure {
+	if r.Value == "" {
+		return nil
+	}
+	for _, notAllowed := range r.Reserved {
+		if r.Value == notAllowed {
+			msg := fmt.Sprintf("%v is reserved and can not be used", r.Value)
+			return fail(r.Name, msg)
+		}
+	}
+	return nil
+}
+
+func (r reserved) DescribeSchema(_ *openapi3.Schema) {}

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -132,7 +132,6 @@ func TestEnum_Validate(t *testing.T) {
 			"kind": {"must be one of (fruit, legume, grain)"},
 		}
 		assert.DeepEqual(t, verr, expected)
-
 	})
 }
 
@@ -152,4 +151,33 @@ func TestEnum_DescribeSchema(t *testing.T) {
 		},
 	}
 	assert.DeepEqual(t, schema, expected, cmpSchema)
+}
+
+type ReservedExample struct {
+	Value string
+}
+
+func (e ReservedExample) ValidationRules() []ValidationRule {
+	words := []string{"cars", "boats", "vans"}
+	return []ValidationRule{
+		ReservedStrings("name", e.Value, words),
+	}
+}
+
+func TestReserved_Validate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		err := Validate(ReservedExample{Value: "ok"})
+		assert.NilError(t, err)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		err := Validate(ReservedExample{Value: "cars"})
+
+		var verr Error
+		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
+		expected := Error{
+			"name": {"cars is reserved and can not be used"},
+		}
+		assert.DeepEqual(t, verr, expected)
+	})
 }

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -16,11 +16,12 @@ type StringExample struct {
 func (s StringExample) ValidationRules() []ValidationRule {
 	return []ValidationRule{
 		&StringRule{
-			Value:           s.Field,
-			Name:            "strField",
-			MinLength:       2,
-			MaxLength:       10,
-			CharacterRanges: []CharRange{AlphabetLower},
+			Value:               s.Field,
+			Name:                "strField",
+			MinLength:           2,
+			MaxLength:           10,
+			CharacterRanges:     []CharRange{AlphabetLower, AlphabetUpper},
+			FirstCharacterRange: []CharRange{AlphabetLower},
 		},
 	}
 }
@@ -61,6 +62,17 @@ func TestStringRule_Validate(t *testing.T) {
 				"length of string is 12, must be no more than 10",
 				`character ' ' at position 6 is not allowed`,
 			},
+		}
+		assert.DeepEqual(t, verr, expected)
+	})
+	t.Run("first character range", func(t *testing.T) {
+		r := StringExample{Field: "NotValid"}
+		err := Validate(r)
+
+		var verr Error
+		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
+		expected := Error{
+			"strField": {"first character 'N' is not allowed"},
 		}
 		assert.DeepEqual(t, verr, expected)
 	})

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -28,6 +28,8 @@ type ExampleRequest struct {
 	TooHigh int
 
 	Kind string
+
+	Unique string
 }
 
 func (r ExampleRequest) ValidationRules() []ValidationRule {
@@ -63,6 +65,7 @@ func (r ExampleRequest) ValidationRules() []ValidationRule {
 		IntRule{Name: "tooLow", Value: r.TooLow, Min: Int(20)},
 		IntRule{Name: "tooHigh", Value: r.TooHigh, Max: Int(20)},
 		Enum("kind", r.Kind, []string{"fruit", "legume", "grain"}),
+		ReservedStrings("unique", r.Unique, []string{"special"}),
 	}
 }
 
@@ -93,6 +96,7 @@ func TestValidate_AllRules(t *testing.T) {
 			TooLow:     2,
 			TooHigh:    22,
 			Kind:       "fish",
+			Unique:     "special",
 		}
 		err := Validate(r)
 		assert.ErrorContains(t, err, "validation failed: ")
@@ -113,6 +117,7 @@ func TestValidate_AllRules(t *testing.T) {
 			"tooHigh":    {"value 22 must be at most 20"},
 			"tooLow":     {"value 2 must be at least 20"},
 			"kind":       {"must be one of (fruit, legume, grain)"},
+			"unique":     {"special is reserved and can not be used"},
 		}
 		assert.DeepEqual(t, fieldError, expected)
 	})


### PR DESCRIPTION
## Summary

This PR adds validation to the org subdomain, including min/max length, character restrictions, and a list of reserved words that we should not allow to be subdomains.

Best viewed by individual commit, more details in commit messages.