### PR TITLE
improve: trim whitespace when entering server from cli

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -643,7 +643,7 @@ func promptNewServer(cli *CLI) (string, error) {
 		cli.surveyIO,
 		survey.WithValidator(survey.Required),
 	)
-	return server, err
+	return strings.TrimSpace(server), err
 }
 
 func promptServerList(cli *CLI, servers []ClientHostConfig) (string, error) {


### PR DESCRIPTION
## Summary

Trims whitespace from the server that user inputted on the cli:
```
$ infra login
Server:      localhost    
```
User entered '    localhost   ' --> trimmed to 'localhost' 


Resolves #3150
