### PR TITLE
feat: make name optional for provider

### DIFF
--- a/api/provider.go
+++ b/api/provider.go
@@ -45,7 +45,6 @@ var kinds = []string{"oidc", "okta", "azure", "google"}
 func (r CreateProviderRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		ValidateName(r.Name),
-		validate.Required("name", r.Name),
 		validate.Required("url", r.URL),
 		validate.Required("clientID", r.ClientID),
 		validate.Required("clientSecret", r.ClientSecret),

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	CharsetAlphaNumeric = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	CharsetPassword     = CharsetAlphaNumeric + `!@#$%^&*()_+-=[]|;:,./<>?`
+	CharsetAlphaNumeric         = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	CharsetAlphaNumericNoVowels = "0123456789BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz" // For user-facing areas, to avoid profanity
+	CharsetPassword             = CharsetAlphaNumeric + `!@#$%^&*()_+-=[]|;:,./<>?`
 )
 
 func init() {

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -87,7 +87,7 @@ func (a *API) CreateProvider(c *gin.Context, r *api.CreateProviderRequest) (*api
 			return nil, fmt.Errorf("Error while generating name for provider: %w", err)
 		}
 		if len(providers) > 0 {
-			randomString, err := generate.CryptoRandom(6, generate.CharsetAlphaNumeric)
+			randomString, err := generate.CryptoRandom(6, generate.CharsetAlphaNumericNoVowels)
 			if err != nil {
 				return nil, fmt.Errorf("Error while generating name for provider: %w", err)
 			}

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/generate"
+	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -78,11 +79,21 @@ func (a *API) CreateProvider(c *gin.Context, r *api.CreateProviderRequest) (*api
 
 	// If name is not provided, generate based on provider kind
 	if provider.Name == "" {
-		randomString, err := generate.CryptoRandom(6, generate.CharsetAlphaNumeric)
+		provider.Name = provider.Kind.String()
+
+		// If provider name is taken, generate a random tag
+		providers, err := access.ListProviders(c, provider.Kind.String(), nil, &data.Pagination{})
 		if err != nil {
-			return nil, errors.New("Error while generating name for provider")
+			return nil, fmt.Errorf("Error while generating name for provider: %w", err)
 		}
-		provider.Name = r.Kind + "-" + randomString
+		if len(providers) > 0 {
+			randomString, err := generate.CryptoRandom(6, generate.CharsetAlphaNumeric)
+			if err != nil {
+				return nil, fmt.Errorf("Error while generating name for provider: %w", err)
+			}
+
+			provider.Name = r.Kind + "-" + randomString
+		}
 	}
 
 	if err := a.setProviderInfoFromServer(c, provider); err != nil {

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
+	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -74,6 +75,15 @@ func (a *API) CreateProvider(c *gin.Context, r *api.CreateProviderRequest) (*api
 		return nil, err
 	}
 	provider.Kind = kind
+
+	// If name is not provided, generate based on provider kind
+	if provider.Name == "" {
+		randomString, err := generate.CryptoRandom(6, generate.CharsetAlphaNumeric)
+		if err != nil {
+			return nil, errors.New("Error while generating name for provider")
+		}
+		provider.Name = r.Kind + "-" + randomString
+	}
 
 	if err := a.setProviderInfoFromServer(c, provider); err != nil {
 		return nil, err

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -205,7 +205,6 @@ func TestAPI_CreateProvider(t *testing.T) {
 				expected := []api.FieldError{
 					{FieldName: "clientID", Errors: []string{"is required"}},
 					{FieldName: "clientSecret", Errors: []string{"is required"}},
-					{FieldName: "name", Errors: []string{"is required"}},
 					{FieldName: "url", Errors: []string{"is required"}},
 				}
 				assert.DeepEqual(t, respBody.FieldErrors, expected)

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -4187,7 +4187,6 @@
                   }
                 },
                 "required": [
-                  "name",
                   "url",
                   "clientID",
                   "clientSecret"

--- a/ui/components/grant-form.js
+++ b/ui/components/grant-form.js
@@ -65,7 +65,7 @@ export default function GrantForm({ grants, roles, onSubmit = () => {} }) {
         >
           <Combobox.Input
             className={`block w-full rounded-md border-gray-300 text-xs shadow-sm focus:border-blue-500 focus:ring-blue-500`}
-            placeholder='User or group'
+            placeholder='Enter user or group'
             onChange={e => {
               setQuery(e.target.value)
               if (e.target.value.length === 0) {

--- a/ui/pages/providers/add.js
+++ b/ui/pages/providers/add.js
@@ -48,7 +48,7 @@ export default function ProvidersAddDetails() {
   const [domainAdminEmail, setDomainAdminEmail] = useState('')
   const [error, setError] = useState('')
   const [errors, setErrors] = useState({})
-  const [name, setName] = useState(kind === 'azure' ? 'azure ad' : kind)
+  const [name, setName] = useState('')
 
   useEffect(() => {
     setURL(type === 'google' ? 'accounts.google.com' : '')
@@ -168,7 +168,7 @@ export default function ProvidersAddDetails() {
           {/* Overview */}
           <div>
             <h3 className='mb-4 text-base font-medium text-gray-900'>
-              Overview
+              Select an identity provider
             </h3>
             <div className='mb-6 grid grid-cols-2 gap-2'>
               {providers.map(
@@ -178,7 +178,6 @@ export default function ProvidersAddDetails() {
                       key={p.name}
                       onClick={() => {
                         setKind(p.kind)
-                        setName(p.kind === 'azure' ? 'azure ad' : p.kind)
                         router.replace(`/providers/add?type=${p.kind}`)
                       }}
                     >
@@ -187,9 +186,27 @@ export default function ProvidersAddDetails() {
                   )
               )}
             </div>
-            <label className='text-2xs font-medium text-gray-700'>Name</label>
+          </div>
+          <div className='w-full'>
+            <div className='mb-1 flex'>
+              <h3 className='text-base font-medium leading-6 text-gray-900'>
+                Information
+              </h3>
+              &nbsp; &nbsp;
+              <a
+                className=' text-gray-500 underline hover:text-gray-600'
+                target='_blank'
+                href={docLink()}
+                rel='noreferrer'
+              >
+                learn more
+              </a>
+            </div>
+
+            <label className='text-2xs font-medium text-gray-700'>
+              Name (optional)
+            </label>
             <input
-              required
               type='text'
               value={name}
               onChange={e => {
@@ -202,22 +219,6 @@ export default function ProvidersAddDetails() {
               }`}
             />
             {errors.name && <ErrorMessage message={errors.name} />}
-          </div>
-          <div className='w-full'>
-            <div className='mb-1 flex'>
-              <h3 className='text-base font-medium leading-6 text-gray-900'>
-                Additional Information
-              </h3>
-              &nbsp;
-              <a
-                className='text-gray-500 underline hover:text-gray-600'
-                target='_blank'
-                href={docLink()}
-                rel='noreferrer'
-              >
-                learn more
-              </a>
-            </div>
             <div className='mt-6 space-y-3'>
               {kind !== 'google' && (
                 <div>

--- a/ui/pages/providers/add.js
+++ b/ui/pages/providers/add.js
@@ -188,7 +188,7 @@ export default function ProvidersAddDetails() {
             </div>
           </div>
           <div className='w-full'>
-            <div className='mb-1 flex space-x-2'>
+            <div className='mb-1 flex items-center space-x-2 text-2xs'>
               <h3 className='text-base font-medium leading-6 text-gray-900'>
                 Information
               </h3>

--- a/ui/pages/providers/add.js
+++ b/ui/pages/providers/add.js
@@ -188,7 +188,7 @@ export default function ProvidersAddDetails() {
             </div>
           </div>
           <div className='w-full'>
-            <div className='mb-1 flex items-center space-x-2 text-2xs'>
+            <div className='mb-1 flex items-center space-x-2 text-xs'>
               <h3 className='text-base font-medium leading-6 text-gray-900'>
                 Information
               </h3>

--- a/ui/pages/providers/add.js
+++ b/ui/pages/providers/add.js
@@ -188,11 +188,10 @@ export default function ProvidersAddDetails() {
             </div>
           </div>
           <div className='w-full'>
-            <div className='mb-1 flex'>
+            <div className='mb-1 flex space-x-2'>
               <h3 className='text-base font-medium leading-6 text-gray-900'>
                 Information
               </h3>
-              &nbsp; &nbsp;
               <a
                 className=' text-gray-500 underline hover:text-gray-600'
                 target='_blank'


### PR DESCRIPTION

## Things changed:

- UI form 
- Provider name will default to the kind (eg. 'okta'), and append a randomly generated string if it is taken
- Reword grey box text from "User or group" to "Enter user or group"
- Introduces a alphanumeric without vowels, for generated strings that will be user-facing to prevent accidental profanity


## Details

### API will now generate name of provider if not provided. 


https://user-images.githubusercontent.com/20054646/192228163-3d62b23f-8103-4ce4-bc32-c5ece0a3cbd7.mov




### The UI is slightly rearranged. 
  - _**Previous:**_ 


  <img width="674" alt="image" src="https://user-images.githubusercontent.com/20054646/192005037-c3626e51-29d1-42e9-9ca1-8fb3ff4e379b.png">


  - _**After:**_
  <img width="656" alt="image" src="https://user-images.githubusercontent.com/20054646/192004865-7158386c-0376-4d8f-8195-f030b5e38b5f.png">

