### PR TITLE
Replace get, list, and update access key queries with sql

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -17,16 +17,17 @@ func ListAccessKeys(c *gin.Context, identityID uid.ID, name string, showExpired 
 		return nil, HandleAuthErr(err, "access keys", "list", roles...)
 	}
 
-	s := []data.SelectorFunc{
-		data.Preload("IssuedForIdentity"),
-		data.ByOptionalIssuedFor(identityID),
-		data.ByOptionalName(name),
+	opts := data.ListAccessKeyOptions{
+		Pagination:     p,
+		IncludeExpired: showExpired,
 	}
-	if !showExpired {
-		s = append(s, data.ByNotExpiredOrExtended())
+	if identityID != 0 {
+		opts.ByIssuedForID = identityID
 	}
-
-	return data.ListAccessKeys(db, p, s...)
+	if name != "" {
+		opts.ByName = name
+	}
+	return data.ListAccessKeys(db, opts)
 }
 
 func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey) (body string, err error) {

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -100,7 +100,7 @@ func updateCredential(c *gin.Context, user *models.Identity, newPassword string,
 			if rCtx, ok := raw.(RequestContext); ok {
 				if accessKey := rCtx.Authenticated.AccessKey; accessKey != nil {
 					accessKey.Scopes = models.CommaSeparatedStrings{}
-					if err = data.SaveAccessKey(db, accessKey); err != nil {
+					if err = data.UpdateAccessKey(db, accessKey); err != nil {
 						return fmt.Errorf("updating access key: %w", err)
 					}
 				}

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -95,7 +95,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	_, err = data.GetIdentity(db, data.ByID(identity.ID))
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 
-	_, err = data.GetAccessKey(db, data.ByKeyID(keyID))
+	_, err = data.GetAccessKey(db, keyID)
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 
 	_, err = data.GetCredential(db, data.ByIdentityID(identity.ID))

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -75,10 +75,10 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 
 	// grant the user a session on initial sign-up
 	accessKey := &models.AccessKey{
-		IssuedFor:         identity.ID,
-		IssuedForIdentity: identity,
-		ProviderID:        data.InfraProvider(db).ID,
-		ExpiresAt:         keyExpiresAt,
+		IssuedFor:     identity.ID,
+		IssuedForName: identity.Name,
+		ProviderID:    data.InfraProvider(db).ID,
+		ExpiresAt:     keyExpiresAt,
 	}
 
 	bearer, err := data.CreateAccessKey(db, accessKey)

--- a/internal/server/authn/authn_method.go
+++ b/internal/server/authn/authn_method.go
@@ -52,7 +52,7 @@ func Login(
 
 	accessKey := &models.AccessKey{
 		IssuedFor:         authenticated.Identity.ID,
-		IssuedForIdentity: authenticated.Identity,
+		IssuedForName:     authenticated.Identity.Name,
 		ProviderID:        authenticated.Provider.ID,
 		ExpiresAt:         authenticated.SessionExpiry,
 		ExtensionDeadline: time.Now().UTC().Add(keyExtension),

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -999,7 +999,7 @@ func (s Server) loadAccessKey(db data.GormTxn, identity *models.Identity, key st
 
 	accessKey.Secret = secret
 
-	if err := data.SaveAccessKey(db, accessKey); err != nil {
+	if err := data.UpdateAccessKey(db, accessKey); err != nil {
 		return err
 	}
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -968,7 +968,7 @@ func (s Server) loadAccessKey(db data.GormTxn, identity *models.Identity, key st
 		return fmt.Errorf("invalid access key format")
 	}
 
-	accessKey, err := data.GetAccessKey(db, data.ByKeyID(keyID))
+	accessKey, err := data.GetAccessKey(db, keyID)
 	if err != nil {
 		if !errors.Is(err, internal.ErrNotFound) {
 			return err

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -100,12 +100,13 @@ func CreateAccessKey(db GormTxn, accessKey *models.AccessKey) (body string, err 
 	return fmt.Sprintf("%s.%s", accessKey.KeyID, accessKey.Secret), nil
 }
 
-func SaveAccessKey(db GormTxn, key *models.AccessKey) error {
+func UpdateAccessKey(tx WriteTxn, key *models.AccessKey) error {
 	if key.Secret != "" {
 		key.SecretChecksum = secretChecksum(key.Secret)
 	}
+	// TODO: we should perform the same validation as Create
 
-	return save(db, key)
+	return update(tx, (*accessKeyTable)(key))
 }
 
 func ListAccessKeys(db GormTxn, p *Pagination, selectors ...SelectorFunc) ([]models.AccessKey, error) {
@@ -185,7 +186,7 @@ func ValidateAccessKey(tx GormTxn, authnKey string) (*models.AccessKey, error) {
 		}
 
 		t.ExtensionDeadline = time.Now().UTC().Add(t.Extension)
-		if err := SaveAccessKey(tx, t); err != nil {
+		if err := UpdateAccessKey(tx, t); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -451,6 +451,20 @@ func handleError(err error) error {
 	return err
 }
 
+func handleReadError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return internal.ErrNotFound
+	case errors.Is(err, sql.ErrNoRows):
+		return internal.ErrNotFound
+	}
+	return err
+}
+
 func delete[T models.Modelable](tx GormTxn, id uid.ID) error {
 	db := tx.GormDB()
 	if isOrgMember(new(T)) {

--- a/internal/server/data/pagination.go
+++ b/internal/server/data/pagination.go
@@ -1,18 +1,23 @@
 package data
 
-import "math"
-
 // Internal Pagination Data
 type Pagination struct {
 	Page       int
 	Limit      int
 	TotalCount int
-	TotalPages int
 }
 
 func (p *Pagination) SetTotalCount(count int) {
 	if p.Limit != 0 {
 		p.TotalCount = count
-		p.TotalPages = int(math.Ceil(float64(count) / float64(p.Limit)))
 	}
+}
+
+func (p *Pagination) PaginateQuery(query *queryBuilder) {
+	if p.Page == 0 && p.Limit == 0 {
+		return
+	}
+
+	offset := p.Limit * (p.Page - 1)
+	query.B("LIMIT ? OFFSET ?", p.Limit, offset)
 }

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -154,7 +154,7 @@ func TestDeleteProviders(t *testing.T) {
 			err = DeleteProviders(db, ByOptionalName(providerDevelop.Name))
 			assert.NilError(t, err)
 
-			_, err = GetAccessKey(db, ByID(key.ID))
+			_, err = GetAccessKey(db, key.KeyID)
 			assert.ErrorContains(t, err, "record not found")
 		})
 
@@ -174,7 +174,7 @@ func TestDeleteProviders(t *testing.T) {
 			err = DeleteProviders(db, ByOptionalName(providerDevelop.Name))
 			assert.NilError(t, err)
 
-			_, err = GetAccessKey(db, ByID(key.ID))
+			_, err = GetAccessKey(db, key.KeyID)
 			assert.NilError(t, err)
 		})
 

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -112,11 +112,18 @@ func update(tx WriteTxn, item Updatable) error {
 	query.B(item.Table())
 	query.B("SET")
 	query.B(columnsForUpdate(item.Columns()), item.Values()...)
-	query.B("WHERE id = ?;", item.Primary())
+	query.B("WHERE deleted_at is null AND id = ?;", item.Primary())
 	_, err := tx.Exec(query.String(), query.Args...)
 	return err
 }
 
 func columnsForUpdate(columns []string) string {
 	return strings.Join(columns, " = ?, ") + " = ?"
+}
+
+func columnsForSelect(tableAlias string, columns []string) string {
+	if tableAlias == "" {
+		return strings.Join(columns, ", ")
+	}
+	return tableAlias + "." + strings.Join(columns, ", "+tableAlias+".")
 }

--- a/internal/server/data/query_test.go
+++ b/internal/server/data/query_test.go
@@ -67,7 +67,7 @@ func TestUpdate(t *testing.T) {
 	tx := &txnCapture{}
 	err := update(tx, e)
 	assert.NilError(t, err)
-	expected := `UPDATE examples SET id = ?, first = ?, age = ? WHERE id = ?; `
+	expected := `UPDATE examples SET id = ?, first = ?, age = ? WHERE deleted_at is null AND id = ?; `
 	assert.Equal(t, tx.query, expected)
 	expectedArgs := []any{uid.ID(123), "first", 111, uid.ID(123)}
 	assert.DeepEqual(t, tx.args, expectedArgs)

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -81,12 +81,6 @@ func ByProviderID(id uid.ID) SelectorFunc {
 	}
 }
 
-func ByKeyID(key string) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("key_id = ?", key)
-	}
-}
-
 func ByOptionalSubject(polymorphicID uid.PolymorphicID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		if polymorphicID == "" {
@@ -109,12 +103,6 @@ func ByOptionalIssuedFor(id uid.ID) SelectorFunc {
 			return db
 		}
 
-		return db.Where("issued_for = ?", id)
-	}
-}
-
-func ByIssuedFor(id uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("issued_for = ?", id)
 	}
 }

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -1,9 +1,6 @@
 package data
 
 import (
-	"strings"
-	"time"
-
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/server/models"
@@ -110,15 +107,6 @@ func ByOptionalIssuedFor(id uid.ID) SelectorFunc {
 func ByIdentityID(identityID uid.ID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("identity_id = ?", identityID)
-	}
-}
-
-func ByNotExpiredOrExtended() SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		query := strings.Builder{}
-		query.WriteString("(expires_at > ? OR expires_at = ? OR expires_at is null) AND ")
-		query.WriteString("(extension_deadline > ? OR extension_deadline = ? OR extension_deadline is null)")
-		return db.Where(query.String(), time.Now().UTC(), time.Time{}, time.Now().UTC(), time.Time{})
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -216,7 +216,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 
 	return &api.LoginResponse{
 		UserID:                 key.IssuedFor,
-		Name:                   key.IssuedForIdentity.Name,
+		Name:                   key.IssuedForName,
 		AccessKey:              result.Bearer,
 		Expires:                api.Time(key.ExpiresAt),
 		PasswordUpdateRequired: result.CredentialUpdateRequired,

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -20,9 +20,9 @@ type AccessKey struct {
 	OrganizationMember
 	Name string `gorm:"uniqueIndex:idx_access_keys_name,where:deleted_at is NULL"`
 	// IssuedFor is the ID of the user that this access key was created for
-	IssuedFor         uid.ID
-	IssuedForIdentity *Identity `gorm:"foreignKey:IssuedFor" db:"-"`
-	ProviderID        uid.ID
+	IssuedFor     uid.ID
+	IssuedForName string
+	ProviderID    uid.ID
 
 	ExpiresAt         time.Time
 	Extension         time.Duration // how long to increase the lifetime extension deadline by
@@ -36,17 +36,12 @@ type AccessKey struct {
 }
 
 func (ak *AccessKey) ToAPI() *api.AccessKey {
-	issuedForName := ""
-	if ak.IssuedForIdentity != nil {
-		issuedForName = ak.IssuedForIdentity.Name
-	}
-
 	return &api.AccessKey{
 		ID:                ak.ID,
 		Name:              ak.Name,
 		Created:           api.Time(ak.CreatedAt),
 		IssuedFor:         ak.IssuedFor,
-		IssuedForName:     issuedForName,
+		IssuedForName:     ak.IssuedForName,
 		ProviderID:        ak.ProviderID,
 		Expires:           api.Time(ak.ExpiresAt),
 		ExtensionDeadline: api.Time(ak.ExtensionDeadline),

--- a/internal/server/pagination.go
+++ b/internal/server/pagination.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"math"
+
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/server/data"
 )
@@ -31,6 +33,6 @@ func PaginationToResponse(p data.Pagination) api.PaginationResponse {
 		Page:       p.Page,
 		Limit:      p.Limit,
 		TotalCount: p.TotalCount,
-		TotalPages: p.TotalPages,
+		TotalPages: int(math.Ceil(float64(p.TotalCount) / float64(p.Limit))),
 	}
 }


### PR DESCRIPTION
## Summary

Branched from #3029, and including the commit from #3093

This PR replaces gorm with sql in the query functions for get, list, and update access keys, and also adds more test coverage for those functions.

The biggest difference is in the pagination, which I'll comment on inline.

## Related Issues

Related to https://github.com/infrahq/infra/issues/2415
