### PR TITLE
maintain: migrate provider user data to direct sql

### DIFF
--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -170,7 +170,7 @@ func UpdateIdentityInfoFromProvider(c RequestContext, oidc providers.OIDCClient)
 			logging.Errorf("failed to revoke invalid user session: %s", nestedErr)
 		}
 
-		if nestedErr := data.DeleteProviderUsers(db, data.ByIdentityID(identity.ID), data.ByProviderID(provider.ID)); nestedErr != nil {
+		if nestedErr := data.DeleteProviderUsers(db, data.DeleteProviderUsersOptions{ByIdentityID: identity.ID, ByProviderID: provider.ID}); nestedErr != nil {
 			logging.Errorf("failed to delete provider user: %s", nestedErr)
 		}
 

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -52,7 +52,7 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 	for _, p := range toDelete {
 		ids = append(ids, p.ID)
 
-		providerUsers, err := ListProviderUsers(db, p.ID)
+		providerUsers, err := listProviderUsers(db, p.ID)
 		if err != nil {
 			return fmt.Errorf("listing provider users: %w", err)
 		}

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -52,7 +52,7 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 	for _, p := range toDelete {
 		ids = append(ids, p.ID)
 
-		providerUsers, err := ListProviderUsers(db, nil, ByProviderID(p.ID))
+		providerUsers, err := ListProviderUsers(db, p.ID)
 		if err != nil {
 			return fmt.Errorf("listing provider users: %w", err)
 		}
@@ -79,7 +79,7 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 			}
 		}
 
-		if err := DeleteProviderUsers(db, ByProviderID(p.ID)); err != nil {
+		if err := DeleteProviderUsers(db, DeleteProviderUsersOptions{ByProviderID: p.ID}); err != nil {
 			return fmt.Errorf("delete provider users: %w", err)
 		}
 

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -93,14 +93,13 @@ func UpdateProviderUser(tx WriteTxn, providerUser *models.ProviderUser) error {
 	return handleError(err)
 }
 
-func ListProviderUsers(tx ReadTxn, providerID uid.ID) ([]models.ProviderUser, error) {
+func listProviderUsers(tx ReadTxn, providerID uid.ID) ([]models.ProviderUser, error) {
 	table := &providerUserTable{}
 	query := querybuilder.New("SELECT")
 	query.B(columnsForSelect(table))
 	query.B("FROM")
 	query.B(table.Table())
 	query.B("WHERE provider_id = ?", providerID)
-	query.B("ORDER BY email ASC")
 	rows, err := tx.Query(query.String(), query.Args...)
 	if err != nil {
 		return nil, err

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -73,17 +73,13 @@ func TestSyncProviderUser(t *testing.T) {
 					err = CreateIdentity(db, user)
 					assert.NilError(t, err)
 
-					pu := &models.ProviderUser{
-						ProviderID: provider.ID,
-						IdentityID: user.ID,
+					pu, err := CreateProviderUser(db, provider, user)
+					assert.NilError(t, err)
 
-						Email:        user.Name,
-						RedirectURL:  "http://example.com",
-						AccessToken:  models.EncryptedAtRest("aaa"),
-						RefreshToken: models.EncryptedAtRest("bbb"),
-						ExpiresAt:    time.Now().UTC().Add(-5 * time.Minute),
-						LastUpdate:   time.Now().UTC().Add(-1 * time.Hour),
-					}
+					pu.RedirectURL = "http://example.com"
+					pu.AccessToken = models.EncryptedAtRest("aaa")
+					pu.RefreshToken = models.EncryptedAtRest("bbb")
+					pu.ExpiresAt = time.Now().UTC().Add(-5 * time.Minute)
 
 					err = UpdateProviderUser(db, pu)
 					assert.NilError(t, err)
@@ -137,17 +133,13 @@ func TestSyncProviderUser(t *testing.T) {
 					err = CreateIdentity(db, user)
 					assert.NilError(t, err)
 
-					pu := &models.ProviderUser{
-						ProviderID: provider.ID,
-						IdentityID: user.ID,
+					pu, err := CreateProviderUser(db, provider, user)
+					assert.NilError(t, err)
 
-						Email:        user.Name,
-						RedirectURL:  "http://example.com",
-						AccessToken:  models.EncryptedAtRest("aaa"),
-						RefreshToken: models.EncryptedAtRest("bbb"),
-						ExpiresAt:    time.Now().UTC().Add(5 * time.Minute),
-						LastUpdate:   time.Now().UTC().Add(-1 * time.Hour),
-					}
+					pu.RedirectURL = "http://example.com"
+					pu.AccessToken = models.EncryptedAtRest("aaa")
+					pu.RefreshToken = models.EncryptedAtRest("bbb")
+					pu.ExpiresAt = time.Now().UTC().Add(5 * time.Minute)
 
 					err = UpdateProviderUser(db, pu)
 					assert.NilError(t, err)
@@ -250,7 +242,7 @@ func TestDeleteProviderUser(t *testing.T) {
 		assert.NilError(t, err)
 
 		// hard delete the provider user
-		err = DeleteProviderUsers(db, ByIdentityID(user.ID), ByProviderID(provider.ID))
+		err = DeleteProviderUsers(db, DeleteProviderUsersOptions{ByIdentityID: user.ID, ByProviderID: provider.ID})
 		assert.NilError(t, err)
 
 		// provider user no longer exists

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -610,7 +610,7 @@ func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 		t.Run("as a user", func(t *testing.T) {
 			ctx := loginAs(db, user)
 			t.Run("with no existing infra user", func(t *testing.T) {
-				err = data.DeleteProviderUsers(db, data.ByIdentityID(user.ID), data.ByProviderID(data.InfraProvider(db).ID))
+				err = data.DeleteProviderUsers(db, data.DeleteProviderUsersOptions{ByIdentityID: user.ID, ByProviderID: data.InfraProvider(db).ID})
 				assert.NilError(t, err)
 
 				cred, _ := data.GetCredential(db, data.ByIdentityID(user.ID))
@@ -798,7 +798,7 @@ func TestAPI_UpdateUser(t *testing.T) {
 		tc.expected(t, resp)
 	}
 
-	var testCases = []testCase{
+	testCases := []testCase{
 		{
 			name: "not authenticated",
 			setup: func(t *testing.T, req *http.Request) {


### PR DESCRIPTION
## Summary
No functional changes here. As a part of SCIM user management I need to be able to apply custom SCIM queries to the provider user look-up. This is much easier using direct SQL so updating the provider user to use the direct SQL now.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

