### PR TITLE
Fix gofmt

### DIFF
--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -33,7 +33,8 @@ jobs:
       - name: install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
       - name: run lint
-        run: make lint
+        # disable auto-fix, and enable verbose
+        run: LINT_ARGS=-v  make lint
 
   test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,11 @@ postgres:
 	@echo 'export POSTGRESQL_CONNECTION="host=localhost port=5432 user=postgres dbname=postgres password=password123"'
 
 
+LINT_ARGS ?= --fix
+
 lint:
 	(cd ./internal/tools/querylinter/cmd; go build -o ./querylinter.so -buildmode=plugin .)
-	golangci-lint run --fix
+	golangci-lint run $(LINT_ARGS)
 
 .PHONY: docs
 docs: docs/api/openapi3.json

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -12,8 +12,8 @@ var (
 	// ErrBadGateway means an invalid response was received from an upstream server (probably an OIDC provider)
 	ErrBadGateway = fmt.Errorf("bad gateway")
 
-	ErrNotFound        = fmt.Errorf("record not found")
-	ErrBadRequest      = fmt.Errorf("bad request")
-	ErrNotImplemented  = fmt.Errorf("not implemented")
-	ErrExpired         = fmt.Errorf("expired")
+	ErrNotFound       = fmt.Errorf("record not found")
+	ErrBadRequest     = fmt.Errorf("bad request")
+	ErrNotImplemented = fmt.Errorf("not implemented")
+	ErrExpired        = fmt.Errorf("expired")
 )

--- a/internal/server/redis/limit.go
+++ b/internal/server/redis/limit.go
@@ -77,10 +77,10 @@ func (lim *Limiter) LoginOK(key string) error {
 	lockout, err := lim.redis.client.Get(context.TODO(), loginKeyLockout(key)).Time()
 	switch {
 	case errors.Is(err, redis.Nil):
-	    // err is redis.Nil when the key does not exist, i.e. no previous failures
-	    return nil
+		// err is redis.Nil when the key does not exist, i.e. no previous failures
+		return nil
 	case err != nil:
-	    return err
+		return err
 	}
 
 	retryAfter := time.Until(lockout)

--- a/internal/version.go
+++ b/internal/version.go
@@ -5,10 +5,10 @@ import (
 )
 
 var (
-	Branch     = "main"
-	Version    = "99.99.99999"
-	Commit     = ""
-	Date       = ""
+	Branch  = "main"
+	Version = "99.99.99999"
+	Commit  = ""
+	Date    = ""
 )
 
 // FullVersion returns the full semantic version string. FullVersion panics if


### PR DESCRIPTION
## Summary

Looks like a recent PR merged without `gofmt` being applied. 

I think when I added the query linter I introduced a bug into our CI config.  `make lint` by default runs fixes, but we don't detect if files have changed in that job, so we were not getting lint failures for problems that were auto-fixed.

This PR fixes the `gofmt`, and fixes the CI config to run without `--fix` so that formatting problems are reported as errors.