### PR TITLE
Forgot Domains

### DIFF
--- a/api/forgotdomain.go
+++ b/api/forgotdomain.go
@@ -1,0 +1,14 @@
+package api
+
+import "github.com/infrahq/infra/internal/validate"
+
+type ForgotDomainRequest struct {
+	Email string `json:"email"`
+}
+
+func (r ForgotDomainRequest) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.Required("email", r.Email),
+		validate.Email("email", r.Email),
+	}
+}

--- a/internal/access/forgotdomain.go
+++ b/internal/access/forgotdomain.go
@@ -1,0 +1,25 @@
+package access
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func ForgotDomainRequest(c *gin.Context, email string) ([]models.ForgottenDomain, error) {
+	// no auth required
+	db := getDB(c)
+
+	domains, err := data.GetForgottenDomainsForEmail(db, email)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(domains) < 1 {
+		return nil, internal.ErrNotFound
+	}
+
+	return domains, nil
+}

--- a/internal/server/data/forgotdomain.go
+++ b/internal/server/data/forgotdomain.go
@@ -7,8 +7,10 @@ import (
 func GetForgottenDomainsForEmail(tx ReadTxn, email string) ([]models.ForgottenDomain, error) {
 	var results []models.ForgottenDomain
 
-	// TODO - use tx.QueryRow and remove .Error and iterate through the rows
 	rows, err := tx.Query("SELECT organizations.name, organizations.domain, identities.last_seen_at FROM identities, organizations WHERE identities.organization_id = organizations.id AND identities.name = ?", email)
+	if err != nil {
+		return results, err
+	}
 	defer rows.Close()
 
 	for rows.Next() {

--- a/internal/server/data/forgotdomain.go
+++ b/internal/server/data/forgotdomain.go
@@ -1,0 +1,26 @@
+package data
+
+import (
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func GetForgottenDomainsForEmail(tx ReadTxn, email string) ([]models.ForgottenDomain, error) {
+	var results []models.ForgottenDomain
+
+	// TODO - use tx.QueryRow and remove .Error and iterate through the rows
+	rows, err := tx.Query("SELECT organizations.name, organizations.domain, identities.last_seen_at FROM identities, organizations WHERE identities.organization_id = organizations.id AND identities.name = ?", email)
+	defer rows.Close()
+
+	for rows.Next() {
+		var r models.ForgottenDomain
+		if err := rows.Scan(&r.OrganizationName, &r.OrganizationDomain, &r.LastSeenAt); err != nil {
+			return results, err
+		}
+		results = append(results, r)
+	}
+
+	if err = rows.Err(); err != nil {
+		return results, err
+	}
+	return results, nil
+}

--- a/internal/server/data/forgotdomain.go
+++ b/internal/server/data/forgotdomain.go
@@ -1,6 +1,9 @@
 package data
 
 import (
+	"time"
+
+	"github.com/infrahq/infra/internal/format"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -15,9 +18,11 @@ func GetForgottenDomainsForEmail(tx ReadTxn, email string) ([]models.ForgottenDo
 
 	for rows.Next() {
 		var r models.ForgottenDomain
-		if err := rows.Scan(&r.OrganizationName, &r.OrganizationDomain, &r.LastSeenAt); err != nil {
+		var lastSeenAt time.Time
+		if err := rows.Scan(&r.OrganizationName, &r.OrganizationDomain, &lastSeenAt); err != nil {
 			return results, err
 		}
+		r.LastSeenAt = format.HumanTime(lastSeenAt, "never")
 		results = append(results, r)
 	}
 

--- a/internal/server/data/forgotdomain_test.go
+++ b/internal/server/data/forgotdomain_test.go
@@ -1,0 +1,63 @@
+package data
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/opt"
+
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func TestGetForgottenDomainsForEmail(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		orgA := &models.Organization{Name: "A Team", Domain: "ateam"}
+		err := CreateOrganization(db, orgA)
+		assert.NilError(t, err)
+
+		orgB := &models.Organization{Name: "B Team", Domain: "bteam"}
+		err = CreateOrganization(db, orgB)
+		assert.NilError(t, err)
+
+		userA := &models.Identity{Name: "john.smith@ateam.com", OrganizationMember: models.OrganizationMember{OrganizationID: orgA.ID}, LastSeenAt: time.Now()}
+		err = CreateIdentity(db, userA)
+		assert.NilError(t, err)
+
+		t.Run("no orgs", func(t *testing.T) {
+			results, err := GetForgottenDomainsForEmail(db, "francis.lynch@teamusa.org")
+			assert.NilError(t, err)
+			assert.Assert(t, len(results) == 0)
+		})
+
+		t.Run("single orgs", func(t *testing.T) {
+			results, err := GetForgottenDomainsForEmail(db, userA.Name)
+			assert.NilError(t, err)
+			assert.Assert(t, len(results) == 1)
+
+			assert.DeepEqual(t, results[0], models.ForgottenDomain{OrganizationName: orgA.Name, OrganizationDomain: orgA.Domain, LastSeenAt: time.Now()}, domainCmpModel)
+		})
+
+		userB := &models.Identity{Name: "john.smith@ateam.com", OrganizationMember: models.OrganizationMember{OrganizationID: orgB.ID}}
+		err = CreateIdentity(db, userB)
+		assert.NilError(t, err)
+
+		t.Run("multi orgs", func(t *testing.T) {
+			results, err := GetForgottenDomainsForEmail(db, userA.Name)
+			assert.NilError(t, err)
+			assert.Assert(t, len(results) == 2)
+
+			for _, r := range results {
+				assert.Assert(t, strings.Contains(r.OrganizationName, " Team"))
+				assert.Assert(t, strings.Contains(r.OrganizationDomain, "team"))
+			}
+		})
+
+	})
+}
+
+var domainCmpModel = cmp.Options{
+	cmp.FilterPath(opt.PathField(models.ForgottenDomain{}, "LastSeenAt"), opt.TimeWithThreshold(2*time.Second)),
+}

--- a/internal/server/data/forgotdomain_test.go
+++ b/internal/server/data/forgotdomain_test.go
@@ -5,10 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/opt"
 
+	"github.com/infrahq/infra/internal/format"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -37,7 +36,7 @@ func TestGetForgottenDomainsForEmail(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Assert(t, len(results) == 1)
 
-			assert.DeepEqual(t, results[0], models.ForgottenDomain{OrganizationName: orgA.Name, OrganizationDomain: orgA.Domain, LastSeenAt: time.Now()}, domainCmpModel)
+			assert.DeepEqual(t, results[0], models.ForgottenDomain{OrganizationName: orgA.Name, OrganizationDomain: orgA.Domain, LastSeenAt: format.HumanTime(time.Now(), "never")})
 		})
 
 		userB := &models.Identity{Name: "john.smith@ateam.com", OrganizationMember: models.OrganizationMember{OrganizationID: orgB.ID}}
@@ -56,8 +55,4 @@ func TestGetForgottenDomainsForEmail(t *testing.T) {
 		})
 
 	})
-}
-
-var domainCmpModel = cmp.Options{
-	cmp.FilterPath(opt.PathField(models.ForgottenDomain{}, "LastSeenAt"), opt.TimeWithThreshold(2*time.Second)),
 }

