### PR TITLE
Use SQL for ListGroups and GetGroup

### DIFF
--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -136,13 +136,13 @@ func logError(fn func() error, msg string) {
 }
 
 func userInGroup(db data.GormTxn, authnUserID uid.ID, groupID uid.ID) bool {
-	groups, err := data.ListGroups(db, data.ListGroupsOptions{ByGroupMember: authnUserID})
+	groups, err := data.ListGroupIDsForUser(db, authnUserID)
 	if err != nil {
 		return false
 	}
 
 	for _, g := range groups {
-		if g.ID == groupID {
+		if g == groupID {
 			return true
 		}
 	}

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -136,7 +136,7 @@ func logError(fn func() error, msg string) {
 }
 
 func userInGroup(db data.GormTxn, authnUserID uid.ID, groupID uid.ID) bool {
-	groups, err := data.ListGroups(db, &data.Pagination{Limit: 1}, data.ByGroupMember(authnUserID), data.ByID(groupID))
+	groups, err := data.ListGroups(db, data.ListGroupsOptions{ByGroupMember: authnUserID})
 	if err != nil {
 		return false
 	}

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -15,18 +15,17 @@ import (
 
 func ListGroups(c *gin.Context, name string, userID uid.ID, p *data.Pagination) ([]models.Group, error) {
 	rCtx := GetRequestContext(c)
-	var selectors []data.SelectorFunc = []data.SelectorFunc{}
-	if name != "" {
-		selectors = append(selectors, data.ByName(name))
-	}
-	if userID != 0 {
-		selectors = append(selectors, data.ByGroupMember(userID))
+
+	opts := data.ListGroupsOptions{
+		ByName:        name,
+		ByGroupMember: userID,
+		Pagination:    p,
 	}
 
 	roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
 	_, err := RequireInfraRole(c, roles...)
 	if err == nil {
-		return data.ListGroups(rCtx.DBTxn, p, selectors...)
+		return data.ListGroups(rCtx.DBTxn, opts)
 	}
 	err = HandleAuthErr(err, "groups", "list", roles...)
 
@@ -37,7 +36,7 @@ func ListGroups(c *gin.Context, name string, userID uid.ID, p *data.Pagination) 
 		case identity == nil:
 			return nil, err
 		case userID == identity.ID:
-			return data.ListGroups(rCtx.DBTxn, p, selectors...)
+			return data.ListGroups(rCtx.DBTxn, opts)
 		}
 	}
 

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -66,7 +66,7 @@ func GetGroup(c *gin.Context, id uid.ID) (*models.Group, error) {
 	} else if err != nil {
 		return nil, err
 	}
-	return data.GetGroup(rCtx.DBTxn, data.ByID(id))
+	return data.GetGroup(rCtx.DBTxn, data.GetGroupOptions{ByID: id})
 }
 
 func DeleteGroup(c *gin.Context, id uid.ID) error {
@@ -114,7 +114,7 @@ func UpdateUsersInGroup(c *gin.Context, groupID uid.ID, uidsToAdd []uid.ID, uids
 		return err
 	}
 
-	_, err = data.GetGroup(db, data.ByID(groupID))
+	_, err = data.GetGroup(db, data.GetGroupOptions{ByID: groupID})
 	if err != nil {
 		return err
 	}

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -111,7 +111,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(grants), 0)
 
-	group, err = data.GetGroup(db, data.ByID(group.ID))
+	group, err = data.GetGroup(db, data.GetGroupOptions{ByID: group.ID})
 	assert.NilError(t, err)
 	assert.Equal(t, group.TotalUsers, 0)
 }

--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -206,7 +206,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 					assert.NilError(t, err)
 				}
 
-				g, err := data.GetGroup(db, data.ByName("Foo"))
+				g, err := data.GetGroup(db, data.GetGroupOptions{ByName: "Foo"})
 				assert.NilError(t, err)
 				assert.Assert(t, g != nil)
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -797,7 +797,7 @@ func (Server) loadGrant(db data.GormTxn, input Grant) (*models.Grant, error) {
 		id = uid.NewIdentityPolymorphicID(user.ID)
 
 	case input.Group != "":
-		group, err := data.GetGroup(db, data.ByName(input.Group))
+		group, err := data.GetGroup(db, data.GetGroupOptions{ByName: input.Group})
 		if err != nil {
 			if !errors.Is(err, internal.ErrNotFound) {
 				return nil, err

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -169,7 +169,7 @@ func ListGrants(tx ReadTxn, opts ListGrantsOptions) ([]models.Grant, error) {
 			}
 			// FIXME: store userID and groupID as a field on the grants table so
 			// that we can replace this with a sub-select or join.
-			groupIDs, err := groupIDsForUser(tx, userID)
+			groupIDs, err := ListGroupIDsForUser(tx, userID)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -132,7 +132,7 @@ func ListGroups(tx ReadTxn, opts ListGroupsOptions) ([]models.Group, error) {
 	return result, nil
 }
 
-func groupIDsForUser(tx ReadTxn, userID uid.ID) ([]uid.ID, error) {
+func ListGroupIDsForUser(tx ReadTxn, userID uid.ID) ([]uid.ID, error) {
 	stmt := `SELECT DISTINCT group_id FROM identities_groups WHERE identity_id = ?`
 	rows, err := tx.Query(stmt, userID)
 	if err != nil {

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -170,7 +170,7 @@ func GetIdentity(tx GormTxn, opts GetIdentityOptions) (*models.Identity, error) 
 	}
 
 	if opts.LoadGroups {
-		groups, err := ListGroups(tx, nil, ByGroupMember(identity.ID))
+		groups, err := ListGroups(tx, ListGroupsOptions{ByGroupMember: identity.ID})
 		if err != nil {
 			return nil, fmt.Errorf("load identity groups: %w", err)
 		}
@@ -341,7 +341,7 @@ func loadIdentitiesGroups(tx GormTxn, identities []models.Identity) error {
 	}
 
 	// look-up the group entities
-	groups, err := ListGroups(tx, nil, ByIDs(maps.Keys(groupIDs)))
+	groups, err := ListGroups(tx, ListGroupsOptions{ByIDs: maps.Keys(groupIDs)})
 	if err != nil {
 		return err
 	}
@@ -491,7 +491,7 @@ func deleteReferencesToIdentities(tx GormTxn, providerID uid.ID, toDelete []mode
 		}
 
 		if len(user.Providers) == 0 {
-			groups, err := ListGroups(tx, nil, ByGroupMember(i.ID))
+			groups, err := ListGroups(tx, ListGroupsOptions{ByGroupMember: i.ID})
 			if err != nil {
 				return []uid.ID{}, fmt.Errorf("list groups for identity: %w", err)
 			}

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -361,7 +361,7 @@ func TestDeleteIdentities(t *testing.T) {
 				// when an identity has no more references its resources are cleaned up
 				_, err = GetCredential(tx, ByIdentityID(identity.ID))
 				assert.Error(t, err, "record not found")
-				groupIDs, err := groupIDsForUser(tx, identity.ID)
+				groupIDs, err := ListGroupIDsForUser(tx, identity.ID)
 				assert.NilError(t, err)
 				assert.Equal(t, len(groupIDs), 0)
 				grants, err := ListGrants(tx, ListGrantsOptions{BySubject: identity.PolyID()})

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -714,7 +714,7 @@ func TestAssignIdentityToGroups(t *testing.T) {
 				assert.NilError(t, err)
 
 				// check the result
-				actual, err := ListGroups(db, nil, ByGroupMember(identity.ID))
+				actual, err := ListGroups(db, ListGroupsOptions{ByGroupMember: identity.ID})
 				assert.NilError(t, err)
 
 				assert.DeepEqual(t, actual, test.ExpectedGroups, cmpModelsGroupShallow)

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -605,7 +605,7 @@ func TestDeleteIdentityWithGroups(t *testing.T) {
 		err = DeleteIdentities(db, opts)
 		assert.NilError(t, err)
 
-		group, err = GetGroup(db, ByID(group.ID))
+		group, err = GetGroup(db, GetGroupOptions{ByID: group.ID})
 		assert.NilError(t, err)
 		assert.Equal(t, group.TotalUsers, 2)
 	})
@@ -692,7 +692,7 @@ func TestAssignIdentityToGroups(t *testing.T) {
 
 				// setup identity's groups
 				for _, gn := range test.StartingGroups {
-					g, err := GetGroup(db, ByName(gn))
+					g, err := GetGroup(db, GetGroupOptions{ByName: gn})
 					if errors.Is(err, internal.ErrNotFound) {
 						g = &models.Group{Name: gn}
 						err = CreateGroup(db, g)

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -199,7 +199,7 @@ func TestSyncProviderUser(t *testing.T) {
 					assert.Assert(t, puGroups["Developers"])
 
 					// check that the direct user-to-group relation was updated
-					storedGroups, err := ListGroups(db, nil, ByGroupMember(pu.IdentityID))
+					storedGroups, err := ListGroups(db, ListGroupsOptions{ByGroupMember: pu.IdentityID})
 					assert.NilError(t, err)
 
 					userGroups := make(map[string]bool)

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -68,7 +68,7 @@ func CreateIdentityToken(db GormTxn, identityID uid.ID) (token *models.Token, er
 		return nil, err
 	}
 
-	identityGroups, err := ListGroups(db, nil, ByGroupMember(identityID))
+	identityGroups, err := ListGroups(db, ListGroupsOptions{ByGroupMember: identityID})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -11,9 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 
-	"github.com/infrahq/infra/internal"
-
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 
+	"github.com/infrahq/infra/internal"
+
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -319,9 +321,8 @@ func TestAPI_DeleteGroup(t *testing.T) {
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusNoContent, resp.Body.String())
-				actual, err := data.ListGroups(srv.DB(), nil, data.ByID(humans.ID))
-				assert.NilError(t, err)
-				assert.Equal(t, len(actual), 0)
+				_, err := data.GetGroup(srv.DB(), data.GetGroupOptions{ByID: humans.ID})
+				assert.ErrorIs(t, err, internal.ErrNotFound)
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Branched from #3199 

Convert `ListGroups` and `GetGroup` to use SQL and add a few more test cases for them.

## Related Issues

Resolves #2415 
