### PR TITLE
maintain: move the human formatter out to its own package

### DIFF
--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/infrahq/infra/api"
+	humanfmt "github.com/infrahq/infra/internal/format"
 	"github.com/infrahq/infra/internal/logging"
 )
 
@@ -87,7 +88,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 						Name:     d.Name,
 						URL:      d.Connection.URL,
 						Status:   status,
-						LastSeen: HumanTime(d.LastSeen.Time(), "never"),
+						LastSeen: humanfmt.HumanTime(d.LastSeen.Time(), "never"),
 					})
 				}
 				if len(rows) > 0 {

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/format"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/uid"
 )
@@ -100,10 +101,10 @@ $ infra keys add connector
 
 			var expMsg strings.Builder
 			expMsg.WriteString("This key will expire in ")
-			expMsg.WriteString(ExactDuration(options.TTL))
+			expMsg.WriteString(format.ExactDuration(options.TTL))
 			if !resp.Expires.Equal(resp.ExtensionDeadline) {
 				expMsg.WriteString(", and must be used every ")
-				expMsg.WriteString(ExactDuration(options.ExtensionDeadline))
+				expMsg.WriteString(format.ExactDuration(options.ExtensionDeadline))
 				expMsg.WriteString(" to remain valid")
 			}
 			cli.Output("Issued access key %q for %q", resp.Name, userName)
@@ -235,9 +236,9 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 				rows = append(rows, row{
 					Name:              k.Name,
 					IssuedFor:         name,
-					Created:           HumanTime(k.Created.Time(), "never"),
-					Expires:           HumanTime(k.Expires.Time(), "never"),
-					ExtensionDeadline: HumanTime(k.ExtensionDeadline.Time(), "never"),
+					Created:           format.HumanTime(k.Created.Time(), "never"),
+					Expires:           format.HumanTime(k.Expires.Time(), "never"),
+					ExtensionDeadline: format.HumanTime(k.ExtensionDeadline.Time(), "never"),
 				})
 			}
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -23,6 +23,7 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/certs"
 	"github.com/infrahq/infra/internal/cmd/types"
+	"github.com/infrahq/infra/internal/format"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/logging"
 )
@@ -561,7 +562,7 @@ func promptLoginOptions(cli *CLI, client *api.Client) (loginMethod loginMethod, 
 
 func promptVerifyTLSCert(cli *CLI, cert *x509.Certificate) error {
 	formatTime := func(t time.Time) string {
-		return fmt.Sprintf("%v (%v)", HumanTime(t, "none"), t.Format(time.RFC1123))
+		return fmt.Sprintf("%v (%v)", format.HumanTime(t, "none"), t.Format(time.RFC1123))
 	}
 	title := "Certificate"
 	if cert.IsCA {

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/infrahq/infra/api"
+	humanfmt "github.com/infrahq/infra/internal/format"
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/uid"
@@ -173,7 +174,7 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 				for _, user := range users {
 					rows = append(rows, row{
 						Name:       user.Name,
-						LastSeenAt: HumanTime(user.LastSeenAt.Time(), "never"),
+						LastSeenAt: humanfmt.HumanTime(user.LastSeenAt.Time(), "never"),
 						Providers:  strings.Join(user.ProviderNames, ", "),
 					})
 				}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,4 +1,4 @@
-package cmd
+package format
 
 import (
 	"fmt"

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,4 +1,4 @@
-package cmd
+package format
 
 import (
 	"testing"


### PR DESCRIPTION
## Summary

This change moves out the human formatter code into its own package so that we can use it in other places, such as when we send emails.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades
