### PR TITLE
Fix order of provider_user index

### DIFF
--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -68,6 +68,7 @@ func migrations() []*migrator.Migration {
 		setDefaultOrgID(),
 		addIdentityVerifiedFields(),
 		cleanCrossOrgGroupMemberships(),
+		fixProviderUserIndex(),
 		// next one here
 	}
 }
@@ -676,6 +677,21 @@ func cleanCrossOrgGroupMemberships() *migrator.Migration {
 			}
 
 			return nil
+		},
+	}
+}
+
+func fixProviderUserIndex() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-09-22T13:00:00",
+		Migrate: func(tx migrator.DB) error {
+			stmt := `
+ALTER TABLE provider_users DROP CONSTRAINT IF EXISTS provider_users_pkey;
+ALTER TABLE provider_users ADD CONSTRAINT
+    provider_users_pkey PRIMARY KEY (provider_id, identity_id);
+`
+			_, err := tx.Exec(stmt)
+			return err
 		},
 	}
 }

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -714,6 +714,20 @@ DELETE FROM settings WHERE id=24567;
 				}
 			},
 		},
+		{
+			label: testCaseLine("2022-09-22T13:00:00"),
+			setup: func(t *testing.T, db WriteTxn) {
+				_, err := db.Exec("INSERT INTO provider_users(provider_id, identity_id) VALUES(1001, 1002)")
+				assert.NilError(t, err)
+			},
+			cleanup: func(t *testing.T, db WriteTxn) {
+				_, err := db.Exec("DELETE FROM provider_users")
+				assert.NilError(t, err)
+			},
+			expected: func(t *testing.T, db WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -266,7 +266,7 @@ ALTER TABLE ONLY password_reset_tokens
     ADD CONSTRAINT password_reset_tokens_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY provider_users
-    ADD CONSTRAINT provider_users_pkey PRIMARY KEY (identity_id, provider_id);
+    ADD CONSTRAINT provider_users_pkey PRIMARY KEY (provider_id, identity_id);
 
 ALTER TABLE ONLY providers
     ADD CONSTRAINT providers_pkey PRIMARY KEY (id);


### PR DESCRIPTION
`gorm` created the index as `PRIMARY KEY (identity_id, provider_id)`

Looking at the queries in #3345 we can see that while some queries use a `WHERE` clause with both of these, two of the queries can use only the `provider_id`. The order of the columns in the index matters. 

https://www.postgresql.org/docs/current/indexes-multicolumn.html has this to say about it (the default index type should be b-tree, even though it's not in the statement, [ref](https://www.postgresql.org/docs/current/indexes-unique.html)).

>A multicolumn B-tree index can be used with query conditions that involve any subset of the index's columns, but the index is most efficient when there are constraints on the leading (leftmost) columns. The exact rule is that equality constraints on leading columns, plus any inequality constraints on the first column that does not have an equality constraint, will be used to limit the portion of the index that is scanned. Constraints on columns to the right of these columns are checked in the index, so they save visits to the table proper, but they do not reduce the portion of the index that has to be scanned.

Since this index includes all the rows in the table, we would have to scan the full index if we did not include an `identity_id`.

We always query with a `provider_id`, but not always with an `identity_id`, so re-ordering this index ensures we can always use it optimally.