### PR TITLE
fix: add build-args back to docker image build

### DIFF
--- a/.github/workflows/cd-containers.yaml
+++ b/.github/workflows/cd-containers.yaml
@@ -25,7 +25,9 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       components: ${{ steps.components.outputs.components }}
+      release-name: ${{ steps.release-name.outputs.release-name }}
     steps:
+      - uses: actions/checkout@v3
       - id: components
         run: |
           COMPONENT_NAME=$(echo ${{ github.event_name == 'workflow_run' && github.event.workflow_run.name || inputs.component-name }} | awk '{ print $NF }')
@@ -36,6 +38,10 @@ jobs:
           esac
 
           echo "::set-output name=components::$COMPONENTS"
+      - id: release-name
+        run: |
+          RELEASE_NAME=${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '$(git describe --tags)' }}
+          echo "::set-output name=release-name::${RELEASE_NAME#v}"
 
   build:
     runs-on: ubuntu-latest
@@ -68,6 +74,9 @@ jobs:
           context: ${{ env.CONTEXT }}
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            BUILDVERSION=${{ needs.prepare.outputs.release-name }}
+            TELEMETRY_WRITE_KEY=${{ secrets.TELEMETRY_WRITE_KEY }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           cache-from: type=registry,ref=${{ env.IMAGE }}:edge

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,8 @@ builds:
         -X github.com/infrahq/infra/internal.Version={{ .Version }}
         -X github.com/infrahq/infra/internal.Commit={{ .FullCommit }}
         -X github.com/infrahq/infra/internal.Date={{ .Date }}
+        -X github.com/infrahq/infra/internal.Prerelease=
+        -X github.com/infrahq/infra/internal.Metadata=
     binary: infra
     main: ./main.go
     goos:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Add back docker build args. These got lost in refactoring.

Also zero out the `Prerelease` and `Metadata` version parts when building the infra CLI using goreleaser

Resolves #3116 