### PR TITLE
feat: connector service.type NodePort

### DIFF
--- a/helm/charts/infra/templates/connector/clusterrole.yaml
+++ b/helm/charts/infra/templates/connector/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
       - pods
       - services
       - namespaces
+      - nodes
     verbs:
       - list
   - apiGroups:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

If connector is using service.type=NodePort, get the node list and find the first external address. If no external address is available, fallback to using the internal IP but warn the user. The internal IP is usable iff the client has a route to that network.

May be worth adding an option to prefer the internal IP which will also disable the warning.

Tested with public node port in EKS.