### PR TITLE
Allow routes to specify transaction options

### DIFF
--- a/internal/server/debug.go
+++ b/internal/server/debug.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"net/http"
 	"net/http/pprof"
 
@@ -17,6 +18,7 @@ var pprofRoute = route[api.EmptyRequest, *api.EmptyResponse]{
 		omitFromTelemetry:          true,
 		omitFromDocs:               true,
 		infraVersionHeaderOptional: true,
+		txnOptions:                 &sql.TxOptions{ReadOnly: true},
 	},
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -57,6 +58,7 @@ var wellKnownJWKsRoute = route[api.EmptyRequest, WellKnownJWKResponse]{
 		omitFromDocs:               true,
 		omitFromTelemetry:          true,
 		infraVersionHeaderOptional: true,
+		txnOptions:                 &sql.TxOptions{ReadOnly: true},
 	},
 }
 

--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -30,9 +31,15 @@ func (a *API) deprecatedRoutes(noAuthnNoOrg *routeGroup) {
 	type SignupEnabledResponse struct {
 		Enabled bool `json:"enabled"`
 	}
-	addDeprecated(a, noAuthnNoOrg, http.MethodGet, "/api/signup",
-		func(c *gin.Context, _ *api.EmptyRequest) (*SignupEnabledResponse, error) {
+
+	add(a, noAuthnNoOrg, http.MethodGet, "/api/signup", route[api.EmptyRequest, *SignupEnabledResponse]{
+		handler: func(c *gin.Context, _ *api.EmptyRequest) (*SignupEnabledResponse, error) {
 			return &SignupEnabledResponse{Enabled: false}, nil
 		},
-	)
+		routeSettings: routeSettings{
+			omitFromTelemetry: true,
+			omitFromDocs:      true,
+			txnOptions:        &sql.TxOptions{ReadOnly: true},
+		},
+	})
 }


### PR DESCRIPTION
## Summary

Branched from #3302, including the changes from #3327

This PR adds TxOptions to `routeSettings`, and uses it to create read-only transactions for some routes. This would also allow us to use different isolation levels if necessary.