### PR TITLE
Use SQL for Create, Update, and Delete groups

### DIFF
--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -130,9 +130,16 @@ func UpdateUsersInGroup(c *gin.Context, groupID uid.ID, uidsToAdd []uid.ID, uids
 		return err
 	}
 
-	err = data.AddUsersToGroup(db, groupID, addIDList)
-	if err != nil {
-		return err
+	if len(addIDList) > 0 {
+		if err := data.AddUsersToGroup(db, groupID, addIDList); err != nil {
+			return err
+		}
 	}
-	return data.RemoveUsersFromGroup(db, groupID, rmIDList)
+
+	if len(rmIDList) > 0 {
+		if err := data.RemoveUsersFromGroup(db, groupID, rmIDList); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -74,12 +74,7 @@ func DeleteGroup(c *gin.Context, id uid.ID) error {
 	if err != nil {
 		return HandleAuthErr(err, "group", "delete", models.InfraAdminRole)
 	}
-
-	selectors := []data.SelectorFunc{
-		data.ByID(id),
-	}
-
-	return data.DeleteGroups(db, selectors...)
+	return data.DeleteGroup(db, id)
 }
 
 func checkIdentitiesInList(db data.GormTxn, ids []uid.ID) ([]uid.ID, error) {

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -138,14 +138,10 @@ func AddUsersToGroup(tx WriteTxn, groupID uid.ID, idsToAdd []uid.ID) error {
 	return handleError(err)
 }
 
-func RemoveUsersFromGroup(db GormTxn, groupID uid.ID, idsToRemove []uid.ID) error {
-	for _, id := range idsToRemove {
-		_, err := db.Exec("DELETE FROM identities_groups WHERE identity_id = ? AND group_id = ?", id, groupID)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+func RemoveUsersFromGroup(tx WriteTxn, groupID uid.ID, idsToRemove []uid.ID) error {
+	stmt := `DELETE FROM identities_groups WHERE group_id = ? AND identity_id IN (?)`
+	_, err := tx.Exec(stmt, groupID, idsToRemove)
+	return handleError(err)
 }
 
 // TODO: do this with a join in ListGroups and GetGroup

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -25,8 +25,8 @@ func (g *groupsTable) ScanFields() []any {
 	return []any{&g.CreatedAt, &g.CreatedBy, &g.CreatedByProvider, &g.DeletedAt, &g.ID, &g.Name, &g.OrganizationID, &g.UpdatedAt}
 }
 
-func CreateGroup(db GormTxn, group *models.Group) error {
-	return add(db, group)
+func CreateGroup(tx WriteTxn, group *models.Group) error {
+	return insert(tx, (*groupsTable)(group))
 }
 
 func GetGroup(db GormTxn, selectors ...SelectorFunc) (*models.Group, error) {

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -7,6 +7,24 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+type groupsTable models.Group
+
+func (g groupsTable) Table() string {
+	return "groups"
+}
+
+func (g groupsTable) Columns() []string {
+	return []string{"created_at", "created_by", "created_by_provider", "deleted_at", "id", "name", "organization_id", "updated_at"}
+}
+
+func (g groupsTable) Values() []any {
+	return []any{g.CreatedAt, g.CreatedBy, g.CreatedByProvider, g.DeletedAt, g.ID, g.Name, g.OrganizationID, g.UpdatedAt}
+}
+
+func (g *groupsTable) ScanFields() []any {
+	return []any{&g.CreatedAt, &g.CreatedBy, &g.CreatedByProvider, &g.DeletedAt, &g.ID, &g.Name, &g.OrganizationID, &g.UpdatedAt}
+}
+
 func CreateGroup(db GormTxn, group *models.Group) error {
 	return add(db, group)
 }

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -10,21 +10,6 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func TestGroup(t *testing.T) {
-	runDBTests(t, func(t *testing.T, db *DB) {
-		everyone := models.Group{Name: "Everyone"}
-
-		err := db.Create(&everyone).Error
-		assert.NilError(t, err)
-
-		var group models.Group
-		err = db.First(&group, &models.Group{Name: everyone.Name}).Error
-		assert.NilError(t, err)
-		assert.Assert(t, 0 != group.ID)
-		assert.Equal(t, everyone.Name, group.Name)
-	})
-}
-
 func TestCreateGroup(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		everyone := models.Group{Name: "Everyone"}

--- a/internal/server/models/group.go
+++ b/internal/server/models/group.go
@@ -13,9 +13,9 @@ type Group struct {
 	CreatedBy         uid.ID
 	CreatedByProvider uid.ID
 
-	Identities []Identity `gorm:"many2many:identities_groups"`
+	Identities []Identity `db:"-" gorm:"many2many:identities_groups"`
 
-	TotalUsers int `gorm:"-:all"`
+	TotalUsers int `db:"-" gorm:"-:all"`
 }
 
 func (g *Group) ToAPI() *api.Group {

--- a/internal/server/models/group.go
+++ b/internal/server/models/group.go
@@ -13,8 +13,6 @@ type Group struct {
 	CreatedBy         uid.ID
 	CreatedByProvider uid.ID
 
-	Identities []Identity `db:"-" gorm:"many2many:identities_groups"`
-
 	TotalUsers int `db:"-" gorm:"-:all"`
 }
 


### PR DESCRIPTION
## Summary

Updates the data query functions for `CreateGroup`, `AddUserstoGroup`, `RemoveUsersFromGroup`, and `DeleteGroup` to use SQL.

Related to #2415 
