### PR TITLE
Support querying for multiple privileges

### DIFF
--- a/api/grant.go
+++ b/api/grant.go
@@ -47,8 +47,16 @@ func (r ListGrantsRequest) ValidationRules() []validate.ValidationRule {
 		validate.MutuallyExclusive(
 			validate.Field{Name: "user", Value: r.User},
 			validate.Field{Name: "group", Value: r.Group},
-			// TODO: validate showInherited only allowed with User
 		),
+		validate.ValidatorFunc(func() *validate.Failure {
+			if r.ShowInherited && r.User == 0 {
+				return &validate.Failure{
+					Name:     "showInherited",
+					Problems: []string{"requires a user ID"},
+				}
+			}
+			return nil
+		}),
 	}
 }
 

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -194,13 +194,13 @@ func grant(t *testing.T, db data.GormTxn, createdBy *models.Identity, subject ui
 
 func can(t *testing.T, db *data.DB, subject uid.PolymorphicID, privilege, resource string) {
 	t.Helper()
-	canAccess, err := Can(db, subject, privilege, resource)
+	canAccess, err := Can(db, subject, resource, privilege)
 	assert.NilError(t, err)
 	assert.Assert(t, canAccess)
 }
 
 func cant(t *testing.T, db *data.DB, subject uid.PolymorphicID, privilege, resource string) {
-	canAccess, err := Can(db, subject, privilege, resource)
+	canAccess, err := Can(db, subject, resource, privilege)
 	assert.NilError(t, err)
 	assert.Assert(t, !canAccess)
 }

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -43,11 +43,13 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 
 	opts := data.ListGrantsOptions{
 		ByResource:                 resource,
-		ByPrivilege:                privilege,
 		BySubject:                  subject,
 		ExcludeConnectorGrant:      !showSystem,
 		IncludeInheritedFromGroups: inherited,
 		Pagination:                 p,
+	}
+	if privilege != "" {
+		opts.ByPrivileges = []string{privilege}
 	}
 	return data.ListGrants(rCtx.DBTxn, opts)
 }

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -105,9 +105,9 @@ func GetGrant(tx ReadTxn, opts GetGrantOptions) (*models.Grant, error) {
 }
 
 type ListGrantsOptions struct {
-	BySubject   uid.PolymorphicID
-	ByPrivilege string
-	ByResource  string
+	BySubject    uid.PolymorphicID
+	ByPrivileges []string
+	ByResource   string
 
 	// IncludeInheritedFromGroups instructs ListGrants to include grants from
 	// groups where the user is a member. This option can only be used when
@@ -154,8 +154,8 @@ func ListGrants(tx ReadTxn, opts ListGrantsOptions) ([]models.Grant, error) {
 			query.B(`AND subject IN (?)`, subjects)
 		}
 	}
-	if opts.ByPrivilege != "" {
-		query.B("AND privilege = ?", opts.ByPrivilege)
+	if len(opts.ByPrivileges) > 0 {
+		query.B("AND privilege IN (?)", opts.ByPrivileges)
 	}
 	if opts.ByResource != "" {
 		query.B("AND resource = ?", opts.ByResource)

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -381,12 +381,22 @@ func TestListGrants(t *testing.T) {
 		})
 		t.Run("by resource and privilege", func(t *testing.T) {
 			actual, err := ListGrants(tx, ListGrantsOptions{
-				ByResource:  "any",
-				ByPrivilege: "view",
+				ByResource:   "any",
+				ByPrivileges: []string{"view"},
 			})
 			assert.NilError(t, err)
 
 			expected := []models.Grant{*grant1, *grant2}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+		})
+		t.Run("with multiple privileges", func(t *testing.T) {
+			actual, err := ListGrants(tx, ListGrantsOptions{
+				ByResource:   "any",
+				ByPrivileges: []string{"view", "admin"},
+			})
+			assert.NilError(t, err)
+
+			expected := []models.Grant{*grant1, *grant2, *grant3}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
 		})
 		t.Run("by subject with include inherited", func(t *testing.T) {

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -775,8 +775,8 @@ func TestAPI_DeleteGrant(t *testing.T) {
 
 	t.Run("last infra admin is deleted", func(t *testing.T) {
 		infraAdminGrants, err := data.ListGrants(srv.DB(), data.ListGrantsOptions{
-			ByPrivilege: models.InfraAdminRole,
-			ByResource:  "infra",
+			ByPrivileges: []string{models.InfraAdminRole},
+			ByResource:   "infra",
 		})
 		assert.NilError(t, err)
 		assert.Assert(t, len(infraAdminGrants) == 1)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -285,3 +285,14 @@ func fieldName(f reflect.StructField) string {
 
 	return strings.ToLower(f.Name[:1]) + f.Name[1:]
 }
+
+// ValidatorFunc wraps a function so that it implements ValidationRule. It can
+// be used to create special validations without having to define a type.
+// The ValidationRule will have a no-op implementation of DescribeSchema.
+type ValidatorFunc func() *Failure
+
+func (f ValidatorFunc) Validate() *Failure {
+	return f()
+}
+
+func (f ValidatorFunc) DescribeSchema(*openapi3.Schema) {}


### PR DESCRIPTION
## Summary

Branched from #3162, this PR resolves a couple TODOs added in that PR. Best viewed by individual commit.

1. validate that `showInherited` is only used when there is a userID. Previously we allowed this, but it did nothing. It's better to be strict about what is allowed, rather than accepting a query parameter that does nothing for the query. This will be even more important with long polling because we won't necessarily support long-polling with every query parameter.
2. remove the need to loop over the roles and perform multiple authorization queries by accepting a slice of privileges and returning all the grants at once.