### PR TITLE
Remove secret storage from connector

### DIFF
--- a/helm/charts/infra/templates/connector/configmap.yaml
+++ b/helm/charts/infra/templates/connector/configmap.yaml
@@ -22,7 +22,7 @@ data:
 {{- if and $accessKey (or (hasPrefix "file:" $accessKey) (hasPrefix "env:" $accessKey)) }}
       accessKey: {{ $accessKey }}
 {{- else }}
-      accessKey: file:/var/run/secrets/infrahq.com/access-key/access-key
+      accessKey: /var/run/secrets/infrahq.com/access-key/access-key
 {{- end }}
 
 {{- with .Values.connector.config.serverTrustedCertificate }}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -295,9 +295,29 @@ func newConnectorCmd() *cobra.Command {
 				return err
 			}
 
+			// backwards compat for old access key values with a prefix
+			accessKey := options.Server.AccessKey.String()
+			switch {
+			case strings.HasPrefix(accessKey, "file:"):
+				filename := strings.TrimPrefix(accessKey, "file:")
+				if err := options.Server.AccessKey.Set(filename); err != nil {
+					return err
+				}
+				logging.L.Warn().Msg("accessKey with 'file:' prefix is deprecated. Use the filename without the file: prefix instead.")
+			case strings.HasPrefix(accessKey, "env:"):
+				key := strings.TrimPrefix(accessKey, "env:")
+				options.Server.AccessKey = types.StringOrFile(os.Getenv(key))
+				logging.L.Warn().Msg("accessKey with 'env:' prefix is deprecated. Use the INFRA_ACCESS_KEY env var instead.")
+			case strings.HasPrefix(accessKey, "plaintext:"):
+				options.Server.AccessKey = types.StringOrFile(strings.TrimPrefix(accessKey, "plaintext:"))
+				logging.L.Warn().Msg("accessKey with 'plaintext:' prefix is deprecated. Use the literal value without a prefix.")
+			}
+
 			// Also accept the same env var as the CLI for setting the access key
 			if accessKey, ok := os.LookupEnv("INFRA_ACCESS_KEY"); ok {
-				options.Server.AccessKey = types.StringOrFile(accessKey)
+				if err := options.Server.AccessKey.Set(accessKey); err != nil {
+					return err
+				}
 			}
 			return runConnector(cmd.Context(), options)
 		},

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/cmd/cliopts"
+	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/connector"
 	"github.com/infrahq/infra/internal/logging"
 )
@@ -294,6 +295,10 @@ func newConnectorCmd() *cobra.Command {
 				return err
 			}
 
+			// Also accept the same env var as the CLI for setting the access key
+			if accessKey, ok := os.LookupEnv("INFRA_ACCESS_KEY"); ok {
+				options.Server.AccessKey = types.StringOrFile(accessKey)
+			}
 			return runConnector(cmd.Context(), options)
 		},
 	}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -359,14 +359,40 @@ func TestInvalidSessions(t *testing.T) {
 	})
 }
 
