### PR TITLE
feat(agent): add retries to tolerate minor interruptions

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/term"
@@ -57,6 +58,7 @@ func isTerminal() bool {
 // UseFileLogger changes L to a logger that writes log output to a file that is
 // rotated.
 func UseFileLogger(filepath string) {
+	zerolog.TimeFieldFormat = time.RFC3339
 	writer := &lumberjack.Logger{
 		Filename:   filepath,
 		MaxSize:    10, // megabytes


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Add a counter to the infra agent. When a request fails, it increments the counter and halt the loop. If the counter exceeds the threshold, the agent will exit. This allows the agent to tolerate some interruption from the upstream service. 

The previous agent will exit immediately after getting an error. This can be frustrating if there's any minor interruptions, maybe due to network instability or long request times.
