### PR TITLE
fix: use the correct field name in org conflict error

### DIFF
--- a/internal/server/data/passwordresettoken.go
+++ b/internal/server/data/passwordresettoken.go
@@ -30,6 +30,7 @@ retry:
 
 	tries++
 	if err = save(db, prt); err != nil {
+		// TODO: must use errors.As for error types
 		if tries <= 3 && errors.Is(err, UniqueConstraintError{}) {
 			logging.Warnf("generated random token %q already exists in the database", token)
 			goto retry // on the off chance the token exists.

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -80,12 +80,29 @@ func TestSendAPIError(t *testing.T) {
 			result: api.Error{Code: http.StatusNotImplemented, Message: "not implemented"},
 		},
 		{
-			err: data.UniqueConstraintError{Table: "user", Column: "name"},
+			err: fmt.Errorf("with context: %w",
+				data.UniqueConstraintError{Table: "user", Column: "name"}),
 			result: api.Error{
 				Code:    http.StatusConflict,
-				Message: "a user with that name already exists",
+				Message: "with context: a user with that name already exists",
 				FieldErrors: []api.FieldError{
 					{FieldName: "name", Errors: []string{"a user with that name already exists"}},
+				},
+			},
+		},
+		{
+			err: api.Error{
+				Code:    http.StatusLocked,
+				Message: "it's locked",
+				FieldErrors: []api.FieldError{
+					{FieldName: "first", Errors: []string{"at max callers"}},
+				},
+			},
+			result: api.Error{
+				Code:    http.StatusLocked,
+				Message: "it's locked",
+				FieldErrors: []api.FieldError{
+					{FieldName: "first", Errors: []string{"at max callers"}},
 				},
 			},
 		},


### PR DESCRIPTION
Use the field name `org.subDomain` so that the UI, and other clients, can correctly associate the error with an input field.

Changing the `UniqueConstraintError.Column` to `org.subDomain` works to fix the field, but then the error becomes "an organization with that org.subDomain already exists", which is unfortunate. We could have added another field to `data.UniqueConstraintError` that would only be used by the API, but that seems like it's fixing the problem in the wrong place.

This PR takes the approach of changing `sendAPIError` to handle an already constructed `api.Error`. This allows API handlers to deal with special cases themselves. This approach also avoids a problem with unwrapping the error to make that modification directly, which would cause us to lose any fmt.Errorf context we added to the error.

Related to #3353
Resolves https://github.com/infrahq/infra/issues/3332