--- a/internal/server/email/forgotdomain.go
+++ b/internal/server/email/forgotdomain.go
@@ -1,0 +1,13 @@
+package email
+
+import (
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+type ForgottenDomainData struct {
+	Domains []models.ForgottenDomain
+}
+
+func SendForgotDomains(name, address string, data ForgottenDomainData) error {
+	return SendTemplate(name, address, EmailTemplateForgottenDomains, data)
+}

--- a/internal/server/email/sendgrid.go
+++ b/internal/server/email/sendgrid.go
@@ -19,6 +19,7 @@ const (
 	EmailTemplateSignup EmailTemplate = iota
 	EmailTemplatePasswordReset
 	EmailTemplateUserInvite
+	EmailTemplateForgottenDomains
 )
 
 type TemplateDetail struct {
@@ -39,6 +40,10 @@ var emailTemplates = map[EmailTemplate]TemplateDetail{
 		TemplateName: "user-invite",
 		Subject:      "{{.FromUserName}} has invited you to Infra",
 	},
+	EmailTemplateForgottenDomains: {
+		TemplateName: "forgot-domain",
+		Subject:      "Your sign-in links",
+	},
 }
 
 var (
@@ -58,21 +63,6 @@ func IsConfigured() bool {
 }
 
 func SendTemplate(name, address string, template EmailTemplate, data any) error {
-	if TestMode {
-		logging.Debugf("sent email to %q: %+v\n", address, data)
-		TestDataSent = append(TestDataSent, data)
-		return nil // quietly return
-	}
-
-	if len(SendgridAPIKey) == 0 {
-		return ErrNotConfigured
-	}
-
-	if name == "" {
-		// until we have real user names
-		name = BuildNameFromEmail(address)
-	}
-
 	details, ok := emailTemplates[template]
 	if !ok {
 		return ErrUnknownTemplate
@@ -110,6 +100,23 @@ func SendTemplate(name, address string, template EmailTemplate, data any) error 
 		return err
 	}
 	msg.HTMLBody = w.Bytes()
+
+	if TestMode {
+		logging.Debugf("sent email to %q: %+v\n", address, data)
+		logging.Debugf("plain: %s", string(msg.PlainBody))
+		logging.Debugf("html: %s", string(msg.HTMLBody))
+		TestDataSent = append(TestDataSent, data)
+		return nil // quietly return
+	}
+
+	if len(SendgridAPIKey) == 0 {
+		return ErrNotConfigured
+	}
+
+	if name == "" {
+		// until we have real user names
+		name = BuildNameFromEmail(address)
+	}
 
 	// TODO: handle rate limiting, retries, understanding which errors are retryable, send queues, whatever
 	if err := SendSMTP(msg); err != nil {

--- a/internal/server/email/sendgrid.go
+++ b/internal/server/email/sendgrid.go
@@ -78,6 +78,11 @@ func SendTemplate(name, address string, template EmailTemplate, data any) error 
 		return fmt.Errorf("rendering subject: %w", err)
 	}
 
+	if name == "" {
+		// until we have real user names
+		name = BuildNameFromEmail(address)
+	}
+
 	msg := Message{
 		FromName:    FromName,
 		FromAddress: FromAddress,
@@ -111,11 +116,6 @@ func SendTemplate(name, address string, template EmailTemplate, data any) error 
 
 	if len(SendgridAPIKey) == 0 {
 		return ErrNotConfigured
-	}
-
-	if name == "" {
-		// until we have real user names
-		name = BuildNameFromEmail(address)
 	}
 
 	// TODO: handle rate limiting, retries, understanding which errors are retryable, send queues, whatever

--- a/internal/server/email/smtp_test.go
+++ b/internal/server/email/smtp_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/infrahq/infra/internal/server/models"
 	"gotest.tools/v3/assert"
 )
 
@@ -191,6 +192,22 @@ func TestSendSignup(t *testing.T) {
 
 	err := SendTemplate("steven", "steven@example.com", EmailTemplateSignup, SignupData{
 		Link: "https://supahdomain.example.com/login",
+	})
+	assert.NilError(t, err)
+}
+
+func TestSendForgotDomain(t *testing.T) {
+	srv := setupSMTPServer(t, successCase)
+	setupClient(srv)
+
+	err := SendTemplate("", "hannibal@ateam.org", EmailTemplateForgottenDomains, ForgottenDomainData{
+		Domains: []models.ForgottenDomain{
+			models.ForgottenDomain{
+				OrganizationName:   "A Team",
+				OrganizationDomain: "ateam.infrahq.com",
+				LastSeenAt:         time.Now(),
+			},
+		},
 	})
 	assert.NilError(t, err)
 }

--- a/internal/server/email/smtp_test.go
+++ b/internal/server/email/smtp_test.go
@@ -12,6 +12,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/infrahq/infra/internal/format"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -206,7 +207,7 @@ func TestSendForgotDomain(t *testing.T) {
 			{
 				OrganizationName:   "A Team",
 				OrganizationDomain: "ateam.infrahq.com",
-				LastSeenAt:         time.Now(),
+				LastSeenAt:         format.HumanTime(time.Now(), "never"),
 			},
 		},
 	})

