### PR TITLE
maintain: track provider groups separate from users

### DIFF
--- a/docs/dev/identity-provider-tracking.md
+++ b/docs/dev/identity-provider-tracking.md
@@ -1,0 +1,29 @@
+# Identity Provider Tracking
+Infra tracks users and groups that exist in external identity providers and maps them access. The following database diagram shows how the relation of groups and users in identity providers are mapped to users and groups within Infra.
+
+Our identity system has two different type of relations, one of which exists in Infra (users and groups controlled by Infra), and the other relation which exists externally (information about users and groups which exist in an identity provider).
+
+To get all the groups a user belongs to as a combination of direct group membership and membership in a mapped identity provider group use the `resolved_identity_groups` view.
+
+## Users and Groups Managed by Infra
+The following tables represent users whose identity is managed by Infra and groups which are controlled by Infra.
+- **Identities**: Known information about a user. This may be a an email and password hash that can be used to login to Infra directly, or information about a user that has logged via an identity provider.
+- **Groups**: Groups which exist in Infra that membership to grants access to some resource.
+- **Identities_Groups**: Identities that have been added as a member of a group within Infra, this membership is added through either membership in an external identity provider group or through direct assignment (represented in the database as being part of an Infra provider group).
+
+## Users and Groups Managed by an Identity Provider
+- **Provider_User**: A user that exists in an identity provider.
+- **Provider_Group**: A group that exists in an identity provider.
+- **Provider_Groups_Provider_Users**: This relation shows which users of an identity provders are members of which groups in the same identity provider.
+
+```mermaid
+erDiagram
+          PROVIDER_GROUPS_MAPPINGS }o--|| PROVIDER : ""
+          GROUP ||--o{ IDENTITIES_GROUPS : "direct membership to infra group"
+          IDENTITIES_GROUPS }o--|| IDENTITY : "direct membership to infra group" 
+          IDENTITY ||--o{ PROVIDER_USER : "infra identity composed of identity provider users"
+          PROVIDER_GROUP }o--|| PROVIDER : "sync groups to infra"
+          PROVIDER_GROUP ||--o{ PROVIDER_GROUPS_PROVIDER_USERS : "sync members to infra"
+          PROVIDER_GROUPS_PROVIDER_USERS }o--|| PROVIDER_USER : "sync members to infra"
+          PROVIDER_USER }o--|| PROVIDER : "sync identities to infra"
+```

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -102,13 +102,13 @@ func TestRequireInfraRole_GrantsFromGroupMembership(t *testing.T) {
 	err := data.CreateIdentity(db, tom)
 	assert.NilError(t, err)
 
-	_, err = data.CreateProviderUser(db, provider, tom)
+	providedTom, err := data.CreateProviderUser(db, provider, tom)
 	assert.NilError(t, err)
 
 	err = data.CreateGroup(db, tomsGroup)
 	assert.NilError(t, err)
 
-	err = data.AssignIdentityToGroups(db, tom, provider, []string{tomsGroup.Name})
+	err = data.AssignUserToProviderGroups(db, providedTom, provider, []string{tomsGroup.Name})
 	assert.NilError(t, err)
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -114,7 +114,7 @@ func UpdateUsersInGroup(c *gin.Context, groupID uid.ID, uidsToAdd []uid.ID, uids
 		return err
 	}
 
-	_, err = data.GetGroup(db, data.ByID(groupID))
+	group, err := data.GetGroup(db, data.ByID(groupID))
 	if err != nil {
 		return err
 	}
@@ -130,13 +130,13 @@ func UpdateUsersInGroup(c *gin.Context, groupID uid.ID, uidsToAdd []uid.ID, uids
 	}
 
 	if len(addIDList) > 0 {
-		if err := data.AddUsersToGroup(db, groupID, addIDList); err != nil {
+		if err := data.AddUsersToGroup(db, group.ID, group.Name, data.InfraProvider(db).ID, addIDList); err != nil {
 			return err
 		}
 	}
 
 	if len(rmIDList) > 0 {
-		if err := data.RemoveUsersFromGroup(db, groupID, rmIDList); err != nil {
+		if err := data.RemoveUsersFromGroup(db, group.ID, rmIDList); err != nil {
 			return err
 		}
 	}

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -130,7 +130,7 @@ func UpdateIdentityInfoFromProvider(c RequestContext, oidc providers.OIDCClient)
 		return fmt.Errorf("user info provider: %w", err)
 	}
 
-	// get current identity provider groups and account status
+	// update current identity provider groups and account status
 	err = data.SyncProviderUser(ctx, db, identity, provider, oidc)
 	if err != nil {
 		if errors.Is(err, internal.ErrBadGateway) {
@@ -139,10 +139,6 @@ func UpdateIdentityInfoFromProvider(c RequestContext, oidc providers.OIDCClient)
 
 		if nestedErr := data.DeleteAccessKeys(db, data.DeleteAccessKeysOptions{ByIssuedForID: identity.ID}); nestedErr != nil {
 			logging.Errorf("failed to revoke invalid user session: %s", nestedErr)
-		}
-
-		if nestedErr := data.DeleteProviderUsers(db, data.DeleteProviderUsersOptions{ByIdentityID: identity.ID, ByProviderID: provider.ID}); nestedErr != nil {
-			logging.Errorf("failed to delete provider user: %s", nestedErr)
 		}
 
 		return fmt.Errorf("sync user: %w", err)

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -88,7 +88,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	group := &models.Group{Name: "Group"}
 	err = data.CreateGroup(db, group)
 	assert.NilError(t, err)
-	err = data.AddUsersToGroup(db, group.ID, []uid.ID{identity.ID})
+	err = data.AddUsersToGroup(db, group.ID, group.Name, data.InfraProvider(db).ID, []uid.ID{identity.ID})
 	assert.NilError(t, err)
 
 	// delete the identity, and make sure all their resources are gone

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -387,9 +387,9 @@ func TestListGrants(t *testing.T) {
 		userID, err := uid.Parse([]byte("userchar"))
 		assert.NilError(t, err)
 
-		assert.NilError(t, AddUsersToGroup(tx, uid.ID(111), []uid.ID{userID}))
-		assert.NilError(t, AddUsersToGroup(tx, uid.ID(112), []uid.ID{userID}))
-		assert.NilError(t, AddUsersToGroup(tx, uid.ID(113), []uid.ID{uid.ID(777)}))
+		assert.NilError(t, AddUsersToGroup(tx, uid.ID(111), "name-111", InfraProvider(db).ID, []uid.ID{userID}))
+		assert.NilError(t, AddUsersToGroup(tx, uid.ID(112), "name-111", InfraProvider(db).ID, []uid.ID{userID}))
+		assert.NilError(t, AddUsersToGroup(tx, uid.ID(113), "name-111", InfraProvider(db).ID, []uid.ID{uid.ID(777)}))
 
 		gGrant1 := &models.Grant{
 			Subject:   uid.NewGroupPolymorphicID(111),

--- a/internal/server/data/providergroup.go
+++ b/internal/server/data/providergroup.go
@@ -1,0 +1,167 @@
+package data
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/infrahq/infra/internal/server/data/querybuilder"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+type providerGroupTable models.ProviderGroup
+
+func (p providerGroupTable) Table() string {
+	return "provider_groups"
+}
+
+func (p providerGroupTable) Columns() []string {
+	return []string{"organization_id", "created_at", "updated_at", "provider_id", "name"}
+}
+
+func (p providerGroupTable) Values() []any {
+	return []any{p.OrganizationID, p.CreatedAt, p.UpdatedAt, p.ProviderID, p.Name}
+}
+
+func (p *providerGroupTable) ScanFields() []any {
+	return []any{&p.OrganizationID, &p.CreatedAt, &p.UpdatedAt, &p.ProviderID, &p.Name}
+}
+
+func (pg *providerGroupTable) OnInsert() error {
+	if pg.CreatedAt.IsZero() {
+		pg.CreatedAt = time.Now()
+	}
+	pg.UpdatedAt = pg.CreatedAt
+	return nil
+}
+
+func (pg *providerGroupTable) OnUpdate() error {
+	pg.UpdatedAt = time.Now()
+	return nil
+}
+
+// CreateProviderGroup adds a database entity for tracking group members at a provider
+func CreateProviderGroup(db WriteTxn, providerGroup *models.ProviderGroup) error {
+	switch {
+	case providerGroup.ProviderID == 0:
+		return fmt.Errorf("providerID is required")
+	case providerGroup.Name == "":
+		return fmt.Errorf("name is required")
+	}
+
+	providerGroup.OrganizationID = db.OrganizationID()
+
+	return insert(db, (*providerGroupTable)(providerGroup))
+}
+
+// GetProviderGroup returns the group with the specified name for a provider
+func GetProviderGroup(tx ReadTxn, providerID uid.ID, name string) (*models.ProviderGroup, error) {
+	providerGroup := &providerGroupTable{}
+	query := querybuilder.New("SELECT")
+	query.B(columnsForSelect(providerGroup))
+	query.B("FROM")
+	query.B(providerGroup.Table())
+	query.B("WHERE organization_id = ?", tx.OrganizationID())
+	query.B("AND provider_id = ?", providerID)
+	query.B("AND name = ?", name)
+
+	err := tx.QueryRow(query.String(), query.Args...).Scan(providerGroup.ScanFields()...)
+	if err != nil {
+		return nil, handleReadError(err)
+	}
+	pg := (*models.ProviderGroup)(providerGroup)
+
+	return pg, nil
+}
+
+type ListProviderGroupOptions struct {
+	ByProviderID       uid.ID
+	ByMemberIdentityID uid.ID
+}
+
+// ListProviderGroups returns all provider groups that match the specified criteria
+func ListProviderGroups(tx ReadTxn, opts ListProviderGroupOptions) ([]models.ProviderGroup, error) {
+	table := &providerGroupTable{}
+	query := querybuilder.New("SELECT")
+	query.B(columnsForSelect(table))
+	query.B("FROM")
+	query.B(table.Table())
+
+	if opts.ByMemberIdentityID != 0 {
+		query.B(`
+			JOIN provider_groups_provider_users 
+			ON provider_groups.name = provider_groups_provider_users.provider_group_name 
+			AND provider_groups.provider_id = provider_groups_provider_users.provider_id
+			`)
+	}
+
+	query.B("WHERE organization_id = ?", tx.OrganizationID())
+	if opts.ByProviderID != 0 {
+		query.B("AND provider_groups.provider_id = ?", opts.ByProviderID)
+	}
+	if opts.ByMemberIdentityID != 0 {
+		query.B(`AND provider_groups_provider_users.provider_user_identity_id = ?`, opts.ByMemberIdentityID)
+	}
+
+	rows, err := tx.Query(query.String(), query.Args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []models.ProviderGroup
+	for rows.Next() {
+		var providerGroup models.ProviderGroup
+		fields := (*providerGroupTable)(&providerGroup).ScanFields()
+
+		if err := rows.Scan(fields...); err != nil {
+			return nil, err
+		}
+
+		result = append(result, providerGroup)
+	}
+
+	return result, rows.Err()
+}
+
+// addMemberToProviderGroups adds a link between a provider user and group that exists in a provider
+func addMemberToProviderGroups(tx GormTxn, user *models.ProviderUser, providerGroupNames []string) error {
+	// the org does not need to be set here since all provider users and groups are org specific
+	query := querybuilder.New("INSERT INTO provider_groups_provider_users (provider_id, provider_user_identity_id, provider_group_name)")
+	query.B("VALUES")
+
+	for i, grpName := range providerGroupNames {
+		query.B("(?, ?, ?)", user.ProviderID, user.IdentityID, grpName)
+		if i+1 != len(providerGroupNames) {
+			query.B(",")
+		}
+	}
+	query.B("ON CONFLICT DO NOTHING")
+
+	_, err := tx.Exec(query.String(), query.Args...)
+	if err != nil {
+		return fmt.Errorf("add member to provider groups %w", err)
+	}
+
+	return nil
+}
+
+func removeMemberFromProviderGroups(tx GormTxn, user *models.ProviderUser, providerGroupNames []string) error {
+	// the org does not need to be set here since all provider users and groups are org specific
+	_, err := tx.Exec(`
+	DELETE FROM provider_groups_provider_users
+	WHERE provider_user_identity_id = ? AND provider_id = ? AND provider_group_name IN ?
+	`,
+		user.IdentityID, user.ProviderID, providerGroupNames)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`
+	DELETE FROM identities_groups
+	WHERE identity_id = ? AND provider_id = ? AND provider_group_name IN ?
+	`,
+		user.IdentityID, user.ProviderID, providerGroupNames)
+
+	return err
+}

--- a/internal/server/data/providergroup_test.go
+++ b/internal/server/data/providergroup_test.go
@@ -1,0 +1,502 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+var cmpModelsGroupShallow = cmp.Comparer(func(x, y models.Group) bool {
+	return x.Name == y.Name && x.OrganizationID == y.OrganizationID
+})
+
+func TestCreateProviderGroup(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		org := &models.Organization{Name: "something", Domain: "example.com"}
+		assert.NilError(t, CreateOrganization(db, org))
+
+		tx := txnForTestCase(t, db, org.ID)
+
+		infraProviderID := InfraProvider(tx).ID
+
+		t.Run("valid", func(t *testing.T) {
+			group := &models.Group{Name: "default"}
+			err := CreateGroup(tx, group)
+			assert.NilError(t, err)
+
+			pg := &models.ProviderGroup{
+				ProviderID: infraProviderID,
+				Name:       "default",
+			}
+			err = CreateProviderGroup(tx, pg)
+			assert.NilError(t, err)
+
+			// check that the provider group we fetch from the DB matches what is expected
+			retrieved, err := GetProviderGroup(tx, pg.ProviderID, pg.Name)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, retrieved, pg, cmpTimeWithDBPrecision)
+		})
+		t.Run("provider ID not specified fails", func(t *testing.T) {
+			pg := &models.ProviderGroup{
+				Name: "default",
+			}
+			err := CreateProviderGroup(tx, pg)
+			assert.ErrorContains(t, err, "providerID is required")
+		})
+		t.Run("name not specified fails", func(t *testing.T) {
+			pg := &models.ProviderGroup{
+				ProviderID: 1234,
+			}
+			err := CreateProviderGroup(tx, pg)
+			assert.ErrorContains(t, err, "name is required")
+		})
+	})
+}
+
+func TestGetProviderGroup(t *testing.T) {
+	type testCase struct {
+		name        string
+		setup       func(t *testing.T, tx *Transaction) (providerID uid.ID, name string)
+		checkResult func(t *testing.T, err error, tx *Transaction, result *models.ProviderGroup)
+	}
+
+	testCases := []testCase{
+		{
+			name: "get existing group",
+			setup: func(t *testing.T, tx *Transaction) (providerID uid.ID, name string) {
+				providerID = InfraProvider(tx).ID
+				name = "group 1"
+
+				testSetup := []TestProviderGroup{
+					{
+						Provider:  InfraProvider(tx),
+						GroupName: name,
+					},
+				}
+
+				setupTestProviderGroups(t, tx, testSetup)
+
+				return providerID, name
+			},
+			checkResult: func(t *testing.T, err error, tx *Transaction, result *models.ProviderGroup) {
+				assert.NilError(t, err)
+				assert.Equal(t, result.ProviderID, InfraProvider(tx).ID)
+				assert.Equal(t, result.Name, "group 1")
+			},
+		},
+		{
+			name: "get non-existent provider ID",
+			setup: func(t *testing.T, tx *Transaction) (providerID uid.ID, name string) {
+				providerID = 123
+				name = "group 1"
+
+				testSetup := []TestProviderGroup{
+					{
+						Provider:  InfraProvider(tx),
+						GroupName: name,
+					},
+				}
+
+				setupTestProviderGroups(t, tx, testSetup)
+
+				return providerID, name
+			},
+			checkResult: func(t *testing.T, err error, tx *Transaction, result *models.ProviderGroup) {
+				assert.ErrorContains(t, err, "record not found")
+			},
+		},
+		{
+			name: "get non-existent provider group name",
+			setup: func(t *testing.T, tx *Transaction) (providerID uid.ID, name string) {
+				providerID = 123
+				name = "does not exist"
+
+				testSetup := []TestProviderGroup{
+					{
+						Provider:  InfraProvider(tx),
+						GroupName: "name",
+					},
+				}
+
+				setupTestProviderGroups(t, tx, testSetup)
+
+				return providerID, name
+			},
+			checkResult: func(t *testing.T, err error, tx *Transaction, result *models.ProviderGroup) {
+				assert.ErrorContains(t, err, "record not found")
+			},
+		},
+	}
+
+	runDBTests(t, func(t *testing.T, db *DB) {
+		org := &models.Organization{Name: "something", Domain: "example.com"}
+		assert.NilError(t, CreateOrganization(db, org))
+
+		tx := txnForTestCase(t, db, org.ID)
+
+		for _, tc := range testCases {
+			providerID, name := tc.setup(t, tx)
+
+			result, err := GetProviderGroup(tx, providerID, name)
+
+			tc.checkResult(t, err, tx, result)
+
+			// clean up
+			_, err = tx.Exec("DELETE FROM identities")
+			assert.NilError(t, err)
+			_, err = tx.Exec("DELETE FROM groups")
+			assert.NilError(t, err)
+			_, err = tx.Exec("DELETE FROM provider_groups_provider_users")
+			assert.NilError(t, err)
+			_, err = tx.Exec("DELETE FROM provider_groups")
+			assert.NilError(t, err)
+			_, err = tx.Exec("DELETE FROM provider_users")
+			assert.NilError(t, err)
+			_, err = tx.Exec("DELETE FROM providers WHERE name != 'infra'")
+			assert.NilError(t, err)
+		}
+	})
+}
+
+func TestListProviderGroups(t *testing.T) {
+	type testCase struct {
+		name  string
+		setup func(t *testing.T, tx *Transaction) (opts ListProviderGroupOptions, expected []models.ProviderGroup)
+	}
+
+	testCases := []testCase{
+		{
+			name: "list all groups",
+			setup: func(t *testing.T, tx *Transaction) (opts ListProviderGroupOptions, expected []models.ProviderGroup) {
+				testSetup := []TestProviderGroup{
+					{
+						Provider:  InfraProvider(tx),
+						GroupName: "group 1",
+					},
+					{
+						Provider:  InfraProvider(tx),
+						GroupName: "group 2",
+					},
+				}
+
+				opts = ListProviderGroupOptions{}
+				expected = setupTestProviderGroups(t, tx, testSetup)
+
+				return opts, expected
+			},
+		},
+		{
+			name: "list all groups for provider",
+			setup: func(t *testing.T, tx *Transaction) (opts ListProviderGroupOptions, expected []models.ProviderGroup) {
+				testSetup := []TestProviderGroup{
+					{
+						Provider:  InfraProvider(tx),
+						GroupName: "group 1",
+					},
+					{
+						Provider:  InfraProvider(tx),
+						GroupName: "group 2",
+					},
+				}
+
+				opts = ListProviderGroupOptions{ByProviderID: InfraProvider(tx).ID}
+				expected = setupTestProviderGroups(t, tx, testSetup)
+
+				return opts, expected
+			},
+		},
+		{
+			name: "list all groups for member ID",
+			setup: func(t *testing.T, tx *Transaction) (opts ListProviderGroupOptions, expected []models.ProviderGroup) {
+				user := models.Identity{
+					Name: "hello@example.com",
+				}
+				err := CreateIdentity(tx, &user)
+				assert.NilError(t, err)
+
+				testSetup := []TestProviderGroup{
+					{
+						Provider:  InfraProvider(tx),
+						GroupName: "group",
+						Members:   []models.Identity{user},
+					},
+				}
+
+				opts = ListProviderGroupOptions{ByMemberIdentityID: user.ID}
+				expected = setupTestProviderGroups(t, tx, testSetup)
+
+				return opts, expected
+			},
+		},
+		{
+			name: "list all groups for member ID and provider ID",
+			setup: func(t *testing.T, tx *Transaction) (opts ListProviderGroupOptions, expected []models.ProviderGroup) {
+				user := models.Identity{
+					Name: "hello@example.com",
+				}
+				err := CreateIdentity(tx, &user)
+				assert.NilError(t, err)
+
+				okta := &models.Provider{
+					Name: "okta",
+					Kind: models.ProviderKindOkta,
+				}
+				err = CreateProvider(tx, okta)
+				assert.NilError(t, err)
+
+				testSetup := []TestProviderGroup{
+					{
+						Provider:  InfraProvider(tx),
+						GroupName: "group",
+						Members:   []models.Identity{user},
+					},
+					// this provider group should not be returned in the test result
+					{
+						Provider:  okta,
+						GroupName: "group",
+						Members:   []models.Identity{user},
+					},
+				}
+
+				opts = ListProviderGroupOptions{ByMemberIdentityID: user.ID, ByProviderID: InfraProvider(tx).ID}
+
+				testProviderGroups := setupTestProviderGroups(t, tx, testSetup)
+				expected = []models.ProviderGroup{testProviderGroups[0]} // the infra provider group
+
+				return opts, expected
+			},
+		},
+	}
+
+	runDBTests(t, func(t *testing.T, db *DB) {
+		org := &models.Organization{Name: "something", Domain: "example.com"}
+		assert.NilError(t, CreateOrganization(db, org))
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				tx := txnForTestCase(t, db, org.ID)
+
+				opts, expected := tc.setup(t, tx)
+
+				result, err := ListProviderGroups(tx, opts)
+
+				assert.NilError(t, err)
+				assert.DeepEqual(t, result, expected, cmpTimeWithDBPrecision)
+			})
+		}
+	})
+}
+
+func TestAddProviderUserToProviderGroup(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		org := &models.Organization{Name: "something", Domain: "example.com"}
+		assert.NilError(t, CreateOrganization(db, org))
+		tx := txnForTestCase(t, db, org.ID)
+
+		testSetup := []TestProviderGroup{
+			{
+				Provider:  InfraProvider(tx),
+				GroupName: "Everyone",
+			},
+			{
+				Provider:  InfraProvider(tx),
+				GroupName: "Developers",
+			},
+		}
+		_ = setupTestProviderGroups(t, tx, testSetup)
+
+		spike := models.Identity{
+			Name: "spike@infrahq.com",
+		}
+
+		createIdentities(t, tx, &spike)
+
+		pu, err := CreateProviderUser(tx, InfraProvider(tx), &spike)
+		assert.NilError(t, err)
+
+		t.Run("add provider user to provider groups", func(t *testing.T) {
+			stmt := `
+				SELECT provider_id FROM provider_groups_provider_users
+				WHERE provider_user_identity_id = ?
+			`
+			err = tx.QueryRow(stmt, pu.IdentityID).Scan()
+			assert.ErrorContains(t, err, "no rows in result set")
+
+			err = addMemberToProviderGroups(tx, pu, []string{"Everyone", "Developers"})
+			assert.NilError(t, err)
+
+			stmt = `
+				SELECT provider_group_name FROM provider_groups_provider_users
+				WHERE provider_id = ? AND provider_user_identity_id = ?
+			`
+			rows, err := tx.Query(stmt, pu.ProviderID, pu.IdentityID)
+			assert.NilError(t, err)
+			defer rows.Close()
+
+			var result []string
+			for rows.Next() {
+				var name string
+				err = rows.Scan(&name)
+				assert.NilError(t, err)
+
+				result = append(result, name)
+			}
+
+			assert.DeepEqual(t, result, []string{"Developers", "Everyone"})
+		})
+	})
+}
+
+func TestRemoveProviderUserFromProviderGroup(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		org := &models.Organization{Name: "something", Domain: "example.com"}
+		assert.NilError(t, CreateOrganization(db, org))
+		tx := txnForTestCase(t, db, org.ID)
+
+		testSetup := []TestProviderGroup{
+			{
+				Provider:  InfraProvider(tx),
+				GroupName: "Everyone",
+			},
+			{
+				Provider:  InfraProvider(tx),
+				GroupName: "Developers",
+			},
+		}
+		_ = setupTestProviderGroups(t, tx, testSetup)
+
+		spike := models.Identity{
+			Name: "spike@infrahq.com",
+		}
+
+		createIdentities(t, tx, &spike)
+
+		pu, err := CreateProviderUser(tx, InfraProvider(tx), &spike)
+		assert.NilError(t, err)
+
+		t.Run("remove provider user from a provider group", func(t *testing.T) {
+			err = addMemberToProviderGroups(tx, pu, []string{"Everyone", "Developers"})
+			assert.NilError(t, err)
+
+			stmt := `
+				SELECT provider_group_name FROM provider_groups_provider_users
+				WHERE provider_id = ? AND provider_user_identity_id = ?
+			`
+			rows, err := tx.Query(stmt, pu.ProviderID, pu.IdentityID)
+			assert.NilError(t, err)
+			defer rows.Close()
+
+			var result []string
+			for rows.Next() {
+				var name string
+				err = rows.Scan(&name)
+				assert.NilError(t, err)
+
+				result = append(result, name)
+			}
+
+			assert.DeepEqual(t, result, []string{"Developers", "Everyone"})
+
+			err = removeMemberFromProviderGroups(tx, pu, []string{"Everyone"})
+			assert.NilError(t, err)
+
+			rows, err = tx.Query(stmt, pu.ProviderID, pu.IdentityID)
+			assert.NilError(t, err)
+			defer rows.Close()
+
+			result = []string{}
+			for rows.Next() {
+				var name string
+				err = rows.Scan(&name)
+				assert.NilError(t, err)
+
+				result = append(result, name)
+			}
+
+			assert.DeepEqual(t, result, []string{"Developers"})
+		})
+		t.Run("remove provider user from all provider groups", func(t *testing.T) {
+			err = addMemberToProviderGroups(tx, pu, []string{"Everyone", "Developers"})
+			assert.NilError(t, err)
+
+			stmt := `
+				SELECT provider_group_name FROM provider_groups_provider_users
+				WHERE provider_id = ? AND provider_user_identity_id = ?
+			`
+			rows, err := tx.Query(stmt, pu.ProviderID, pu.IdentityID)
+			assert.NilError(t, err)
+			defer rows.Close()
+
+			var result []string
+			for rows.Next() {
+				var name string
+				err = rows.Scan(&name)
+				assert.NilError(t, err)
+
+				result = append(result, name)
+			}
+
+			assert.DeepEqual(t, result, []string{"Developers", "Everyone"})
+
+			err = removeMemberFromProviderGroups(tx, pu, []string{"Everyone", "Developers"})
+			assert.NilError(t, err)
+
+			err = tx.QueryRow(stmt, pu.ProviderID, pu.IdentityID).Scan()
+			assert.ErrorContains(t, err, "no rows in result set")
+		})
+	})
+}
+
+type TestProviderGroup struct {
+	Provider  *models.Provider
+	GroupName string
+	Members   []models.Identity
+}
+
+func setupTestProviderGroups(t *testing.T, tx *Transaction, testProviderGroups []TestProviderGroup) []models.ProviderGroup {
+	// parent groups need to be create first, in case any provider groups share the same parent
+	parentGroups := make(map[string]*models.Group)
+	for _, testPg := range testProviderGroups {
+		if parentGroups[testPg.GroupName] == nil {
+			group := &models.Group{Name: testPg.GroupName}
+			err := CreateGroup(tx, group)
+			assert.NilError(t, err)
+
+			parentGroups[group.Name] = group
+		}
+	}
+
+	created := []models.ProviderGroup{}
+	for _, testPg := range testProviderGroups {
+		pg := &models.ProviderGroup{
+			ProviderID: testPg.Provider.ID,
+			Name:       testPg.GroupName,
+		}
+		err := CreateProviderGroup(tx, pg)
+		assert.NilError(t, err)
+
+		memberIDs := []uid.ID{}
+		for i := range testPg.Members {
+			member, err := CreateProviderUser(tx, testPg.Provider, &testPg.Members[i])
+			assert.NilError(t, err)
+
+			err = addMemberToProviderGroups(tx, member, []string{testPg.GroupName})
+			assert.NilError(t, err)
+
+			memberIDs = append(memberIDs, member.IdentityID)
+		}
+
+		if len(memberIDs) > 0 {
+			err = AddUsersToGroup(tx, parentGroups[testPg.GroupName].ID, pg.Name, pg.ProviderID, memberIDs)
+			assert.NilError(t, err)
+		}
+
+		created = append(created, *pg)
+	}
+
+	return created
+}

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -197,7 +197,9 @@ CREATE TABLE identities (
 
 CREATE TABLE identities_groups (
     identity_id bigint NOT NULL,
-    group_id bigint NOT NULL
+    group_id bigint NOT NULL,
+    provider_id bigint NOT NULL,
+    provider_group_name text NOT NULL
 );
 
 CREATE TABLE organizations (
@@ -218,11 +220,24 @@ CREATE TABLE password_reset_tokens (
     organization_id bigint
 );
 
+CREATE TABLE provider_groups (
+    organization_id bigint NOT NULL,
+    provider_id bigint NOT NULL,
+    name text NOT NULL,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+
+CREATE TABLE provider_groups_provider_users (
+    provider_id bigint NOT NULL,
+    provider_group_name text NOT NULL,
+    provider_user_identity_id bigint NOT NULL
+);
+
 CREATE TABLE provider_users (
     identity_id bigint NOT NULL,
     provider_id bigint NOT NULL,
     email text,
-    groups text,
     last_update timestamp with time zone,
     redirect_url text,
     access_token text,
@@ -292,9 +307,6 @@ ALTER TABLE ONLY grants
 ALTER TABLE ONLY groups
     ADD CONSTRAINT groups_pkey PRIMARY KEY (id);
 
-ALTER TABLE ONLY identities_groups
-    ADD CONSTRAINT identities_groups_pkey PRIMARY KEY (identity_id, group_id);
-
 ALTER TABLE ONLY identities
     ADD CONSTRAINT identities_pkey PRIMARY KEY (id);
 
@@ -335,6 +347,8 @@ CREATE INDEX idx_grants_update_index ON grants USING btree (organization_id, upd
 
 CREATE UNIQUE INDEX idx_groups_name ON groups USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 
+CREATE UNIQUE INDEX idx_identities_groups ON identities_groups USING btree (identity_id, group_id, provider_id, provider_group_name);
+
 CREATE UNIQUE INDEX idx_identities_name ON identities USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_identities_verified ON identities USING btree (organization_id, verification_token) WHERE (deleted_at IS NULL);
@@ -342,6 +356,10 @@ CREATE UNIQUE INDEX idx_identities_verified ON identities USING btree (organizat
 CREATE UNIQUE INDEX idx_organizations_domain ON organizations USING btree (domain) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_password_reset_tokens_token ON password_reset_tokens USING btree (token);
+
+CREATE UNIQUE INDEX idx_provider_group_names ON provider_groups USING btree (name, provider_id, organization_id);
+
+CREATE UNIQUE INDEX idx_provider_groups_provider_users ON provider_groups_provider_users USING btree (provider_group_name, provider_id, provider_user_identity_id);
 
 CREATE UNIQUE INDEX idx_providers_name ON providers USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -74,7 +74,7 @@ func TestAPI_ListGrants(t *testing.T) {
 		err := data.CreateGroup(srv.DB(), group)
 		assert.NilError(t, err)
 
-		err = data.AddUsersToGroup(srv.DB(), group.ID, users)
+		err = data.AddUsersToGroup(srv.DB(), group.ID, group.Name, data.InfraProvider(srv.DB()).ID, users)
 		assert.NilError(t, err)
 
 		return group.ID
@@ -544,7 +544,7 @@ func TestAPI_ListGrants_InheritedGrants(t *testing.T) {
 		err := data.CreateGroup(srv.DB(), group)
 		assert.NilError(t, err)
 
-		err = data.AddUsersToGroup(srv.DB(), group.ID, users)
+		err = data.AddUsersToGroup(srv.DB(), group.ID, group.Name, data.InfraProvider(srv.DB()).ID, users)
 		assert.NilError(t, err)
 
 		return group.ID

--- a/internal/server/models/providergroup.go
+++ b/internal/server/models/providergroup.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"time"
+
+	"github.com/infrahq/infra/uid"
+)
+
+// ProviderGroup is a local copy of the of a group from an identity provider
+// See this diagram for more details about how this model relates to a group
+// https://github.com/infrahq/infra/blob/main/docs/dev/identity-provider-tracking.md
+type ProviderGroup struct {
+	OrganizationMember
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	ProviderID uid.ID
+	Name       string
+
+	// for loading, not for saving
+	Members []ProviderUser
+}

--- a/internal/server/models/provideruser.go
+++ b/internal/server/models/provideruser.go
@@ -15,7 +15,6 @@ type ProviderUser struct {
 	Email      string
 	GivenName  string
 	FamilyName string
-	Groups     CommaSeparatedStrings
 	LastUpdate time.Time
 
 	RedirectURL string // needs to match the redirect URL specified when the token was issued for refreshing

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -191,6 +191,8 @@ func TestAPI_ListUsers(t *testing.T) {
 		Groups: []models.Group{humans},
 	}
 	createIdentities(t, srv.DB(), &anotherID)
+	err := data.AddUsersToGroup(srv.DB(), humans.ID, humans.Name, data.InfraProvider(srv.DB()).ID, []uid.ID{anotherID.ID})
+	assert.NilError(t, err)
 
 	createID := func(t *testing.T, name string) uid.ID {
 		t.Helper()


### PR DESCRIPTION
- add provider information to trace identity group membership relations
- migrate provider user groups to provider groups

## Summary
In order to track where users had their groups assigned to them more accurately updating the database schema to track and resolve group membership. This means tracking the state of external identity provider groups with relations to their provider users, and adding provider information to identities_groups relations.

`identities_groups` relations now have the form (identity_id, group_id, provider_id, provider_group_name) to allow mapping external groups from identity providers to groups within Infra. This behavior will be a later change, this PR keeps the same behavior of automatically mapping groups from identity providers to groups within Infra that have the same name.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3138
Resolves #2982
