### PR TITLE
fix: check signup password requirements in api

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -55,5 +55,12 @@ func (r SignupRequest) ValidationRules() []validate.ValidationRule {
 		validate.Required("name", r.Name),
 		validate.Email("name", r.Name),
 		validate.Required("password", r.Password),
+		// check the admin user's password requirements against our basic password requirements
+		validate.StringRule{
+			Name:      "password",
+			Value:     r.Password,
+			MinLength: 8,
+			MaxLength: 253,
+		},
 	}
 }

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -37,12 +37,6 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 	rCtx.DBTxn = db
 	c.Set(RequestContextKey, rCtx)
 
-	// check the admin user's password requirements against our basic password requirements
-	err := checkPasswordRequirements(db, details.Password)
-	if err != nil {
-		return nil, "", err
-	}
-
 	identity := &models.Identity{
 		Name: details.Name,
 	}

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -61,7 +61,7 @@ func TestAPI_Signup(t *testing.T) {
 
 				expected := []api.FieldError{
 					{FieldName: "org.subDomain", Errors: []string{
-						"subDomain must be at least 3 characters",
+						"must be at least 3 characters",
 						"character '@' at position 1 is not allowed",
 					}},
 				}
@@ -89,13 +89,13 @@ func TestAPI_Signup(t *testing.T) {
 
 				expected := []api.FieldError{
 					{FieldName: "password", Errors: []string{
-						"password must be at least 8 characters",
+						"must be at least 8 characters",
 					}},
 				}
 				assert.DeepEqual(t, respBody.FieldErrors, expected)
 
 				// the org should have been rolled back
-				_, err = data.GetOrganization(srv.DB(), data.ByDomain("hello.example.com"))
+				_, err = data.GetOrganization(srv.DB(), data.ByDomain("hello.exampledomain.com"))
 				assert.ErrorIs(t, err, internal.ErrNotFound)
 			},
 		},

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -4840,6 +4840,8 @@
                     "type": "object"
                   },
                   "password": {
+                    "maxLength": 253,
+                    "minLength": 8,
                     "type": "string"
                   }
                 },

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -84,11 +84,11 @@ func (s StringRule) Validate() *Failure {
 		problems = append(problems, fmt.Sprintf(format, args...))
 	}
 	if s.MinLength > 0 && len(value) < s.MinLength {
-		add("%s must be at least %d characters", s.Name, s.MinLength)
+		add("must be at least %d characters", s.MinLength)
 	}
 
 	if s.MaxLength > 0 && len(value) > s.MaxLength {
-		add("%s can be at most %d characters", s.Name, s.MaxLength)
+		add("can be at most %d characters", s.MaxLength)
 	}
 
 	if len(s.FirstCharacterRange) > 0 {

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -84,11 +84,11 @@ func (s StringRule) Validate() *Failure {
 		problems = append(problems, fmt.Sprintf(format, args...))
 	}
 	if s.MinLength > 0 && len(value) < s.MinLength {
-		add("length of string is %d, must be at least %d", len(value), s.MinLength)
+		add("%s must be at least %d characters", s.Name, s.MinLength)
 	}
 
 	if s.MaxLength > 0 && len(value) > s.MaxLength {
-		add("length of string is %d, must be no more than %d", len(value), s.MaxLength)
+		add("%s can be at most %d characters", s.Name, s.MaxLength)
 	}
 
 	if len(s.FirstCharacterRange) > 0 {

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -30,12 +30,12 @@ func TestStringRule_Validate(t *testing.T) {
 	t.Run("min length", func(t *testing.T) {
 		r := StringExample{Field: "a"}
 		err := Validate(r)
-		assert.ErrorContains(t, err, "strField must be at least 2 characters")
+		assert.ErrorContains(t, err, "must be at least 2 characters")
 	})
 	t.Run("max length", func(t *testing.T) {
 		r := StringExample{Field: "abcdefghijklm"}
 		err := Validate(r)
-		assert.ErrorContains(t, err, "strField can be at most 10 characters")
+		assert.ErrorContains(t, err, "can be at most 10 characters")
 	})
 	t.Run("character ranges", func(t *testing.T) {
 		r := StringExample{Field: "almost~valid"}
@@ -45,7 +45,7 @@ func TestStringRule_Validate(t *testing.T) {
 		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
 		expected := Error{
 			"strField": {
-				"strField can be at most 10 characters",
+				"can be at most 10 characters",
 				"character '~' at position 6 is not allowed",
 			},
 		}
@@ -59,7 +59,7 @@ func TestStringRule_Validate(t *testing.T) {
 		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
 		expected := Error{
 			"strField": {
-				"strField can be at most 10 characters",
+				"can be at most 10 characters",
 				`character ' ' at position 6 is not allowed`,
 			},
 		}

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -30,12 +30,12 @@ func TestStringRule_Validate(t *testing.T) {
 	t.Run("min length", func(t *testing.T) {
 		r := StringExample{Field: "a"}
 		err := Validate(r)
-		assert.ErrorContains(t, err, "length of string is 1, must be at least 2")
+		assert.ErrorContains(t, err, "strField must be at least 2 characters")
 	})
 	t.Run("max length", func(t *testing.T) {
 		r := StringExample{Field: "abcdefghijklm"}
 		err := Validate(r)
-		assert.ErrorContains(t, err, "length of string is 13, must be no more than 10")
+		assert.ErrorContains(t, err, "strField can be at most 10 characters")
 	})
 	t.Run("character ranges", func(t *testing.T) {
 		r := StringExample{Field: "almost~valid"}
@@ -45,7 +45,7 @@ func TestStringRule_Validate(t *testing.T) {
 		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
 		expected := Error{
 			"strField": {
-				"length of string is 12, must be no more than 10",
+				"strField can be at most 10 characters",
 				"character '~' at position 6 is not allowed",
 			},
 		}
@@ -59,7 +59,7 @@ func TestStringRule_Validate(t *testing.T) {
 		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
 		expected := Error{
 			"strField": {
-				"length of string is 12, must be no more than 10",
+				"strField can be at most 10 characters",
 				`character ' ' at position 6 is not allowed`,
 			},
 		}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -111,8 +111,8 @@ func TestValidate_AllRules(t *testing.T) {
 			},
 			"emailAddr":  {"invalid email address"},
 			"emailOther": {`email address must not contain display name "Display Name"`},
-			"tooFew":     {"tooFew must be at least 5 characters"},
-			"tooMany":    {"tooMany can be at most 5 characters"},
+			"tooFew":     {"must be at least 5 characters"},
+			"tooMany":    {"can be at most 5 characters"},
 			"wrongOnes":  {"character 'C' at position 2 is not allowed"},
 			"tooHigh":    {"value 22 must be at most 20"},
 			"tooLow":     {"value 2 must be at least 20"},
@@ -183,14 +183,14 @@ func TestValidate_Traversal(t *testing.T) {
 		assert.Assert(t, errors.As(err, &fieldError))
 		expected := Error{
 			"":    {"one of (first, second, third) is required"},
-			"any": {"any can be at most 3 characters"},
+			"any": {"can be at most 3 characters"},
 			"sub.nested": {
 				"only one of (either, or) can have a value",
 				"one of (first, second, third) is required",
 			},
 			"sub.nested.id": {"is required"},
 			"sub.ok":        {"is required"},
-			"tooFew":        {"tooFew must be at least 5 characters"},
+			"tooFew":        {"must be at least 5 characters"},
 			"many":          {"one of (first, second, third) is required"},
 			"many.id":       {"is required"},
 		}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -111,8 +111,8 @@ func TestValidate_AllRules(t *testing.T) {
 			},
 			"emailAddr":  {"invalid email address"},
 			"emailOther": {`email address must not contain display name "Display Name"`},
-			"tooFew":     {"length of string is 1, must be at least 5"},
-			"tooMany":    {"length of string is 6, must be no more than 5"},
+			"tooFew":     {"tooFew must be at least 5 characters"},
+			"tooMany":    {"tooMany can be at most 5 characters"},
 			"wrongOnes":  {"character 'C' at position 2 is not allowed"},
 			"tooHigh":    {"value 22 must be at most 20"},
 			"tooLow":     {"value 2 must be at least 20"},
@@ -183,14 +183,14 @@ func TestValidate_Traversal(t *testing.T) {
 		assert.Assert(t, errors.As(err, &fieldError))
 		expected := Error{
 			"":    {"one of (first, second, third) is required"},
-			"any": {"length of string is 6, must be no more than 3"},
+			"any": {"any can be at most 3 characters"},
 			"sub.nested": {
 				"only one of (either, or) can have a value",
 				"one of (first, second, third) is required",
 			},
 			"sub.nested.id": {"is required"},
 			"sub.ok":        {"is required"},
-			"tooFew":        {"length of string is 1, must be at least 5"},
+			"tooFew":        {"tooFew must be at least 5 characters"},
 			"many":          {"one of (first, second, third) is required"},
 			"many.id":       {"is required"},
 		}


### PR DESCRIPTION
- update string length api error to be more ui friendly
- validate signup password between 8 and 253 characters

## Summary
Due to #3076 it was possible it sign-up and fail the password check after your org was created. Leaving the org in a bad state. Move the password requirement check to the API to prevent this.

Also updating the string error message to be more UI friendly.

<img width="456" alt="Screen Shot 2022-08-31 at 3 42 48 PM" src="https://user-images.githubusercontent.com/5853428/187757544-2bf9330c-b01e-4e7b-aa2a-33daa909087b.png">

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

