### PR TITLE
Use SQL for GetGrant and DeleteGrants

### DIFF
--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -115,5 +115,5 @@ func DeleteGrant(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "grant", "delete", models.InfraAdminRole)
 	}
 
-	return data.DeleteGrants(db, data.ByID(id))
+	return data.DeleteGrants(db, data.DeleteGrantsOptions{ByID: id})
 }

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -16,7 +16,7 @@ func GetGrant(c *gin.Context, id uid.ID) (*models.Grant, error) {
 		return nil, HandleAuthErr(err, "grant", "get", models.InfraAdminRole)
 	}
 
-	return data.GetGrant(db, data.ByID(id))
+	return data.GetGrant(db, data.GetGrantOptions{ByID: id})
 }
 
 func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, privilege string, inherited bool, showSystem bool, p *data.Pagination) ([]models.Grant, error) {

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -103,7 +103,7 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 		}
 	}
 
-	err = data.DeleteGrants(db, data.BySubject(uid.NewIdentityPolymorphicID(id)))
+	err = data.DeleteGrants(db, data.DeleteGrantsOptions{BySubject: uid.NewIdentityPolymorphicID(id)})
 	if err != nil {
 		return fmt.Errorf("delete identity creds: %w", err)
 	}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -834,7 +834,11 @@ func (Server) loadGrant(db data.GormTxn, input Grant) (*models.Grant, error) {
 		input.Role = models.BasePermissionConnect
 	}
 
