### PR TITLE
improve: add configurable db connection options

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server"
+	"github.com/infrahq/infra/internal/server/data"
 )
 
 func newServerCmd() *cobra.Command {
@@ -98,6 +99,12 @@ func defaultServerOptions(infraDir string) server.Options {
 			HTTP:    ":80",
 			HTTPS:   ":443",
 			Metrics: ":9090",
+		},
+
+		DB: data.NewDBOptions{
+			MaxOpenConnections: 100,
+			MaxIdleConnections: 100,
+			MaxIdleTimeout:     5 * time.Minute,
 		},
 	}
 }

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/server"
+	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/testing/database"
 )
 
@@ -276,6 +277,12 @@ users:
 								Password:  "the-password",
 							},
 						},
+					},
+
+					DB: data.NewDBOptions{
+						MaxOpenConnections: 100,
+						MaxIdleConnections: 100,
+						MaxIdleTimeout:     5 * time.Minute,
 					},
 				}
 			},

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -703,7 +703,7 @@ DELETE FROM settings WHERE id=24567;
 	var initialSchema string
 	runStep(t, "initial schema", func(t *testing.T) {
 		patch.ModelsSymmetricKey(t)
-		rawDB, err := newRawDB(database.PostgresDriver(t, "").Dialector)
+		rawDB, err := newRawDB(database.PostgresDriver(t, "").Dialector, NewDBOptions{})
 		assert.NilError(t, err)
 
 		db := &DB{DB: rawDB}
@@ -717,7 +717,7 @@ DELETE FROM settings WHERE id=24567;
 		assert.NilError(t, err)
 	})
 
-	db, err := newRawDB(database.PostgresDriver(t, "").Dialector)
+	db, err := newRawDB(database.PostgresDriver(t, "").Dialector, NewDBOptions{})
 	assert.NilError(t, err)
 	for i, tc := range testCases {
 		runStep(t, tc.label.Name, func(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -76,6 +76,8 @@ type Options struct {
 	Addr ListenerOptions
 	UI   UIOptions
 	TLS  TLSOptions
+
+	DB data.NewDBOptions
 }
 
 type ListenerOptions struct {
@@ -154,10 +156,10 @@ func New(options Options) (*Server, error) {
 	if !ok {
 		return nil, fmt.Errorf("key provider %s not configured", options.DBEncryptionKeyProvider)
 	}
-	db, err := data.NewDB(driver, data.NewDBOptions{
-		EncryptionKeyProvider: dbKeyProvider,
-		RootKeyID:             options.DBEncryptionKey,
-	})
+	options.DB.EncryptionKeyProvider = dbKeyProvider
+	options.DB.RootKeyID = options.DBEncryptionKey
+
+	db, err := data.NewDB(driver, options.DB)
 	if err != nil {
 		return nil, fmt.Errorf("db: %w", err)
 	}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Move default server options from `cmd/server.go` to `server/server.go`. This seems like a more reasonable place to set defaults. Specifically, it can set defaults for nested options without exposing internal structures like `data.Options`

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
