### PR TITLE
Move db encryption key loading to data package

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -23,7 +23,7 @@ func setupDB(t *testing.T) *data.DB {
 	driver := database.PostgresDriver(t, "_access")
 
 	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver.Dialector, nil)
+	db, err := data.NewDB(driver.Dialector, data.NewDBOptions{})
 	assert.NilError(t, err)
 	return db
 }

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -19,7 +19,7 @@ func setupDB(t *testing.T) *data.DB {
 	driver := database.PostgresDriver(t, "_authn")
 
 	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver.Dialector, nil)
+	db, err := data.NewDB(driver.Dialector, data.NewDBOptions{})
 	assert.NilError(t, err)
 
 	return db

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -24,7 +24,8 @@ import (
 )
 
 type NewDBOptions struct {
-	LoadDBKey func(db GormTxn) error
+	EncryptionKeyProvider EncryptionKeyProvider
+	RootKeyID             string
 }
 
 // NewDB creates a new database connection and runs any required database migrations
@@ -40,12 +41,12 @@ func NewDB(connection gorm.Dialector, dbOpts NewDBOptions) (*DB, error) {
 	opts := migrator.Options{
 		InitSchema: initializeSchema,
 		LoadKey: func(tx migrator.DB) error {
-			if dbOpts.LoadDBKey == nil {
+			if dbOpts.EncryptionKeyProvider == nil {
 				return nil
 			}
 			// TODO: use the passed in tx instead of dataDB once the queries
 			// used by loadDBKey are ported to sql
-			return dbOpts.LoadDBKey(dataDB)
+			return loadDBKey(dataDB, dbOpts.EncryptionKeyProvider, dbOpts.RootKeyID)
 		},
 	}
 	m := migrator.New(dataDB, opts, migrations())

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -44,9 +44,7 @@ func NewDB(connection gorm.Dialector, dbOpts NewDBOptions) (*DB, error) {
 			if dbOpts.EncryptionKeyProvider == nil {
 				return nil
 			}
-			// TODO: use the passed in tx instead of dataDB once the queries
-			// used by loadDBKey are ported to sql
-			return loadDBKey(dataDB, dbOpts.EncryptionKeyProvider, dbOpts.RootKeyID)
+			return loadDBKey(tx, dbOpts.EncryptionKeyProvider, dbOpts.RootKeyID)
 		},
 	}
 	m := migrator.New(dataDB, opts, migrations())

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -20,7 +20,7 @@ func setupDB(t *testing.T, driver gorm.Dialector) *DB {
 	t.Helper()
 	patch.ModelsSymmetricKey(t)
 
-	db, err := NewDB(driver, nil)
+	db, err := NewDB(driver, NewDBOptions{})
 	assert.NilError(t, err)
 
 	logging.PatchLogger(t, zerolog.NewTestWriter(t))

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -31,7 +31,7 @@ func setupDB(t *testing.T) *data.DB {
 	driver := database.PostgresDriver(t, "_server")
 
 	tpatch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver.Dialector, nil)
+	db, err := data.NewDB(driver.Dialector, data.NewDBOptions{})
 	assert.NilError(t, err)
 	t.Cleanup(func() {
 		assert.NilError(t, db.Close())

--- a/internal/server/models/encryption_test.go
+++ b/internal/server/models/encryption_test.go
@@ -30,7 +30,7 @@ func TestEncryptedAtRest(t *testing.T) {
 	patch.ModelsSymmetricKey(t)
 
 	pg := database.PostgresDriver(t, "_models")
-	db, err := data.NewDB(pg.Dialector, nil)
+	db, err := data.NewDB(pg.Dialector, data.NewDBOptions{})
 	assert.NilError(t, err)
 
 	_, err = db.Exec(StructForTesting{}.Schema())
@@ -66,7 +66,7 @@ func TestEncryptedAtRest_WithBytes(t *testing.T) {
 	patch.ModelsSymmetricKey(t)
 
 	pg := database.PostgresDriver(t, "_models")
-	db, err := data.NewDB(pg.Dialector, nil)
+	db, err := data.NewDB(pg.Dialector, data.NewDBOptions{})
 	assert.NilError(t, err)
 
 	settings, err := data.GetSettings(db)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -151,7 +151,9 @@ func New(options Options) (*Server, error) {
 		return nil, fmt.Errorf("driver: %w", err)
 	}
 
-	db, err := data.NewDB(driver, server.loadDBKey)
+	db, err := data.NewDB(driver, data.NewDBOptions{
+		LoadDBKey: server.loadDBKey,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("db: %w", err)
 	}


### PR DESCRIPTION
## Summary

Branched from #3167

This PR introduces `NewDBOptions` as a struct that lets us pass options to `NewDB`. We'll be able to use this to set connection pool settings, and we'll very likely have other settings to pass along as well.

The PR also moves the `loadDBKey` function to the data package. This encryption key is only used by models as part of `Scan` and `Value` methods when reading and writing to the database, so it's primarily a concern on the data package.  
Moving it to the data package should make it easier to support separate keys per organization (if that's something we want to do), and should make it easier to handle key rotation. It may also give us a way to remove the package-level symmetric key, which will be necessary if we make either of those changes.

Also resolves a TODO about using the passed in transaction, instead of one from the closure.