### PR TITLE
fix: extend list of reserved domains in signup

### DIFF
--- a/api/restricted_subdomains.yaml
+++ b/api/restricted_subdomains.yaml
@@ -9,12 +9,16 @@ reject: # these are always rejected
     - admin
     - api
     - app
+    - beta
     - blog
     - cache
+    - chat
     - connector
+    - data
     - docs
     - dns
     - db
+    - demo
     - dev
     - devel
     - download
@@ -25,6 +29,7 @@ reject: # these are always rejected
     - events
     - feed
     - feeds
+    - file
     - files
     - feedback
     - forum
@@ -34,9 +39,14 @@ reject: # these are always rejected
     - grants
     - help
     - host
-    - info
+    - html
+    - icon
+    - icons
     - image
     - images
+    - img
+    - info
+    - ipv4
     - legal
     - links
     - login
@@ -64,6 +74,7 @@ reject: # these are always rejected
     - system
     - test
     - testing
+    - team
     - teams
     - vpn
     - web
@@ -112,6 +123,7 @@ requires-approval: # these require approval before they can be used. Anything le
     - delete
     - design
     - destroy
+    - devel
     - develop
     - developer
     - developers
@@ -150,8 +162,10 @@ requires-approval: # these require approval before they can be used. Anything le
     - iphone
     - jabber
     - knowledgebase
+    - ldap
     - legacy
     - library
+    - local
     - localhost
     - loghost
     - loopback
@@ -189,11 +203,14 @@ requires-approval: # these require approval before they can be used. Anything le
     - picture
     - pictures
     - policy
+    - pop
+    - pop3
     - portal
     - postmaster
     - press
     - preview
     - private
+    - prod
     - product
     - production
     - products
@@ -207,6 +224,7 @@ requires-approval: # these require approval before they can be used. Anything le
     - reports
     - research
     - reviews
+    - root
     - router
     - sandbox
     - secure
@@ -215,7 +233,8 @@ requires-approval: # these require approval before they can be used. Anything le
     - setting
     - settings
     - sharepoint
-    - shopping
+    - shop
+    - site
     - sitebuilder
     - sitemap
     - social
@@ -230,10 +249,12 @@ requires-approval: # these require approval before they can be used. Anything le
     - styles
     - survey
     - syndicated
+    - temp
     - termsofservice
     - thumbs
     - ticket
     - tickets
+    - tmp
     - tracker
     - tracking
     - training

