### PR TITLE
fix(helm): also no postgres if db host set in env

### DIFF
--- a/helm/charts/infra/templates/postgres/_helpers.tpl
+++ b/helm/charts/infra/templates/postgres/_helpers.tpl
@@ -120,5 +120,11 @@ postgres 'envFrom' values. Merges global and local values.
 Infer whether postgres should be deployed based on postgres.enabled, server.enabled, and external postgres connection configurations.
 */}}
 {{- define "postgres.enabled" -}}
-{{- and .Values.postgres.enabled (include "server.enabled" . | eq "true") (not .Values.server.config.dbHost) }}
+{{- $hasDBHost := not .Values.server.config.dbHost }}
+{{- range .Values.server.env }}
+{{- if eq .name "INFRA_SERVER_DB_HOST" }}
+{{- $hasDBHost = false }}
+{{- end }}
+{{- end }}
+{{- and .Values.postgres.enabled (include "server.enabled" . | eq "true") $hasDBHost }}
 {{- end }}

--- a/helm/charts/infra/templates/server/secret.yaml
+++ b/helm/charts/infra/templates/server/secret.yaml
@@ -36,6 +36,8 @@ metadata:
   name: {{ include "server.fullname" . }}-encryption-key
   labels:
 {{- include "server.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 data:
 {{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-encryption-key" (include "server.fullname" .)) -}}
 {{- if $secret.data }}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The DB host may also be set with environment variables so try to detect that as well. 

Keep `infra-server-encryption-key` through helm delete. When using an external database, the data does not get deleted when uninstalling the chart. If the encryption key changes, the database cannot be reused. 

https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource