### PR TITLE
fix: domain error msg did not show up

### DIFF
--- a/ui/pages/signup/index.js
+++ b/ui/pages/signup/index.js
@@ -52,6 +52,10 @@ export default function Signup() {
         for (const error of e.fieldErrors) {
           errors[error.fieldName.toLowerCase()] =
             error.errors[0] || 'invalid value'
+
+          if (error.fieldName.toLowerCase() === 'org.subdomain') {
+            errors.domain = errors[error.fieldName.toLowerCase()]
+          }
         }
         setErrors(errors)
       } else {

--- a/ui/pages/signup/index.js
+++ b/ui/pages/signup/index.js
@@ -174,16 +174,14 @@ export default function Signup() {
                   setError('')
                 }}
                 className={`block w-full min-w-0 rounded-l-lg px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm ${
-                  errors['org.subdomain'] ? 'border-red-500' : 'border-gray-300'
+                  errors.domain ? 'border-red-500' : 'border-gray-300'
                 }`}
               />
               <span className='inline-flex select-none items-center rounded-r-lg border border-l-0 border-gray-300 bg-gray-50 px-3 text-2xs text-gray-500 shadow-sm'>
                 .{baseDomain}
               </span>
             </div>
-            {errors['org.subdomain'] && (
-              <ErrorMessage message={errors['org.subdomain']} />
-            )}
+            {errors.domain && <ErrorMessage message={errors.domain} />}
           </div>
         </div>
         <button


### PR DESCRIPTION
## Summary
The problem that the domain error msg did not show up was because the fieldname is not consistent for different type of error message 

for domain field, there is two types of error messages 
1. validation error 
2. conflict (when the name is being taken)

and between these two error messages, the fieldnames are different:

{"code":400,"message":"validation failed: **org.subDomain**: infra is reserved and can not be used","fieldErrors":[{"fieldName":"org.subDomain","errors":["infra is reserved and can not be used"]}]}

v.s.

{"code":409,"message":"create org on sign-up: creating org: an organization with that domain already exists","fieldErrors":[{"fieldName":"**domain**","errors":[" an organization with that domain already exists"]}]}

If it is possible we should standardize it for different type of error messages so that the client side doesn't need to check what type of error it is. 

## 📷 

<img width="466" alt="Screen Shot 2022-09-30 at 10 00 37 AM" src="https://user-images.githubusercontent.com/63033505/193286885-058e1baa-1a82-48c0-99ab-7b222ee64c1d.png">
<img width="738" alt="Screen Shot 2022-09-30 at 9 40 12 AM" src="https://user-images.githubusercontent.com/63033505/193286888-219eee76-8ea5-4368-bade-5c560d02c2dc.png">
<img width="747" alt="Screen Shot 2022-09-30 at 10 23 45 AM" src="https://user-images.githubusercontent.com/63033505/193291621-4b57b8f6-dec4-44f8-b9b6-bf140de5c770.png">


## Related Issues

Resolves #3332 
