### PR TITLE
feat: patch provider endpoint (api), edit provider (ui)

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -272,6 +272,10 @@ func (c Client) CreateProvider(req *CreateProviderRequest) (*Provider, error) {
 	return post[CreateProviderRequest, Provider](c, "/api/providers", req)
 }
 
+func (c Client) PatchProvider(req PatchProviderRequest) (*Provider, error) {
+	return patch[PatchProviderRequest, Provider](c, fmt.Sprintf("/api/providers/%s", req.ID.String()), &req)
+}
+
 func (c Client) UpdateProvider(req UpdateProviderRequest) (*Provider, error) {
 	return put[UpdateProviderRequest, Provider](c, fmt.Sprintf("/api/providers/%s", req.ID.String()), &req)
 }

--- a/api/provider.go
+++ b/api/provider.go
@@ -52,6 +52,12 @@ func (r CreateProviderRequest) ValidationRules() []validate.ValidationRule {
 	}
 }
 
+type PatchProviderRequest struct {
+	ID           uid.ID `uri:"id" json:"-"`
+	Name         string `json:"name" example:"okta"`
+	ClientSecret string `json:"clientSecret" example:"jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU"`
+}
+
 type UpdateProviderRequest struct {
 	ID           uid.ID                  `uri:"id" json:"-"`
 	Name         string                  `json:"name" example:"okta"`

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -107,6 +107,20 @@ func (a *API) CreateProvider(c *gin.Context, r *api.CreateProviderRequest) (*api
 	return provider.ToAPI(), nil
 }
 
+func (a *API) PatchProvider(c *gin.Context, r *api.PatchProviderRequest) (*api.Provider, error) {
+	provider, err := access.GetProvider(c, r.ID)
+	if err != nil {
+		return nil, err
+	}
+	if r.Name != "" {
+		provider.Name = r.Name
+	}
+	if r.ClientSecret != "" {
+		provider.ClientSecret = models.EncryptedAtRest(r.ClientSecret)
+	}
+	return nil, access.SaveProvider(c, provider)
+}
+
 func (a *API) UpdateProvider(c *gin.Context, r *api.UpdateProviderRequest) (*api.Provider, error) {
 	provider := &models.Provider{
 		Model: models.Model{

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -118,7 +118,10 @@ func (a *API) PatchProvider(c *gin.Context, r *api.PatchProviderRequest) (*api.P
 	if r.ClientSecret != "" {
 		provider.ClientSecret = models.EncryptedAtRest(r.ClientSecret)
 	}
-	return nil, access.SaveProvider(c, provider)
+	if err = access.SaveProvider(c, provider); err != nil {
+		return nil, err
+	}
+	return provider.ToAPI(), nil
 }
 
 func (a *API) UpdateProvider(c *gin.Context, r *api.UpdateProviderRequest) (*api.Provider, error) {

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -551,10 +551,8 @@ func TestAPI_PatchProvider(t *testing.T) {
 	routes := srv.GenerateRoutes()
 
 	provider := &models.Provider{
-		Name:    "private",
-		Kind:    models.ProviderKindAzure,
-		AuthURL: "https://example.com/v1/auth",
-		Scopes:  []string{"openid", "email"},
+		Name: "name",
+		Kind: models.ProviderKindOkta,
 	}
 
 	err := data.CreateProvider(srv.DB(), provider)
@@ -616,8 +614,7 @@ func TestAPI_PatchProvider(t *testing.T) {
 		{
 			name: "valid provider (no external checks)",
 			body: api.PatchProviderRequest{
-				Name:         "new-name-google",
-				ClientSecret: "new-client-secret",
+				Name: "new-name-google",
 			},
 			setup: func(t *testing.T, req *http.Request) {
 				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{})
@@ -631,15 +628,11 @@ func TestAPI_PatchProvider(t *testing.T) {
 				assert.NilError(t, err)
 
 				expected := &api.Provider{
-					ID:       respBody.ID, // does not matter
-					Name:     "google",
-					Created:  respBody.Created, // does not matter
-					Updated:  respBody.Updated, // does not matter
-					URL:      "accounts.google.com",
-					ClientID: "client-id",
-					Kind:     string(models.ProviderKindGoogle),
-					AuthURL:  "example.com/v1/auth",
-					Scopes:   []string{"openid", "email"},
+					ID:      respBody.ID, // does not matter
+					Name:    "new-name-google",
+					Created: respBody.Created, // does not matter
+					Updated: respBody.Updated, // does not matter
+					Kind:    respBody.Kind,
 				}
 				assert.DeepEqual(t, respBody, expected)
 			},

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -343,7 +343,7 @@ func TestAPI_CreateProvider(t *testing.T) {
 		{
 			name: "valid provider (name is provided)",
 			body: api.CreateProviderRequest{
-				Name:         "google-123",
+				Name:         "google-1234",
 				URL:          "accounts.google.com",
 				ClientID:     "client-id",
 				ClientSecret: "client-secret",

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -558,6 +558,11 @@ func TestAPI_PatchProvider(t *testing.T) {
 	err := data.CreateProvider(srv.DB(), provider)
 	assert.NilError(t, err)
 
+	selectors := []data.SelectorFunc{
+		data.ByOptionalName(provider.Name),
+	}
+	createdRes, err := data.ListProviders(srv.DB(), &data.Pagination{}, selectors...)
+
 	type testCase struct {
 		name     string
 		body     api.PatchProviderRequest
@@ -614,6 +619,7 @@ func TestAPI_PatchProvider(t *testing.T) {
 		{
 			name: "valid provider (no external checks)",
 			body: api.PatchProviderRequest{
+				ID:   createdRes[0].ID,
 				Name: "new-name-google",
 			},
 			setup: func(t *testing.T, req *http.Request) {

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -558,11 +558,6 @@ func TestAPI_PatchProvider(t *testing.T) {
 	err := data.CreateProvider(srv.DB(), provider)
 	assert.NilError(t, err)
 
-	selectors := []data.SelectorFunc{
-		data.ByOptionalName(provider.Name),
-	}
-	createdRes, err := data.ListProviders(srv.DB(), &data.Pagination{}, selectors...)
-
 	type testCase struct {
 		name     string
 		body     api.PatchProviderRequest
@@ -619,7 +614,7 @@ func TestAPI_PatchProvider(t *testing.T) {
 		{
 			name: "valid provider (no external checks)",
 			body: api.PatchProviderRequest{
-				ID:   createdRes[0].ID,
+				ID:   provider.ID,
 				Name: "new-name-google",
 			},
 			setup: func(t *testing.T, req *http.Request) {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -85,6 +85,7 @@ func (s *Server) GenerateRoutes() Routes {
 	del(a, authn, "/api/grants/:id", a.DeleteGrant)
 
 	post(a, authn, "/api/providers", a.CreateProvider)
+	patch(a, authn, "/api/providers/:id", a.PatchProvider)
 	put(a, authn, "/api/providers/:id", a.UpdateProvider)
 	del(a, authn, "/api/providers/:id", a.DeleteProvider)
 

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -4453,6 +4453,119 @@
           "Providers"
         ]
       },
+      "patch": {
+        "description": "PatchProvider",
+        "operationId": "PatchProvider",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.0.0",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "4yJ3n3D8E2",
+              "format": "uid",
+              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "clientSecret": {
+                    "example": "jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU",
+                    "type": "string"
+                  },
+                  "name": {
+                    "example": "okta",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Provider"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "PatchProvider",
+        "tags": [
+          "Providers"
+        ]
+      },
       "put": {
         "description": "UpdateProvider",
         "operationId": "UpdateProvider",

--- a/ui/components/role-select.js
+++ b/ui/components/role-select.js
@@ -27,8 +27,8 @@ export default function RoleSelect({
       resource && `/api/destinations?name=${hasParent ? parts[0] : resource}`
   )
 
-  let [referenceElement, setReferenceElement] = useState()
-  let [popperElement, setPopperElement] = useState()
+  const [referenceElement, setReferenceElement] = useState(null)
+  const [popperElement, setPopperElement] = useState(null)
   let { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: 'bottom-end',
     modifiers: [

--- a/ui/pages/providers/[id].js
+++ b/ui/pages/providers/[id].js
@@ -34,7 +34,6 @@ export default function ProvidersEditDetails() {
         const res = await fetch(`/api/providers/${id}`, {
           method: 'PATCH',
           body: JSON.stringify({
-            id,
             name,
             clientSecret,
           }),

--- a/ui/pages/providers/[id].js
+++ b/ui/pages/providers/[id].js
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import useSWR, { useSWRConfig } from 'swr'
+
+import ErrorMessage from '../../components/error-message'
+import Dashboard from '../../components/layouts/dashboard'
+
+export default function ProvidersEditDetails() {
+  const router = useRouter()
+
+  const id = router.query.id
+
+  const { mutate } = useSWRConfig()
+  const { data: provider } = useSWR(`/api/providers/${id}`)
+
+  const [name, setName] = useState('')
+  const [clientSecret, setClientSecret] = useState('***********')
+  const [error, setError] = useState('')
+  const [errors, setErrors] = useState({})
+
+  useEffect(() => {
+    setName(provider?.name)
+  }, [provider])
+
+  async function onSubmit(e) {
+    e.preventDefault()
+
+    setErrors({})
+    setError('')
+
+    try {
+      await mutate('/api/providers', async () => {
+        const res = await fetch(`/api/providers/${id}`, {
+          method: 'PATCH',
+          body: JSON.stringify({
+            id,
+            name,
+            clientSecret,
+          }),
+        })
+
+        const data = await res.json()
+
+        if (!res.ok) {
+          throw data
+        }
+
+        return {}
+      })
+    } catch (e) {
+      if (e.fieldErrors) {
+        const errors = {}
+        for (const error of e.fieldErrors) {
+          errors[error.fieldName.toLowerCase()] =
+            error.errors[0] || 'invalid value'
+        }
+        setErrors(errors)
+      } else {
+        setError(e.message)
+      }
+
+      return false
+    }
+
+    router.replace('/providers')
+
+    return false
+  }
+
+  return (
+    <div className='mx-auto w-full max-w-2xl'>
+      <Head>
+        <title>Edit Identity Provider</title>
+      </Head>
+      <header className='my-6 flex items-center justify-between'>
+        <h1 className='py-1 font-display text-xl font-medium'>Edit provider</h1>
+      </header>
+      <div className='flex w-full flex-col'>
+        <form onSubmit={onSubmit} className='mb-6 space-y-8'>
+          {/* Overview */}
+          <div>
+            <label className='text-2xs font-medium text-gray-700'>Name</label>
+            <input
+              type='text'
+              value={name}
+              onChange={e => {
+                setName(e.target.value)
+                setErrors({})
+                setError('')
+              }}
+              className={`mt-1 block w-full rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm ${
+                errors.name ? 'border-red-500' : 'border-gray-300'
+              }`}
+            />
+            {errors.name && <ErrorMessage message={errors.name} />}
+          </div>
+          <div className='w-full'>
+            <div className='mt-6 space-y-3'>
+              {provider?.kind !== 'google' && (
+                <div>
+                  <label className='text-2xs font-medium text-gray-700'>
+                    URL (Domain)
+                  </label>
+                  <input
+                    type='text'
+                    value={provider?.url}
+                    readOnly
+                    className={`mt-1 block w-full rounded-md border-gray-300 bg-gray-200 text-gray-600 shadow-sm focus:border-gray-300 focus:ring-0 sm:text-sm`}
+                  />
+                </div>
+              )}
+
+              <div>
+                <label className='text-2xs font-medium text-gray-700'>
+                  Client ID
+                </label>
+                <input
+                  readOnly
+                  type='search'
+                  value={provider?.clientID}
+                  className={`mt-1 block w-full rounded-md border-gray-300 bg-gray-200 text-gray-600 shadow-sm focus:border-gray-300 focus:ring-0 sm:text-sm`}
+                />
+              </div>
+
+              <div>
+                <label className='text-2xs font-medium text-gray-700'>
+                  Client Secret
+                </label>
+                <input
+                  type='password'
+                  value={clientSecret}
+                  onFocus={() => setClientSecret('')}
+                  onChange={e => {
+                    setClientSecret(e.target.value)
+                    setErrors({})
+                    setError('')
+                  }}
+                  className={`mt-1 block w-full rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm ${
+                    errors.clientsecret ? 'border-red-500' : 'border-gray-300'
+                  }`}
+                />
+                {errors.clientsecret && (
+                  <ErrorMessage message={errors.clientsecret} />
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className='flex items-center justify-between'>
+            <div>{error && <ErrorMessage message={error} />}</div>
+            <div className='pt-5 pb-3'>
+              <button
+                type='submit'
+                className='inline-flex items-center rounded-md border border-transparent bg-black px-4 py-2 text-xs font-medium text-white shadow-sm hover:bg-gray-800'
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+ProvidersEditDetails.layout = page => <Dashboard> {page}</Dashboard>

--- a/ui/pages/providers/add.js
+++ b/ui/pages/providers/add.js
@@ -353,7 +353,7 @@ export default function ProvidersAddDetails() {
               </div>
             </div>
           )}
-          {error && <ErrorMessage message={error} center />}
+          {error && <ErrorMessage message={error} />}
 
           <div className='flex items-center justify-end space-x-3 pt-5 pb-3'>
             <button

--- a/ui/pages/providers/index.js
+++ b/ui/pages/providers/index.js
@@ -2,8 +2,13 @@ import useSWR from 'swr'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import dayjs from 'dayjs'
+import { usePopper } from 'react-popper'
+import { Menu, Transition } from '@headlessui/react'
+import * as ReactDOM from 'react-dom'
+
+import { DotsHorizontalIcon, XIcon, PencilIcon } from '@heroicons/react/outline'
 
 import Table from '../../components/table'
 import Dashboard from '../../components/layouts/dashboard'
@@ -92,25 +97,96 @@ export default function Providers() {
             accessorKey: 'clientID',
           },
           {
+            id: 'actions',
             cell: function Cell(info) {
-              const [open, setOpen] = useState(false)
+              const [deleteOpen, setDeleteOpen] = useState(false)
+              let [referenceElement, setReferenceElement] = useState()
+              let [popperElement, setPopperElement] = useState()
+              let { styles, attributes } = usePopper(
+                referenceElement,
+                popperElement,
+                {
+                  placement: 'bottom-end',
+                  modifiers: [
+                    {
+                      name: 'flip',
+                      enabled: false,
+                    },
+                  ],
+                }
+              )
+
               return (
-                <div className='text-right'>
-                  <button
-                    onClick={() => setOpen(true)}
-                    className='p-1 text-2xs text-gray-500/75 hover:text-gray-600'
-                  >
-                    Remove
-                    <span className='sr-only'>{info.row.original.name}</span>
-                  </button>
+                <div className='flex justify-end'>
+                  <Menu as='div' className='relative inline-block text-left'>
+                    <Menu.Button
+                      ref={setReferenceElement}
+                      className='cursor-pointer rounded-md border border-transparent px-1 text-gray-400 hover:bg-gray-50 hover:text-gray-600 group-hover:border-gray-200 group-hover:text-gray-500 group-hover:shadow-md group-hover:shadow-gray-300/20'
+                    >
+                      <DotsHorizontalIcon className='z-0 h-[18px]' />
+                    </Menu.Button>
+                    {ReactDOM.createPortal(
+                      <div
+                        ref={setPopperElement}
+                        style={styles.popper}
+                        {...attributes.popper}
+                      >
+                        <Transition
+                          as={Fragment}
+                          enter='transition ease-out duration-100'
+                          enterFrom='transform opacity-0 scale-95'
+                          enterTo='transform opacity-100 scale-100'
+                          leave='transition ease-in duration-75'
+                          leaveFrom='transform opacity-100 scale-100'
+                          leaveTo='transform opacity-0 scale-95'
+                        >
+                          <Menu.Items className='absolute right-0 z-10 mt-2 w-40 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg shadow-gray-300/20 ring-1 ring-black ring-opacity-5 focus:outline-none'>
+                            <div className='px-1 py-1'>
+                              <Menu.Item>
+                                {({ active }) => (
+                                  <button
+                                    className={`${
+                                      active ? 'bg-gray-50' : 'bg-white'
+                                    } group flex w-full items-center rounded-md px-2 py-1.5 text-xs font-medium text-gray-600`}
+                                    onClick={() =>
+                                      router.replace(
+                                        `/providers/${info.row.original.id}`
+                                      )
+                                    }
+                                  >
+                                    <PencilIcon className='mr-1 mt-px h-3.5 w-3.5' />{' '}
+                                    Edit
+                                  </button>
+                                )}
+                              </Menu.Item>
+                              <Menu.Item>
+                                {({ active }) => (
+                                  <button
+                                    className={`${
+                                      active ? 'bg-gray-50' : 'bg-white'
+                                    } group flex w-full items-center rounded-md px-2 py-1.5 text-xs font-medium text-red-500`}
+                                    onClick={() => setDeleteOpen(true)}
+                                  >
+                                    <XIcon className='mr-1 mt-px h-3.5 w-3.5' />{' '}
+                                    Remove
+                                  </button>
+                                )}
+                              </Menu.Item>
+                            </div>
+                          </Menu.Items>
+                        </Transition>
+                      </div>,
+                      document.querySelector('body')
+                    )}
+                  </Menu>
                   <DeleteModal
-                    open={open}
-                    setOpen={setOpen}
+                    open={deleteOpen}
+                    setOpen={setDeleteOpen}
                     onSubmit={async () => {
                       await fetch(`/api/providers/${info.row.original.id}`, {
                         method: 'DELETE',
                       })
-                      setOpen(false)
+                      setDeleteOpen(false)
 
                       mutate({
                         items: providers.filter(
@@ -132,7 +208,6 @@ export default function Providers() {
                 </div>
               )
             },
-            id: 'delete',
           },
         ]}
       />

--- a/ui/pages/providers/index.js
+++ b/ui/pages/providers/index.js
@@ -100,8 +100,8 @@ export default function Providers() {
             id: 'actions',
             cell: function Cell(info) {
               const [deleteOpen, setDeleteOpen] = useState(false)
-              let [referenceElement, setReferenceElement] = useState()
-              let [popperElement, setPopperElement] = useState()
+              const [referenceElement, setReferenceElement] = useState(null)
+              const [popperElement, setPopperElement] = useState(null)
               let { styles, attributes } = usePopper(
                 referenceElement,
                 popperElement,

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -325,8 +325,8 @@ export default function Users() {
             id: 'actions',
             cell: function Cell(info) {
               const [open, setOpen] = useState(false)
-              let [referenceElement, setReferenceElement] = useState()
-              let [popperElement, setPopperElement] = useState()
+              const [referenceElement, setReferenceElement] = useState(null)
+              const [popperElement, setPopperElement] = useState(null)
               let { styles, attributes } = usePopper(
                 referenceElement,
                 popperElement,


### PR DESCRIPTION
## Summary

https://user-images.githubusercontent.com/20054646/192602353-20db233a-7222-43eb-987b-7f53d967926b.mov

## Details

- Added a patch endpoint to allow partial update to provider, so the front end does not have to populate all the fields
- Created an edit provider page, where user can set a new provider name or provider secret 
- Changed text 'remove' into a '...' icon with a dropdown for edit and remove
