### PR TITLE
Remove deprecated identity value from gin.Context

### DIFF
--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -35,9 +35,9 @@ const ResourceInfraAPI = "infra"
 
 // RequireInfraRole checks that the identity in the context can perform an action on a resource based on their granted roles
 func RequireInfraRole(c *gin.Context, oneOfRoles ...string) (data.GormTxn, error) {
-	db := getDB(c)
-
-	identity := AuthenticatedIdentity(c)
+	rCtx := GetRequestContext(c)
+	db := rCtx.DBTxn
+	identity := rCtx.Authenticated.User
 	if identity == nil {
 		return nil, fmt.Errorf("no active identity")
 	}

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -96,7 +96,9 @@ func TestUpdateCredentials(t *testing.T) {
 	})
 
 	t.Run("Update own credentials is NOT single use password", func(t *testing.T) {
-		c.Set("identity", user)
+		rCtx := GetRequestContext(c)
+		rCtx.Authenticated.User = user
+		c.Set(RequestContextKey, rCtx)
 
 		err := UpdateCredential(c, user, "newPassword")
 		assert.NilError(t, err)

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -13,18 +13,8 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-// isUserInGroup is used by authorization checks to see if the calling user is requesting their own attributes
-func isUserInGroup(c *gin.Context, requestedResourceID uid.ID) (bool, error) {
-	user := AuthenticatedIdentity(c)
-
-	if user != nil {
-		return userInGroup(getDB(c), user.ID, requestedResourceID), nil
-	}
-
-	return false, nil
-}
-
 func ListGroups(c *gin.Context, name string, userID uid.ID, p *data.Pagination) ([]models.Group, error) {
+	rCtx := GetRequestContext(c)
 	var selectors []data.SelectorFunc = []data.SelectorFunc{}
 	if name != "" {
 		selectors = append(selectors, data.ByName(name))
@@ -34,21 +24,20 @@ func ListGroups(c *gin.Context, name string, userID uid.ID, p *data.Pagination) 
 	}
 
 	roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
-	db, err := RequireInfraRole(c, roles...)
+	_, err := RequireInfraRole(c, roles...)
 	if err == nil {
-		return data.ListGroups(db, p, selectors...)
+		return data.ListGroups(rCtx.DBTxn, p, selectors...)
 	}
 	err = HandleAuthErr(err, "groups", "list", roles...)
 
 	if errors.Is(err, ErrNotAuthorized) {
 		// Allow an authenticated identity to view their own groups
-		db := getDB(c)
-		identity := AuthenticatedIdentity(c)
+		identity := rCtx.Authenticated.User
 		switch {
 		case identity == nil:
 			return nil, err
 		case userID == identity.ID:
-			return data.ListGroups(db, p, selectors...)
+			return data.ListGroups(rCtx.DBTxn, p, selectors...)
 		}
 	}
 
@@ -65,13 +54,19 @@ func CreateGroup(c *gin.Context, group *models.Group) error {
 }
 
 func GetGroup(c *gin.Context, id uid.ID) (*models.Group, error) {
+	rCtx := GetRequestContext(c)
 	roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
-	db, err := hasAuthorization(c, id, isUserInGroup, roles...)
-	if err != nil {
-		return nil, HandleAuthErr(err, "group", "get", roles...)
+	_, err := RequireInfraRole(c, roles...)
+	err = HandleAuthErr(err, "group", "get", roles...)
+	if errors.Is(err, ErrNotAuthorized) {
+		if !userInGroup(rCtx.DBTxn, rCtx.Authenticated.User.ID, id) {
+			return nil, err
+		}
+		// authorized by user belonging to the requested group
+	} else if err != nil {
+		return nil, err
 	}
-
-	return data.GetGroup(db, data.ByID(id))
+	return data.GetGroup(rCtx.DBTxn, data.ByID(id))
 }
 
 func DeleteGroup(c *gin.Context, id uid.ID) error {

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -16,18 +16,8 @@ import (
 
 // isIdentitySelf is used by authorization checks to see if the calling identity is requesting their own attributes
 func isIdentitySelf(c *gin.Context, userID uid.ID) (bool, error) {
-	identity := AuthenticatedIdentity(c)
+	identity := GetRequestContext(c).Authenticated.User
 	return identity != nil && identity.ID == userID, nil
-}
-
-// AuthenticatedIdentity returns the identity that is associated with the access key
-// that was used to authenticate the request.
-// Returns nil if there is no identity in the context, which likely means the
-// request was not authenticated.
-//
-// Deprecated: use GetRequestContext
-func AuthenticatedIdentity(c *gin.Context) *models.Identity {
-	return GetRequestContext(c).Authenticated.User
 }
 
 func GetIdentity(c *gin.Context, id uid.ID) (*models.Identity, error) {

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -25,15 +25,9 @@ func isIdentitySelf(c *gin.Context, userID uid.ID) (bool, error) {
 // Returns nil if there is no identity in the context, which likely means the
 // request was not authenticated.
 //
-// TODO: remove once all callers use RequestContext.Authenticated.User
-// See https://github.com/infrahq/infra/issues/2796
+// Deprecated: use GetRequestContext
 func AuthenticatedIdentity(c *gin.Context) *models.Identity {
-	if raw, ok := c.Get("identity"); ok {
-		if identity, ok := raw.(*models.Identity); ok {
-			return identity
-		}
-	}
-	return nil
+	return GetRequestContext(c).Authenticated.User
 }
 
 func GetIdentity(c *gin.Context, id uid.ID) (*models.Identity, error) {

--- a/internal/server/groups.go
+++ b/internal/server/groups.go
@@ -36,7 +36,7 @@ func (a *API) CreateGroup(c *gin.Context, r *api.CreateGroupRequest) (*api.Group
 		Name: r.Name,
 	}
 
-	authIdent := access.AuthenticatedIdentity(c)
+	authIdent := getRequestContext(c).Authenticated.User
 	if authIdent != nil {
 		group.CreatedBy = authIdent.ID
 	}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -79,8 +79,10 @@ func createAdmin(t *testing.T, db data.GormTxn) *models.Identity {
 
 func loginAs(tx *data.Transaction, user *models.Identity) *gin.Context {
 	ctx, _ := gin.CreateTestContext(nil)
-	ctx.Set(access.RequestContextKey, access.RequestContext{DBTxn: tx})
-	ctx.Set("identity", user)
+	ctx.Set(access.RequestContextKey, access.RequestContext{
+		DBTxn:         tx,
+		Authenticated: access.Authenticated{User: user},
+	})
 	return ctx
 }
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -93,9 +93,6 @@ func authenticateRequest(c *gin.Context, tx *data.Transaction, srv *Server) erro
 	}
 	c.Set(access.RequestContextKey, rCtx)
 
-	// TODO: remove once everything uses RequestContext
-	c.Set("identity", authned.User)
-
 	if err := handleInfraDestinationHeader(c); err != nil {
 		return err
 	}

--- a/internal/server/organizations.go
+++ b/internal/server/organizations.go
@@ -38,7 +38,7 @@ func (a *API) CreateOrganization(c *gin.Context, r *api.CreateOrganizationReques
 	}
 
 	// TODO: This should be removed in the future in favour of setting CreatedBy automatically
-	authIdent := access.AuthenticatedIdentity(c)
+	authIdent := getRequestContext(c).Authenticated.User
 	if authIdent != nil {
 		org.CreatedBy = authIdent.ID
 	}

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -102,7 +102,7 @@ func (t *Telemetry) EnqueueHeartbeat() {
 func (t *Telemetry) RouteEvent(c *gin.Context, event string, properties ...map[string]interface{}) {
 	var uid string
 	if c != nil {
-		if u := access.AuthenticatedIdentity(c); u != nil {
+		if u := access.GetRequestContext(c).Authenticated.User; u != nil {
 			uid = u.ID.String()
 		}
 	}

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -31,7 +31,7 @@ func (a *API) ListUsers(c *gin.Context, r *api.ListUsersRequest) (*api.ListRespo
 
 func (a *API) GetUser(c *gin.Context, r *api.GetUserRequest) (*api.User, error) {
 	if r.ID.IsSelf {
-		iden := access.AuthenticatedIdentity(c)
+		iden := access.GetRequestContext(c).Authenticated.User
 		if iden == nil {
 			return nil, fmt.Errorf("%w: no user is logged in", internal.ErrUnauthorized)
 		}


### PR DESCRIPTION
## Summary

We introduced `RequestContext` a little while ago to replace the untyped and mutable `gin.Context`. At the time we left a few things in `gin.Context` to keep the change small. This PR removes the last value (`identity`) from `gin.Context`.

Also updates the authorization check in `GetGroup` to match the style we use in `ListGroups` and `ListGrants`.