### PR TITLE
fix(build): fix workflows for release

### DIFF
--- a/.github/workflows/cd-binaries.yaml
+++ b/.github/workflows/cd-binaries.yaml
@@ -55,6 +55,7 @@ jobs:
     needs: [prepare, build]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: binaries

--- a/.github/workflows/cd-containers.yaml
+++ b/.github/workflows/cd-containers.yaml
@@ -24,36 +24,29 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      component-name: ${{ steps.component-name.outputs.component-name }}
-      container-image-name: ${{ steps.component-name.outputs.container-image-name }}
-      container-image-context: ${{ steps.component-name.outputs.container-image-context }}
+      components: ${{ steps.components.outputs.components }}
     steps:
-      - id: component-name
+      - id: components
         run: |
-          COMPONENT_NAME=$(echo ${{ github.event_name == 'workflow_run' && github.event.workflow_run.name || inputs.component-name }} | awk '{ print $NF }' )
-          if [ "$COMPONENT_NAME" = "core" ]; then
-            CONTAINER_IMAGE_NAME='infrahq/infra'
-            CONTAINER_IMAGE_CONTEXT='.'
-          elif [ "$COMPONENT_NAME" = "ui" ]; then
-            CONTAINER_IMAGE_NAME='infrahq/ui'
-            CONTAINER_IMAGE_CONTEXT='ui'
-          else 
-            echo Missing Infra component name.
-            exit 1
-          fi
+          COMPONENT_NAME=$(echo ${{ github.event_name == 'workflow_run' && github.event.workflow_run.name || inputs.component-name }} | awk '{ print $NF }')
+          case $COMPONENT_NAME in
+            core) COMPONENTS='[{"name":"core","container-image-name":"infrahq/infra","container-image-context":"."}]' ;;
+            ui) COMPONENTS='[{"name":"ui","container-image-name":"infrahq/ui","container-image-context":"ui"}]' ;;
+            *) COMPONENTS='[{"name":"core","container-image-name":"infrahq/infra","container-image-context":"."},{"name":"ui","container-image-name":"infrahq/ui","container-image-context":"ui"}]' ;;
+          esac
 
-          echo "::notice ::Infra component name $COMPONENT_NAME"
-          echo "::set-output name=component-name::$COMPONENT_NAME"
-          echo "::set-output name=container-image-name::$CONTAINER_IMAGE_NAME"
-          echo "::set-output name=container-image-context::$CONTAINER_IMAGE_CONTEXT"
+          echo "::set-output name=components::$COMPONENTS"
 
   build:
     runs-on: ubuntu-latest
     needs: [prepare]
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      matrix:
+        component: ${{ fromJson(needs.prepare.outputs.components) }}
     env:
-      IMAGE: ${{ needs.prepare.outputs.container-image-name }}
-      CONTEXT: ${{ needs.prepare.outputs.container-image-context }}
+      IMAGE: ${{ matrix.component.container-image-name }}
+      CONTEXT: ${{ matrix.component.container-image-context }}
     steps:
       - uses: actions/checkout@v3
       - uses: docker/login-action@v2
@@ -86,12 +79,13 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
+        component: ${{ fromJson(needs.prepare.outputs.components) }}
         environment:
           - name: Development
           - name: Production
     environment: ${{ matrix.environment.name }}
     concurrency:
-      group: ${{ github.workflow }}-synchronize-${{ matrix.environment.name }}-${{ needs.prepare.outputs.component-name }}
+      group: ${{ github.workflow }}-synchronize-${{ matrix.environment.name }}-${{ matrix.component.name }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -105,5 +99,4 @@ jobs:
           argocd-tools: |
             argocd-image-updater
       - run: |
-          echo Syncing Infra component-name ${{ needs.prepare.outputs.component-name }}
-          argocd-image-updater run --once --match-application-label=ci.infrahq.com/component=${{ needs.prepare.outputs.component-name }}
+          argocd-image-updater run --once --match-application-label=ci.infrahq.com/component=${{ matrix.component.name }}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

fix container build to build both `infrahq/infra` and `infrahq/ui` components when not explicitly set. this can happen when triggered by a tag

checkout in binary publish job so `gh` is aware of the repo