--- a/internal/server/email/smtp_test.go
+++ b/internal/server/email/smtp_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/infrahq/infra/internal/server/models"
 	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/server/models"
 )
 
 func setupClient(srv net.Listener) {
@@ -202,7 +203,7 @@ func TestSendForgotDomain(t *testing.T) {
 
 	err := SendTemplate("", "hannibal@ateam.org", EmailTemplateForgottenDomains, ForgottenDomainData{
 		Domains: []models.ForgottenDomain{
-			models.ForgottenDomain{
+			{
 				OrganizationName:   "A Team",
 				OrganizationDomain: "ateam.infrahq.com",
 				LastSeenAt:         time.Now(),

--- a/internal/server/email/templates/forgot-domain.text.html
+++ b/internal/server/email/templates/forgot-domain.text.html
@@ -1,5 +1,5 @@
 
 <p>Someone has requested links to each of the organizations associated with your Infra account. If this was not you, you can safely ignore this email.</p>
 
-{{range $v := .Domains}}<p><a href="https://{{$v.OrganizationDomain}}/login">{{$v.OrganizationDomain}}</a></p>
+{{range $v := .Domains}}<p>{{$v.OrganizationName}} <a href="https://{{$v.OrganizationDomain}}/login">https://{{$v.OrganizationDomain}}/login</a> (last seen {{$v.LastSeenAt}})</p>
 {{end}}

--- a/internal/server/email/templates/forgot-domain.text.html
+++ b/internal/server/email/templates/forgot-domain.text.html
@@ -1,0 +1,5 @@
+
+<p>Someone has requested links to each of the organizations associated with your Infra account. If this was not you, you can safely ignore this email.</p>
+
+{{range $v := .Domains}}<p><a href="https://{{$v.OrganizationDomain}}/login">{{$v.OrganizationDomain}}</a></p>
+{{end}}

--- a/internal/server/email/templates/forgot-domain.text.plain
+++ b/internal/server/email/templates/forgot-domain.text.plain
@@ -1,5 +1,5 @@
 Someone has requested links to each of the organizations associated with your Infra account. If this was not you, you can safely ignore this email.
 
 You can sign in to your organization here:
-{{range $v := .Domains}}  https://{{$v.OrganizationDomain}}/login 
+{{range $v := .Domains}}  {{$v.OrganizationName}}	https://{{$v.OrganizationDomain}}/login 	(last seen {{$v.LastSeenAt}})
 {{end}}

--- a/internal/server/email/templates/forgot-domain.text.plain
+++ b/internal/server/email/templates/forgot-domain.text.plain
@@ -1,0 +1,5 @@
+Someone has requested links to each of the organizations associated with your Infra account. If this was not you, you can safely ignore this email.
+
+You can sign in to your organization here:
+{{range $v := .Domains}}  https://{{$v.OrganizationDomain}}/login 
+{{end}}

--- a/internal/server/forgotdomain.go
+++ b/internal/server/forgotdomain.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/access"
+	"github.com/infrahq/infra/internal/logging"
+	//"github.com/infrahq/infra/internal/server/email"
+)
+
+func (a *API) RequestForgotDomains(c *gin.Context, r *api.ForgotDomainRequest) (*api.EmptyResponse, error) {
+	logging.Infof("forgot domain")
+	domains, err := access.ForgotDomainRequest(c, r.Email)
+
+	if err != nil {
+		if errors.Is(err, internal.ErrNotFound) {
+			logging.Infof("No orgs found for user %s", r.Email)
+			return nil, nil // This is okay. we don't notify the user if we failed to find the email.
+		}
+		return nil, err
+	}
+
+	// TODO: Send the email
+	for _, d := range domains {
+		logging.Infof("Forgot domain: %s -- '%s' '%s'", r.Email, d.OrganizationName, d.OrganizationDomain)
+	}
+
+	return nil, nil
+}

--- a/internal/server/forgotdomain.go
+++ b/internal/server/forgotdomain.go
@@ -8,25 +8,22 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
-	"github.com/infrahq/infra/internal/logging"
-	//"github.com/infrahq/infra/internal/server/email"
+	"github.com/infrahq/infra/internal/server/email"
 )
 
 func (a *API) RequestForgotDomains(c *gin.Context, r *api.ForgotDomainRequest) (*api.EmptyResponse, error) {
-	logging.Infof("forgot domain")
 	domains, err := access.ForgotDomainRequest(c, r.Email)
 
 	if err != nil {
 		if errors.Is(err, internal.ErrNotFound) {
-			logging.Infof("No orgs found for user %s", r.Email)
 			return nil, nil // This is okay. we don't notify the user if we failed to find the email.
 		}
 		return nil, err
 	}
 
-	// TODO: Send the email
-	for _, d := range domains {
-		logging.Infof("Forgot domain: %s -- '%s' '%s'", r.Email, d.OrganizationName, d.OrganizationDomain)
+	err = email.SendForgotDomains("", r.Email, email.ForgottenDomainData{Domains: domains})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/internal/server/models/forgotdomain.go
+++ b/internal/server/models/forgotdomain.go
@@ -1,11 +1,7 @@
 package models
 
-import (
-	"time"
-)
-
 type ForgottenDomain struct {
 	OrganizationName   string
 	OrganizationDomain string
-	LastSeenAt         time.Time
+	LastSeenAt         string
 }

--- a/internal/server/models/forgotdomain.go
+++ b/internal/server/models/forgotdomain.go
@@ -1,0 +1,11 @@
+package models
+
+import (
+	"time"
+)
+
+type ForgottenDomain struct {
+	OrganizationName   string
+	OrganizationDomain string
+	LastSeenAt         time.Time
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -104,6 +104,7 @@ func (s *Server) GenerateRoutes() Routes {
 	post(a, noAuthnNoOrg, "/api/signup", a.Signup)
 	get(a, noAuthnNoOrg, "/api/version", a.Version)
 	get(a, noAuthnNoOrg, "/api/server-configuration", a.GetServerConfiguration)
+	post(a, noAuthnNoOrg, "/api/forgot-domain-request", a.RequestForgotDomains)
 
 	// no auth required, org required
 	noAuthnWithOrg := apiGroup.Group("/", unauthenticatedMiddleware(a.server), orgRequired())

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -2023,6 +2023,109 @@
         ]
       }
     },
+    "/api/forgot-domain-request": {
+      "post": {
+        "description": "RequestForgotDomains",
+        "operationId": "RequestForgotDomains",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.0.0",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "email": {
+                    "format": "email",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "RequestForgotDomains",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
     "/api/grants": {
       "get": {
         "description": "ListGrants",

--- a/ui/pages/forgot-domain/index.js
+++ b/ui/pages/forgot-domain/index.js
@@ -37,7 +37,8 @@ export default function ForgotDomain() {
         <h1 className='text-base font-bold leading-snug'>Forgot Domain</h1>
         {submitted ? (
           <p className='my-3 max-w-[260px] text-xs text-gray-300'>
-            Please check your email to find a list of organizations which match your email address.
+            Please check your email to find a list of organizations which match
+            your email address.
           </p>
         ) : (
           <>
@@ -92,7 +93,7 @@ export default function ForgotDomain() {
           </>
         )}
       </>
-  </>
+    </>
   )
 }
 

--- a/ui/pages/forgot-domain/index.js
+++ b/ui/pages/forgot-domain/index.js
@@ -9,6 +9,7 @@ export default function ForgotDomain() {
 
   async function onSubmit(e) {
     e.preventDefault()
+    setSubmitted(true)
 
     try {
       const res = await fetch('/api/forgot-domain-request', {
@@ -23,7 +24,6 @@ export default function ForgotDomain() {
       }
 
       await res.json()
-      setSubmitted(true)
     } catch (e) {
       console.error(e)
     }

--- a/ui/pages/forgot-domain/index.js
+++ b/ui/pages/forgot-domain/index.js
@@ -79,7 +79,7 @@ export default function ForgotDomain() {
                 />
               </div>
               <button
-                disabled={!email}
+                disabled={!email || submitted}
                 className='mt-6 mb-2 rounded-lg border border-violet-300 px-4 py-3 text-2xs text-violet-100 hover:border-violet-100 disabled:pointer-events-none disabled:opacity-30'
               >
                 Submit

--- a/ui/pages/forgot-domain/index.js
+++ b/ui/pages/forgot-domain/index.js
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+
+import LoginLayout from '../../components/layouts/login'
+
+export default function ForgotDomain() {
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  async function onSubmit(e) {
+    e.preventDefault()
+
+    try {
+      const res = await fetch('/api/forgot-domain-request', {
+        method: 'post',
+        body: JSON.stringify({
+          email,
+        }),
+      })
+
+      if (!res.ok) {
+        throw await res.json()
+      }
+
+      await res.json()
+      setSubmitted(true)
+    } catch (e) {
+      console.error(e)
+    }
+
+    return false
+  }
+
+  return (
+    <>
+      <>
+        <h1 className='text-base font-bold leading-snug'>Forgot Domain</h1>
+        {submitted ? (
+          <p className='my-3 max-w-[260px] text-xs text-gray-300'>
+            Please check your email to find a list of organizations which match your email address.
+          </p>
+        ) : (
+          <>
+            <h2 className='my-3 max-w-[260px] text-center text-xs text-gray-300'>
+              Please enter your email
+            </h2>
+            <div className='relative mt-4 w-full'>
+              <div
+                className='absolute inset-0 flex items-center'
+                aria-hidden='true'
+              >
+                <div className='w-full border-t border-gray-800' />
+              </div>
+            </div>
+            <form
+              onSubmit={onSubmit}
+              className='relative flex w-full max-w-sm flex-col'
+            >
+              <div className='my-2 w-full'>
+                <label
+                  htmlFor='email'
+                  className='text-3xs uppercase text-gray-500'
+                >
+                  Email
+                </label>
+                <input
+                  required
+                  autoFocus
+                  id='email'
+                  placeholder='enter your email'
+                  onChange={e => {
+                    setEmail(e.target.value)
+                    setError('')
+                  }}
+                  className={`w-full border-b border-gray-800 bg-transparent px-px py-2 text-2xs placeholder:italic focus:border-b focus:border-gray-200 focus:outline-none ${
+                    error ? 'border-pink-500/60' : ''
+                  }`}
+                />
+              </div>
+              <button
+                disabled={!email}
+                className='mt-6 mb-2 rounded-lg border border-violet-300 px-4 py-3 text-2xs text-violet-100 hover:border-violet-100 disabled:pointer-events-none disabled:opacity-30'
+              >
+                Submit
+              </button>
+              {error && (
+                <p className='absolute -bottom-3.5 mx-auto w-full text-center text-2xs text-pink-400'>
+                  {error}
+                </p>
+              )}
+            </form>
+          </>
+        )}
+      </>
+  </>
+  )
+}
+
+ForgotDomain.layout = page => <LoginLayout>{page}</LoginLayout>


### PR DESCRIPTION
## Summary

Provide a UI screen + API endpoint to allow users to recover any domain/org sign-ins that they have previously created. 

It's possible that users may forget how to sign-in to a given org given that we don't support 'at-large' users. In order for a user to sign in, they *must* know the correct domain name. This change allows the user to specify an email address which we will send an email which contains each of the URLs which they can use to sign-in.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


