### PR TITLE
maintain: add other ways to abort the about command

### DIFF
--- a/internal/cmd/about.go
+++ b/internal/cmd/about.go
@@ -419,7 +419,7 @@ mainloop:
 		case ev := <-eventQueue:
 			if ev.Type == tm.EventKey {
 				switch {
-				case ev.Key == tm.KeyEsc:
+				case ev.Key == tm.KeyEsc || ev.Key == tm.KeyCtrlC || ev.Ch == 'q':
 					break mainloop
 				case ev.Key == tm.KeyArrowRight:
 					i.angleX += 0.01


### PR DESCRIPTION
## Summary

Adds ctrl-C and the 'q' key as ways to get out of `infra about`