--- a/api/restricted_subdomains.yaml
+++ b/api/restricted_subdomains.yaml
@@ -1,0 +1,283 @@
+--- # Reserved subdomains. anything <= 5 characters requires approval.
+reject: # these are always rejected
+    - about
+    - api
+    - auth
+    - infra
+    - infrahq
+    - abuse
+    - admin
+    - api
+    - app
+    - blog
+    - cache
+    - connector
+    - docs
+    - dns
+    - db
+    - dev
+    - devel
+    - download
+    - downloads
+    - email
+    - cloud
+    - dashboard
+    - events
+    - feed
+    - feeds
+    - files
+    - feedback
+    - forum
+    - forums
+    - ftp
+    - get
+    - grants
+    - help
+    - host
+    - info
+    - image
+    - images
+    - legal
+    - links
+    - login
+    - mail
+    - media
+    - messages
+    - mx
+    - ns
+    - privacy
+    - proxy
+    - public
+    - search
+    - server
+    - signup
+    - smtp
+    - ssh
+    - stage
+    - staging
+    - start
+    - static
+    - stats
+    - status
+    - statuspage
+    - support
+    - system
+    - test
+    - testing
+    - teams
+    - vpn
+    - web
+    - www
+
+requires-approval: # these require approval before they can be used. Anything len <= 5 is automatically on the requires-approval list
+    - access
+    - account
+    - accounts
+    - administrator
+    - administrators
+    - affiliate
+    - affiliates
+    - analytics
+    - archive
+    - assets
+    - autoconfig
+    - autodiscover
+    - backup
+    - backups
+    - bastion
+    - billing
+    - bookmark
+    - bookmarks
+    - business
+    - calendar
+    - careers
+    - citrix
+    - client
+    - clients
+    - comment
+    - comments
+    - communities
+    - community
+    - connect
+    - contact
+    - content
+    - contributors
+    - control
+    - copyright
+    - cpanel
+    - create
+    - cssproxy
+    - customize
+    - dbadmin
+    - delete
+    - design
+    - destroy
+    - develop
+    - developer
+    - developers
+    - development
+    - direct
+    - directory
+    - diversity
+    - domain
+    - domains
+    - drupal
+    - embedded
+    - english
+    - example
+    - exchange
+    - explore
+    - extranet
+    - facebook
+    - favorite
+    - favorites
+    - finance
+    - firewall
+    - friend
+    - friends
+    - gallery
+    - gateway
+    - general
+    - gmail
+    - groups
+    - guide
+    - guides
+    - hosting
+    - hostmaster
+    - intranet
+    - invite
+    - ipfixe
+    - iphone
+    - jabber
+    - knowledgebase
+    - legacy
+    - library
+    - localhost
+    - loghost
+    - loopback
+    - mailadmin
+    - mailer
+    - mailhost
+    - mailing
+    - mailman
+    - mailserver
+    - manage
+    - market
+    - marketing
+    - master
+    - member
+    - members
+    - mirror
+    - mobile
+    - monitor
+    - monitoring
+    - moodle
+    - network-ip
+    - newsletter
+    - office
+    - official
+    - oldmail
+    - online
+    - origin
+    - outlook
+    - partner
+    - partners
+    - payment
+    - payments
+    - photos
+    - phpmyadmin
+    - picture
+    - pictures
+    - policy
+    - portal
+    - postmaster
+    - press
+    - preview
+    - private
+    - product
+    - production
+    - products
+    - profile
+    - project
+    - projects
+    - redirect
+    - register
+    - remote
+    - report
+    - reports
+    - research
+    - reviews
+    - router
+    - sandbox
+    - secure
+    - service
+    - services
+    - setting
+    - settings
+    - sharepoint
+    - shopping
+    - sitebuilder
+    - sitemap
+    - social
+    - software
+    - speedtest
+    - sports
+    - statistics
+    - storage
+    - stream
+    - streaming
+    - student
+    - styles
+    - survey
+    - syndicated
+    - termsofservice
+    - thumbs
+    - ticket
+    - tickets
+    - tracker
+    - tracking
+    - training
+    - travel
+    - update
+    - updates
+    - upgrade
+    - upgrades
+    - upload
+    - username
+    - usernames
+    - videos
+    - volunteer
+    - volunteers
+    - webconf
+    - webdisk
+    - webmail
+    - webmaster
+    - wordpress
+    # some Fortune 500 companies
+    - walmart # (Walmart)
+    - apple # (Apple)
+    - verizon # (Verizon)
+    - costco # (Costco)
+    - amazon # (Amazon)
+    - boeing # (Boeing)
+    - microsoft # (Microsoft)
+    - citigroup # (Citigroup)
+    - statefarm # (State Farm Insurance Cos.)
+    - google # (Alphabet)
+    - comcast # (Comcast)
+    - target # (Target)
+    - pepsico # (PepsiCo)
+    - disney # (Disney)
+    - pfizer # (Pfizer)
+    - bestbuy # (Best Buy)
+    - oracle # (Oracle)
+    - americanexpress # (American Express)
+    - mcdonalds # (McDonald’s)
+    - staples # (Staples)
+    - starbucks # (Starbucks)
+    - facebook # (Facebook)
+    - jcpenney # (J.C. Penney)
+    - mastercard # (MasterCard)
+    - paypal # (PayPal Holdings)
+    - netflix # (Netflix)
+    - salesforce # (salesforce)

