### PR TITLE
fix: reduce request transaction lifetime

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -610,11 +610,7 @@ func (s Server) loadConfig(config Config) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := tx.Rollback(); err != nil {
-			logging.L.Error().Err(err).Msg("failed to rollback database transaction")
-		}
-	}()
+	defer logError(tx.Rollback, "failed to rollback loadConfig transaction")
 	tx = tx.WithOrgID(org.ID)
 
 	if config.DefaultOrganizationDomain != org.Domain {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/redis"
 	"github.com/infrahq/infra/internal/validate"
@@ -197,26 +198,18 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 			}
 		}
 
-		tx, err := a.server.db.Begin(c.Request.Context())
-		if err != nil {
-			return err
-		}
-		defer func() {
-			if err := tx.Rollback(); err != nil {
-				logging.L.Error().Err(err).Msg("failed to rollback database transaction")
-			}
-		}()
-
+		var err error
 		if route.noAuthentication {
-			err = validateRequestOrganization(c, tx, a.server)
+			err = validateRequestOrganization(c, a.server)
 		} else {
-			err = authenticateRequest(c, tx, a.server)
+			err = authenticateRequest(c, a.server)
 		}
 		if err != nil {
 			return err
 		}
 
-		org := getRequestContext(c).Authenticated.Organization
+		rCtx := getRequestContext(c)
+		org := rCtx.Authenticated.Organization
 		if !route.noOrgRequired {
 			if org == nil {
 				return internal.ErrBadRequest
@@ -234,6 +227,18 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 		if err := readRequest(c, req); err != nil {
 			return err
 		}
+
+		tx, err := a.server.db.Begin(c.Request.Context())
+		if err != nil {
+			return err
+		}
+		defer logError(tx.Rollback, "failed to rollback request handler transaction")
+
+		if org := rCtx.Authenticated.Organization; org != nil {
+			tx = tx.WithOrgID(org.ID)
+		}
+		rCtx.DBTxn = tx
+		c.Set(access.RequestContextKey, rCtx)
 
 		resp, err := route.handler(c, req)
 		if err != nil {


### PR DESCRIPTION
PostgreSQL row and table locks are held until the end of the transaction.

Previously we were using a single transaction for the entire lifetime of the request. One of the first things we did with that transaction was update the access key and user record associated with the request.

That update would block any other requests from that user until the first request finished. For short lived requests that was fine, but longer requests (anything making HTTP requests to an IDP, or blocking and waiting for updates) would prevent the user from making concurrent requests.

This commit fixes the problem by committing the "middleware" transaction first, then starting a new transaction for the request handler. The middleware transaction should be short lived, because it only does a few database operations and returns. It doesn't block or make external requests.