### PR TITLE
fix: use correct case when sending forgot domain email

### DIFF
--- a/internal/server/data/forgotdomain.go
+++ b/internal/server/data/forgotdomain.go
@@ -22,7 +22,7 @@ func GetForgottenDomainsForEmail(tx ReadTxn, email string) ([]models.ForgottenDo
 		if err := rows.Scan(&r.OrganizationName, &r.OrganizationDomain, &lastSeenAt); err != nil {
 			return results, err
 		}
-		r.LastSeenAt = format.HumanTime(lastSeenAt, "never")
+		r.LastSeenAt = format.HumanTimeWithCase(lastSeenAt, "never", false)
 		results = append(results, r)
 	}
 

--- a/internal/server/data/forgotdomain_test.go
+++ b/internal/server/data/forgotdomain_test.go
@@ -40,7 +40,7 @@ func TestGetForgottenDomainsForEmail(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Assert(t, len(results) == 1)
 
-			assert.DeepEqual(t, results[0], models.ForgottenDomain{OrganizationName: orgA.Name, OrganizationDomain: orgA.Domain, LastSeenAt: format.HumanTime(time.Now(), "never")})
+			assert.DeepEqual(t, results[0], models.ForgottenDomain{OrganizationName: orgA.Name, OrganizationDomain: orgA.Domain, LastSeenAt: format.HumanTimeWithCase(time.Now(), "never", false)})
 		})
 
 		userB := &models.Identity{Name: "john.smith@ateam.com", OrganizationMember: models.OrganizationMember{OrganizationID: orgB.ID}}


### PR DESCRIPTION
## Summary

The forgot domain email was not using the correct capitalization inside the last seen field.

## Checklist

- [x] Wrote appropriate unit tests