-func TestConnectorCmd(t *testing.T) {
-	var actual connector.Options
-	patchRunConnector(t, func(ctx context.Context, options connector.Options) error {
-		actual = options
-		return nil
-	})
+func TestConnectorCmd_LoadConfig(t *testing.T) {
+	type testCase struct {
+		name     string
+		config   string
+		setup    func(t *testing.T)
+		expected func() connector.Options
+	}
 
-	content := `
+	run := func(t *testing.T, tc testCase) {
+		var actual connector.Options
+		patchRunConnector(t, func(ctx context.Context, options connector.Options) error {
+			actual = options
+			return nil
+		})
+
+		if tc.setup != nil {
+			tc.setup(t)
+		}
+
+		dir := fs.NewDir(t, t.Name(), fs.WithFile("config.yaml", tc.config))
+
+		ctx := context.Background()
+		err := Run(ctx, "connector", "-f", dir.Join("config.yaml"))
+		assert.NilError(t, err)
+		assert.DeepEqual(t, actual, tc.expected())
+	}
+
+	keyDir := fs.NewDir(t, t.Name(), fs.WithFile("accesskeyfile", "the-access-key"))
+	filename := keyDir.Join("accesskeyfile")
+
+	testCases := []testCase{
+		{
+			name: "full config",
+			config: `
 server:
   url: the-server
   accessKey: /var/run/secrets/key
@@ -375,30 +401,128 @@ server:
 name: the-name
 caCert: /path/to/cert
 caKey: /path/to/key
-`
-
-	dir := fs.NewDir(t, t.Name(), fs.WithFile("config.yaml", content))
-
-	ctx := context.Background()
-	err := Run(ctx, "connector", "-f", dir.Join("config.yaml"))
-	assert.NilError(t, err)
-
-	expected := connector.Options{
-		Name: "the-name",
-		Addr: connector.ListenerOptions{
-			HTTPS:   ":443",
-			Metrics: ":9090",
+addr:
+  https: localhost:414
+  metrics: 127.0.0.1:8000
+`,
+			expected: func() connector.Options {
+				return connector.Options{
+					Name: "the-name",
+					Addr: connector.ListenerOptions{
+						HTTPS:   "localhost:414",
+						Metrics: "127.0.0.1:8000",
+					},
+					Server: connector.ServerOptions{
+						URL:                "the-server",
+						AccessKey:          "/var/run/secrets/key",
+						SkipTLSVerify:      true,
+						TrustedCertificate: "ca.pem",
+					},
+					CACert: "/path/to/cert",
+					CAKey:  "/path/to/key",
+				}
+			},
 		},
-		Server: connector.ServerOptions{
-			URL:                "the-server",
-			AccessKey:          "/var/run/secrets/key",
-			SkipTLSVerify:      true,
-			TrustedCertificate: "ca.pem",
+		{
+			name:   "access key with file: prefix (deprecated)",
+			config: fmt.Sprintf("server:\n  accessKey: file:%v\n", filename),
+			expected: func() connector.Options {
+				expected := defaultConnectorOptions()
+				expected.Server.AccessKey = "the-access-key"
+				return expected
+			},
 		},
-		CACert: "/path/to/cert",
-		CAKey:  "/path/to/key",
+		{
+			name:   "access key from file",
+			config: fmt.Sprintf("server:\n  accessKey: %v\n", filename),
+			expected: func() connector.Options {
+				expected := defaultConnectorOptions()
+				expected.Server.AccessKey = "the-access-key"
+				return expected
+			},
+		},
+		{
+			name: "access key with env: prefix (deprecated)",
+			setup: func(t *testing.T) {
+				t.Setenv("CUSTOM_ENV_VAR", "the-key-from-env")
+			},
+			config: `
+server:
+  accessKey: env:CUSTOM_ENV_VAR
+`,
+			expected: func() connector.Options {
+				expected := defaultConnectorOptions()
+				expected.Server.AccessKey = "the-key-from-env"
+				return expected
+			},
+		},
+		{
+			name: "access key from INFRA_ACCESS_KEY",
+			setup: func(t *testing.T) {
+				t.Setenv("INFRA_ACCESS_KEY", "the-key-from-env")
+			},
+			config: `{}`,
+			expected: func() connector.Options {
+				expected := defaultConnectorOptions()
+				expected.Server.AccessKey = "the-key-from-env"
+				return expected
+			},
+		},
+		{
+			name: "access key from INFRA_ACCESS_KEY points at a file",
+			setup: func(t *testing.T) {
+				t.Setenv("INFRA_ACCESS_KEY", filename)
+			},
+			config: `{}`,
+			expected: func() connector.Options {
+				expected := defaultConnectorOptions()
+				expected.Server.AccessKey = "the-access-key"
+				return expected
+			},
+		},
+		{
+			name:   "access key from INFRA_CONNECTOR_SERVER_ACCESS_KEY",
+			config: `{}`,
+			setup: func(t *testing.T) {
+				t.Setenv("INFRA_CONNECTOR_SERVER_ACCESS_KEY", "the-key-from-env")
+			},
+			expected: func() connector.Options {
+				expected := defaultConnectorOptions()
+				expected.Server.AccessKey = "the-key-from-env"
+				return expected
+			},
+		},
+		{
+			name: "access key literal from file",
+			config: `
+server:
+  accessKey: the-literal-key
+`,
+			expected: func() connector.Options {
+				expected := defaultConnectorOptions()
+				expected.Server.AccessKey = "the-literal-key"
+				return expected
+			},
+		},
+		{
+			name: "access key literal with plaintext prefix (deprecated)",
+			config: `
+server:
+  accessKey: plaintext:the-literal-key
+`,
+			expected: func() connector.Options {
+				expected := defaultConnectorOptions()
+				expected.Server.AccessKey = "the-literal-key"
+				return expected
+			},
+		},
 	}
-	assert.DeepEqual(t, actual, expected)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
 }
 
 func patchRunConnector(t *testing.T, fn func(context.Context, connector.Options) error) {

--- a/internal/connector/authn.go
+++ b/internal/connector/authn.go
@@ -36,7 +36,7 @@ func newAuthenticator(url string, options Options) *authenticator {
 	return &authenticator{
 		client:          &http.Client{Transport: transport},
 		baseURL:         url,
-		serverAccessKey: options.Server.AccessKey,
+		serverAccessKey: options.Server.AccessKey.String(),
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR removes `infrahq/secrets` from the connector. The connector only ever used secrets from `env`, `file`, and `plaintext`, all of which we can read directly without needing to add an `env:`, `file:`, or `plaintext:` prefix to the value. 

This PR preserves backwards compatibility by removing any `env:` or `file:` prefixes from values before looking for the file or env var.

Also:
* changes the helm chart to create a configmap without the `file:` prefix on the access key value.
* adds support for reading the access key from `INFRA_ACCESS_KEY` env var in the connector. This matches the CLI. Unlikely anyone will use this yet though, since everyone is using the helm chart, not running the connector directly.
* adds support for reading the connector proxy CA and key from literals, in addition to files. This will be useful at least for writing integration tests of the connector, but may also be useful to others deploying the connector in different envrionments.