--- a/api/signup.go
+++ b/api/signup.go
@@ -44,7 +44,7 @@ func (r SignupOrg) ValidationRules() []validate.ValidationRule {
 		validate.StringRule{
 			Name:      "subDomain",
 			Value:     r.Subdomain,
-			MinLength: 6,
+			MinLength: 4,
 			MaxLength: 63,
 			CharacterRanges: []validate.CharRange{
 				validate.AlphabetLower,

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -3,8 +3,9 @@ package api
 import (
 	"testing"
 
-	"github.com/infrahq/infra/internal/validate"
 	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/validate"
 )
 
 func TestSignupWithReservedDomain(t *testing.T) {

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -21,7 +21,7 @@ func TestSignupWithReservedDomain(t *testing.T) {
 	err := validate.Validate(req)
 	assert.Error(t, err, "validation failed: org.subDomain: infrahq is reserved and can not be used")
 
-	req.Org.Subdomain = "authz"
+	req.Org.Subdomain = "zzz"
 	err = validate.Validate(req)
-	assert.Error(t, err, "validation failed: org.subDomain: must be at least 6 characters")
+	assert.Error(t, err, "validation failed: org.subDomain: must be at least 4 characters")
 }

--- a/api/signup_test.go
+++ b/api/signup_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/infrahq/infra/internal/validate"
+	"gotest.tools/v3/assert"
+)
+
+func TestSignupWithReservedDomain(t *testing.T) {
+	req := SignupRequest{
+		Name:     "foo@example.com",
+		Password: "abcdef1235464$!",
+		Org: SignupOrg{
+			Name:      "Foo",
+			Subdomain: "infrahq",
+		},
+	}
+
+	err := validate.Validate(req)
+	assert.Error(t, err, "validation failed: org.subDomain: infrahq is reserved and can not be used")
+
+	req.Org.Subdomain = "authz"
+	err = validate.Validate(req)
+	assert.Error(t, err, "validation failed: org.subDomain: must be at least 6 characters")
+}

--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	google.golang.org/grpc v1.47.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -338,7 +338,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 		Password: passwd,
 		Org: api.SignupOrg{
 			Name:      "infrahq",
-			Subdomain: "myorg",
+			Subdomain: "myorg1243",
 		},
 	}
 	err := json.NewEncoder(&buf).Encode(signupReq)

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -61,7 +61,7 @@ func TestAPI_Signup(t *testing.T) {
 
 				expected := []api.FieldError{
 					{FieldName: "org.subDomain", Errors: []string{
-						"must be at least 6 characters",
+						"must be at least 4 characters",
 						"character '@' at position 1 is not allowed",
 					}},
 				}

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -61,7 +61,7 @@ func TestAPI_Signup(t *testing.T) {
 
 				expected := []api.FieldError{
 					{FieldName: "org.subDomain", Errors: []string{
-						"must be at least 3 characters",
+						"must be at least 6 characters",
 						"character '@' at position 1 is not allowed",
 					}},
 				}
@@ -76,7 +76,7 @@ func TestAPI_Signup(t *testing.T) {
 					Password: "short",
 					Org: api.SignupOrg{
 						Name:      "My org is awesome",
-						Subdomain: "hello",
+						Subdomain: "helloo",
 					},
 				}
 			},
@@ -131,7 +131,7 @@ func TestAPI_Signup(t *testing.T) {
 				return api.SignupRequest{
 					Name:     "admin@example.com",
 					Password: "password",
-					Org:      api.SignupOrg{Name: "acme", Subdomain: "acme"},
+					Org:      api.SignupOrg{Name: "acme", Subdomain: "acme-co"},
 				}
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -150,7 +150,7 @@ func TestAPI_Signup(t *testing.T) {
 				return api.SignupRequest{
 					Name:     "admin@example.com",
 					Password: "password",
-					Org:      api.SignupOrg{Name: "acme", Subdomain: "acme"},
+					Org:      api.SignupOrg{Name: "acme", Subdomain: "acme-co"},
 				}
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -165,7 +165,7 @@ func TestAPI_Signup(t *testing.T) {
 				assert.Equal(t, respBody.Organization.Name, "acme")
 
 				// the organization exists
-				org, err := data.GetOrganization(srv.DB(), data.ByDomain("acme.exampledomain.com"))
+				org, err := data.GetOrganization(srv.DB(), data.ByDomain("acme-co.exampledomain.com"))
 				assert.NilError(t, err)
 				assert.Equal(t, org.ID, respBody.Organization.ID)
 

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -4932,7 +4932,7 @@
                       "subDomain": {
                         "format": "[a-zA-Z0-9\\-]",
                         "maxLength": 63,
-                        "minLength": 3,
+                        "minLength": 6,
                         "type": "string"
                       }
                     },

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -4932,7 +4932,7 @@
                       "subDomain": {
                         "format": "[a-zA-Z0-9\\-]",
                         "maxLength": 63,
-                        "minLength": 6,
+                        "minLength": 4,
                         "type": "string"
                       }
                     },


### PR DESCRIPTION
## Summary

- extend list of reserved domains
- don't allow domains of 5 char or less (would have to be created manually by us if we want it)
- add test
- one change we might want to make after this (or in this pr) is to have different error messages for the reserved list vs the reject list. the reserve list should say to sign up with a different domain and/or contact us or something along those lines.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades
