### PR TITLE
Use SQL for CreateGrant

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,8 @@ issues:
   exclude-rules:
     - linters: [staticcheck]
       text: "\"io/ioutil\" has been deprecated"
+    - linters: [errcheck]
+      text: "tx\\.Rollback"
 
 linters:
   enable:

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/infrahq/infra/internal/generate"
+	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -114,8 +115,8 @@ type ListAccessKeyOptions struct {
 
 func ListAccessKeys(tx ReadTxn, opts ListAccessKeyOptions) ([]models.AccessKey, error) {
 	table := &accessKeyTable{}
-	query := Query("SELECT")
-	query.B(columnsForSelect("k", table.Columns()))
+	query := querybuilder.New("SELECT")
+	query.B(columnsForSelect("k", table))
 	query.B(", u.name")
 	if opts.Pagination != nil {
 		query.B(", count(*) OVER()")
@@ -168,8 +169,8 @@ func ListAccessKeys(tx ReadTxn, opts ListAccessKeyOptions) ([]models.AccessKey, 
 // this query is not scoped by an organization_id.
 func GetAccessKey(tx ReadTxn, keyID string) (*models.AccessKey, error) {
 	accessKey := &accessKeyTable{}
-	query := Query("SELECT")
-	query.B(columnsForSelect("", accessKey.Columns()))
+	query := querybuilder.New("SELECT")
+	query.B(columnsForSelect("", accessKey))
 	query.B("FROM")
 	query.B(accessKey.Table())
 	query.B("WHERE deleted_at is null")
@@ -193,7 +194,7 @@ type DeleteAccessKeysOptions struct {
 }
 
 func DeleteAccessKeys(tx WriteTxn, opts DeleteAccessKeysOptions) error {
-	query := Query("UPDATE access_keys")
+	query := querybuilder.New("UPDATE access_keys")
 	query.B("SET deleted_at = ? WHERE", time.Now())
 	switch {
 	case opts.ByID != 0:

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -10,6 +10,24 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+type grantTable models.Grant
+
+func (g grantTable) Table() string {
+	return "grants"
+}
+
+func (g grantTable) Columns() []string {
+	return []string{"created_at", "created_by", "deleted_at", "id", "organization_id", "privilege", "resource", "subject", "updated_at"}
+}
+
+func (g grantTable) Values() []any {
+	return []any{g.CreatedAt, g.CreatedBy, g.DeletedAt, g.ID, g.OrganizationID, g.Privilege, g.Resource, g.Subject, g.UpdatedAt}
+}
+
+func (g *grantTable) ScanFields() []any {
+	return []any{&g.CreatedAt, &g.CreatedBy, &g.DeletedAt, &g.ID, &g.OrganizationID, &g.Privilege, &g.Resource, &g.Subject, &g.UpdatedAt}
+}
+
 func CreateGrant(db GormTxn, grant *models.Grant) error {
 	switch {
 	case grant.Subject == "":

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -10,25 +10,25 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-type grantTable models.Grant
+type grantsTable models.Grant
 
-func (g grantTable) Table() string {
+func (g grantsTable) Table() string {
 	return "grants"
 }
 
-func (g grantTable) Columns() []string {
+func (g grantsTable) Columns() []string {
 	return []string{"created_at", "created_by", "deleted_at", "id", "organization_id", "privilege", "resource", "subject", "updated_at"}
 }
 
-func (g grantTable) Values() []any {
+func (g grantsTable) Values() []any {
 	return []any{g.CreatedAt, g.CreatedBy, g.DeletedAt, g.ID, g.OrganizationID, g.Privilege, g.Resource, g.Subject, g.UpdatedAt}
 }
 
-func (g *grantTable) ScanFields() []any {
+func (g *grantsTable) ScanFields() []any {
 	return []any{&g.CreatedAt, &g.CreatedBy, &g.DeletedAt, &g.ID, &g.OrganizationID, &g.Privilege, &g.Resource, &g.Subject, &g.UpdatedAt}
 }
 
-func CreateGrant(db GormTxn, grant *models.Grant) error {
+func CreateGrant(tx WriteTxn, grant *models.Grant) error {
 	switch {
 	case grant.Subject == "":
 		return fmt.Errorf("subject is required")
@@ -37,7 +37,8 @@ func CreateGrant(db GormTxn, grant *models.Grant) error {
 	case grant.Resource == "":
 		return fmt.Errorf("resource is required")
 	}
-	return add(db, grant)
+
+	return insert(tx, (*grantsTable)(grant))
 }
 
 func GetGrant(db GormTxn, selectors ...SelectorFunc) (*models.Grant, error) {

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -1,48 +1,82 @@
 package data
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
+	"github.com/infrahq/infra/uid"
+
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func TestDuplicateGrant(t *testing.T) {
+func TestCreateGrant_DuplicateGrant(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
-		g := models.Grant{
-			Model:     models.Model{ID: 1},
-			Subject:   "i:1234567",
-			Privilege: "view",
-			Resource:  "infra",
-		}
-		g2 := models.Grant{
-			Model:     models.Model{ID: 2},
-			Subject:   "i:1234567",
-			Privilege: "view",
-			Resource:  "infra",
-		}
+		t.Run("success", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 
-		err := CreateGrant(db, &g)
-		assert.NilError(t, err)
+			actual := models.Grant{
+				Subject:   "i:1234567",
+				Privilege: "view",
+				Resource:  "infra",
+				CreatedBy: uid.ID(1091),
+			}
+			err := CreateGrant(tx, &actual)
+			assert.NilError(t, err)
+			assert.Assert(t, actual.ID != 0)
 
-		err = CreateGrant(db, &g2)
-		assert.ErrorContains(t, err, "already exists")
+			expected := models.Grant{
+				Model: models.Model{
+					ID:        uid.ID(999),
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrganizationID},
+				Subject:            "i:1234567",
+				Privilege:          "view",
+				Resource:           "infra",
+				CreatedBy:          uid.ID(1091),
+			}
+			assert.DeepEqual(t, actual, expected, cmpModel)
+		})
+		t.Run("duplicate grant", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 
-		grants, err := ListGrants(db, nil, BySubject("i:1234567"), ByResource("infra"))
-		assert.NilError(t, err)
-		assert.Assert(t, is.Len(grants, 1))
+			g := models.Grant{
+				Subject:   "i:1234567",
+				Privilege: "view",
+				Resource:  "infra",
+			}
+			err := CreateGrant(tx, &g)
+			assert.NilError(t, err)
 
-		g3 := models.Grant{
-			Model:     models.Model{ID: 3},
-			Subject:   "i:1234567",
-			Privilege: "edit",
-			Resource:  "infra",
-		}
-		// check that unique constraint needs all three fields
+			g2 := models.Grant{
+				Subject:   "i:1234567",
+				Privilege: "view",
+				Resource:  "infra",
+			}
+			err = CreateGrant(tx, &g2)
+			var ucErr UniqueConstraintError
+			assert.Assert(t, errors.As(err, &ucErr))
+			assert.DeepEqual(t, ucErr, UniqueConstraintError{Table: "grants"})
 
-		err = CreateGrant(db, &g3)
-		assert.NilError(t, err)
+			grants, err := ListGrants(tx, nil,
+				BySubject("i:1234567"),
+				ByResource("infra"))
+			assert.NilError(t, err)
+			assert.Assert(t, is.Len(grants, 1))
+
+			g3 := models.Grant{
+				Subject:   "i:1234567",
+				Privilege: "edit",
+				Resource:  "infra",
+			}
+			// check that unique constraint needs all three fields
+			err = CreateGrant(tx, &g3)
+			assert.NilError(t, err)
+		})
 	})
 }

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -8,12 +8,11 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
-	"github.com/infrahq/infra/uid"
-
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
-func TestCreateGrant_DuplicateGrant(t *testing.T) {
+func TestCreateGrant(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		t.Run("success", func(t *testing.T) {
 			tx := txnForTestCase(t, db, db.DefaultOrg.ID)

--- a/internal/server/data/pagination.go
+++ b/internal/server/data/pagination.go
@@ -1,5 +1,7 @@
 package data
 
+import "github.com/infrahq/infra/internal/server/data/querybuilder"
+
 // Internal Pagination Data
 type Pagination struct {
 	Page       int
@@ -13,7 +15,7 @@ func (p *Pagination) SetTotalCount(count int) {
 	}
 }
 
-func (p *Pagination) PaginateQuery(query *queryBuilder) {
+func (p *Pagination) PaginateQuery(query *querybuilder.Query) {
 	if p.Page == 0 && p.Limit == 0 {
 		return
 	}

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -58,7 +58,7 @@ func insert(tx WriteTxn, item Insertable) error {
 	query.B(placeholderForColumns(item), item.Values()...)
 	query.B(");")
 	_, err := tx.Exec(query.String(), query.Args...)
-	return err
+	return handleError(err)
 }
 
 func columnsForInsert(table Table) string {
@@ -86,7 +86,7 @@ func update(tx WriteTxn, item Updatable) error {
 	query.B(columnsForUpdate(item), item.Values()...)
 	query.B("WHERE deleted_at is null AND id = ?;", item.Primary())
 	_, err := tx.Exec(query.String(), query.Args...)
-	return err
+	return handleError(err)
 }
 
 func columnsForUpdate(table Table) string {

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -3,38 +3,9 @@ package data
 import (
 	"strings"
 
+	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/uid"
 )
-
-type queryBuilder struct {
-	query strings.Builder
-	Args  []interface{}
-}
-
-// Query initializes a queryBuilder and returns it populated with stmt.
-// The stmt string can generally contain any SELECT, FROM, or JOIN
-// clauses, and may contain the entire query as long as there are no
-// query parameters.
-// Use queryBuilder.B to add sections of a query with parameters.
-func Query(stmt string) *queryBuilder {
-	q := &queryBuilder{}
-	q.query.WriteString(stmt + " ")
-	return q
-}
-
-// B adds clause and args to the query. The clause must be a trusted string
-// literal. Any arguments must be passed as args so that they are properly
-// escaped by the database driver.
-func (q *queryBuilder) B(clause string, args ...interface{}) {
-	q.query.WriteString(clause + " ")
-	q.Args = append(q.Args, args...)
-}
-
-// String returns the query string, which is used as the first parameter to
-// WriteTxn.Exec, or ReadTxn.Query. You must also pass q.Args as the varargs.
-func (q *queryBuilder) String() string {
-	return q.query.String()
-}
 
 type Table interface {
 	Table() string
@@ -79,22 +50,23 @@ func insert(tx WriteTxn, item Insertable) error {
 	}
 	setOrg(tx, item)
 
-	query := Query("INSERT INTO")
+	query := querybuilder.New("INSERT INTO")
 	query.B(item.Table())
 	query.B("(")
-	query.B(columnsForInsert(item.Columns()))
+	query.B(columnsForInsert(item))
 	query.B(") VALUES (")
-	query.B(placeholderForColumns(item.Columns()), item.Values()...)
+	query.B(placeholderForColumns(item), item.Values()...)
 	query.B(");")
 	_, err := tx.Exec(query.String(), query.Args...)
 	return err
 }
 
-func columnsForInsert(columns []string) string {
-	return strings.Join(columns, ", ")
+func columnsForInsert(table Table) string {
+	return strings.Join(table.Columns(), ", ")
 }
 
-func placeholderForColumns(columns []string) string {
+func placeholderForColumns(table Table) string {
+	columns := table.Columns()
 	result := make([]string, len(columns))
 	for i := range columns {
 		result[i] = "?"
@@ -108,22 +80,22 @@ func update(tx WriteTxn, item Updatable) error {
 	}
 	setOrg(tx, item)
 
-	query := Query("UPDATE")
+	query := querybuilder.New("UPDATE")
 	query.B(item.Table())
 	query.B("SET")
-	query.B(columnsForUpdate(item.Columns()), item.Values()...)
+	query.B(columnsForUpdate(item), item.Values()...)
 	query.B("WHERE deleted_at is null AND id = ?;", item.Primary())
 	_, err := tx.Exec(query.String(), query.Args...)
 	return err
 }
 
-func columnsForUpdate(columns []string) string {
-	return strings.Join(columns, " = ?, ") + " = ?"
+func columnsForUpdate(table Table) string {
+	return strings.Join(table.Columns(), " = ?, ") + " = ?"
 }
 
-func columnsForSelect(tableAlias string, columns []string) string {
+func columnsForSelect(tableAlias string, table Table) string {
 	if tableAlias == "" {
-		return strings.Join(columns, ", ")
+		return strings.Join(table.Columns(), ", ")
 	}
-	return tableAlias + "." + strings.Join(columns, ", "+tableAlias+".")
+	return tableAlias + "." + strings.Join(table.Columns(), ", "+tableAlias+".")
 }

--- a/internal/server/data/querybuilder/builder.go
+++ b/internal/server/data/querybuilder/builder.go
@@ -1,0 +1,52 @@
+/*
+Package querybuilder is a small package which provides a single type for building
+sql queries. Generally a single type would be too small for a whole package. In
+this case a separate packages is used because it is easier to perform static
+analysis for potential SQL injection. The query field of Query can only be
+directly accessed from this package, so internal/tools/querylinter only needs
+to check for use of exported methods.
+*/
+package querybuilder
+
+import "strings"
+
+// Query builds a sql statement from one or more trusted strings, and a list
+// of untrusted arguments.
+type Query struct {
+	// query is used as the trusted and unescaped query string. Only trusted
+	// string literals should be added to query. internal/tools/querylinter
+	// provides a linter that checks the use of exported methods, but there is
+	// no linter for this package. When making changes to Query ensure
+	// that the linter is updated to cover any new methods that may add strings
+	// to the query field.
+	query strings.Builder
+	// Args is a list of untrusted arguments that will be escaped by the
+	// database driver when constructing the query statement.
+	Args []interface{}
+}
+
+// New initializes a Query and returns it populated with stmt.
+// The stmt string must be a string literal, that will generally contain
+// SELECT, UPDATE, DELETE FROM, or INSERT INTO.
+//
+// Use Query.B to add sections of a query with parameters.
+func New(stmt string) *Query {
+	q := &Query{}
+	q.query.WriteString(stmt + " ")
+	return q
+}
+
+// B adds clause and args to the query. The clause must be a trusted string
+// literal. Any arguments must be passed as args so that they are properly
+// escaped by the database driver.
+func (q *Query) B(clause string, args ...interface{}) {
+	q.query.WriteString(clause + " ")
+	q.Args = append(q.Args, args...)
+}
+
+// String returns the query statement, which is used as the first parameter to
+// WriteTxn.Exec, or ReadTxn.Query. You must also pass q.Args as the varargs to
+// the transaction method.
+func (q *Query) String() string {
+	return q.query.String()
+}

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -94,16 +94,6 @@ func BySubject(polymorphicID uid.PolymorphicID) SelectorFunc {
 	}
 }
 
-func ByOptionalIssuedFor(id uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		if id == 0 {
-			return db
-		}
-
-		return db.Where("issued_for = ?", id)
-	}
-}
-
 func ByIdentityID(identityID uid.ID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("identity_id = ?", identityID)


### PR DESCRIPTION
## Summary

Primarily this PR converts `data.CreateGrant` from using gorm to using sql. It includes a few other small changes to reduce conflicts, so best viewed by individual commit.

This PR also:
* moves the query builder into its own package. This was cherry-picked out of #3060 to prevent conflicts. As part of that change the constructor and type name for the query builder have changed.
* adds a transaction around the `NewDB` initialize operations. Not strictly necessary, but a nice to have to ensure that any problems setting up the db are rolled back. 
* adds an exclude rule for `tx.Rollback` so that we can ignore the rollback error. I think generally that error is not going to be relevant.
* adds `handleErr` in `insert` and `update` helpers, which I missed when I added those functions.

Related to #2415
