### PR TITLE
maintain: remove two access helper functions

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -36,6 +36,10 @@ func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey) (body string, 
 		return "", HandleAuthErr(err, "access key", "create", models.InfraAdminRole)
 	}
 
+	if accessKey.ProviderID == 0 {
+		accessKey.ProviderID = data.InfraProvider(db).ID
+	}
+
 	body, err = data.CreateAccessKey(db, accessKey)
 	if err != nil {
 		return "", fmt.Errorf("create token: %w", err)

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -63,9 +63,3 @@ func DeleteProvider(c *gin.Context, id uid.ID) error {
 
 	return data.DeleteProviders(db, data.ByID(id))
 }
-
-func InfraProvider(c *gin.Context) *models.Provider {
-	db := getDB(c)
-
-	return data.InfraProvider(db)
-}


### PR DESCRIPTION

## Summary

Branched from #3141, this PR makes a similar change.
These functions `InfraProvider`, and `InfraConnectorIdentity` are not providing access. They exist because of the rules we have established for how the data package can be accessed. We can refactor the code slightly to remove the need for these functions by calling the functions in the `data` package directly from `access`.

