### PR TITLE
fix: dont require server config base url on login

### DIFF
--- a/ui/lib/serverconfig.js
+++ b/ui/lib/serverconfig.js
@@ -3,7 +3,7 @@ import useSWR from 'swr'
 export function useServerConfig() {
   const { data: { isEmailConfigured, isSignupEnabled, baseDomain } = {} } =
     useSWR(`/api/server-configuration`, {
-      revalidateIfStale: false
+      revalidateIfStale: false,
     })
 
   return {

--- a/ui/lib/serverconfig.js
+++ b/ui/lib/serverconfig.js
@@ -2,7 +2,9 @@ import useSWR from 'swr'
 
 export function useServerConfig() {
   const { data: { isEmailConfigured, isSignupEnabled, baseDomain } = {} } =
-    useSWR(`/api/server-configuration`)
+    useSWR(`/api/server-configuration`, {
+      revalidateIfStale: false
+    })
 
   return {
     isEmailConfigured,

--- a/ui/pages/login/callback.js
+++ b/ui/pages/login/callback.js
@@ -3,14 +3,12 @@ import { useRouter } from 'next/router'
 import { useSWRConfig } from 'swr'
 
 import { useUser } from '../../lib/hooks'
-import { useServerConfig } from '../../lib/serverconfig'
 import { saveToVisitedOrgs } from '.'
 
 import LoginLayout from '../../components/layouts/login'
 
 export default function Callback() {
   const { mutate } = useSWRConfig()
-  const { baseDomain } = useServerConfig()
   const { login } = useUser()
 
   const router = useRouter()
@@ -32,7 +30,6 @@ export default function Callback() {
       window.localStorage.removeItem('next')
       saveToVisitedOrgs(
         window.location.host,
-        baseDomain,
         user?.organizationName
       )
     }
@@ -45,8 +42,7 @@ export default function Callback() {
       state === window.localStorage.getItem('state') &&
       code &&
       providerID &&
-      redirectURL &&
-      baseDomain
+      redirectURL
     ) {
       finish({
         providerID,
@@ -58,7 +54,7 @@ export default function Callback() {
       window.localStorage.removeItem('state')
       window.localStorage.removeItem('redirectURL')
     }
-  }, [code, state, mutate, router, baseDomain, login])
+  }, [code, state, mutate, router, login])
 
   if (!isReady) {
     return null

--- a/ui/pages/login/callback.js
+++ b/ui/pages/login/callback.js
@@ -28,10 +28,7 @@ export default function Callback() {
       router.replace(next ? decodeURIComponent(next) : '/')
 
       window.localStorage.removeItem('next')
-      saveToVisitedOrgs(
-        window.location.host,
-        user?.organizationName
-      )
+      saveToVisitedOrgs(window.location.host, user?.organizationName)
     }
 
     const providerID = window.localStorage.getItem('providerID')

--- a/ui/pages/login/index.js
+++ b/ui/pages/login/index.js
@@ -29,7 +29,7 @@ function oidcLogin({ id, clientID, authURL, scopes }, next) {
   )}&state=${state}`
 }
 
-export function saveToVisitedOrgs(domain, baseDomain, orgName) {
+export function saveToVisitedOrgs(domain, orgName) {
   const cookies = new Cookies()
 
   let visitedOrgs = cookies.get('orgs') || []
@@ -40,9 +40,16 @@ export function saveToVisitedOrgs(domain, baseDomain, orgName) {
       name: orgName,
     })
 
+    // set the cookie domain to a general base domain
+    let cookieDomain = window.location.host
+    let parts = cookieDomain.split('.')
+    if (parts.length > 2) {
+      cookieDomain = parts.slice(-2).join('.') // join the last two parts of the domain
+    }
+    
     cookies.set('orgs', visitedOrgs, {
       path: '/',
-      domain: `.${baseDomain}`,
+      domain: `.${cookieDomain}`,
     })
   }
 }
@@ -100,7 +107,7 @@ export default function Login() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [errors, setErrors] = useState({})
-  const { baseDomain, isEmailConfigured } = useServerConfig()
+  const { isEmailConfigured } = useServerConfig()
   const { login } = useUser()
 
   async function onSubmit(e) {
@@ -127,7 +134,6 @@ export default function Login() {
 
       saveToVisitedOrgs(
         window.location.host,
-        baseDomain,
         data?.organizationName
       )
     } catch (e) {

--- a/ui/pages/login/index.js
+++ b/ui/pages/login/index.js
@@ -44,7 +44,8 @@ export function saveToVisitedOrgs(domain, orgName) {
     let cookieDomain = window.location.host
     let parts = cookieDomain.split('.')
     if (parts.length > 2) {
-      cookieDomain = parts.slice(-2).join('.') // join the last two parts of the domain
+      parts.shift() // remove the org
+      cookieDomain = parts.join('.') // join the last two parts of the domain
     }
 
     cookies.set('orgs', visitedOrgs, {

--- a/ui/pages/login/index.js
+++ b/ui/pages/login/index.js
@@ -46,7 +46,7 @@ export function saveToVisitedOrgs(domain, orgName) {
     if (parts.length > 2) {
       cookieDomain = parts.slice(-2).join('.') // join the last two parts of the domain
     }
-    
+
     cookies.set('orgs', visitedOrgs, {
       path: '/',
       domain: `.${cookieDomain}`,

--- a/ui/pages/login/index.js
+++ b/ui/pages/login/index.js
@@ -132,10 +132,7 @@ export default function Login() {
 
       router.replace(next ? decodeURIComponent(next) : '/')
 
-      saveToVisitedOrgs(
-        window.location.host,
-        data?.organizationName
-      )
+      saveToVisitedOrgs(window.location.host, data?.organizationName)
     } catch (e) {
       console.error(e)
       if (e.fieldErrors) {


### PR DESCRIPTION
## Summary
When no server URL is set in server configuration set the default server URL to the current host on response. This allows the login response to continue when the optional `baseURL` server configuration is not set, but it also ensures that we wait until we have checked the server to see if there is one set.

## Checklist
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3374 
