### PR TITLE
Use SQL for encryption keys table

### DIFF
--- a/internal/server/data/encryption_key.go
+++ b/internal/server/data/encryption_key.go
@@ -8,6 +8,24 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
+type encryptionKeysTable models.EncryptionKey
+
+func (e encryptionKeysTable) Table() string {
+	return "encryption_keys"
+}
+
+func (e encryptionKeysTable) Columns() []string {
+	return []string{"algorithm", "created_at", "deleted_at", "encrypted", "id", "key_id", "name", "root_key_id", "updated_at"}
+}
+
+func (e encryptionKeysTable) Values() []any {
+	return []any{e.Algorithm, e.CreatedAt, e.DeletedAt, e.Encrypted, e.ID, e.KeyID, e.Name, e.RootKeyID, e.UpdatedAt}
+}
+
+func (e *encryptionKeysTable) ScanFields() []any {
+	return []any{&e.Algorithm, &e.CreatedAt, &e.DeletedAt, &e.Encrypted, &e.ID, &e.KeyID, &e.Name, &e.RootKeyID, &e.UpdatedAt}
+}
+
 func CreateEncryptionKey(db GormTxn, key *models.EncryptionKey) (*models.EncryptionKey, error) {
 	if key.KeyID == 0 {
 		// not a security issue; just an identifier

--- a/internal/server/data/encryption_key.go
+++ b/internal/server/data/encryption_key.go
@@ -1,10 +1,10 @@
 package data
 
 import (
+	"fmt"
 	mathrand "math/rand"
 
-	"gorm.io/gorm"
-
+	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -26,25 +26,34 @@ func (e *encryptionKeysTable) ScanFields() []any {
 	return []any{&e.Algorithm, &e.CreatedAt, &e.DeletedAt, &e.Encrypted, &e.ID, &e.KeyID, &e.Name, &e.RootKeyID, &e.UpdatedAt}
 }
 
-func CreateEncryptionKey(db GormTxn, key *models.EncryptionKey) (*models.EncryptionKey, error) {
+func CreateEncryptionKey(tx WriteTxn, key *models.EncryptionKey) error {
+	switch {
+	case key.Name == "":
+		return fmt.Errorf("a name is required for EncryptionKey")
+	case key.RootKeyID == "":
+		return fmt.Errorf("a root key ID is required for EncryptionKey")
+	case key.Algorithm == "":
+		return fmt.Errorf("an algorithm is required for EncryptionKey")
+	}
 	if key.KeyID == 0 {
 		// not a security issue; just an identifier
 		key.KeyID = mathrand.Int31() // nolint:gosec
 	}
 
-	if err := add(db, key); err != nil {
-		return nil, err
-	}
-
-	return key, nil
+	return insert(tx, (*encryptionKeysTable)(key))
 }
 
-func GetEncryptionKey(db GormTxn, selector SelectorFunc) (result *models.EncryptionKey, err error) {
-	return get[models.EncryptionKey](db, selector)
-}
+func GetEncryptionKeyByName(tx ReadTxn, name string) (*models.EncryptionKey, error) {
+	table := &encryptionKeysTable{}
+	query := querybuilder.New("SELECT")
+	query.B(columnsForSelect(table))
+	query.B("FROM encryption_keys")
+	query.B("WHERE deleted_at is null")
+	query.B("AND name = ?", name)
 
-func ByEncryptionKeyID(keyID int32) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("key_id = ?", keyID)
+	row := tx.QueryRow(query.String(), query.Args...)
+	if err := row.Scan(table.ScanFields()...); err != nil {
+		return nil, handleReadError(err)
 	}
+	return (*models.EncryptionKey)(table), nil
 }

--- a/internal/server/data/encryption_key_test.go
+++ b/internal/server/data/encryption_key_test.go
@@ -2,31 +2,76 @@ package data
 
 import (
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func TestEncryptionKeys(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
-		k, err := CreateEncryptionKey(db, &models.EncryptionKey{
-			Name:      "foo",
-			Encrypted: []byte{0x00},
-			Algorithm: "foo",
+		tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+		t.Run("create", func(t *testing.T) {
+			key := &models.EncryptionKey{
+				KeyID:     11,
+				Name:      "first",
+				Encrypted: []byte("encrypted"),
+				Algorithm: "better",
+				RootKeyID: "main",
+			}
+			err := CreateEncryptionKey(db, key)
+			assert.NilError(t, err)
+
+			expected := &models.EncryptionKey{
+				Model: models.Model{
+					ID:        uid.ID(999),
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				KeyID:     11,
+				Name:      "first",
+				Encrypted: []byte("encrypted"),
+				Algorithm: "better",
+				RootKeyID: "main",
+			}
+			assert.DeepEqual(t, key, expected, cmpModel)
 		})
-		assert.NilError(t, err)
 
-		assert.Assert(t, k.KeyID != 0)
+		t.Run("get not found", func(t *testing.T) {
+			_, err := GetEncryptionKeyByName(tx, "does-not-exist")
+			assert.ErrorIs(t, err, internal.ErrNotFound)
+		})
 
-		k2, err := GetEncryptionKey(db, ByEncryptionKeyID(k.KeyID))
-		assert.NilError(t, err)
+		t.Run("get by name", func(t *testing.T) {
+			err := CreateEncryptionKey(db, &models.EncryptionKey{
+				KeyID:     12,
+				Name:      "second",
+				Encrypted: []byte("encrypted"),
+				Algorithm: "good",
+				RootKeyID: "main",
+			})
+			assert.NilError(t, err)
 
-		assert.Equal(t, "foo", k2.Name)
+			actual, err := GetEncryptionKeyByName(tx, "second")
+			assert.NilError(t, err)
 
-		k3, err := GetEncryptionKey(db, ByName("foo"))
-		assert.NilError(t, err)
-
-		assert.Equal(t, k.ID, k3.ID)
+			expected := &models.EncryptionKey{
+				Model: models.Model{
+					ID:        uid.ID(999),
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				KeyID:     12,
+				Name:      "second",
+				Encrypted: []byte("encrypted"),
+				Algorithm: "good",
+				RootKeyID: "main",
+			}
+			assert.DeepEqual(t, actual, expected, cmpModel)
+		})
 	})
 }

--- a/internal/server/models/encryption_key.go
+++ b/internal/server/models/encryption_key.go
@@ -3,7 +3,12 @@ package models
 type EncryptionKey struct {
 	Model
 
-	KeyID     int32 `gorm:"uniqueIndex:idx_encryption_keys_key_id"` // a short identifier for the key that can be embedded with the encrypted payload
+	// KeyID is not used yet. KeyID is intended to be a short identifier for the key
+	// that can be embedded with the encrypted payload. Today we use the first 4
+	// bytes of a checksum of the encrypted data key instead of this identifier.
+	// In the future we will use this identifier to support key rotation.
+	KeyID int32
+	// TODO: missing a unique index on name
 	Name      string
 	Encrypted []byte
 	Algorithm string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -378,7 +378,7 @@ func (s *Server) loadDBKey(db data.GormTxn) error {
 		return fmt.Errorf("key provider %s not configured", s.options.DBEncryptionKeyProvider)
 	}
 
-	keyRec, err := data.GetEncryptionKey(db, data.ByName(dbKeyName))
+	keyRec, err := data.GetEncryptionKeyByName(db, dbKeyName)
 	if err != nil {
 		if errors.Is(err, internal.ErrNotFound) {
 			return createDBKey(db, provider, s.options.DBEncryptionKey)
@@ -410,9 +410,7 @@ func createDBKey(db data.GormTxn, provider secrets.SymmetricKeyProvider, rootKey
 		Algorithm: sKey.Algorithm,
 		RootKeyID: sKey.RootKeyID,
 	}
-
-	_, err = data.CreateEncryptionKey(db, key)
-	if err != nil {
+	if err := data.CreateEncryptionKey(db, key); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

This PR updates the implementation of `CreateEncryptionKey` and `GetEncryptionKey` to use SQL instead of gorm.

## Related Issues

Related to #2415 
