### PR TITLE
fix: do not use request for signup cookie exchange

### DIFF
--- a/internal/server/cookie.go
+++ b/internal/server/cookie.go
@@ -61,11 +61,11 @@ func deleteCookie(c *gin.Context, name, domain string) {
 }
 
 // exchangeSignupCookieForSession sets the auth cookie on the current host making the request
-func exchangeSignupCookieForSession(c *gin.Context, opts Options) {
+func exchangeSignupCookieForSession(c *gin.Context, opts Options) string {
 	signupCookie, err := getCookie(c.Request, cookieSignupName)
 	if err != nil {
 		logging.L.Trace().Err(err).Msg("failed to find signup cookie, this may be expected")
-		return
+		return ""
 	}
 
 	exp := time.Now().UTC().Add(opts.SessionDuration)
@@ -78,4 +78,6 @@ func exchangeSignupCookieForSession(c *gin.Context, opts Options) {
 	}
 	setCookie(c, conf)
 	deleteCookie(c, cookieSignupName, opts.BaseDomain)
+
+	return signupCookie
 }

--- a/internal/server/cookie_test.go
+++ b/internal/server/cookie_test.go
@@ -45,7 +45,8 @@ func TestResendAuthCookie(t *testing.T) {
 	}
 	c.Set(access.RequestContextKey, rCtx)
 
-	exchangeSignupCookieForSession(c, Options{SessionDuration: 1 * time.Minute, BaseDomain: baseDomain})
+	bearer := exchangeSignupCookieForSession(c, Options{SessionDuration: 1 * time.Minute, BaseDomain: baseDomain})
+	assert.Equal(t, "aaa", bearer)
 
 	assert.Equal(t, len(c.Writer.Header()["Set-Cookie"]), 2)
 

--- a/internal/server/cookie_test.go
+++ b/internal/server/cookie_test.go
@@ -53,5 +53,5 @@ func TestResendAuthCookie(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, matched)
 
-	assert.Equal(t, "auth=; Path=/; Domain=example.com; Max-Age=0; HttpOnly; Secure", c.Writer.Header()["Set-Cookie"][1])
+	assert.Equal(t, "signup=; Path=/; Domain=example.com; Max-Age=0; HttpOnly; Secure", c.Writer.Header()["Set-Cookie"][1])
 }

--- a/internal/server/cookie_test.go
+++ b/internal/server/cookie_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 	"time"
 
@@ -44,12 +45,13 @@ func TestResendAuthCookie(t *testing.T) {
 	}
 	c.Set(access.RequestContextKey, rCtx)
 
-	exchangeSignupCookieForSession(c, baseDomain)
+	exchangeSignupCookieForSession(c, Options{SessionDuration: 1 * time.Minute, BaseDomain: baseDomain})
 
 	assert.Equal(t, len(c.Writer.Header()["Set-Cookie"]), 2)
-	expectedCookies := []string{
-		"auth=aaa; Path=/; Domain=dev.example.com; Max-Age=299; HttpOnly; SameSite=Strict",
-		"auth=; Path=/; Domain=example.com; Max-Age=0; HttpOnly; Secure",
-	}
-	assert.DeepEqual(t, c.Writer.Header()["Set-Cookie"], expectedCookies)
+
+	matched, err := regexp.MatchString("auth=aaa; Path=/; Domain=dev.example.com; Max-Age=\\d\\d; HttpOnly; SameSite=Strict", c.Writer.Header()["Set-Cookie"][0])
+	assert.NilError(t, err)
+	assert.Assert(t, matched)
+
+	assert.Equal(t, "auth=; Path=/; Domain=example.com; Max-Age=0; HttpOnly; Secure", c.Writer.Header()["Set-Cookie"][1])
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -303,12 +303,11 @@ func reqBearerToken(c *gin.Context, opts Options) (string, error) {
 		 Signup takes priority over the auth cookie to ensure a new signup always get the correct session.
 		 If this isn't a new org, check for the 'auth' cookie which contains an access key.
 		*/
-		cookie, err := getCookie(c.Request, cookieSignupName)
-		if err == nil {
-			exchangeSignupCookieForSession(c, opts)
-		} else {
-			logging.L.Trace().Err(err).Msg("sign-up cookie not found, falling back to auth cookie")
+		cookie := exchangeSignupCookieForSession(c, opts)
+		if cookie == "" {
+			logging.L.Trace().Msg("sign-up cookie not found, falling back to auth cookie")
 
+			var err error
 			cookie, err = getCookie(c.Request, cookieAuthorizationName)
 			if err != nil {
 				return "", fmt.Errorf("%w: valid token not found in request", internal.ErrUnauthorized)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -198,7 +198,7 @@ func orgRequired() gin.HandlerFunc {
 func requireAccessKey(c *gin.Context, db data.GormTxn, srv *Server) (access.Authenticated, error) {
 	var u access.Authenticated
 
-	bearer, err := reqBearerToken(c, srv.options.BaseDomain)
+	bearer, err := reqBearerToken(c, srv.options)
 	if err != nil {
 		return u, err
 	}
@@ -288,7 +288,7 @@ hostLookup:
 	return org, nil
 }
 
-func reqBearerToken(c *gin.Context, baseDomain string) (string, error) {
+func reqBearerToken(c *gin.Context, opts Options) (string, error) {
 	header := c.Request.Header.Get("Authorization")
 
 	bearer := ""
@@ -305,7 +305,7 @@ func reqBearerToken(c *gin.Context, baseDomain string) (string, error) {
 		*/
 		cookie, err := getCookie(c.Request, cookieSignupName)
 		if err == nil {
-			exchangeSignupCookieForSession(c, baseDomain)
+			exchangeSignupCookieForSession(c, opts)
 		} else {
 			logging.L.Trace().Err(err).Msg("sign-up cookie not found, falling back to auth cookie")
 


### PR DESCRIPTION
## Summary
#3059 had an issue that it wouldn't set the new auth cookie after sign-up because moving around the cookie logic meant that the key wasn't set where I expected it to be previously. 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades
