### PR TITLE
fix: allow users to issue access keys to themselves

### DIFF
--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -37,7 +37,7 @@ func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey) (body string, 
 
 	if rCtx.Authenticated.AccessKey != nil && !rCtx.Authenticated.AccessKey.Scopes.Includes(models.ScopeAllowCreateAccessKey) {
 		// non-login access keys can not currently create other access keys.
-		return "", fmt.Errorf("%w: cannot use an access key to create other access keys", internal.ErrBadRequest)
+		return "", fmt.Errorf("%w: cannot use an access key not issued from login to create other access keys", internal.ErrBadRequest)
 	}
 
 	if accessKey.IssuedFor == rCtx.Authenticated.User.ID {

--- a/internal/access/access_key_test.go
+++ b/internal/access/access_key_test.go
@@ -1,0 +1,45 @@
+package access
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func TestAccessKeys_SelfManagement(t *testing.T) {
+	db := setupDB(t)
+
+	org := &models.Organization{Name: "joe's jackets", Domain: "joes-jackets"}
+	err := data.CreateOrganization(db, org)
+	assert.NilError(t, err)
+	db.OrganizationID()
+
+	user := &models.Identity{Name: "joe@example.com", OrganizationMember: models.OrganizationMember{OrganizationID: org.ID}}
+	err = data.CreateIdentity(db, user)
+	assert.NilError(t, err)
+
+	c, _ := loginAs(&data.Transaction{DB: db.DB}, user, org)
+
+	t.Run("can manage my own keys", func(t *testing.T) {
+		key := &models.AccessKey{
+			Name:               "foo key",
+			OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
+			IssuedFor:          user.ID,
+			ExpiresAt:          time.Now().Add(1 * time.Minute),
+		}
+		_, err = CreateAccessKey(c, key)
+		assert.NilError(t, err)
+
+		err = DeleteAccessKey(c, key.ID)
+		assert.NilError(t, err)
+	})
+
+	t.Run("can list my own keys", func(t *testing.T) {
+		_, err := ListAccessKeys(c, user.ID, "", true, &data.Pagination{})
+		assert.NilError(t, err)
+	})
+}

--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -28,6 +28,17 @@ func setupDB(t *testing.T) *data.DB {
 	return db
 }
 
+func loginAs(db *data.Transaction, user *models.Identity, org *models.Organization) (*gin.Context, *data.Transaction) {
+	ctx, _ := gin.CreateTestContext(nil)
+	tx := db.WithOrgID(org.ID)
+	ctx.Set(RequestContextKey, RequestContext{
+		DBTxn:         tx,
+		Authenticated: Authenticated{User: user, Organization: org},
+	})
+
+	return ctx, tx
+}
+
 func setupAccessTestContext(t *testing.T) (*gin.Context, *data.Transaction, *models.Provider) {
 	// setup db and context
 	db := setupDB(t)

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -95,7 +95,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	_, err = data.GetIdentity(db, data.ByID(identity.ID))
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 
-	_, err = data.GetAccessKey(db, keyID)
+	_, err = data.GetAccessKey(db, data.GetAccessKeysOptions{ByKeyID: keyID})
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 
 	_, err = data.GetCredential(db, data.ByIdentityID(identity.ID))

--- a/internal/server/access_keys.go
+++ b/internal/server/access_keys.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/access"
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api.ListResponse[api.AccessKey], error) {
+	p := PaginationFromRequest(r.PaginationRequest)
+	accessKeys, err := access.ListAccessKeys(c, r.UserID, r.Name, r.ShowExpired, &p)
+	if err != nil {
+		return nil, err
+	}
+
+	result := api.NewListResponse(accessKeys, PaginationToResponse(p), func(accessKey models.AccessKey) api.AccessKey {
+		return *accessKey.ToAPI()
+	})
+
+	return result, nil
+}
+
+func (a *API) DeleteAccessKey(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
+	return nil, access.DeleteAccessKey(c, r.ID)
+}
+
+func (a *API) CreateAccessKey(c *gin.Context, r *api.CreateAccessKeyRequest) (*api.CreateAccessKeyResponse, error) {
+	accessKey := &models.AccessKey{
+		IssuedFor:         r.UserID,
+		Name:              r.Name,
+		ExpiresAt:         time.Now().UTC().Add(time.Duration(r.TTL)),
+		Extension:         time.Duration(r.ExtensionDeadline),
+		ExtensionDeadline: time.Now().UTC().Add(time.Duration(r.ExtensionDeadline)),
+	}
+
+	raw, err := access.CreateAccessKey(c, accessKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.CreateAccessKeyResponse{
+		ID:                accessKey.ID,
+		Created:           api.Time(accessKey.CreatedAt),
+		Name:              accessKey.Name,
+		IssuedFor:         accessKey.IssuedFor,
+		Expires:           api.Time(accessKey.ExpiresAt),
+		ExtensionDeadline: api.Time(accessKey.ExtensionDeadline),
+		AccessKey:         raw,
+	}, nil
+}

--- a/internal/server/access_keys.go
+++ b/internal/server/access_keys.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/models"

--- a/internal/server/authn/authn_method.go
+++ b/internal/server/authn/authn_method.go
@@ -57,6 +57,7 @@ func Login(
 		ExpiresAt:         authenticated.SessionExpiry,
 		ExtensionDeadline: time.Now().UTC().Add(keyExtension),
 		Extension:         keyExtension,
+		Scopes:            models.CommaSeparatedStrings{models.ScopeAllowCreateAccessKey},
 	}
 
 	if authenticated.AuthScope.PasswordResetOnly {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -989,6 +989,7 @@ func (s Server) loadAccessKey(db data.GormTxn, identity *models.Identity, key st
 			KeyID:      keyID,
 			Secret:     secret,
 			ProviderID: provider.ID,
+			Scopes:     models.CommaSeparatedStrings{models.ScopeAllowCreateAccessKey}, // allows user to create access keys
 		}
 
 		if _, err := data.CreateAccessKey(db, accessKey); err != nil {

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -165,16 +165,29 @@ func ListAccessKeys(tx ReadTxn, opts ListAccessKeyOptions) ([]models.AccessKey, 
 	return result, rows.Err()
 }
 
+type GetAccessKeysOptions struct {
+	ByID    uid.ID
+	ByKeyID string
+}
+
 // GetAccessKey using the keyID. Note that the keyID is globally unique, so
 // this query is not scoped by an organization_id.
-func GetAccessKey(tx ReadTxn, keyID string) (*models.AccessKey, error) {
+func GetAccessKey(tx ReadTxn, opts GetAccessKeysOptions) (*models.AccessKey, error) {
+	if opts.ByID == 0 && len(opts.ByKeyID) == 0 {
+		return nil, fmt.Errorf("GetAccessKey must supply either id or key_id")
+	}
 	accessKey := &accessKeyTable{}
 	query := querybuilder.New("SELECT")
 	query.B(columnsForSelect(accessKey))
 	query.B("FROM")
 	query.B(accessKey.Table())
 	query.B("WHERE deleted_at is null")
-	query.B("AND key_id = ?", keyID)
+	if len(opts.ByKeyID) > 0 {
+		query.B("AND key_id = ?", opts.ByKeyID)
+	}
+	if opts.ByID > 0 {
+		query.B("and id = ?", opts.ByID)
+	}
 
 	err := tx.QueryRow(query.String(), query.Args...).Scan(accessKey.ScanFields()...)
 	if err != nil {
@@ -219,7 +232,7 @@ func ValidateAccessKey(tx WriteTxn, authnKey string) (*models.AccessKey, error) 
 		return nil, fmt.Errorf("invalid access key format")
 	}
 
-	t, err := GetAccessKey(tx, keyID)
+	t, err := GetAccessKey(tx, GetAccessKeysOptions{ByKeyID: keyID})
 	if err != nil {
 		return nil, fmt.Errorf("%w: could not get access key from database, it may not exist", err)
 	}

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -57,7 +57,7 @@ func TestCreateAccessKey(t *testing.T) {
 			assert.Equal(t, pair, key.KeyID+"."+key.Secret)
 
 			// check that we can fetch the same value from the db
-			fromDB, err := GetAccessKey(tx, key.KeyID)
+			fromDB, err := GetAccessKey(tx, GetAccessKeysOptions{ByKeyID: key.KeyID})
 			assert.NilError(t, err)
 
 			// fromDB should not have the secret value
@@ -87,7 +87,7 @@ func TestCreateAccessKey(t *testing.T) {
 			assert.Equal(t, pair, key.KeyID+"."+key.Secret)
 
 			// check that we can fetch the same value from the db
-			fromDB, err := GetAccessKey(tx, key.KeyID)
+			fromDB, err := GetAccessKey(tx, GetAccessKeysOptions{ByKeyID: key.KeyID})
 			assert.NilError(t, err)
 			// fromDB should not have the secret value
 			key.Secret = ""
@@ -548,7 +548,7 @@ func TestUpdateAccessKey(t *testing.T) {
 		err = UpdateAccessKey(tx, orig)
 		assert.NilError(t, err)
 
-		actual, err := GetAccessKey(tx, orig.KeyID)
+		actual, err := GetAccessKey(tx, GetAccessKeysOptions{ByKeyID: orig.KeyID})
 		assert.NilError(t, err)
 
 		expected := key()
@@ -583,7 +583,7 @@ func TestGetAccessKey(t *testing.T) {
 		createAccessKeys(t, db, ak, other)
 
 		t.Run("found", func(t *testing.T) {
-			actual, err := GetAccessKey(db, ak.KeyID)
+			actual, err := GetAccessKey(db, GetAccessKeysOptions{ByKeyID: ak.KeyID})
 			assert.NilError(t, err)
 			expected := *ak
 			expected.Secret = ""
@@ -591,7 +591,7 @@ func TestGetAccessKey(t *testing.T) {
 		})
 
 		t.Run("not found", func(t *testing.T) {
-			_, err := GetAccessKey(db, "not-this-key-id")
+			_, err := GetAccessKey(db, GetAccessKeysOptions{ByKeyID: "not-this-key-id"})
 			assert.ErrorIs(t, err, internal.ErrNotFound)
 		})
 
@@ -599,7 +599,7 @@ func TestGetAccessKey(t *testing.T) {
 			err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByID: ak.ID})
 			assert.NilError(t, err)
 
-			_, err = GetAccessKey(db, ak.KeyID)
+			_, err = GetAccessKey(db, GetAccessKeysOptions{ByKeyID: ak.KeyID})
 			assert.ErrorIs(t, err, internal.ErrNotFound)
 		})
 	})

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -154,7 +154,7 @@ func TestDeleteProviders(t *testing.T) {
 			err = DeleteProviders(db, ByOptionalName(providerDevelop.Name))
 			assert.NilError(t, err)
 
-			_, err = GetAccessKey(db, key.KeyID)
+			_, err = GetAccessKey(db, GetAccessKeysOptions{ByKeyID: key.KeyID})
 			assert.ErrorContains(t, err, "record not found")
 		})
 
@@ -174,7 +174,7 @@ func TestDeleteProviders(t *testing.T) {
 			err = DeleteProviders(db, ByOptionalName(providerDevelop.Name))
 			assert.NilError(t, err)
 
-			_, err = GetAccessKey(db, key.KeyID)
+			_, err = GetAccessKey(db, GetAccessKeysOptions{ByKeyID: key.KeyID})
 			assert.NilError(t, err)
 		})
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -71,49 +71,6 @@ type WellKnownJWKResponse struct {
 	Keys []jose.JSONWebKey `json:"keys"`
 }
 
-func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api.ListResponse[api.AccessKey], error) {
-	p := PaginationFromRequest(r.PaginationRequest)
-	accessKeys, err := access.ListAccessKeys(c, r.UserID, r.Name, r.ShowExpired, &p)
-	if err != nil {
-		return nil, err
-	}
-
-	result := api.NewListResponse(accessKeys, PaginationToResponse(p), func(accessKey models.AccessKey) api.AccessKey {
-		return *accessKey.ToAPI()
-	})
-
-	return result, nil
-}
-
-func (a *API) DeleteAccessKey(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
-	return nil, access.DeleteAccessKey(c, r.ID)
-}
-
-func (a *API) CreateAccessKey(c *gin.Context, r *api.CreateAccessKeyRequest) (*api.CreateAccessKeyResponse, error) {
-	accessKey := &models.AccessKey{
-		IssuedFor:         r.UserID,
-		Name:              r.Name,
-		ExpiresAt:         time.Now().UTC().Add(time.Duration(r.TTL)),
-		Extension:         time.Duration(r.ExtensionDeadline),
-		ExtensionDeadline: time.Now().UTC().Add(time.Duration(r.ExtensionDeadline)),
-	}
-
-	raw, err := access.CreateAccessKey(c, accessKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return &api.CreateAccessKeyResponse{
-		ID:                accessKey.ID,
-		Created:           api.Time(accessKey.CreatedAt),
-		Name:              accessKey.Name,
-		IssuedFor:         accessKey.IssuedFor,
-		Expires:           api.Time(accessKey.ExpiresAt),
-		ExtensionDeadline: api.Time(accessKey.ExtensionDeadline),
-		AccessKey:         raw,
-	}, nil
-}
-
 func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.SignupResponse, error) {
 	if !a.server.options.EnableSignup {
 		return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -12,7 +12,10 @@ var (
 	AccessKeySecretLength = 24 // the length of the secret used to validate an access key
 )
 
-const ScopePasswordReset = "password-reset"
+const (
+	ScopePasswordReset        = "password-reset"
+	ScopeAllowCreateAccessKey = "create-key"
+)
 
 // AccessKey is a session token presented to the Infra server as proof of authentication
 type AccessKey struct {


### PR DESCRIPTION
## Summary

fix: allow users to issue access keys to themselves

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->
