### PR TITLE
Reduce verbosity in GenerateRoutes

### DIFF
--- a/internal/server/apimigrator.go
+++ b/internal/server/apimigrator.go
@@ -231,18 +231,18 @@ func (m *apiMigration) RedirectHandler() gin.HandlerFunc {
 
 type HTTPMethodBindFunc func(relativePath string, handlers ...gin.HandlerFunc) gin.IRoutes
 
-func bindRoute(a *API, r *gin.RouterGroup, method, path string, handler gin.HandlerFunc) {
+func bindRoute(a *API, r *gin.RouterGroup, routeID routeIdentifier, handler gin.HandlerFunc) {
 	// build up the handlers into a map of all the paths we need to bind into.
 	routes := map[string][]gin.HandlerFunc{}
 	// set the default path
-	routes[path] = []gin.HandlerFunc{handler}
+	routes[routeID.path] = []gin.HandlerFunc{handler}
 
 	// we're going to build this list in referse order, prepending middleware.
 	// we start with the current migration and prepend versions backwards,
 	// 0.1.3, then 0.1.2, then 0.1.1.
 	sort.Slice(a.migrations, sortVersionDescendingOrder(a.migrations))
 	for _, migration := range a.migrations {
-		if strings.ToUpper(migration.method) != method {
+		if strings.ToUpper(migration.method) != routeID.method {
 			continue
 		}
 
@@ -274,7 +274,7 @@ func bindRoute(a *API, r *gin.RouterGroup, method, path string, handler gin.Hand
 
 	// now bind all relevant paths with Gin
 	for path, handlers := range routes {
-		r.Handle(method, path, handlers...)
+		r.Handle(routeID.method, path, handlers...)
 	}
 }
 

--- a/internal/server/debug.go
+++ b/internal/server/debug.go
@@ -11,6 +11,13 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
+var pprofRoute = route[api.EmptyRequest, *api.EmptyResponse]{
+	handler:                    pprofHandler,
+	omitFromTelemetry:          true,
+	omitFromDocs:               true,
+	infraVersionHeaderOptional: true,
+}
+
 func pprofHandler(c *gin.Context, _ *api.EmptyRequest) (*api.EmptyResponse, error) {
 	if _, err := access.RequireInfraRole(c, models.InfraSupportAdminRole); err != nil {
 		return nil, access.HandleAuthErr(err, "debug", "run", models.InfraSupportAdminRole)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -49,8 +49,11 @@ func (a *API) CreateToken(c *gin.Context, r *api.EmptyRequest) (*api.CreateToken
 	return nil, fmt.Errorf("%w: no identity found in access key", internal.ErrUnauthorized)
 }
 
-type WellKnownJWKResponse struct {
-	Keys []jose.JSONWebKey `json:"keys"`
+var wellKnownJWKsRoute = route[api.EmptyRequest, WellKnownJWKResponse]{
+	handler:                    wellKnownJWKsHandler,
+	omitFromDocs:               true,
+	omitFromTelemetry:          true,
+	infraVersionHeaderOptional: true,
 }
 
 func wellKnownJWKsHandler(c *gin.Context, _ *api.EmptyRequest) (WellKnownJWKResponse, error) {
@@ -61,6 +64,10 @@ func wellKnownJWKsHandler(c *gin.Context, _ *api.EmptyRequest) (WellKnownJWKResp
 	}
 
 	return WellKnownJWKResponse{Keys: keys}, nil
+}
+
+type WellKnownJWKResponse struct {
+	Keys []jose.JSONWebKey `json:"keys"`
 }
 
 func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api.ListResponse[api.AccessKey], error) {

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -48,7 +48,7 @@ var funcPartialNameToTagNames = []struct {
 // openAPIRouteDefinition converts the route into a format that can be used
 // by API.register. This is necessary because currently methods can not have
 // generic parameters.
-func openAPIRouteDefinition[Req, Res any](route route[Req, Res]) (
+func openAPIRouteDefinition[Req, Res any](routeID routeIdentifier, route route[Req, Res]) (
 	method string,
 	path string,
 	funcName string,
@@ -57,7 +57,7 @@ func openAPIRouteDefinition[Req, Res any](route route[Req, Res]) (
 ) {
 	//nolint:gocritic
 	reqT, resultT := reflect.TypeOf(*new(Req)), reflect.TypeOf(*new(Res))
-	return route.method, route.path, getFuncName(route.handler), reqT, resultT
+	return routeID.method, routeID.path, getFuncName(route.handler), reqT, resultT
 }
 
 // register adds the route to the API.OpenAPIDocument.

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin"
 
-	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/validate"
@@ -97,12 +96,7 @@ func (s *Server) GenerateRoutes() Routes {
 
 	put(a, authn, "/api/settings", a.UpdateSettings)
 
-	add(a, authn, http.MethodGet, "/api/debug/pprof/*profile", route[api.EmptyRequest, *api.EmptyResponse]{
-		handler:                    pprofHandler,
-		omitFromTelemetry:          true,
-		omitFromDocs:               true,
-		infraVersionHeaderOptional: true,
-	})
+	add(a, authn, http.MethodGet, "/api/debug/pprof/*profile", pprofRoute)
 
 	// no auth required, org not required
 	noAuthnNoOrg := &routeGroup{RouterGroup: apiGroup.Group("/"), noAuthentication: true, noOrgRequired: true}
@@ -122,13 +116,7 @@ func (s *Server) GenerateRoutes() Routes {
 	get(a, noAuthnWithOrg, "/api/providers", a.ListProviders)
 	get(a, noAuthnWithOrg, "/api/settings", a.GetSettings)
 
-	// no auth required, org required, undocumented in api spec
-	add(a, noAuthnWithOrg, http.MethodGet, "/.well-known/jwks.json", route[api.EmptyRequest, WellKnownJWKResponse]{
-		handler:                    wellKnownJWKsHandler,
-		omitFromDocs:               true,
-		omitFromTelemetry:          true,
-		infraVersionHeaderOptional: true,
-	})
+	add(a, noAuthnWithOrg, http.MethodGet, "/.well-known/jwks.json", wellKnownJWKsRoute)
 
 	a.deprecatedRoutes(noAuthnNoOrg)
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -97,9 +97,7 @@ func (s *Server) GenerateRoutes() Routes {
 
 	put(a, authn, "/api/settings", a.UpdateSettings)
 
-	add(a, authn, route[api.EmptyRequest, *api.EmptyResponse]{
-		method:                     http.MethodGet,
-		path:                       "/api/debug/pprof/*profile",
+	add(a, authn, http.MethodGet, "/api/debug/pprof/*profile", route[api.EmptyRequest, *api.EmptyResponse]{
 		handler:                    pprofHandler,
 		omitFromTelemetry:          true,
 		omitFromDocs:               true,
@@ -125,9 +123,7 @@ func (s *Server) GenerateRoutes() Routes {
 	get(a, noAuthnWithOrg, "/api/settings", a.GetSettings)
 
 	// no auth required, org required, undocumented in api spec
-	add(a, noAuthnWithOrg, route[api.EmptyRequest, WellKnownJWKResponse]{
-		method:                     http.MethodGet,
-		path:                       "/.well-known/jwks.json",
+	add(a, noAuthnWithOrg, http.MethodGet, "/.well-known/jwks.json", route[api.EmptyRequest, WellKnownJWKResponse]{
 		handler:                    wellKnownJWKsHandler,
 		omitFromDocs:               true,
 		omitFromTelemetry:          true,
@@ -148,14 +144,17 @@ func (s *Server) GenerateRoutes() Routes {
 type HandlerFunc[Req, Res any] func(c *gin.Context, req *Req) (Res, error)
 
 type route[Req, Res any] struct {
-	method                     string
-	path                       string
 	handler                    HandlerFunc[Req, Res]
 	omitFromDocs               bool
 	omitFromTelemetry          bool
 	infraVersionHeaderOptional bool
 	noAuthentication           bool
 	noOrgRequired              bool
+}
+
+type routeIdentifier struct {
+	method string
+	path   string
 }
 
 // TODO: replace this when routes are defined as package-level vars instead of
@@ -166,22 +165,25 @@ type routeGroup struct {
 	noOrgRequired    bool
 }
 
-func add[Req, Res any](a *API, group *routeGroup, route route[Req, Res]) {
-	route.path = path.Join(group.BasePath(), route.path)
+func add[Req, Res any](a *API, group *routeGroup, method, urlPath string, route route[Req, Res]) {
+	routeID := routeIdentifier{
+		method: method,
+		path:   path.Join(group.BasePath(), urlPath),
+	}
 
 	if !route.omitFromDocs {
-		a.register(openAPIRouteDefinition(route))
+		a.register(openAPIRouteDefinition(routeID, route))
 	}
 
 	route.noAuthentication = group.noAuthentication
 	route.noOrgRequired = group.noOrgRequired
 
 	handler := func(c *gin.Context) {
-		if err := wrapRoute(a, route)(c); err != nil {
+		if err := wrapRoute(a, routeID, route)(c); err != nil {
 			sendAPIError(c, err)
 		}
 	}
-	bindRoute(a, group.RouterGroup, route.method, route.path, handler)
+	bindRoute(a, group.RouterGroup, routeID, handler)
 }
 
 // wrapRoute builds a gin.HandlerFunc from a route. The returned function
@@ -191,7 +193,7 @@ func add[Req, Res any](a *API, group *routeGroup, route route[Req, Res]) {
 // a request scoped database transaction, authenticates the request, reads the
 // request fields into a request struct, and returns an HTTP response with a
 // status code and response body built from the response type.
-func wrapRoute[Req, Res any](a *API, route route[Req, Res]) func(*gin.Context) error {
+func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, Res]) func(*gin.Context) error {
 	return func(c *gin.Context) error {
 		if !route.infraVersionHeaderOptional {
 			if _, err := requestVersion(c.Request); err != nil {
@@ -239,10 +241,10 @@ func wrapRoute[Req, Res any](a *API, route route[Req, Res]) func(*gin.Context) e
 		}
 
 		if !route.omitFromTelemetry {
-			a.t.RouteEvent(c, route.path, Properties{"method": strings.ToLower(route.method)})
+			a.t.RouteEvent(c, routeID.path, Properties{"method": strings.ToLower(routeID.method)})
 		}
 
-		c.JSON(responseStatusCode(route.method, resp), resp)
+		c.JSON(responseStatusCode(routeID.method, resp), resp)
 		return nil
 	}
 }
@@ -284,34 +286,30 @@ func responseStatusCode(method string, resp any) int {
 }
 
 func get[Req, Res any](a *API, r *routeGroup, path string, handler HandlerFunc[Req, Res]) {
-	add(a, r, route[Req, Res]{
-		method:            http.MethodGet,
-		path:              path,
+	add(a, r, http.MethodGet, path, route[Req, Res]{
 		handler:           handler,
 		omitFromTelemetry: true,
 	})
 }
 
 func post[Req, Res any](a *API, r *routeGroup, path string, handler HandlerFunc[Req, Res]) {
-	add(a, r, route[Req, Res]{method: http.MethodPost, path: path, handler: handler})
+	add(a, r, http.MethodPost, path, route[Req, Res]{handler: handler})
 }
 
 func put[Req, Res any](a *API, r *routeGroup, path string, handler HandlerFunc[Req, Res]) {
-	add(a, r, route[Req, Res]{method: http.MethodPut, path: path, handler: handler})
+	add(a, r, http.MethodPut, path, route[Req, Res]{handler: handler})
 }
 
 func patch[Req, Res any](a *API, r *routeGroup, path string, handler HandlerFunc[Req, Res]) {
-	add(a, r, route[Req, Res]{method: http.MethodPatch, path: path, handler: handler})
+	add(a, r, http.MethodPatch, path, route[Req, Res]{handler: handler})
 }
 
 func del[Req any, Res any](a *API, r *routeGroup, path string, handler HandlerFunc[Req, Res]) {
-	add(a, r, route[Req, Res]{method: http.MethodDelete, path: path, handler: handler})
+	add(a, r, http.MethodDelete, path, route[Req, Res]{handler: handler})
 }
 
 func addDeprecated[Req, Res any](a *API, r *routeGroup, method string, path string, handler HandlerFunc[Req, Res]) {
-	add(a, r, route[Req, Res]{
-		method:            method,
-		path:              path,
+	add(a, r, method, path, route[Req, Res]{
 		handler:           handler,
 		omitFromTelemetry: true,
 		omitFromDocs:      true,

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -191,8 +191,6 @@ func TestWrapRoute_TxnRollbackOnError(t *testing.T) {
 	router := gin.New()
 
 	r := route[api.EmptyRequest, *api.EmptyResponse]{
-		method: "POST",
-		path:   "/do",
 		handler: func(c *gin.Context, request *api.EmptyRequest) (*api.EmptyResponse, error) {
 			rCtx := getRequestContext(c)
 
@@ -213,7 +211,7 @@ func TestWrapRoute_TxnRollbackOnError(t *testing.T) {
 	}
 
 	api := &API{server: srv}
-	add(api, rg(router.Group("/")), r)
+	add(api, rg(router.Group("/")), "POST", "/do", r)
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/do", nil)
@@ -233,8 +231,6 @@ func TestWrapRoute_HandleErrorOnCommit(t *testing.T) {
 	router := gin.New()
 
 	r := route[api.EmptyRequest, *api.EmptyResponse]{
-		method: "POST",
-		path:   "/do",
 		handler: func(c *gin.Context, request *api.EmptyRequest) (*api.EmptyResponse, error) {
 			rCtx := getRequestContext(c)
 
@@ -248,7 +244,7 @@ func TestWrapRoute_HandleErrorOnCommit(t *testing.T) {
 	}
 
 	api := &API{server: srv}
-	add(api, rg(router.Group("/")), r)
+	add(api, rg(router.Group("/")), "POST", "/do", r)
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/do", nil)


### PR DESCRIPTION
## Summary

Most routes in `GenerateRoutes` are added with a single. We have a few special cases that have to set fields on the `route` definition, which makes them more verbose.  

This PR changes `add` to accept the `method` and `path` separate from the `route` struct. This allows us to move the route definition to a package-level variable, and keep `GenerateRoutes` to a single line per route.