### PR TITLE
maintain: use the same encrypted at rest type for both strings and bytes

### DIFF
--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -46,7 +46,7 @@ func initializeSettings(tx GormTxn, orgID uid.ID) (*models.Settings, error) {
 
 	settings = &models.Settings{
 		OrganizationMember: models.OrganizationMember{OrganizationID: orgID},
-		PrivateJWK:         secs,
+		PrivateJWK:         models.EncryptedAtRest(secs),
 		PublicJWK:          pubs,
 	}
 

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -24,7 +24,7 @@ func createJWT(db GormTxn, identity *models.Identity, groups []string, expires t
 	}
 
 	var sec jose.JSONWebKey
-	if err := sec.UnmarshalJSON(settings.PrivateJWK); err != nil {
+	if err := sec.UnmarshalJSON([]byte(settings.PrivateJWK)); err != nil {
 		return "", err
 	}
 

--- a/internal/server/models/encryption.go
+++ b/internal/server/models/encryption.go
@@ -35,8 +35,13 @@ func (s EncryptedAtRest) Value() (driver.Value, error) {
 }
 
 func (s *EncryptedAtRest) Scan(v interface{}) error {
-	vStr, ok := v.(string)
-	if !ok {
+	var vStr string
+	switch typ := v.(type) {
+	case string:
+		vStr = typ
+	case []byte:
+		vStr = string(typ)
+	default:
 		return fmt.Errorf("unsupported type: %T", v)
 	}
 
@@ -55,52 +60,6 @@ func (s *EncryptedAtRest) Scan(v interface{}) error {
 	}
 
 	*s = EncryptedAtRest(b)
-
-	return nil
-}
-
-// EncryptedAtRestBytes defines a field that knows how to encrypt and decrypt itself with Gorm
-// it depends on the SymmetricKey being set for this package.
-type EncryptedAtRestBytes []byte
-
-func (b EncryptedAtRestBytes) Value() (driver.Value, error) {
-	if SkipSymmetricKey {
-		return []byte(b), nil
-	}
-
-	if SymmetricKey == nil {
-		return nil, fmt.Errorf("models.SymmetricKey is not set")
-	}
-
-	be, err := secrets.Seal(SymmetricKey, b)
-	if err != nil {
-		return nil, fmt.Errorf("sealing secret field: %w", err)
-	}
-
-	return be, err
-}
-
-func (b *EncryptedAtRestBytes) Scan(v interface{}) error {
-	vBytes, ok := v.([]byte)
-	if !ok {
-		return fmt.Errorf("unsupported type: %T", v)
-	}
-
-	if SkipSymmetricKey {
-		*b = EncryptedAtRestBytes(vBytes)
-		return nil
-	}
-
-	if SymmetricKey == nil {
-		return fmt.Errorf("models.SymmetricKey is not set")
-	}
-
-	plain, err := secrets.Unseal(SymmetricKey, vBytes)
-	if err != nil {
-		return fmt.Errorf("unsealing secret field: %w", err)
-	}
-
-	*b = EncryptedAtRestBytes(plain)
 
 	return nil
 }

--- a/internal/server/models/settings.go
+++ b/internal/server/models/settings.go
@@ -8,7 +8,7 @@ type Settings struct {
 	Model
 	OrganizationMember
 
-	PrivateJWK EncryptedAtRestBytes
+	PrivateJWK EncryptedAtRest
 	PublicJWK  []byte
 
 	LowercaseMin int `gorm:"default:0"`


### PR DESCRIPTION
## Summary

We had two copies of this type that were almost identical. One for []byte and one for string. Since `string` and `[]byte` are compatible, we can use the same type for both `bytea` and `text` database columns.

I added a test to show this type working with a `bytea` type column. The test was written first, so it also showed that a value serialzied using `EncryptedAtRestBytes` could be later read using `EncryptedAtRest`. This works because the `Value()` method uses the same function to encode the data going into the database.