### PR TITLE
fix: typo in db file path

### DIFF
--- a/helm/charts/infra/templates/postgres/statefulset.yaml
+++ b/helm/charts/infra/templates/postgres/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
           command: [sh, -c]
           args:
             - |
-              DB_FILE=/var/lib/infrahq/server/sqlite3.deb
+              DB_FILE=/var/lib/infrahq/server/sqlite3.db
               if [ -f "$DB_FILE" ]; then
                 apk add --no-cache sqlite
                 # perform a basic migration but drop any encrypted fields. these items will need to be recreated. only resource


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Typo in SQLite file path prevents migration to Postgres from happening.