### PR TITLE
fix(helm): create clusterroles based on values not lookup

### DIFF
--- a/helm/charts/infra/templates/connector/clusterrole.yaml
+++ b/helm/charts/infra/templates/connector/clusterrole.yaml
@@ -37,44 +37,7 @@ rules:
       - watch
       - bind
       - escalate
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "logs") }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: logs
-  labels:
-{{- include "connector.clusterRoleLabels" . | nindent 4 }}
-rules:
-  - apiGroups: [""]
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - replicasets
-      - statefulsets
-      - daemonsets
-    verbs:
-      - get
-  - apiGroups: [""]
-    resources:
-      - pods/log
-    verbs:
-      - get
-      - watch
-{{- end }}
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "exec") }}
+{{- if and .Values.connector.defaultRoles.create .Values.connector.defaultRoles.roles.exec }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -111,7 +74,44 @@ rules:
       - get
       - create
 {{- end }}
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "port-forward") }}
+{{- if and .Values.connector.defaultRoles.create .Values.connector.defaultRoles.roles.logs }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: logs
+  labels:
+{{- include "connector.clusterRoleLabels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - pods/log
+    verbs:
+      - get
+      - watch
+{{- end }}
+{{- if and .Values.connector.defaultRoles.create .Values.connector.defaultRoles.roles.portForward }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -780,6 +780,14 @@ connector:
   ## No effect unless `autoscaling.enabled` is `false`
   replicas: 1
 
+  ## Create default cluster roles to assign with Infra
+  defaultRoles:
+    create: true
+    roles:
+      exec: true
+      logs: true
+      portForward: true
+
   ## Infra connector image configurations
   image:
     ## The image repository to use for the connector deployment


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Using lookup is not stable since the outcome is dependent on the state of the system. It becomes essentially a toggle as the user installs/upgrades the connector.

Example:
1. No `logs` cluster role so Helm includes and install it
1. Lookup finds `logs` so Helm omits and removes it
1. Go to 1.

The original intent with the look up is to prevent overriding any existing roles with the same name.

Instead of using lookup, the chart now contains values to include or omit specific roles. If a role already exists, Helm will refuse to overwrite it and the user can disable the role with `connector.defaultRoles.roles.<role>=false`.

If the user instead wants to disable creating default roles entirely, they can set `connector.defaultRoles.create=false`.

Resolves #3262 
