### PR TITLE
Add a scipt to sync linter deps before running lint

### DIFF
--- a/internal/tools/querylinter/go.mod
+++ b/internal/tools/querylinter/go.mod
@@ -3,12 +3,12 @@ module github.com/infrahq/infra/internal/tools/querylinter
 go 1.19
 
 require (
+	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 	golang.org/x/tools v0.1.12
 	gotest.tools/v3 v3.3.0
 )
 
 require (
-	github.com/google/go-cmp v0.5.5 // indirect
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 )

--- a/internal/tools/querylinter/go.sum
+++ b/internal/tools/querylinter/go.sum
@@ -1,5 +1,6 @@
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -29,7 +30,6 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gotest.tools/v3 v3.3.0 h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
 gotest.tools/v3 v3.3.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=

--- a/internal/tools/querylinter/sync/sync-mod.go
+++ b/internal/tools/querylinter/sync/sync-mod.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(_ []string) error {
+	binary, err := exec.LookPath("golangci-lint")
+	if err != nil {
+		return fmt.Errorf("lookup golangci-lint in PATH: %w", err)
+	}
+	fmt.Println("Found", binary)
+
+	out, err := execCmd("go", "version", "-m", binary)
+	if err != nil {
+		return fmt.Errorf("version for golangci-lint: %w", err)
+	}
+
+	target, err := parseTargetVersions(out)
+	if err != nil {
+		return fmt.Errorf("parse output from 'go version -m': %w", err)
+	}
+	if target.GoVersion != runtime.Version() {
+		return fmt.Errorf("Go version does not match runtime version %v", runtime.Version())
+	}
+
+	goModFile, err := readGoMod()
+	if err != nil {
+		return fmt.Errorf("read go.mod: %w", err)
+	}
+	for _, require := range goModFile.Require {
+		targetVersion, ok := target.Modules[require.Mod.Path]
+		if !ok || targetVersion == require.Mod.Version {
+			continue
+		}
+		fmt.Printf("UPDATE: module %v needs version %v\n", require.Mod.Path, targetVersion)
+		require.Mod.Version = targetVersion
+	}
+	goModFile.SetRequire(goModFile.Require)
+
+	if err := writeFile(goModFile); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	if _, err := execCmd("go", "mod", "tidy"); err != nil {
+		return fmt.Errorf("go mod tidy: %w", err)
+	}
+	return nil
+}
+
+func writeFile(file *modfile.File) error {
+	file.Cleanup()
+
+	raw, err := file.Format()
+	if err != nil {
+		return fmt.Errorf("failed to format: %w", err)
+	}
+
+	return os.WriteFile("go.mod", raw, 0644)
+}
+
+func readGoMod() (*modfile.File, error) {
+	raw, err := os.ReadFile("go.mod")
+	if err != nil {
+		return nil, err
+	}
+	return modfile.Parse("go.mod", raw, nil)
+}
+
+func execCmd(cmd string, args ...string) (*bytes.Buffer, error) {
+	c := exec.Command(cmd, args...)
+	stdout := new(bytes.Buffer)
+	c.Stdout = stdout
+	c.Stderr = os.Stderr
+	return stdout, c.Run()
+}
+
+func parseTargetVersions(source io.Reader) (targetVersions, error) {
+	target := targetVersions{Modules: make(map[string]string)}
+	scan := bufio.NewScanner(source)
+	if !scan.Scan() {
+		return target, fmt.Errorf("no output")
+	}
+	_, target.GoVersion, _ = strings.Cut(scan.Text(), ": ")
+	for scan.Scan() {
+		fields := strings.Fields(scan.Text())
+		if len(fields) != 4 || fields[0] != "dep" {
+			continue
+		}
+		target.Modules[fields[1]] = fields[2]
+	}
+
+	return target, scan.Err()
+}
+
+type targetVersions struct {
+	GoVersion string
+	Modules   map[string]string
+}


### PR DESCRIPTION
## Summary

Our custom linter is run by `golangci-lint` as a Go plugin. Go plugins must be built with the exact same version of Go, and the exact same version of all shared Go modules.

`make lint` will fail if someone updates `golangci-lint` on their local machine. This PR addresses the problem by adding a command to update the `go.mod` of the `querylinter` module based on the modules used by their local `golangci-lint`.

Usage:

From the `internal/tools/querylinter` directory, run
```
go run ./sync/sync-mod.go
```