### PR TITLE
Add a bit more validation on create and update

### DIFF
--- a/internal/server/authn/key_exchange.go
+++ b/internal/server/authn/key_exchange.go
@@ -21,7 +21,7 @@ func NewKeyExchangeAuthentication(requestingAccessKey string) LoginMethod {
 }
 
 func (a *keyExchangeAuthn) Authenticate(_ context.Context, db data.GormTxn, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
-	validatedRequestKey, err := data.ValidateAccessKey(db, a.RequestingAccessKey)
+	validatedRequestKey, err := data.ValidateRequestAccessKey(db, a.RequestingAccessKey)
 	if err != nil {
 		return AuthenticatedIdentity{}, fmt.Errorf("invalid access key in exchange: %w", err)
 	}

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -164,17 +164,17 @@ func createAccessKeyWithExtensionDeadline(t *testing.T, db GormTxn, ttl, extensi
 	return body, token
 }
 
-func TestCheckAccessKeySecret(t *testing.T) {
+func TestValidateRequestAccessKey(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		body, _ := createTestAccessKey(t, db, time.Hour*5)
 
-		_, err := ValidateAccessKey(db, body)
+		_, err := ValidateRequestAccessKey(db, body)
 		assert.NilError(t, err)
 
 		random := generate.MathRandom(models.AccessKeySecretLength, generate.CharsetAlphaNumeric)
 		authorization := fmt.Sprintf("%s.%s", strings.Split(body, ".")[0], random)
 
-		_, err = ValidateAccessKey(db, authorization)
+		_, err = ValidateRequestAccessKey(db, authorization)
 		assert.Error(t, err, "access key invalid secret")
 	})
 }
@@ -270,7 +270,7 @@ func TestCheckAccessKeyExpired(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		body, _ := createTestAccessKey(t, db, -1*time.Hour)
 
-		_, err := ValidateAccessKey(db, body)
+		_, err := ValidateRequestAccessKey(db, body)
 		assert.ErrorIs(t, err, ErrAccessKeyExpired)
 	})
 }
@@ -279,7 +279,7 @@ func TestCheckAccessKeyPastExtensionDeadline(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		body, _ := createAccessKeyWithExtensionDeadline(t, db, 1*time.Hour, -1*time.Hour)
 
-		_, err := ValidateAccessKey(db, body)
+		_, err := ValidateRequestAccessKey(db, body)
 		assert.ErrorIs(t, err, ErrAccessKeyDeadlineExceeded)
 	})
 }

--- a/internal/server/data/credential.go
+++ b/internal/server/data/credential.go
@@ -8,8 +8,11 @@ import (
 )
 
 func validateCredential(c *models.Credential) error {
-	if len(c.PasswordHash) == 0 {
-		return fmt.Errorf("passwordHash is required")
+	switch {
+	case len(c.PasswordHash) == 0:
+		return fmt.Errorf("Credential.PasswordHash is required")
+	case c.IdentityID == 0:
+		return fmt.Errorf("Credential.IdentityID is required")
 	}
 	return nil
 }

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -9,6 +9,9 @@ import (
 
 // CreateOrganization creates a new organization and sets the current db context to execute on this org
 func CreateOrganization(tx GormTxn, org *models.Organization) error {
+	if org.Name == "" {
+		return fmt.Errorf("Organization.Name is required")
+	}
 	err := add(tx, org)
 	if err != nil {
 		return fmt.Errorf("creating org: %w", err)

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -607,7 +607,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 	srv := setupServer(t, withAdminUser)
 	routes := srv.GenerateRoutes()
 
-	accessKey, err := data.ValidateAccessKey(srv.DB(), adminAccessKey(srv))
+	accessKey, err := data.ValidateRequestAccessKey(srv.DB(), adminAccessKey(srv))
 	assert.NilError(t, err)
 
 	someUser := models.Identity{Name: "someone@example.com"}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -173,7 +173,7 @@ func requireAccessKey(c *gin.Context, db *data.Transaction, srv *Server) (access
 		return u, err
 	}
 
-	accessKey, err := data.ValidateAccessKey(db, bearer)
+	accessKey, err := data.ValidateRequestAccessKey(db, bearer)
 	if err != nil {
 		if errors.Is(err, data.ErrAccessKeyExpired) {
 			return u, err


### PR DESCRIPTION
## Summary

This validation is only to catch programming errors. A user should never see these errors, they are exclusively safeguards to try and make bugs more obvious in tests.

We already have this same validation on a bunch of types (Grants and ProviderUser both have many checks). This PR adds a few more to other types.