### PR TITLE
Make data.Transaction.Rollback a noop if the transaction was already committed

### DIFF
--- a/internal/server/apimigrator.go
+++ b/internal/server/apimigrator.go
@@ -66,7 +66,7 @@ func addRequestRewrite[oldReq any, newReq any](api *API, method, path, version s
 
 			oldReqObj := new(oldReq)
 
-			err = bind(c, oldReqObj)
+			err = readRequest(c, oldReqObj)
 			if err != nil {
 				sendAPIError(c, err)
 				return

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -167,7 +167,7 @@ func (t *Transaction) GormDB() *gorm.DB {
 	return t.DB
 }
 
-// Rollback the transaction. If the transaction was already committed than do
+// Rollback the transaction. If the transaction was already committed then do
 // nothing.
 func (t *Transaction) Rollback() error {
 	if t.committed.Load() {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -127,32 +127,6 @@ func validateOrgMatchesRequest(req *http.Request, tx data.GormTxn, accessKeyOrg 
 	}
 }
 
-func withDBTxn(ctx context.Context, db *data.DB, fn func(tx *data.Transaction) error) error {
-	tx, err := db.Begin(ctx)
-	if err != nil {
-		return err
-	}
-
-	// See https://github.com/golang/go/issues/25448 for why this does not use
-	// recover.
-	var success bool
-
-	defer func() {
-		if success {
-			err = tx.Commit()
-		} else {
-			err = tx.Rollback()
-		}
-		if err != nil {
-			logging.L.Error().Err(err).Msg("failed to commit database transaction")
-		}
-	}()
-
-	err = fn(tx)
-	success = err == nil
-	return err
-}
-
 // validateRequestOrganization is the alternative to authenticateRequest used
 // for routes that don't require authentication. It checks for an optional
 // access key, and if one does not exist, finds the organizationID from the

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -202,14 +202,9 @@ func wrapRoute[Req, Res any](a *API, route route[Req, Res]) func(*gin.Context) e
 		if err != nil {
 			return err
 		}
-		// See https://github.com/golang/go/issues/25448 for why this does not use
-		// recover.
-		var committed bool
 		defer func() {
-			if !committed {
-				if err := tx.Rollback(); err != nil {
-					logging.L.Error().Err(err).Msg("failed to rollback database transaction")
-				}
+			if err := tx.Rollback(); err != nil {
+				logging.L.Error().Err(err).Msg("failed to rollback database transaction")
 			}
 		}()
 
@@ -241,7 +236,6 @@ func wrapRoute[Req, Res any](a *API, route route[Req, Res]) func(*gin.Context) e
 		if err := tx.Commit(); err != nil {
 			return err
 		}
-		committed = true
 
 		if !route.omitFromTelemetry {
 			a.t.RouteEvent(c, route.path, Properties{"method": strings.ToLower(route.method)})

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -247,14 +247,7 @@ func wrapRoute[Req, Res any](a *API, route route[Req, Res]) func(*gin.Context) e
 			a.t.RouteEvent(c, route.path, Properties{"method": strings.ToLower(route.method)})
 		}
 
-		statusCode := defaultResponseCodeForMethod(route.method)
-		if c, ok := any(resp).(statusCoder); ok {
-			if code := c.StatusCode(); code != 0 {
-				statusCode = code
-			}
-		}
-
-		c.JSON(statusCode, resp)
+		c.JSON(responseStatusCode(route.method, resp), resp)
 		return nil
 	}
 }
@@ -279,7 +272,12 @@ func trimWhitespace(req interface{}) {
 	}
 }
 
-func defaultResponseCodeForMethod(method string) int {
+func responseStatusCode(method string, resp any) int {
+	if c, ok := resp.(statusCoder); ok {
+		if code := c.StatusCode(); code != 0 {
+			return code
+		}
+	}
 	switch method {
 	case http.MethodPost:
 		return http.StatusCreated

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -229,11 +229,9 @@ func wrapRoute[Req, Res any](a *API, route route[Req, Res]) func(*gin.Context) e
 		}
 
 		req := new(Req)
-		if err := bind(c, req); err != nil {
+		if err := readRequest(c, req); err != nil {
 			return err
 		}
-
-		trimWhitespace(req)
 
 		resp, err := route.handler(c, req)
 		if err != nil {
@@ -327,7 +325,7 @@ func addDeprecated[Req, Res any](a *API, r *routeGroup, method string, path stri
 	})
 }
 
-func bind(c *gin.Context, req interface{}) error {
+func readRequest(c *gin.Context, req interface{}) error {
 	if err := c.ShouldBindUri(req); err != nil {
 		return fmt.Errorf("%w: %s", internal.ErrBadRequest, err)
 	}
@@ -348,6 +346,7 @@ func bind(c *gin.Context, req interface{}) error {
 		}
 	}
 
+	trimWhitespace(req)
 	return nil
 }
 

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func TestBindsQuery(t *testing.T) {
+func TestReadRequest_FromQuery(t *testing.T) {
 	c, _ := gin.CreateTestContext(nil)
 
 	uri, err := url.Parse("/foo?alpha=beta")
@@ -32,13 +32,13 @@ func TestBindsQuery(t *testing.T) {
 	r := &struct {
 		Alpha string `form:"alpha"`
 	}{}
-	err = bind(c, r)
+	err = readRequest(c, r)
 	assert.NilError(t, err)
 
 	assert.Equal(t, "beta", r.Alpha)
 }
 
-func TestBindsJSON(t *testing.T) {
+func TestReadRequest_JSON(t *testing.T) {
 	c, _ := gin.CreateTestContext(nil)
 
 	uri, err := url.Parse("/foo")
@@ -55,13 +55,13 @@ func TestBindsJSON(t *testing.T) {
 	r := &struct {
 		Alpha string `json:"alpha"`
 	}{}
-	err = bind(c, r)
+	err = readRequest(c, r)
 	assert.NilError(t, err)
 
 	assert.Equal(t, "zeta", r.Alpha)
 }
 
-func TestBindsUUIDs(t *testing.T) {
+func TestReadRequest_UUIDs(t *testing.T) {
 	c, _ := gin.CreateTestContext(nil)
 
 	uri, err := url.Parse("/foo/e4d97df2")
@@ -70,13 +70,13 @@ func TestBindsUUIDs(t *testing.T) {
 	c.Request = &http.Request{URL: uri, Method: "GET"}
 	c.Params = append(c.Params, gin.Param{Key: "id", Value: "e4d97df2"})
 	r := &api.Resource{}
-	err = bind(c, r)
+	err = readRequest(c, r)
 	assert.NilError(t, err)
 
 	assert.Equal(t, "e4d97df2", r.ID.String())
 }
 
-func TestBindsSnowflake(t *testing.T) {
+func TestReadRequest_Snowflake(t *testing.T) {
 	c, _ := gin.CreateTestContext(nil)
 
 	id := uid.New()
@@ -91,14 +91,14 @@ func TestBindsSnowflake(t *testing.T) {
 		ID     uid.ID `uri:"id"`
 		FormID uid.ID `form:"form_id"`
 	}{}
-	err = bind(c, r)
+	err = readRequest(c, r)
 	assert.NilError(t, err)
 
 	assert.Equal(t, id, r.ID)
 	assert.Equal(t, id2, r.FormID)
 }
 
-func TestBindsEmptyRequest(t *testing.T) {
+func TestReadRequest_EmptyRequest(t *testing.T) {
 	c, _ := gin.CreateTestContext(nil)
 
 	uri, err := url.Parse("/foo")
@@ -106,7 +106,7 @@ func TestBindsEmptyRequest(t *testing.T) {
 
 	c.Request = &http.Request{URL: uri, Method: "GET"}
 	r := &api.EmptyRequest{}
-	err = bind(c, r)
+	err = readRequest(c, r)
 	assert.NilError(t, err)
 }
 
@@ -129,7 +129,7 @@ func TestTimestampAndDurationSerialization(t *testing.T) {
 		Deadline  api.Time     `json:"deadline"`
 		Extension api.Duration `json:"extension"`
 	}{}
-	err = bind(c, r)
+	err = readRequest(c, r)
 	assert.NilError(t, err)
 
 	expected := time.Date(2022, 3, 23, 17, 50, 59, 0, time.UTC)


### PR DESCRIPTION
## Summary

Branched from #3103

This PR does some cleanup around transactions. Best viewed by individual commit.

1. make `data.Transaction.Rollback` a noop if the transaction was already committed. This makes it possible to defer the rollback, and simplifies the logic where we use transactions.
2. remove `withDBTxn` since it is no longer necessary with the above change.
3. extracts a few small things from `wrapRoute`. This function has grown a lot, moving a few small things out of it helps keep it focused and easy to read.