### PR TITLE
improve: add tab sync to website

### DIFF
--- a/website/components/tabs.js
+++ b/website/components/tabs.js
@@ -1,18 +1,57 @@
 import { useState, createContext, useEffect, useRef } from 'react'
+import { useRouter } from 'next/router'
 
+// Individual tabs
 export const TabContext = createContext()
 
-export default function Tabs({ labels, children }) {
-  const [currentTab, setCurrentTab] = useState(labels[0])
+export function useTabGroups() {
+  const router = useRouter()
+
+  const groups = {}
+
+  for (const [k, v] of Object.entries(router.query)) {
+    if (k.startsWith('group')) {
+      groups[k.replace('group-', '')] = v
+    }
+  }
+
+  function setGroups(groups = {}) {
+    const query = {}
+    for (const [k, v] of Object.entries(groups)) {
+      query[`group-${k}`] = v
+    }
+
+    router.push(
+      {
+        pathname: router.pathname,
+        query: { ...router.query, ...query },
+      },
+      undefined,
+      { shallow: true }
+    )
+  }
+
+  return [groups, setGroups]
+}
+
+export default function Tabs({ labels, children, group = 'default' }) {
+  const [groups, setGroups] = useTabGroups()
+  const [currentTab, setCurrentTab] = useState(groups?.[group] || labels[0])
   const tabsRef = useRef({})
   const activeRef = useRef(null)
 
   useEffect(() => {
+    setCurrentTab(groups?.[group] || currentTab)
+  }, [groups, group, currentTab])
+
+  useEffect(() => {
     function resize() {
-      const tabElement = tabsRef.current[currentTab]
-      activeRef.current.style.transform = `translateX(${tabElement.offsetLeft}px) translateY(${tabElement.offsetTop}px)`
-      activeRef.current.style.width = `${tabElement.offsetWidth}px`
-      activeRef.current.style.height = `${tabElement.offsetHeight}px`
+      const tabElement = tabsRef.current?.[currentTab]
+      if (tabElement && activeRef.current) {
+        activeRef.current.style.transform = `translateX(${tabElement.offsetLeft}px) translateY(${tabElement.offsetTop}px)`
+        activeRef.current.style.width = `${tabElement.offsetWidth}px`
+        activeRef.current.style.height = `${tabElement.offsetHeight}px`
+      }
     }
 
     resize()
@@ -21,7 +60,7 @@ export default function Tabs({ labels, children }) {
     return () => {
       window.removeEventListener('resize', resize)
     }
-  }, [currentTab])
+  }, [currentTab, labels, setCurrentTab])
 
   return (
     <TabContext.Provider value={currentTab}>
@@ -41,7 +80,10 @@ export default function Tabs({ labels, children }) {
                 ? ' text-blue-700 hover:text-blue-700'
                 : 'text-gray-500 hover:text-gray-800'
             } rounded-lg px-7 py-1.5 text-sm font-medium leading-loose transition-colors`}
-            onClick={() => setCurrentTab(label)}
+            onClick={() => {
+              setCurrentTab(label)
+              setGroups({ ...groups, [group || 'default']: label })
+            }}
           >
             {label}
           </button>

--- a/website/components/tabs.js
+++ b/website/components/tabs.js
@@ -1,7 +1,6 @@
-import { useState, createContext, useEffect, useRef } from 'react'
+import { createContext, useEffect, useRef } from 'react'
 import { useRouter } from 'next/router'
 
-// Individual tabs
 export const TabContext = createContext()
 
 export function useTabGroups() {
@@ -36,13 +35,9 @@ export function useTabGroups() {
 
 export default function Tabs({ labels, children, group = 'default' }) {
   const [groups, setGroups] = useTabGroups()
-  const [currentTab, setCurrentTab] = useState(groups?.[group] || labels[0])
+  const currentTab = groups?.[group] || labels[0]
   const tabsRef = useRef({})
   const activeRef = useRef(null)
-
-  useEffect(() => {
-    setCurrentTab(groups?.[group] || currentTab)
-  }, [groups, group, currentTab])
 
   useEffect(() => {
     function resize() {
@@ -60,7 +55,7 @@ export default function Tabs({ labels, children, group = 'default' }) {
     return () => {
       window.removeEventListener('resize', resize)
     }
-  }, [currentTab, labels, setCurrentTab])
+  }, [currentTab, labels])
 
   return (
     <TabContext.Provider value={currentTab}>
@@ -68,7 +63,7 @@ export default function Tabs({ labels, children, group = 'default' }) {
         <div
           ref={activeRef}
           className={`absolute h-4 w-4 rounded-lg bg-blue-600/5 ${
-            activeRef.current ? 'transition-all' : ''
+            activeRef.current && groups?.[group] ? 'transition-all' : ''
           }`}
         ></div>
         {labels.map(label => (
@@ -81,7 +76,6 @@ export default function Tabs({ labels, children, group = 'default' }) {
                 : 'text-gray-500 hover:text-gray-800'
             } rounded-lg px-7 py-1.5 text-sm font-medium leading-loose transition-colors`}
             onClick={() => {
-              setCurrentTab(label)
               setGroups({ ...groups, [group || 'default']: label })
             }}
           >

--- a/website/components/tabs.js
+++ b/website/components/tabs.js
@@ -9,7 +9,7 @@ export function useTabGroups() {
   const groups = {}
 
   for (const [k, v] of Object.entries(router.query)) {
-    if (k.startsWith('group')) {
+    if (k.startsWith('group-')) {
       groups[k.replace('group-', '')] = v
     }
   }

--- a/website/lib/markdoc/config.js
+++ b/website/lib/markdoc/config.js
@@ -100,7 +100,11 @@ export const config = {
   tags: {
     tabs: {
       render: 'Tabs',
-      attributes: {},
+      attributes: {
+        group: {
+          type: String,
+        },
+      },
       transform(node, config) {
         const tabs = node
           .transformChildren(config)
@@ -110,7 +114,7 @@ export const config = {
           typeof tab === 'object' ? tab.attributes.label : null
         )
 
-        return new Tag(this.render, { labels }, tabs)
+        return new Tag(this.render, { ...node.attributes, labels }, tabs)
       },
     },
     tab: {


### PR DESCRIPTION
This commit synchronizes tab selection for tabs on the same page. It stores this selection in the browser query parameter so they persist between refreshes. Note: tabs use a default "group" and are automatically synchronized. To avoid this use the group="example" attribute in the tab tag in markdoc.
