### PR TITLE
improve server db connection string options

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -321,36 +321,37 @@ func getDatabaseDriver(options Options, secretStorage map[string]secrets.SecretS
 // getPostgresConnectionString parses postgres configuration options and returns the connection string
 func getPostgresConnectionString(options Options, secretStorage map[string]secrets.SecretStorage) (string, error) {
 	var pgConn strings.Builder
-	pgConn.WriteString(options.DBConnectionString)
+	pgConn.WriteString(options.DBConnectionString + " ")
 
 	if options.DBHost != "" {
 		// config has separate postgres parameters set, combine them into a connection DSN now
 		fmt.Fprintf(&pgConn, "host=%s ", options.DBHost)
+	}
 
-		if options.DBUsername != "" {
-			fmt.Fprintf(&pgConn, "user=%s ", options.DBUsername)
+	if options.DBUsername != "" {
+		fmt.Fprintf(&pgConn, "user=%s ", options.DBUsername)
+	}
 
-			if options.DBPassword != "" {
-				pass, err := secrets.GetSecret(options.DBPassword, secretStorage)
-				if err != nil {
-					return "", fmt.Errorf("postgres secret: %w", err)
-				}
-
-				fmt.Fprintf(&pgConn, "password=%s ", pass)
-			}
+	if options.DBPassword != "" {
+		pass, err := secrets.GetSecret(options.DBPassword, secretStorage)
+		if err != nil {
+			return "", fmt.Errorf("postgres secret: %w", err)
 		}
 
-		if options.DBPort > 0 {
-			fmt.Fprintf(&pgConn, "port=%d ", options.DBPort)
-		}
+		fmt.Fprintf(&pgConn, "password=%s ", pass)
+	}
 
-		if options.DBName != "" {
-			fmt.Fprintf(&pgConn, "dbname=%s ", options.DBName)
-		}
+	if options.DBPort > 0 {
+		fmt.Fprintf(&pgConn, "port=%d ", options.DBPort)
+	}
 
-		if options.DBParameters != "" {
-			fmt.Fprint(&pgConn, options.DBParameters)
-		}
+	if options.DBName != "" {
+		fmt.Fprintf(&pgConn, "dbname=%s ", options.DBName)
+	}
+
+	// TODO: deprecate DBParameters now that we accept DBConnectionString
+	if options.DBParameters != "" {
+		fmt.Fprint(&pgConn, options.DBParameters)
 	}
 
 	return strings.TrimSpace(pgConn.String()), nil

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -85,6 +85,16 @@ func TestGetPostgresConnectionURL(t *testing.T) {
 	url, err = getPostgresConnectionString(options, storage)
 	assert.NilError(t, err)
 	assert.Equal(t, "host=localhost user=user password=secret port=5432 dbname=postgres", url)
+
+	t.Run("connection string with password from secrets", func(t *testing.T) {
+		options := Options{
+			DBConnectionString: "host=localhost user=user port=5432",
+			DBPassword:         "plaintext:foo",
+		}
+		dsn, err := getPostgresConnectionString(options, storage)
+		assert.NilError(t, err)
+		assert.Equal(t, "host=localhost user=user port=5432 password=foo", dsn)
+	})
 }
 
 func TestServer_Run(t *testing.T) {


### PR DESCRIPTION
Previously the db connection string could either be entirely set by the
`dbConnectionString` option, or the user had to set `dbHost` if they wanted
to use the other options.

With this change the user can set `dbConnectionString` for most options,
and use only `dbPassword` to pull the secret value from a safe place.

This should allow us to deprecate most of the other db options at some point.
It also makes `dbParameters` effectively a duplicate of `dbConnectionString`, so
it would probably make sense to deprecate and remove at least one of those.

Branched from #3084, that will need to merge first.