### PR TITLE
Allow the connector to run outside of a kube pod (part 2)

### DIFF
--- a/api/destination.go
+++ b/api/destination.go
@@ -23,6 +23,7 @@ type Destination struct {
 }
 
 type DestinationConnection struct {
+	// TODO: URL is not a full url, it's set to a host:port by the connector
 	URL string `json:"url" example:"aa60eexample.us-west-2.elb.amazonaws.com"`
 	CA  PEM    `json:"ca" example:"-----BEGIN CERTIFICATE-----\nMIIDNTCCAh2gAwIBAgIRALRetnpcTo9O3V2fAK3ix+c\n-----END CERTIFICATE-----\n"`
 }

--- a/internal/cmd/types/url.go
+++ b/internal/cmd/types/url.go
@@ -1,7 +1,11 @@
 package types
 
 import (
+	"errors"
+	"fmt"
+	"net"
 	"net/url"
+	"strconv"
 
 	"github.com/goware/urlx"
 )
@@ -32,4 +36,40 @@ func (u *URL) Type() string {
 
 func (u *URL) Value() *url.URL {
 	return (*url.URL)(u)
+}
+
+// HostPort is used to accept hostnames or IP addresses that may include an
+// optional port.
+type HostPort struct {
+	Host string
+	Port int
+}
+
+func (h *HostPort) Set(raw string) error {
+	host, port, err := net.SplitHostPort(raw)
+	addrErr := &net.AddrError{}
+	switch {
+	case errors.As(err, &addrErr) && addrErr.Err == "missing port in address":
+		h.Host = raw
+		return nil
+	case err != nil:
+		return err
+	}
+	h.Host = host
+	h.Port, err = strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("port %q must be a number", port)
+	}
+	return nil
+}
+
+func (h *HostPort) String() string {
+	if h.Port == 0 {
+		return h.Host
+	}
+	return net.JoinHostPort(h.Host, strconv.Itoa(h.Port))
+}
+
+func (h *HostPort) Type() string {
+	return "hostname"
 }

--- a/internal/cmd/types/url_test.go
+++ b/internal/cmd/types/url_test.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHostPort(t *testing.T) {
+	type testCase struct {
+		name        string
+		input       string
+		expectedErr string
+		expected    HostPort
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		hp := HostPort{}
+		err := hp.Set(tc.input)
+
+		if tc.expectedErr != "" {
+			assert.ErrorContains(t, err, tc.expectedErr)
+			return
+		}
+		assert.NilError(t, err)
+		assert.DeepEqual(t, hp, tc.expected)
+	}
+
+	testCases := []testCase{
+		{
+			name:     "ipv4 address",
+			input:    "10.10.10.1",
+			expected: HostPort{Host: "10.10.10.1"},
+		},
+		{
+			name:     "ipv4 with port",
+			input:    "10.10.10.1:1010",
+			expected: HostPort{Host: "10.10.10.1", Port: 1010},
+		},
+		{
+			name:     "hostname",
+			input:    "example.com",
+			expected: HostPort{Host: "example.com"},
+		},
+		{
+			name:     "hostname with port",
+			input:    "example.com:8080",
+			expected: HostPort{Host: "example.com", Port: 8080},
+		},
+		{
+			name:     "ipv6 address",
+			input:    "[aa00:aa00:aa00:aa00:aa00:aa00]",
+			expected: HostPort{Host: "[aa00:aa00:aa00:aa00:aa00:aa00]"},
+		},
+		{
+			name:     "ipv6 address with port",
+			input:    "[aa00:aa00:aa00:aa00:aa00:aa00]:8080",
+			expected: HostPort{Host: "aa00:aa00:aa00:aa00:aa00:aa00", Port: 8080},
+		},
+		{
+			name:        "invalid input",
+			input:       "10:10:10",
+			expectedErr: "too many colons in address",
+		},
+		{
+			name:        "invalid port",
+			input:       "localhost:dog",
+			expectedErr: `port "dog" must be a number`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -44,6 +44,8 @@ type Options struct {
 	// This value is sent to the infra API server to update the
 	// Destination.Connection.URL.
 	EndpointAddr types.HostPort
+
+	Kubernetes KubernetesOptions
 }
 
 type ServerOptions struct {
@@ -58,6 +60,19 @@ type ListenerOptions struct {
 	Metrics string
 }
 
+type KubernetesOptions struct {
+	// AuthToken may be used to override the token used to authenticate with the
+	// kubernetes API server. When the connector is run in-cluster, the
+	// service account associated with the pod will be used by default.
+	// When run outside of cluster there is no default, and this value must
+	// be set to a token that has permission to impersonate users in the cluster.
+	AuthToken types.StringOrFile
+
+	// Host is looked up from either the in-cluster config, or the kubectl
+	// config.
+	// CA is looked up from either the in-cluster config or the kubectl config.
+}
+
 // connector stores all the dependencies for the connector operations.
 type connector struct {
 	k8s         *kubernetes.Kubernetes
@@ -68,7 +83,7 @@ type connector struct {
 }
 
 func Run(ctx context.Context, options Options) error {
-	k8s, err := kubernetes.NewKubernetes()
+	k8s, err := kubernetes.NewKubernetes(options.Kubernetes.AuthToken.String())
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -32,10 +32,14 @@ type Kubernetes struct {
 	Config *rest.Config
 }
 
-func NewKubernetes() (*Kubernetes, error) {
+func NewKubernetes(authToken string) (*Kubernetes, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
+	}
+
+	if authToken != "" {
+		config.BearerToken = authToken
 	}
 
 	if err := rest.LoadTLSFiles(config); err != nil {


### PR DESCRIPTION
## Summary

Branched from #2613

This PR completes the work to allow the connector to run outside of a kube pod (primarily for testing).

Two options are added to the connector config (both can be omitted when run from inside the cluster, and are documented as being optional).
* `endpointAddr` - is the address of the connector proxy that is sent to the Infra API, to tell clients where to connect. Sometimes this will be the same value as `addrs.https`, but it may be different if there are load balancers or other proxies in-between. When set this allows us to skip the "lookup service host and port" steps, which require the service to exist in kuberenetes.
* `kubernetes.authToken` - gives us a way to specify a token (likely for a service account) that will be used to communicate with the kube API. I set this up locally using the following:

```
kubectl create serviceaccount infra-connector
kubectl create token infra-connector > kube.token
kubectl create clusterrolebinding infra-connector --clusterrole=cluster-admin --serviceaccount=default:infra-connector
```

For now the kube API hostname/port, and kube API CA are both still being looked up from either in-cluster, or the kubeconfig, but it might make more sense to specify those as options directly (instead of falling back to kubeconfig).

Resolves #2500