-	grant, err := data.GetGrant(db, data.BySubject(id), data.ByResource(input.Resource), data.ByPrivilege(input.Role))
+	grant, err := data.GetGrant(db, data.GetGrantOptions{
+		BySubject:   id,
+		ByResource:  input.Resource,
+		ByPrivilege: input.Role,
+	})
 	if err != nil {
 		if !errors.Is(err, internal.ErrNotFound) {
 			return nil, err

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -773,7 +773,10 @@ func (s Server) loadGrants(db data.GormTxn, grants []Grant) error {
 	}
 
 	// remove any grant previously defined by config
-	if err := data.DeleteGrants(db, data.NotIDs(keep), data.CreatedBy(models.CreatedBySystem)); err != nil {
+	if err := data.DeleteGrants(db, data.DeleteGrantsOptions{
+		NotIDs:      keep,
+		ByCreatedBy: models.CreatedBySystem,
+	}); err != nil {
 		return err
 	}
 

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -3,12 +3,14 @@ package data
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal/logging"
+	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
@@ -70,18 +72,46 @@ func ListGrants(db GormTxn, p *Pagination, selectors ...SelectorFunc) ([]models.
 	return list[models.Grant](db, p, selectors...)
 }
 
-func DeleteGrants(db GormTxn, selectors ...SelectorFunc) error {
-	toDelete, err := list[models.Grant](db, nil, selectors...)
-	if err != nil {
-		return err
+type DeleteGrantsOptions struct {
+	// ByID instructs DeleteGrants to delete the grant with this ID. When set
+	// all other fields on this struct are ignored.
+	ByID uid.ID
+	// BySubject instructs DeleteGrants to delete all grants that match this
+	// subject. When set other fields below this on this struct are ignored.
+	BySubject uid.PolymorphicID
+
+	// ByCreatedBy instructs DeleteGrants to delete all the grants that were
+	// created by this user. Can be used with NotIDs
+	ByCreatedBy uid.ID
+	// NotIDs instructs DeleteGrants to exclude any grants with these IDs to
+	// be excluded. In other words, these IDs will not be deleted, even if they
+	// match ByCreatedBy.
+	// Can only be used with ByCreatedBy.
+	NotIDs []uid.ID
+}
+
+func DeleteGrants(tx WriteTxn, opts DeleteGrantsOptions) error {
+	query := querybuilder.New("UPDATE grants")
+	query.B("SET deleted_at = ?", time.Now())
+	query.B("WHERE organization_id = ? AND", tx.OrganizationID())
+	query.B("deleted_at is null AND")
+
+	switch {
+	case opts.ByID != 0:
+		query.B("id = ?", opts.ByID)
+	case opts.BySubject != "":
+		query.B("subject = ?", opts.BySubject)
+	case opts.ByCreatedBy != 0:
+		query.B("created_by = ?", opts.ByCreatedBy)
+		if len(opts.NotIDs) > 0 {
+			query.B("AND id not in (?)", opts.NotIDs)
+		}
+	default:
+		return fmt.Errorf("DeleteGrants requires an ID to delete")
 	}
 
-	ids := make([]uid.ID, 0)
-	for _, g := range toDelete {
-		ids = append(ids, g.ID)
-	}
-
-	return deleteAll[models.Grant](db, ByIDs(ids))
+	_, err := tx.Exec(query.String(), query.Args...)
+	return err
 }
 
 func ByOptionalPrivilege(s string) SelectorFunc {

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -79,3 +79,88 @@ func TestCreateGrant(t *testing.T) {
 		})
 	})
 }
+
+func TestDeleteGrants(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		otherOrg := &models.Organization{Name: "other", Domain: "other.example.org"}
+		assert.NilError(t, CreateOrganization(db, otherOrg))
+
+		t.Run("empty options", func(t *testing.T) {
+			err := DeleteGrants(db, DeleteGrantsOptions{})
+			assert.ErrorContains(t, err, "requires an ID to delete")
+		})
+		t.Run("by id", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			grant := &models.Grant{Subject: "i:any", Privilege: "view", Resource: "any"}
+			toKeep := &models.Grant{Subject: "i:any2", Privilege: "view", Resource: "any"}
+			createGrants(t, tx, grant, toKeep)
+
+			err := DeleteGrants(tx, DeleteGrantsOptions{ByID: grant.ID})
+			assert.NilError(t, err)
+
+			actual, err := ListGrants(tx, nil, ByResource("any"))
+			assert.NilError(t, err)
+			expected := []models.Grant{
+				{Model: models.Model{ID: toKeep.ID}},
+			}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+		})
+		t.Run("by subject", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			grant1 := &models.Grant{Subject: "i:any1", Privilege: "view", Resource: "any"}
+			grant2 := &models.Grant{Subject: "i:any1", Privilege: "edit", Resource: "any"}
+			toKeep := &models.Grant{Subject: "i:any2", Privilege: "view", Resource: "any"}
+			createGrants(t, tx, grant1, grant2, toKeep)
+
+			otherOrgGrant := &models.Grant{Subject: "i:any1", Privilege: "view", Resource: "any"}
+			createGrants(t, tx.WithOrgID(otherOrg.ID), otherOrgGrant)
+
+			err := DeleteGrants(tx, DeleteGrantsOptions{BySubject: grant1.Subject})
+			assert.NilError(t, err)
+
+			actual, err := ListGrants(tx, nil, ByResource("any"))
+			assert.NilError(t, err)
+			expected := []models.Grant{
+				{Model: models.Model{ID: toKeep.ID}},
+			}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+
+			actual, err = ListGrants(tx.WithOrgID(otherOrg.ID), nil, ByResource("any"))
+			assert.NilError(t, err)
+			assert.Equal(t, len(actual), 1)
+		})
+		t.Run("by created_by and not ids", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			createdBy := uid.ID(9234)
+			grant1 := &models.Grant{Subject: "i:any1", Privilege: "view", Resource: "any", CreatedBy: createdBy}
+			grant2 := &models.Grant{Subject: "i:any2", Privilege: "view", Resource: "any", CreatedBy: createdBy}
+			toKeep1 := &models.Grant{Subject: "i:any3", Privilege: "view", Resource: "any", CreatedBy: createdBy}
+			toKeep2 := &models.Grant{Subject: "i:any4", Privilege: "view", Resource: "any"}
+			createGrants(t, tx, grant1, grant2, toKeep1, toKeep2)
+
+			err := DeleteGrants(tx, DeleteGrantsOptions{
+				ByCreatedBy: createdBy,
+				NotIDs:      []uid.ID{toKeep1.ID},
+			})
+			assert.NilError(t, err)
+
+			actual, err := ListGrants(tx, nil, ByResource("any"))
+			assert.NilError(t, err)
+			expected := []models.Grant{
+				{Model: models.Model{ID: toKeep1.ID}},
+				{Model: models.Model{ID: toKeep2.ID}},
+			}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+		})
+	})
+}
+
+func createGrants(t *testing.T, tx WriteTxn, grants ...*models.Grant) {
+	t.Helper()
+	for _, grant := range grants {
+		assert.NilError(t, CreateGrant(tx, grant))
+	}
+}

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -62,7 +62,7 @@ func DeleteGroups(db GormTxn, selectors ...SelectorFunc) error {
 	for _, g := range toDelete {
 		ids = append(ids, g.ID)
 
-		err := DeleteGrants(db, BySubject(g.PolyID()))
+		err := DeleteGrants(db, DeleteGrantsOptions{BySubject: g.PolyID()})
 		if err != nil {
 			return err
 		}

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -152,7 +152,7 @@ func DeleteIdentities(tx GormTxn, selectors ...SelectorFunc) error {
 	for _, i := range toDelete {
 		ids = append(ids, i.ID)
 
-		err := DeleteGrants(tx, BySubject(i.PolyID()))
+		err := DeleteGrants(tx, DeleteGrantsOptions{BySubject: i.PolyID()})
 		if err != nil {
 			return err
 		}

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -48,7 +48,11 @@ func TestCreateOrganization(t *testing.T) {
 		}
 		assert.DeepEqual(t, connector, expectedConnector)
 
-		connectorGrant, err := GetGrant(tx, BySubject(connector.PolyID()), ByPrivilege(models.InfraConnectorRole), ByResource("infra"))
+		connectorGrant, err := GetGrant(tx, GetGrantOptions{
+			BySubject:   connector.PolyID(),
+			ByPrivilege: models.InfraConnectorRole,
+			ByResource:  "infra",
+		})
 		assert.NilError(t, err)
 		expectedConnectorGrant := &models.Grant{
 			Model:              connectorGrant.Model,


### PR DESCRIPTION
## Summary

Converts `GetGrant` and `DeleteGrants` to use sql.

Also changes `columnsForSelect` to accept only the table type. This makes linting easier (no string arg to check), and will make our queries more consistent by always using the table name instead of an alias to qualify field names.

Adds a bunch of tests for both functions.


## Related Issues

Related to #2415

