### PR TITLE
Add a check to the data migration test

### DIFF
--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -861,7 +861,7 @@ func dumpSchema(t *testing.T, conn string, args ...string) string {
 
 	out := new(bytes.Buffer)
 	// https://www.postgresql.org/docs/current/app-pgdump.html
-	args = append([]string{"--no-owner", "--no-tablespaces", "--schema=testing"}, args...)
+	args = append(args, "--no-owner", "--no-tablespaces", "--schema=testing")
 	cmd := exec.Command("pg_dump", args...)
 	cmd.Env = envs
 	cmd.Stdout = out


### PR DESCRIPTION
This will ensure that we don't leave stale test data in the database, which could cause subsequent test cases to fail.

Also adds a missing `DELETE` to cleanup some stale entries from an existing test case.
