### PR TITLE
Use a transaction to run data migrations

### DIFF
--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -507,6 +507,15 @@ func addDefaultOrganization() *migrator.Migration {
 	return &migrator.Migration{
 		ID: "2022-08-10T13:35",
 		Migrate: func(tx migrator.DB) error {
+			row := tx.QueryRow(`SELECT count(id) from organizations where name='Default'`)
+			var count int
+			if err := row.Scan(&count); err != nil {
+				return err
+			}
+			if count > 0 {
+				return nil
+			}
+
 			stmt := `
 INSERT INTO organizations(id, name, created_at, updated_at)
 VALUES (?, ?, ?, ?);

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -47,8 +47,9 @@ func TestMigrations(t *testing.T) {
 			t.Fatalf("there are more test cases than migrations")
 		}
 		mgs := allMigrations[:index+1]
+		currentMigration := mgs[len(mgs)-1]
 
-		if mID := mgs[len(mgs)-1].ID; mID != tc.label.Name {
+		if mID := currentMigration.ID; mID != tc.label.Name {
 			t.Error("the list of test cases is not in the same order as the list of migrations")
 			t.Fatalf("test case %v was run with migration ID %v", tc.label.Name, mID)
 		}
@@ -79,6 +80,10 @@ func TestMigrations(t *testing.T) {
 		err := m.Migrate()
 		assert.NilError(t, err)
 
+		t.Run("run again to check idempotency", func(t *testing.T) {
+			err := currentMigration.Migrate(db)
+			assert.NilError(t, err)
+		})
 		tc.expected(t, db)
 	}
 

--- a/internal/server/data/sqlfunc.go
+++ b/internal/server/data/sqlfunc.go
@@ -8,6 +8,10 @@ func sqlFunctionsMigration() *migrator.Migration {
 	return &migrator.Migration{
 		ID: "2022-08-22T14:58:00Z",
 		Migrate: func(tx migrator.DB) error {
+			if migrator.HasFunction(tx, "uidIntToStr") {
+				return nil
+			}
+
 			sql := `
 			CREATE FUNCTION uidIntToStr(id BIGINT) RETURNS text
 			LANGUAGE PLPGSQL
@@ -81,7 +85,6 @@ func sqlFunctionsMigration() *migrator.Migration {
 			`
 			_, err := tx.Exec(sql)
 			return err
-
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Also run each migration twice in the migration test to check for idempotence. Includes a couple fixes to migrations to make them idempotent.