### PR TITLE
Remove GormDB from query functions that already used SQL

### DIFF
--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -225,8 +225,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 				assert.NilError(t, err)
 
 				pu.Groups = []string{"existing3"}
-				err = db.GormDB().Save(pu).Error
-				assert.NilError(t, err)
+				assert.NilError(t, data.UpdateProviderUser(db, pu))
 
 				return &mockOIDCImplementation{
 					UserEmailResp:  "eugwnw@example.com",

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -73,6 +73,14 @@ func (d *DB) Close() error {
 	return sqlDB.Close()
 }
 
+func (d *DB) SQLdb() *sql.DB {
+	sqlDB, err := d.DB.DB()
+	if err != nil {
+		panic("DB must have an sql.DB ConnPool")
+	}
+	return sqlDB
+}
+
 func (d *DB) DriverName() string {
 	return d.Dialector.Name()
 }

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -107,6 +107,7 @@ func RemoveUsersFromGroup(db GormTxn, groupID uid.ID, idsToRemove []uid.ID) erro
 	return nil
 }
 
+// TODO: do this with a join in ListGroups and GetGroup
 func CountUsersInGroup(tx GormTxn, groupID uid.ID) (int64, error) {
 	db := tx.GormDB()
 	var count int64

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -12,7 +12,6 @@ import (
 )
 
 func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.Provider, newGroups []string) error {
-	db := tx.GormDB()
 	pu, err := GetProviderUser(tx, provider.ID, user.ID)
 	if err != nil {
 		return err
@@ -24,14 +23,15 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 
 	pu.Groups = newGroups
 	pu.LastUpdate = time.Now().UTC()
-	if err := save(tx, pu); err != nil {
+	if err := UpdateProviderUser(tx, pu); err != nil {
 		return fmt.Errorf("save: %w", err)
 	}
 
 	// remove user from groups
 	if len(groupsToBeRemoved) > 0 {
-		err = db.Exec("delete from identities_groups where identity_id = ? and group_id in (select id from groups where name in (?))", user.ID, groupsToBeRemoved).Error
-		if err != nil {
+		stmt := `DELETE FROM identities_groups WHERE identity_id = ? AND group_id in (
+		   SELECT id from groups where name in (?))`
+		if _, err := tx.Exec(stmt, user.ID, groupsToBeRemoved); err != nil {
 			return err
 		}
 		for _, name := range groupsToBeRemoved {
@@ -44,13 +44,27 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 		}
 	}
 
-	var addIDs []struct {
+	type idNamePair struct {
 		ID   uid.ID
 		Name string
 	}
-	err = db.Table("groups").Select("id, name").Where("name in (?)", groupsToBeAdded).Scan(&addIDs).Error
+	var addIDs []idNamePair
+
+	stmt := `SELECT id, name FROM groups WHERE name in (?)`
+	rows, err := tx.Query(stmt, groupsToBeAdded)
 	if err != nil {
-		return fmt.Errorf("group ids: %w", err)
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var item idNamePair
+		if err := rows.Scan(&item.ID, &item.Name); err != nil {
+			return err
+		}
+		addIDs = append(addIDs, item)
+	}
+	if rows.Err() != nil {
+		return err
 	}
 
 	for _, name := range groupsToBeAdded {
@@ -77,13 +91,26 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 		}
 
 		var ids []uid.ID
-		if err := db.Raw("SELECT identity_id FROM identities_groups WHERE identity_id = ? AND group_id = ?", user.ID, groupID).Scan(&ids).Error; err != nil {
-			return fmt.Errorf("select: %w", handleError(err))
+		rows, err := tx.Query("SELECT identity_id FROM identities_groups WHERE identity_id = ? AND group_id = ?", user.ID, groupID)
+		if err != nil {
+			return err
+		}
+
+		for rows.Next() {
+			var item uid.ID
+			if err := rows.Scan(&item); err != nil {
+				rows.Close()
+				return err
+			}
+			ids = append(ids, item)
+		}
+		if rows.Err() != nil {
+			return err
 		}
 
 		if len(ids) == 0 {
 			// add user to group
-			err = db.Exec("insert into identities_groups (identity_id, group_id) values (?, ?)", user.ID, groupID).Error
+			_, err = tx.Exec("insert into identities_groups (identity_id, group_id) values (?, ?)", user.ID, groupID)
 			if err != nil {
 				return fmt.Errorf("insert: %w", handleError(err))
 			}

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -30,7 +30,7 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 	// remove user from groups
 	if len(groupsToBeRemoved) > 0 {
 		stmt := `DELETE FROM identities_groups WHERE identity_id = ? AND group_id in (
-		   SELECT id from groups where name in (?))`
+		   SELECT id FROM groups WHERE name IN (?))`
 		if _, err := tx.Exec(stmt, user.ID, groupsToBeRemoved); err != nil {
 			return err
 		}
@@ -50,7 +50,7 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 	}
 	var addIDs []idNamePair
 
-	stmt := `SELECT id, name FROM groups WHERE name in (?)`
+	stmt := `SELECT id, name FROM groups WHERE name IN (?)`
 	rows, err := tx.Query(stmt, groupsToBeAdded)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 
 		if len(ids) == 0 {
 			// add user to group
-			_, err = tx.Exec("insert into identities_groups (identity_id, group_id) values (?, ?)", user.ID, groupID)
+			_, err = tx.Exec("INSERT INTO identities_groups (identity_id, group_id) VALUES (?, ?)", user.ID, groupID)
 			if err != nil {
 				return fmt.Errorf("insert: %w", handleError(err))
 			}

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -97,7 +97,7 @@ type providersCount struct {
 }
 
 func CountProvidersByKind(tx ReadTxn) ([]providersCount, error) {
-	rows, err := tx.Query("SELECT kind, COUNT(*) as count FROM providers WHERE kind <> 'infra' AND deleted_at IS NULL GROUP BY kind")
+	rows, err := tx.Query("SELECT kind, COUNT(*) AS count FROM providers WHERE kind <> 'infra' AND deleted_at IS NULL GROUP BY kind")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -96,12 +96,21 @@ type providersCount struct {
 	Count float64
 }
 
-func CountProvidersByKind(tx GormTxn) ([]providersCount, error) {
-	db := tx.GormDB()
-	var results []providersCount
-	if err := db.Raw("SELECT kind, COUNT(*) as count FROM providers WHERE kind <> 'infra' AND deleted_at IS NULL GROUP BY kind").Scan(&results).Error; err != nil {
+func CountProvidersByKind(tx ReadTxn) ([]providersCount, error) {
+	rows, err := tx.Query("SELECT kind, COUNT(*) as count FROM providers WHERE kind <> 'infra' AND deleted_at IS NULL GROUP BY kind")
+	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
-	return results, nil
+	var results []providersCount
+	for rows.Next() {
+		var item providersCount
+		if err := rows.Scan(&item.Kind, &item.Count); err != nil {
+			return nil, err
+		}
+		results = append(results, item)
+	}
+
+	return results, rows.Err()
 }

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -214,11 +214,13 @@ func TestRecreateProviderSameDomain(t *testing.T) {
 
 func TestCountProvidersByKind(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
-		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "oidc", Kind: "oidc"}))
-		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "okta", Kind: "okta"}))
-		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "okta2", Kind: "okta"}))
-		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "azure", Kind: "azure"}))
-		assert.NilError(t, CreateProvider(db, &models.Provider{Name: "google", Kind: "google"}))
+		createProviders(t, db,
+			&models.Provider{Name: "oidc", Kind: "oidc"},
+			&models.Provider{Name: "okta", Kind: "okta"},
+			&models.Provider{Name: "okta2", Kind: "okta"},
+			&models.Provider{Name: "azure", Kind: "azure"},
+			&models.Provider{Name: "google", Kind: "google"},
+		)
 
 		actual, err := CountProvidersByKind(db)
 		assert.NilError(t, err)

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -10,12 +10,9 @@ import (
 	"github.com/infrahq/infra/metrics"
 )
 
-func setupMetrics(db data.GormTxn) *prometheus.Registry {
+func setupMetrics(db *data.DB) *prometheus.Registry {
 	registry := metrics.NewRegistry(productVersion())
-
-	if sqlDB, err := db.GormDB().DB(); err == nil {
-		registry.MustRegister(collectors.NewDBStatsCollector(sqlDB, db.DriverName()))
-	}
+	registry.MustRegister(collectors.NewDBStatsCollector(db.SQLdb(), db.DriverName()))
 
 	registry.MustRegister(metrics.NewCollector(prometheus.Opts{
 		Namespace: "infra",

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -78,7 +78,10 @@ func setupMetrics(db data.GormTxn) *prometheus.Registry {
 
 		values := make([]metrics.Metric, 0, len(results))
 		for _, result := range results {
-			values = append(values, metrics.Metric{Count: float64(result.Count), LabelValues: []string{result.Kind}})
+			values = append(values, metrics.Metric{
+				Count:       result.Count,
+				LabelValues: []string{result.Kind},
+			})
 		}
 
 		return values

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	run := func(db data.GormTxn, s string) []byte {
+	run := func(db *data.DB, s string) []byte {
 		patchProductVersion(t, "9.9.9")
 		registry := setupMetrics(db)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -144,7 +144,7 @@ func New(options Options) (*Server, error) {
 		return nil, fmt.Errorf("db: %w", err)
 	}
 	server.db = db
-	server.metricsRegistry = setupMetrics(server.DB())
+	server.metricsRegistry = setupMetrics(server.db)
 
 	if options.EnableTelemetry {
 		server.tel = NewTelemetry(server.DB(), db.DefaultOrgSettings.ID)


### PR DESCRIPTION
## Summary

Branched from #3094 

This PR removes `GormTxn` from a few functions that were already using regular SQL through the gorm interface. 


## Related Issues

Related to https://github.com/infrahq/infra/issues/2415