### PR TITLE
improve: cache docker build from edge instead of latest

### DIFF
--- a/.github/workflows/cd-containers.yaml
+++ b/.github/workflows/cd-containers.yaml
@@ -77,7 +77,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.IMAGE }}:latest
+          cache-from: type=registry,ref=${{ env.IMAGE }}:edge
           cache-to: type=inline
 
   synchronize:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`edge` contains changes from main while `latest` contains changes from the latest tag. `edge` is more applicable in this case. this should speed up the docker image build