### PR TITLE
Use SQL for Destination{Create,Update,Delete}

### DIFF
--- a/internal/access/destination.go
+++ b/internal/access/destination.go
@@ -44,5 +44,5 @@ func DeleteDestination(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "destination", "delete", models.InfraAdminRole)
 	}
 
-	return data.DeleteDestinations(db, data.ByID(id))
+	return data.DeleteDestination(db, id)
 }

--- a/internal/access/destination.go
+++ b/internal/access/destination.go
@@ -24,7 +24,7 @@ func SaveDestination(rCtx RequestContext, destination *models.Destination) error
 		return HandleAuthErr(err, "destination", "update", roles...)
 	}
 
-	return data.SaveDestination(rCtx.DBTxn, destination)
+	return data.UpdateDestination(rCtx.DBTxn, destination)
 }
 
 func GetDestination(c *gin.Context, id uid.ID) (*models.Destination, error) {

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -439,9 +439,9 @@ func handleError(err error) error {
 				"idx_groups_name":             "name",
 				"idx_providers_name":          "name",
 				"idx_access_keys_name":        "name",
-				"idx_destinations_unique_id":  "uniqueId",
+				"idx_destinations_unique_id":  "uniqueID",
 				"idx_access_keys_key_id":      "keyId",
-				"idx_credentials_identity_id": "identityId",
+				"idx_credentials_identity_id": "identityID",
 				"idx_organizations_domain":    "domain",
 			}
 

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -29,16 +29,19 @@ func (d *destinationsTable) ScanFields() []any {
 
 func validateDestination(dest *models.Destination) error {
 	if dest.Name == "" {
-		return fmt.Errorf("name is required")
+		return fmt.Errorf("Destination.Name is required")
+	}
+	if dest.UniqueID == "" {
+		return fmt.Errorf("Destination.UniqueID is required")
 	}
 	return nil
 }
 
-func CreateDestination(db GormTxn, destination *models.Destination) error {
+func CreateDestination(db WriteTxn, destination *models.Destination) error {
 	if err := validateDestination(destination); err != nil {
 		return err
 	}
-	return add(db, destination)
+	return insert(db, (*destinationsTable)(destination))
 }
 
 func SaveDestination(db GormTxn, destination *models.Destination) error {

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -27,6 +27,23 @@ func (d *destinationsTable) ScanFields() []any {
 	return []any{&d.ConnectionCA, &d.ConnectionURL, &d.CreatedAt, &d.DeletedAt, &d.ID, &d.LastSeenAt, &d.Name, &d.OrganizationID, &d.Resources, &d.Roles, &d.UniqueID, &d.UpdatedAt, &d.Version}
 }
 
+// destinationsUpdateTable is used to update the destination. It excludes
+// the CreatedAt field, because that field is not part of the input to
+// UpdateDestination.
+type destinationsUpdateTable models.Destination
+
+func (d destinationsUpdateTable) Table() string {
+	return "destinations"
+}
+
+func (d destinationsUpdateTable) Columns() []string {
+	return []string{"connection_ca", "connection_url", "deleted_at", "id", "last_seen_at", "name", "organization_id", "resources", "roles", "unique_id", "updated_at", "version"}
+}
+
+func (d destinationsUpdateTable) Values() []any {
+	return []any{d.ConnectionCA, d.ConnectionURL, d.DeletedAt, d.ID, d.LastSeenAt, d.Name, d.OrganizationID, d.Resources, d.Roles, d.UniqueID, d.UpdatedAt, d.Version}
+}
+
 func validateDestination(dest *models.Destination) error {
 	if dest.Name == "" {
 		return fmt.Errorf("Destination.Name is required")
@@ -37,18 +54,18 @@ func validateDestination(dest *models.Destination) error {
 	return nil
 }
 
-func CreateDestination(db WriteTxn, destination *models.Destination) error {
+func CreateDestination(tx WriteTxn, destination *models.Destination) error {
 	if err := validateDestination(destination); err != nil {
 		return err
 	}
-	return insert(db, (*destinationsTable)(destination))
+	return insert(tx, (*destinationsTable)(destination))
 }
 
-func SaveDestination(db GormTxn, destination *models.Destination) error {
+func UpdateDestination(tx WriteTxn, destination *models.Destination) error {
 	if err := validateDestination(destination); err != nil {
 		return err
 	}
-	return save(db, destination)
+	return update(tx, (*destinationsUpdateTable)(destination))
 }
 
 func GetDestination(db GormTxn, selectors ...SelectorFunc) (*models.Destination, error) {

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -9,6 +9,24 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+type destinationsTable models.Destination
+
+func (d destinationsTable) Table() string {
+	return "destinations"
+}
+
+func (d destinationsTable) Columns() []string {
+	return []string{"connection_ca", "connection_url", "created_at", "deleted_at", "id", "last_seen_at", "name", "organization_id", "resources", "roles", "unique_id", "updated_at", "version"}
+}
+
+func (d destinationsTable) Values() []any {
+	return []any{d.ConnectionCA, d.ConnectionURL, d.CreatedAt, d.DeletedAt, d.ID, d.LastSeenAt, d.Name, d.OrganizationID, d.Resources, d.Roles, d.UniqueID, d.UpdatedAt, d.Version}
+}
+
+func (d *destinationsTable) ScanFields() []any {
+	return []any{&d.ConnectionCA, &d.ConnectionURL, &d.CreatedAt, &d.DeletedAt, &d.ID, &d.LastSeenAt, &d.Name, &d.OrganizationID, &d.Resources, &d.Roles, &d.UniqueID, &d.UpdatedAt, &d.Version}
+}
+
 func validateDestination(dest *models.Destination) error {
 	if dest.Name == "" {
 		return fmt.Errorf("name is required")

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -7,6 +7,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -121,6 +122,21 @@ func TestUpdateDestination(t *testing.T) {
 			}
 			assert.DeepEqual(t, actual, expected, cmpModel)
 		})
+	})
+}
+
+func TestDeleteDestination(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+		dest := &models.Destination{Name: "kube", UniqueID: "1111"}
+		createDestinations(t, tx, dest)
+
+		err := DeleteDestination(tx, dest.ID)
+		assert.NilError(t, err)
+
+		_, err = GetDestination(tx, ByID(dest.ID))
+		assert.ErrorIs(t, err, internal.ErrNotFound)
 	})
 }
 


### PR DESCRIPTION
## Summary

This PR converts the three destination write queries to use SQL.

`DestinationUpdate` is a bit of a special case. We don't receive the created_at time, so we have to exclude it from the query. I did that by creating a second set of methods for `Columns` and `Values`. We could also select the row first, but it seems like we should be able to do an update and omit the rows that we don't care to update. If this becomes a more common pattern then maybe we can support that difference in the Table interface somehow.

Also updated `CountDestinationsByConnectedVersion` to remove a sub-select.

## Related Issues

Related to #2415 
