### PR TITLE
fix(build): ignore synchronize job if triggered by tag

### DIFF
--- a/.github/workflows/cd-containers.yaml
+++ b/.github/workflows/cd-containers.yaml
@@ -76,7 +76,7 @@ jobs:
   synchronize:
     runs-on: ubuntu-latest
     needs: [prepare, build]
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ !contains(fromJson('["workflow_run","tag"]'), github.event_name) || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         component: ${{ fromJson(needs.prepare.outputs.components) }}

--- a/.github/workflows/cd-helm.yaml
+++ b/.github/workflows/cd-helm.yaml
@@ -1,11 +1,13 @@
 name: cd / helm
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - ci / helm
+    types:
+      - completed
     branches:
       - main
-    paths:
-      - 'helm/**'
   workflow_dispatch:
     inputs:
       override-chart:
@@ -16,6 +18,7 @@ on:
 jobs:
   package:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v3
       - uses: azure/setup-helm@v1
@@ -30,6 +33,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [package]
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Tag triggers shouldn't try to deploy since 1) it's not allowed to deploy to environments and 2) deployments do not use any tags produced by a tag build.