### PR TITLE
maintain: change makefile to update local dev versions

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	Branch     = "main"
-	Version    = "0.14.4"
+	Version    = "0.0.0"
 	Prerelease = ""
 	Metadata   = "dev"
 	Commit     = ""


### PR DESCRIPTION
## Summary

The version cli/server when you're building with the dev build with the makefile is pegged at `0.14.4`.  This can be misleading and confusing if you're expecting the actual version (e.g. right now we're currently on `0.15.2`).

This change snags the current appVersion from the helm chart (although we can snag it from somewhere else if/when we move the helm chart) and patches our binary with the updated version (instead of `0.14.4`).

