### PR TITLE
fix(build): need fetch-depth:0 for git tags

### DIFF
--- a/.github/workflows/cd-containers.yaml
+++ b/.github/workflows/cd-containers.yaml
@@ -28,6 +28,8 @@ jobs:
       release-name: ${{ steps.release-name.outputs.release-name }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - id: components
         run: |
           COMPONENT_NAME=$(echo ${{ github.event_name == 'workflow_run' && github.event.workflow_run.name || inputs.component-name }} | awk '{ print $NF }')


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`actions/checkout` defaults to a depth 1 checkout which doesn't have enough information for `git describe --tags` so change to infinite depth (0)