### PR TITLE
helm chart: fix configmap generation with config.tls not empty

### DIFF
--- a/helm/charts/infra/Chart.yaml
+++ b/helm/charts/infra/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: infra
 description: A Helm chart for Infra
 type: application
-version: 0.20.1
+version: 0.20.2
 appVersion: 0.15.1

--- a/helm/charts/infra/templates/server/configmap.yaml
+++ b/helm/charts/infra/templates/server/configmap.yaml
@@ -7,7 +7,8 @@ metadata:
 {{- include "server.labels" . | nindent 4 }}
 data:
   infra.yaml: |
-{{- range $key, $val := omit .Values.server.config "addr" "tls" "providers" "grants" "users" "identities" "secrets" "keys" }}
+{{- range $key, $val := omit .Values.server.config "addr" "ui" "providers" "grants" "users" "identities" "secrets" "keys" }}
+{{- if $val }}
 {{- if kindIs "invalid" $val }}
     # skipping invalid value: {{ $val }} ({{ kindOf $val }})
 {{- else if kindIs "map" $val }}
@@ -20,6 +21,7 @@ data:
     {{ $key }}: {{ tpl $val $ }}
 {{- else }}
     {{ $key }}: {{ $val }}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary

- Providing explicit `config.tls` settings will not be rendered in the `infra-server` configmap because "tls" is ommited: https://github.com/infrahq/infra/blob/d87cc531bfa8b3ff3e9bd09a4be54a432a7dd35c/helm/charts/infra/templates/server/configmap.yaml#L10
- I think "ui" should be skipped from generic rendering, as it is already handled some lines below
- To avoid duplicate sections and potentially invalid yaml, added a test for non empty value for any key in `config`
