### PR TITLE
Add option to set the default organization domain from server config

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -80,9 +80,10 @@ func (u User) ValidationRules() []validate.ValidationRule {
 }
 
 type Config struct {
-	Providers []Provider
-	Grants    []Grant
-	Users     []User
+	DefaultOrganizationDomain string
+	Providers                 []Provider
+	Grants                    []Grant
+	Users                     []User
 }
 
 func (c Config) ValidationRules() []validate.ValidationRule {
@@ -607,6 +608,13 @@ func (s Server) loadConfig(config Config) error {
 	org := s.db.DefaultOrg
 	return s.db.Transaction(func(db *gorm.DB) error {
 		tx := data.NewTransaction(db, org.ID)
+
+		if config.DefaultOrganizationDomain != org.Domain {
+			org.Domain = config.DefaultOrganizationDomain
+			if err := data.UpdateOrganization(tx, org); err != nil {
+				return fmt.Errorf("update default org domain: %w", err)
+			}
+		}
 
 		// inject internal infra provider
 		config.Providers = append(config.Providers, Provider{

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -603,11 +603,8 @@ func (s Server) loadConfig(config Config) error {
 	if err := validate.Validate(config); err != nil {
 		return err
 	}
-	org, err := data.GetOrganization(s.DB(), data.ByName(models.DefaultOrganizationName))
-	if err != nil {
-		return err
-	}
 
+	org := s.db.DefaultOrg
 	return s.db.Transaction(func(db *gorm.DB) error {
 		tx := data.NewTransaction(db, org.ID)
 

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -395,6 +395,7 @@ func TestLoadConfigWithProviders(t *testing.T) {
 	s := setupServer(t)
 
 	config := Config{
+		DefaultOrganizationDomain: "super.example.com",
 		Providers: []Provider{
 			{
 				Name:         "okta",
@@ -432,6 +433,10 @@ func TestLoadConfigWithProviders(t *testing.T) {
 	assert.NilError(t, err)
 
 	defaultOrg := s.db.DefaultOrg
+
+	updatedOrg, err := data.GetOrganization(s.db, data.ByID(defaultOrg.ID))
+	assert.NilError(t, err)
+	assert.Equal(t, updatedOrg.Domain, "super.example.com")
 
 	var okta models.Provider
 	err = s.db.Raw("SELECT * FROM providers WHERE name = 'okta' AND organization_id = ? LIMIT 1;", defaultOrg.ID).Scan(&okta).Error

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -190,12 +190,15 @@ func newRawDB(connection gorm.Dialector) (*gorm.DB, error) {
 	return db, nil
 }
 
+const defaultOrganizationID = 1000
+
 func initialize(db *DB) error {
-	org, err := GetOrganization(db, ByName(models.DefaultOrganizationName))
+	org, err := GetOrganization(db, ByID(defaultOrganizationID))
 	switch {
 	case errors.Is(err, internal.ErrNotFound):
 		org = &models.Organization{
-			Name:      models.DefaultOrganizationName,
+			Model:     models.Model{ID: defaultOrganizationID},
+			Name:      "Default",
 			CreatedBy: models.CreatedBySystem,
 		}
 		if err := CreateOrganization(db, org); err != nil {

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -163,3 +163,13 @@ func TestSetOrg(t *testing.T) {
 	setOrg(tx, model)
 	assert.Equal(t, model.OrganizationID, uid.ID(123456))
 }
+
+func TestNewDB(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		assert.Equal(t, db.DefaultOrg.ID, uid.ID(defaultOrganizationID))
+
+		org, err := GetOrganization(db, ByID(defaultOrganizationID))
+		assert.NilError(t, err)
+		assert.DeepEqual(t, org, db.DefaultOrg, cmpTimeWithDBPrecision)
+	})
+}

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -65,6 +65,7 @@ func migrations() []*migrator.Migration {
 		addOrganizationDomain(),
 		dropOrganizationNameIndex(),
 		sqlFunctionsMigration(),
+		setDefaultOrgID(),
 		// next one here
 	}
 }
@@ -555,6 +556,16 @@ func dropOrganizationNameIndex() *migrator.Migration {
 		ID: "2022-08-12T11:05",
 		Migrate: func(tx migrator.DB) error {
 			_, err := tx.Exec(`DROP INDEX IF EXISTS idx_organizations_name`)
+			return err
+		},
+	}
+}
+
+func setDefaultOrgID() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-08-30T11:45",
+		Migrate: func(tx migrator.DB) error {
+			_, err := tx.Exec(`UPDATE organizations set id=? WHERE name='Default'`, defaultOrganizationID)
 			return err
 		},
 	}

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -73,3 +73,7 @@ func DeleteOrganizations(db GormTxn, selectors ...SelectorFunc) error {
 
 	return delete[models.Organization](db, toDelete.ID)
 }
+
+func UpdateOrganization(tx GormTxn, org *models.Organization) error {
+	return save(tx, org)
+}

--- a/internal/server/models/organization.go
+++ b/internal/server/models/organization.go
@@ -5,8 +5,6 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-const DefaultOrganizationName = "Default"
-
 type Organization struct {
 	Model
 


### PR DESCRIPTION
This PR makes the following changes:
* adds a migration to update the default org to use ID=1000. This gives us a reliable way of looking up the default config, without depending on a configuration setting.
* adds a new server option `DefaultOrganizationDomain` that allows someone to set the domain name of the default org as part of the infrastructure-as-code `loadConfig` function.



Fixes #3025