### PR TITLE
maintain: add version cli test + remove server version w/ saas

### DIFF
--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -40,6 +40,17 @@ func version(cli *CLI) error {
 		return nil
 	}
 
+	config, err := currentHostConfig()
+	if err != nil {
+		return err
+	}
+
+	// Don't bother printing the server version for SaaS
+	if strings.HasSuffix(config.Host, ".infrahq.com") {
+		fmt.Fprintln(w)
+		return nil
+	}
+
 	version, err := client.GetServerVersion()
 	if err != nil {
 		fmt.Fprintln(w, "Server:\t", "disconnected")

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal"
+)
+
+func TestVersionCmd(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	t.Run("version no server", func(t *testing.T) {
+		ctx, bufs := PatchCLI(context.Background())
+
+		err := Run(ctx, "version")
+		assert.NilError(t, err)
+
+		intVersion := strings.TrimPrefix(internal.FullVersion(), "v")
+		assert.Equal(t, bufs.Stdout.String(), fmt.Sprintf(expectedDisconnectedOutput, intVersion))
+	})
+
+	t.Run("version saas server", func(t *testing.T) {
+		ctx, bufs := PatchCLI(context.Background())
+
+		cfg := ClientConfig{
+			ClientConfigVersion: clientConfigVersion,
+			Hosts: []ClientHostConfig{
+				{
+					Name:      "user1",
+					Host:      "awesome.infrahq.com",
+					AccessKey: "something",
+					UserID:    1,
+					Current:   true,
+					Expires:   api.Time(time.Now().Add(time.Hour * 2).UTC().Truncate(time.Second)),
+				},
+			},
+		}
+
+		err := writeConfig(&cfg)
+		assert.NilError(t, err)
+
+		err = Run(ctx, "version")
+		assert.NilError(t, err)
+
+		intVersion := strings.TrimPrefix(internal.FullVersion(), "v")
+		assert.Equal(t, bufs.Stdout.String(), fmt.Sprintf(expectedSaasServerOutput, intVersion))
+	})
+
+	t.Run("version local server", func(t *testing.T) {
+		ctx, bufs := PatchCLI(context.Background())
+
+		intVersion := strings.TrimPrefix(internal.FullVersion(), "v")
+
+		handler := func(resp http.ResponseWriter, req *http.Request) {
+			if req.URL.Path != "/api/version" {
+				resp.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			resp.WriteHeader(http.StatusOK)
+			_, _ = resp.Write([]byte(fmt.Sprintf(`{"version": "%s"}`, intVersion)))
+		}
+
+		srv := httptest.NewTLSServer(http.HandlerFunc(handler))
+		t.Cleanup(srv.Close)
+
+		cfg := ClientConfig{
+			ClientConfigVersion: clientConfigVersion,
+			Hosts: []ClientHostConfig{
+				{
+					Name:          "user1",
+					Host:          srv.Listener.Addr().String(),
+					AccessKey:     "something",
+					UserID:        1,
+					Current:       true,
+					SkipTLSVerify: true,
+					Expires:       api.Time(time.Now().Add(time.Hour * 2).UTC().Truncate(time.Second)),
+				},
+			},
+		}
+
+		err := writeConfig(&cfg)
+		assert.NilError(t, err)
+
+		err = Run(ctx, "version")
+		assert.NilError(t, err)
+
+		assert.Equal(t, bufs.Stdout.String(), fmt.Sprintf(expectedLocalServerOutput, intVersion, intVersion))
+	})
+}
+
+var expectedDisconnectedOutput = `
+ Client: %s
+ Server: disconnected
+
+`
+
+var expectedSaasServerOutput = `
+ Client: %s
+
+`
+
+var expectedLocalServerOutput = `
+ Client: %s
+ Server: %s
+
+`


### PR DESCRIPTION
## Summary

This change removes displaying "Server: x.y.z" with the `infra version` command if the user is using an `infrahq.com` organization. It also adds CLI tests for the various different states (disconnected, saas, and local)

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

Fixes #3272