### PR TITLE
Fix `infra list` with destinations named with a prefix of infra

### DIFF
--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -59,7 +59,7 @@ func list(cli *CLI) error {
 
 	keys := make([]string, 0, len(gs))
 	for k := range gs {
-		if strings.HasPrefix(k, "infra") {
+		if isInfraDestination(k) {
 			continue
 		}
 
@@ -105,6 +105,12 @@ func list(cli *CLI) error {
 	}
 
 	return writeKubeconfig(user, destinations, grants)
+}
+
+// isInfraDestination returns true if the resource string identifies the infra
+// server.
+func isInfraDestination(resource string) bool {
+	return resource == "infra" || strings.HasPrefix(resource, "infra.")
 }
 
 func getUserDestinationGrants(client *api.Client) (*api.User, []api.Destination, []api.Grant, error) {

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -31,6 +31,7 @@ func TestListCmd(t *testing.T) {
 			{User: "admin", Resource: "infra", Role: "admin"},
 			{User: "manygrants@example.com", Resource: "space", Role: "explorer"},
 			{User: "manygrants@example.com", Resource: "moon", Role: "inhabitant"},
+			{User: "manygrants@example.com", Resource: "infra-this-is-not", Role: "view"},
 		},
 	}
 	setupServerOptions(t, &opts)
@@ -57,6 +58,16 @@ func TestListCmd(t *testing.T) {
 		Name:     "moon",
 		Connection: api.DestinationConnection{
 			URL: "http://localhost:10124/",
+			CA:  destinationCA,
+		},
+	})
+	assert.NilError(t, err)
+
+	_, err = c.CreateDestination(&api.CreateDestinationRequest{
+		UniqueID: "maintain",
+		Name:     "infra-this-is-not",
+		Connection: api.DestinationConnection{
+			URL: "http://localhost:10126/",
 			CA:  destinationCA,
 		},
 	})

--- a/internal/cmd/testdata/TestListCmd/with_many_grants
+++ b/internal/cmd/testdata/TestListCmd/with_many_grants
@@ -1,3 +1,4 @@
-  NAME   ACCESS      
-  moon   inhabitant  
-  space  explorer    
+  NAME               ACCESS      
+  infra-this-is-not  view        
+  moon               inhabitant  
+  space              explorer    


### PR DESCRIPTION
## Summary

This bug was causing `infra list` to hide access to destinations named with `infra...` prefix.  Also fixes a similar bug related to filtering of destination names that may have displayed some grants for a destination that did not exist , if there was another destination where the name was a prefix of the other.

Also refactor the logic a bit to remove one of the iterations. We can build the list of resource names when we find a resource that is not yet in the map.