### PR TITLE
Use SQL for list grants

### DIFF
--- a/api/grant.go
+++ b/api/grant.go
@@ -47,6 +47,7 @@ func (r ListGrantsRequest) ValidationRules() []validate.ValidationRule {
 		validate.MutuallyExclusive(
 			validate.Field{Name: "user", Value: r.User},
 			validate.Field{Name: "group", Value: r.Group},
+			// TODO: validate showInherited only allowed with User
 		),
 	}
 }

--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -43,7 +43,6 @@ func RequireInfraRole(c *gin.Context, oneOfRoles ...string) (data.GormTxn, error
 	}
 
 	// TODO: use privilege in (...) instead of iterating over roles
-	// TODO: check for test coverage that uses permission from a group
 	for _, role := range oneOfRoles {
 		ok, err := Can(db, identity.PolyID(), role, ResourceInfraAPI)
 		if err != nil {

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -20,12 +20,8 @@ func ListAccessKeys(c *gin.Context, identityID uid.ID, name string, showExpired 
 	opts := data.ListAccessKeyOptions{
 		Pagination:     p,
 		IncludeExpired: showExpired,
-	}
-	if identityID != 0 {
-		opts.ByIssuedForID = identityID
-	}
-	if name != "" {
-		opts.ByName = name
+		ByIssuedForID:  identityID,
+		ByName:         name,
 	}
 	return data.ListAccessKeys(db, opts)
 }

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -86,11 +86,11 @@ func TestBasicGrant(t *testing.T) {
 	cant(t, db, "i:bob", "read", "infra.groups.1") // currently we check for exact grant match, this may change as grants evolve
 	cant(t, db, "i:bob", "write", "infra.groups")
 
-	grant(t, db, tom, "i:alice", "read", "infra.machines")
-	can(t, db, "i:alice", "read", "infra.machines")
-	cant(t, db, "i:alice", "read", "infra")
-	cant(t, db, "i:alice", "read", "infra.machines.1")
-	cant(t, db, "i:alice", "write", "infra.machines")
+	grant(t, db, tom, "i:a11ce", "read", "infra.machines")
+	can(t, db, "i:a11ce", "read", "infra.machines")
+	cant(t, db, "i:a11ce", "read", "infra")
+	cant(t, db, "i:a11ce", "read", "infra.machines.1")
+	cant(t, db, "i:a11ce", "write", "infra.machines")
 }
 
 func TestUsersGroupGrant(t *testing.T) {
@@ -192,6 +192,7 @@ func grant(t *testing.T, db data.GormTxn, currentUser *models.Identity, subject 
 }
 
 func can(t *testing.T, db *data.DB, subject uid.PolymorphicID, privilege, resource string) {
+	t.Helper()
 	canAccess, err := Can(db, subject, privilege, resource)
 	assert.NilError(t, err)
 	assert.Assert(t, canAccess)

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -45,7 +45,7 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 		ByResource:                 resource,
 		ByPrivilege:                privilege,
 		BySubject:                  subject,
-		ExcludeCreatedBySystem:     !showSystem,
+		ExcludeConnectorGrant:      !showSystem,
 		IncludeInheritedFromGroups: inherited,
 		Pagination:                 p,
 	}

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -101,7 +101,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	_, err = data.GetCredential(db, data.ByIdentityID(identity.ID))
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 
-	grants, err := data.ListGrants(db, nil, data.BySubject(identity.PolyID()))
+	grants, err := data.ListGrants(db, data.ListGrantsOptions{BySubject: identity.PolyID()})
 	assert.NilError(t, err)
 	assert.Equal(t, len(grants), 0)
 

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -152,11 +152,11 @@ func ListAccessKeys(tx ReadTxn, opts ListAccessKeyOptions) ([]models.AccessKey, 
 	var result []models.AccessKey
 	for rows.Next() {
 		var key models.AccessKey
+
 		fields := append((*accessKeyTable)(&key).ScanFields(), &key.IssuedForName)
 		if opts.Pagination != nil {
 			fields = append(fields, &opts.Pagination.TotalCount)
 		}
-
 		if err := rows.Scan(fields...); err != nil {
 			return nil, err
 		}

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -114,9 +114,9 @@ type ListGrantsOptions struct {
 	// BySubject is a non-zero userID.
 	IncludeInheritedFromGroups bool
 
-	// ExcludeCreatedBySystem instructs ListGrants to exclude grants where the
-	// CreatedBy is models.CreatedBySystem.
-	ExcludeCreatedBySystem bool
+	// ExcludeConnectorGrant instructs ListGrants to exclude grants where
+	// privilege=connector and resource=infra.
+	ExcludeConnectorGrant bool
 
 	Pagination *Pagination
 }
@@ -160,8 +160,8 @@ func ListGrants(tx ReadTxn, opts ListGrantsOptions) ([]models.Grant, error) {
 	if opts.ByResource != "" {
 		query.B("AND resource = ?", opts.ByResource)
 	}
-	if opts.ExcludeCreatedBySystem {
-		query.B("AND created_by <> ?", models.CreatedBySystem)
+	if opts.ExcludeConnectorGrant {
+		query.B("AND NOT (privilege = 'connector' AND resource = 'infra')")
 	}
 
 	query.B("ORDER BY id ASC")

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -63,9 +63,10 @@ func TestCreateGrant(t *testing.T) {
 			assert.Assert(t, errors.As(err, &ucErr))
 			assert.DeepEqual(t, ucErr, UniqueConstraintError{Table: "grants"})
 
-			grants, err := ListGrants(tx, nil,
-				BySubject("i:1234567"),
-				ByResource("infra"))
+			grants, err := ListGrants(tx, ListGrantsOptions{
+				BySubject:  "i:1234567",
+				ByResource: "infra",
+			})
 			assert.NilError(t, err)
 			assert.Assert(t, is.Len(grants, 1))
 
@@ -100,7 +101,7 @@ func TestDeleteGrants(t *testing.T) {
 			err := DeleteGrants(tx, DeleteGrantsOptions{ByID: grant.ID})
 			assert.NilError(t, err)
 
-			actual, err := ListGrants(tx, nil, ByResource("any"))
+			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any"})
 			assert.NilError(t, err)
 			expected := []models.Grant{
 				{Model: models.Model{ID: toKeep.ID}},
@@ -121,14 +122,14 @@ func TestDeleteGrants(t *testing.T) {
 			err := DeleteGrants(tx, DeleteGrantsOptions{BySubject: grant1.Subject})
 			assert.NilError(t, err)
 
-			actual, err := ListGrants(tx, nil, ByResource("any"))
+			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any"})
 			assert.NilError(t, err)
 			expected := []models.Grant{
 				{Model: models.Model{ID: toKeep.ID}},
 			}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
 
-			actual, err = ListGrants(tx.WithOrgID(otherOrg.ID), nil, ByResource("any"))
+			actual, err = ListGrants(tx.WithOrgID(otherOrg.ID), ListGrantsOptions{ByResource: "any"})
 			assert.NilError(t, err)
 			assert.Equal(t, len(actual), 1)
 		})
@@ -148,7 +149,7 @@ func TestDeleteGrants(t *testing.T) {
 			})
 			assert.NilError(t, err)
 
-			actual, err := ListGrants(tx, nil, ByResource("any"))
+			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any"})
 			assert.NilError(t, err)
 			expected := []models.Grant{
 				{Model: models.Model{ID: toKeep1.ID}},
@@ -255,6 +256,188 @@ func TestGetGrant(t *testing.T) {
 				CreatedBy:          uid.ID(777),
 			}
 			assert.DeepEqual(t, actual, expected, cmpModel)
+		})
+	})
+}
+
+func TestListGrants(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+		user := &models.Identity{Name: "usera@example.com"}
+		createIdentities(t, tx, user)
+
+		grant1 := &models.Grant{
+			Subject:   "i:userchar",
+			Privilege: "view",
+			Resource:  "any",
+			CreatedBy: uid.ID(777),
+		}
+		grant2 := &models.Grant{
+			Subject:   "i:userbeta",
+			Privilege: "view",
+			Resource:  "any",
+			CreatedBy: uid.ID(777),
+		}
+		grant3 := &models.Grant{
+			Subject:   "i:userchar",
+			Privilege: "admin",
+			Resource:  "any",
+			CreatedBy: uid.ID(777),
+		}
+		grant4 := &models.Grant{
+			Subject:   "i:userchar",
+			Privilege: "view",
+			Resource:  "infra",
+			CreatedBy: uid.ID(777),
+		}
+		deleted := &models.Grant{
+			Subject:   "i:userchar",
+			Privilege: "view",
+			Resource:  "any",
+			CreatedBy: uid.ID(777),
+		}
+		deleted.DeletedAt.Time = time.Now()
+		deleted.DeletedAt.Valid = true
+		createGrants(t, tx, grant1, grant2, grant3, grant4, deleted)
+
+		userID, err := uid.Parse([]byte("userchar"))
+		assert.NilError(t, err)
+
+		assert.NilError(t, AddUsersToGroup(tx, uid.ID(111), []uid.ID{userID}))
+		assert.NilError(t, AddUsersToGroup(tx, uid.ID(112), []uid.ID{userID}))
+		assert.NilError(t, AddUsersToGroup(tx, uid.ID(113), []uid.ID{uid.ID(777)}))
+
+		gGrant1 := &models.Grant{
+			Subject:   uid.NewGroupPolymorphicID(111),
+			Privilege: "view",
+			Resource:  "shared",
+			CreatedBy: uid.ID(777),
+		}
+		gGrant2 := &models.Grant{
+			Subject:   uid.NewGroupPolymorphicID(112),
+			Privilege: "admin",
+			Resource:  "shared",
+			CreatedBy: uid.ID(777),
+		}
+		gGrant3 := &models.Grant{
+			Subject:   uid.NewGroupPolymorphicID(113),
+			Privilege: "admin",
+			Resource:  "special",
+			CreatedBy: uid.ID(777),
+		}
+		createGrants(t, tx, gGrant1, gGrant2, gGrant3)
+
+		otherOrg := &models.Organization{Name: "other", Domain: "other.example.org"}
+		assert.NilError(t, CreateOrganization(tx, otherOrg))
+
+		otherOrgGrant := &models.Grant{
+			Subject:            "i:userchar",
+			Privilege:          "view",
+			Resource:           "any",
+			CreatedBy:          uid.ID(778),
+			OrganizationMember: models.OrganizationMember{OrganizationID: otherOrg.ID},
+		}
+		createGrants(t, tx.WithOrgID(otherOrg.ID), otherOrgGrant)
+
+		connectorUser := InfraConnectorIdentity(db)
+
+		connector, err := GetGrant(tx, GetGrantOptions{
+			BySubject:   uid.NewIdentityPolymorphicID(connectorUser.ID),
+			ByPrivilege: models.InfraConnectorRole,
+			ByResource:  "infra",
+		})
+		assert.NilError(t, err)
+
+		t.Run("default", func(t *testing.T) {
+			actual, err := ListGrants(tx, ListGrantsOptions{})
+			assert.NilError(t, err)
+
+			expected := []models.Grant{
+				*connector,
+				*grant1,
+				*grant2,
+				*grant3,
+				*grant4,
+				*gGrant1,
+				*gGrant2,
+				*gGrant3,
+			}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+		})
+		t.Run("by subject", func(t *testing.T) {
+			actual, err := ListGrants(tx, ListGrantsOptions{BySubject: "i:userchar"})
+			assert.NilError(t, err)
+
+			expected := []models.Grant{*grant1, *grant3, *grant4}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+		})
+		t.Run("by resource", func(t *testing.T) {
+			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any"})
+			assert.NilError(t, err)
+
+			expected := []models.Grant{*grant1, *grant2, *grant3}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+		})
+		t.Run("by resource and privilege", func(t *testing.T) {
+			actual, err := ListGrants(tx, ListGrantsOptions{
+				ByResource:  "any",
+				ByPrivilege: "view",
+			})
+			assert.NilError(t, err)
+
+			expected := []models.Grant{*grant1, *grant2}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+		})
+		t.Run("by subject with include inherited", func(t *testing.T) {
+			actual, err := ListGrants(tx, ListGrantsOptions{
+				BySubject:                  "i:userchar",
+				IncludeInheritedFromGroups: true,
+			})
+			assert.NilError(t, err)
+
+			expected := []models.Grant{*grant1, *grant3, *grant4, *gGrant1, *gGrant2}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+		})
+		t.Run("exclude created by system", func(t *testing.T) {
+			actual, err := ListGrants(tx, ListGrantsOptions{ExcludeCreatedBySystem: true})
+			assert.NilError(t, err)
+
+			expected := []models.Grant{
+				*grant1,
+				*grant2,
+				*grant3,
+				*grant4,
+				*gGrant1,
+				*gGrant2,
+				*gGrant3,
+			}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+		})
+		t.Run("with pagination", func(t *testing.T) {
+			pagination := &Pagination{Page: 2, Limit: 3}
+			actual, err := ListGrants(tx, ListGrantsOptions{Pagination: pagination})
+			assert.NilError(t, err)
+
+			expected := []models.Grant{*grant3, *grant4, *gGrant1}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+
+			expectedPagination := &Pagination{Page: 2, Limit: 3, TotalCount: 8}
+			assert.DeepEqual(t, pagination, expectedPagination)
+		})
+		t.Run("by resource with pagination", func(t *testing.T) {
+			pagination := &Pagination{Page: 1, Limit: 2}
+			actual, err := ListGrants(tx, ListGrantsOptions{
+				Pagination: pagination,
+				ByResource: "any",
+			})
+			assert.NilError(t, err)
+
+			expected := []models.Grant{*grant1, *grant2}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+
+			expectedPagination := &Pagination{Page: 1, Limit: 2, TotalCount: 3}
+			assert.DeepEqual(t, pagination, expectedPagination)
 		})
 	})
 }

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -399,8 +399,8 @@ func TestListGrants(t *testing.T) {
 			expected := []models.Grant{*grant1, *grant3, *grant4, *gGrant1, *gGrant2}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
 		})
-		t.Run("exclude created by system", func(t *testing.T) {
-			actual, err := ListGrants(tx, ListGrantsOptions{ExcludeCreatedBySystem: true})
+		t.Run("exclude connector grant", func(t *testing.T) {
+			actual, err := ListGrants(tx, ListGrantsOptions{ExcludeConnectorGrant: true})
 			assert.NilError(t, err)
 
 			expected := []models.Grant{

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -52,6 +52,25 @@ func ByGroupMember(id uid.ID) SelectorFunc {
 	}
 }
 
+func groupIDsForUser(tx ReadTxn, userID uid.ID) ([]uid.ID, error) {
+	stmt := `SELECT DISTINCT group_id FROM identities_groups WHERE identity_id = ?`
+	rows, err := tx.Query(stmt, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []uid.ID
+	for rows.Next() {
+		var id uid.ID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		result = append(result, id)
+	}
+	return result, rows.Err()
+}
+
 func DeleteGroups(db GormTxn, selectors ...SelectorFunc) error {
 	toDelete, err := ListGroups(db, nil, selectors...)
 	if err != nil {

--- a/internal/server/data/pagination.go
+++ b/internal/server/data/pagination.go
@@ -16,10 +16,12 @@ func (p *Pagination) SetTotalCount(count int) {
 }
 
 func (p *Pagination) PaginateQuery(query *querybuilder.Query) {
-	if p.Page == 0 && p.Limit == 0 {
+	if p.Limit == 0 {
 		return
 	}
-
+	if p.Page == 0 {
+		p.Page = 1
+	}
 	offset := p.Limit * (p.Page - 1)
 	query.B("LIMIT ? OFFSET ?", p.Limit, offset)
 }

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -78,22 +78,6 @@ func ByProviderID(id uid.ID) SelectorFunc {
 	}
 }
 
-func ByOptionalSubject(polymorphicID uid.PolymorphicID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		if polymorphicID == "" {
-			return db
-		}
-
-		return db.Where("subject = ?", string(polymorphicID))
-	}
-}
-
-func BySubject(polymorphicID uid.PolymorphicID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("subject = ?", string(polymorphicID))
-	}
-}
-
 func ByIdentityID(identityID uid.ID) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("identity_id = ?", identityID)
@@ -144,12 +128,6 @@ func ByProviderKind(kind models.ProviderKind) SelectorFunc {
 func NotPrivilege(privilege string) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Not("privilege = ?", privilege)
-	}
-}
-
-func NotInfraConnector() SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where(`NOT (privilege = 'connector' AND resource = 'infra')`)
 	}
 }
 

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -783,7 +783,10 @@ func TestAPI_DeleteGrant(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("last infra admin is deleted", func(t *testing.T) {
-		infraAdminGrants, err := data.ListGrants(srv.DB(), nil, data.ByPrivilege(models.InfraAdminRole), data.ByResource("infra"))
+		infraAdminGrants, err := data.ListGrants(srv.DB(), data.ListGrantsOptions{
+			ByPrivilege: models.InfraAdminRole,
+			ByResource:  "infra",
+		})
 		assert.NilError(t, err)
 		assert.Assert(t, len(infraAdminGrants) == 1)
 

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -175,7 +175,7 @@ func TestTrimWhitespace(t *testing.T) {
 	err = json.Unmarshal(resp.Body.Bytes(), rb)
 	assert.NilError(t, err)
 
-	assert.Equal(t, len(rb.Items), 2)
+	assert.Equal(t, len(rb.Items), 2, rb.Items)
 	expected := api.Grant{
 		User:      userID,
 		Privilege: "admin",


### PR DESCRIPTION
## Summary

Branched from #3155

This PR converts list grants to SQL, and adds a bunch of tests.

It also changes `access.RequireInfraRole` to use `IncludeInheritedFromGroups`, instead of iterating over all the groups a user belongs to.

## Related Issues

Related to #2415 
