### PR TITLE
improve: move database dialector to data package

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -20,10 +20,8 @@ import (
 
 func setupDB(t *testing.T) *data.DB {
 	t.Helper()
-	driver := database.PostgresDriver(t, "_access")
-
 	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver.Dialector, data.NewDBOptions{})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_access").DSN})
 	assert.NilError(t, err)
 	return db
 }

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -16,10 +16,8 @@ import (
 
 func setupDB(t *testing.T) *data.DB {
 	t.Helper()
-	driver := database.PostgresDriver(t, "_authn")
-
 	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver.Dialector, data.NewDBOptions{})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_authn").DSN})
 	assert.NilError(t, err)
 
 	return db

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
+	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"github.com/infrahq/infra/internal"
@@ -24,6 +25,8 @@ import (
 )
 
 type NewDBOptions struct {
+	DSN string
+
 	EncryptionKeyProvider EncryptionKeyProvider
 	RootKeyID             string
 
@@ -35,8 +38,8 @@ type NewDBOptions struct {
 // NewDB creates a new database connection and runs any required database migrations
 // before returning the connection. The loadDBKey function is called after
 // initializing the schema, but before any migrations.
-func NewDB(connection gorm.Dialector, dbOpts NewDBOptions) (*DB, error) {
-	db, err := newRawDB(connection, dbOpts)
+func NewDB(dbOpts NewDBOptions) (*DB, error) {
+	db, err := newRawDB(dbOpts)
 	if err != nil {
 		return nil, fmt.Errorf("db conn: %w", err)
 	}
@@ -216,8 +219,12 @@ func (t *Transaction) WithOrgID(orgID uid.ID) *Transaction {
 }
 
 // newRawDB creates a new database connection without running migrations.
-func newRawDB(connection gorm.Dialector, options NewDBOptions) (*gorm.DB, error) {
-	db, err := gorm.Open(connection, &gorm.Config{
+func newRawDB(options NewDBOptions) (*gorm.DB, error) {
+	if options.DSN == "" {
+		return nil, fmt.Errorf("missing postgres dsn")
+	}
+
+	db, err := gorm.Open(postgres.Open(options.DSN), &gorm.Config{
 		Logger: logging.NewDatabaseLogger(time.Second),
 	})
 	if err != nil {

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func setupDB(t *testing.T, driver gorm.Dialector) *DB {
+func setupDB(t *testing.T) *DB {
 	t.Helper()
 	patch.ModelsSymmetricKey(t)
 
-	db, err := NewDB(driver, NewDBOptions{})
+	db, err := NewDB(NewDBOptions{DSN: database.PostgresDriver(t, "_data").DSN})
 	assert.NilError(t, err)
 
 	logging.PatchLogger(t, zerolog.NewTestWriter(t))
@@ -43,8 +43,7 @@ func txnForTestCase(t *testing.T, db *DB, orgID uid.ID) *Transaction {
 // against postgresql.
 func runDBTests(t *testing.T, run func(t *testing.T, db *DB)) {
 	t.Run("postgres", func(t *testing.T) {
-		pgsql := database.PostgresDriver(t, "")
-		db := setupDB(t, pgsql.Dialector)
+		db := setupDB(t)
 		run(t, db)
 		db.Rollback()
 	})

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -729,7 +729,7 @@ DELETE FROM settings WHERE id=24567;
 	var initialSchema string
 	runStep(t, "initial schema", func(t *testing.T) {
 		patch.ModelsSymmetricKey(t)
-		rawDB, err := newRawDB(database.PostgresDriver(t, "").Dialector, NewDBOptions{})
+		rawDB, err := newRawDB(NewDBOptions{DSN: database.PostgresDriver(t, "").DSN})
 		assert.NilError(t, err)
 
 		db := &DB{DB: rawDB}
@@ -743,7 +743,7 @@ DELETE FROM settings WHERE id=24567;
 		assert.NilError(t, err)
 	})
 
-	db, err := newRawDB(database.PostgresDriver(t, "").Dialector, NewDBOptions{})
+	db, err := newRawDB(NewDBOptions{DSN: database.PostgresDriver(t, "").DSN})
 	assert.NilError(t, err)
 	for i, tc := range testCases {
 		runStep(t, tc.label.Name, func(t *testing.T) {

--- a/internal/server/data/sqlfunc_test.go
+++ b/internal/server/data/sqlfunc_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-
-	"github.com/infrahq/infra/internal/testing/database"
 )
 
 func TestSQLUidStrToIntRoundTrip(t *testing.T) {
@@ -15,7 +13,7 @@ func TestSQLUidStrToIntRoundTrip(t *testing.T) {
 		intval int64
 		err    string
 	}
-	db := setupDB(t, database.PostgresDriver(t, "").Dialector)
+	db := setupDB(t)
 
 	run := func(t *testing.T, tc testCase) {
 		var i int64

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -28,10 +28,8 @@ import (
 
 func setupDB(t *testing.T) *data.DB {
 	t.Helper()
-	driver := database.PostgresDriver(t, "_server")
-
 	tpatch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(driver.Dialector, data.NewDBOptions{})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_server").DSN})
 	assert.NilError(t, err)
 	t.Cleanup(func() {
 		assert.NilError(t, db.Close())

--- a/internal/server/models/encryption_test.go
+++ b/internal/server/models/encryption_test.go
@@ -29,8 +29,7 @@ CREATE TABLE struct_for_testings (
 func TestEncryptedAtRest(t *testing.T) {
 	patch.ModelsSymmetricKey(t)
 
-	pg := database.PostgresDriver(t, "_models")
-	db, err := data.NewDB(pg.Dialector, data.NewDBOptions{})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_models").DSN})
 	assert.NilError(t, err)
 
 	_, err = db.Exec(StructForTesting{}.Schema())
@@ -65,8 +64,7 @@ func TestEncryptedAtRest(t *testing.T) {
 func TestEncryptedAtRest_WithBytes(t *testing.T) {
 	patch.ModelsSymmetricKey(t)
 
-	pg := database.PostgresDriver(t, "_models")
-	db, err := data.NewDB(pg.Dialector, data.NewDBOptions{})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_models").DSN})
 	assert.NilError(t, err)
 
 	settings, err := data.GetSettings(db)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Move the database connection and configuration parsing to the data package. This allows the data package to more fully abstract the database. In particular, the database password value is resolved before passing it to `NewDB()` so it doesn't need the server secret storage nor import secrets 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
