### PR TITLE
ci: run core ci workflow on more paths

### DIFF
--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -6,6 +6,9 @@ on:
       - go.mod
       - go.sum
       - '**/*.go'
+      - '.github/workflows/ci-core.yaml'
+      - '.golangci.yml'
+
   push:
     branches:
       - main
@@ -13,6 +16,8 @@ on:
       - go.mod
       - go.sum
       - '**/*.go'
+      - '.github/workflows/*-core.yaml'
+      - '.golangci.yml'
 
 jobs:
   lint:


### PR DESCRIPTION
If any of the github workflow files change, or if the linter config changes we should run the core CI workflow.
