### PR TITLE
fix: clients should stop requesting when told their token is invalid

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -35,7 +35,9 @@ type Client struct {
 	AccessKey string
 	HTTP      http.Client
 	// Headers are HTTP headers that will be added to every request made by the Client.
-	Headers        http.Header
+	Headers http.Header
+	// OnUnauthorized is a callback hook for the client to get notified of a 401 Unauthorized response to any query.
+	// This is useful as clients often need to discard expired access keys.
 	OnUnauthorized func()
 }
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -97,7 +97,7 @@ func defaultAPIClient() (*api.Client, error) {
 		if config.isExpired() {
 			return nil, Error{Message: "Access key is expired, please login again", OriginalError: ErrAccessKeyExpired}
 		}
-		return nil, Error{Message: "Missing access key, must login or provide an INFRA_ACCESS_KEY", OriginalError: ErrAccessKeyMissing}
+		return nil, Error{Message: "Missing access key, must login or set INFRA_ACCESS_KEY in your environment", OriginalError: ErrAccessKeyMissing}
 	}
 
 	if envServer, ok := os.LookupEnv("INFRA_SERVER"); ok {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -84,10 +84,20 @@ func defaultAPIClient() (*api.Client, error) {
 	}
 
 	server := config.Host
-	accessKey := config.AccessKey
+	var accessKey string
+	if !config.isExpired() {
+		accessKey = config.AccessKey
+	}
 
 	if envAccessKey, ok := os.LookupEnv("INFRA_ACCESS_KEY"); ok {
 		accessKey = envAccessKey
+	}
+
+	if len(accessKey) == 0 {
+		if config.isExpired() {
+			return nil, Error{Message: "Access key is expired, please login again", OriginalError: ErrAccessKeyExpired}
+		}
+		return nil, Error{Message: "Missing access key, must login or provide an INFRA_ACCESS_KEY", OriginalError: ErrAccessKeyMissing}
 	}
 
 	if envServer, ok := os.LookupEnv("INFRA_SERVER"); ok {
@@ -107,6 +117,42 @@ func apiClient(host string, accessKey string, transport *http.Transport) *api.Cl
 			Timeout:   60 * time.Second,
 			Transport: transport,
 		},
+		OnUnauthorized: logoutCurrent,
+	}
+}
+
+func logoutCurrent() {
+	config, err := readConfig()
+	if err != nil {
+		logging.Debugf("logging out: read config: %s", err)
+		return
+	}
+
+	var host *ClientHostConfig
+	for i := range config.Hosts {
+		if config.Hosts[i].Current {
+			host = &config.Hosts[i]
+			break
+		}
+	}
+
+	if host == nil {
+		return
+	}
+
+	host.AccessKey = ""
+	host.Expires = api.Time{}
+	host.UserID = 0
+	host.Name = ""
+
+	if err := clearKubeconfig(); err != nil {
+		logging.Debugf("logging out: clear kube config: %s", err)
+		return
+	}
+
+	if err := writeConfig(config); err != nil {
+		logging.Debugf("logging out: write config: %s", err)
+		return
 	}
 }
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -95,9 +95,9 @@ func defaultAPIClient() (*api.Client, error) {
 
 	if len(accessKey) == 0 {
 		if config.isExpired() {
-			return nil, Error{Message: "Access key is expired, please login again", OriginalError: ErrAccessKeyExpired}
+			return nil, Error{Message: "Access key is expired, please `infra login` again", OriginalError: ErrAccessKeyExpired}
 		}
-		return nil, Error{Message: "Missing access key, must login or set INFRA_ACCESS_KEY in your environment", OriginalError: ErrAccessKeyMissing}
+		return nil, Error{Message: "Missing access key, must `infra login` or set INFRA_ACCESS_KEY in your environment", OriginalError: ErrAccessKeyMissing}
 	}
 
 	if envServer, ok := os.LookupEnv("INFRA_SERVER"); ok {
@@ -144,11 +144,6 @@ func logoutCurrent() {
 	host.Expires = api.Time{}
 	host.UserID = 0
 	host.Name = ""
-
-	if err := clearKubeconfig(); err != nil {
-		logging.Debugf("logging out: clear kube config: %s", err)
-		return
-	}
 
 	if err := writeConfig(config); err != nil {
 		logging.Debugf("logging out: write config: %s", err)

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -12,9 +12,11 @@ import (
 
 var (
 	//lint:ignore ST1005, user facing error
-	ErrConfigNotFound = errors.New(`Could not read local credentials. Are you logged in? Use "infra login" to login`)
-	ErrUserNotFound   = errors.New(`user not found`)
-	ErrGroupNotFound  = errors.New(`group not found`)
+	ErrConfigNotFound   = errors.New(`Could not read local credentials. Are you logged in? Use "infra login" to login`)
+	ErrUserNotFound     = errors.New(`user not found`)
+	ErrGroupNotFound    = errors.New(`group not found`)
+	ErrAccessKeyExpired = errors.New(`access key expired`)
+	ErrAccessKeyMissing = errors.New(`access key missing`)
 )
 
 type LoginError struct {

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -188,6 +188,7 @@ func TestLogout(t *testing.T) {
 		expected.Hosts[0].AccessKey = ""
 		expected.Hosts[0].Name = ""
 		expected.Hosts[0].UserID = 0
+		expected.Hosts[0].Expires = api.Time{}
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
@@ -209,6 +210,7 @@ func TestLogout(t *testing.T) {
 		expected.Hosts[0].AccessKey = ""
 		expected.Hosts[0].Name = ""
 		expected.Hosts[0].UserID = 0
+		expected.Hosts[0].Expires = api.Time{}
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
@@ -230,6 +232,7 @@ func TestLogout(t *testing.T) {
 		expected.Hosts[0].AccessKey = ""
 		expected.Hosts[0].Name = ""
 		expected.Hosts[0].UserID = 0
+		expected.Hosts[0].Expires = api.Time{}
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		kubeconfig := expectedKubeCfg
@@ -272,9 +275,11 @@ func TestLogout(t *testing.T) {
 		expected.Hosts[0].AccessKey = ""
 		expected.Hosts[0].Name = ""
 		expected.Hosts[0].UserID = 0
+		expected.Hosts[0].Expires = api.Time{}
 		expected.Hosts[1].AccessKey = ""
 		expected.Hosts[1].Name = ""
 		expected.Hosts[1].UserID = 0
+		expected.Hosts[1].Expires = api.Time{}
 		assert.DeepEqual(t, &expected, updatedCfg)
 
 		updatedKubeCfg, err := clientConfig().RawConfig()

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -227,7 +227,8 @@ func Run(ctx context.Context, options Options) error {
 		<-ctx.Done()
 		shutdownCtx, shutdownCancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
 		defer shutdownCancel()
-		tlsServer.Shutdown(shutdownCtx)
+		err = tlsServer.Shutdown(shutdownCtx)
+		logging.Warnf("shutdown: %s", err)
 		wg.Done()
 	}()
 


### PR DESCRIPTION
## Summary

Clients (incl connectors) should respect the 401 Unauthorized received from an access token; it's not a transient error and requesting with it in the future will never work.

If the client knows the token is expired it shouldn't bother requesting.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

