### PR TITLE
feat: SCIM list provider users

### DIFF
--- a/api/scim.go
+++ b/api/scim.go
@@ -1,0 +1,67 @@
+package api
+
+import "github.com/infrahq/infra/internal/validate"
+
+type SCIMUserName struct {
+	GivenName  string `json:"givenName"`
+	FamilyName string `json:"familyName"`
+}
+
+type SCIMUserEmail struct {
+	Primary bool   `json:"primary"`
+	Value   string `json:"value"`
+}
+
+func (r SCIMUserEmail) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.Required("value", r.Value),
+		validate.Email("value", r.Value),
+	}
+}
+
+const UserSchema = "urn:ietf:params:scim:schemas:core:2.0:User"
+
+type SCIMMetadata struct {
+	ResourceType string `json:"resourceType"`
+}
+
+type SCIMUser struct {
+	Schemas  []string        `json:"schemas"`
+	ID       string          `json:"id"`
+	UserName string          `json:"userName"`
+	Name     SCIMUserName    `json:"name"`
+	Emails   []SCIMUserEmail `json:"emails"`
+	Active   bool            `json:"active"`
+	Meta     SCIMMetadata    `json:"meta"`
+}
+
+type SCIMParametersRequest struct {
+	// these pagination parameters must conform to the SCIM spec, rather than our standard pagination
+	StartIndex int `form:"startIndex"`
+	Count      int `form:"count"`
+}
+
+func (r SCIMParametersRequest) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.IntRule{
+			Name:  "startIndex",
+			Value: r.StartIndex,
+			Min:   validate.Int(0),
+		},
+		validate.IntRule{
+			Name:  "count",
+			Value: r.Count,
+			Min:   validate.Int(0),
+		},
+	}
+}
+
+const ListResponseSchema = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+
+type ListProviderUsersResponse struct {
+	Schemas      []string   `json:"schemas"`
+	TotalResults int        `json:"totalResults"`
+	Resources    []SCIMUser `json:"Resources"` // intentionally capitalized
+	StartIndex   int        `json:"startIndex"`
+	ItemsPerPage int        `json:"itemsPerPage"`
+}

--- a/internal/access/scim.go
+++ b/internal/access/scim.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"

--- a/internal/access/scim.go
+++ b/internal/access/scim.go
@@ -1,0 +1,23 @@
+package access
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+func ListProviderUsers(c *gin.Context, providerID uid.ID, p *data.SCIMParameters) ([]models.ProviderUser, error) {
+	db, err := RequireInfraRole(c, models.InfraSCIMRole)
+	if err != nil {
+		return nil, HandleAuthErr(err, "scim", "list users", models.InfraSCIMRole)
+	}
+
+	users, err := data.ListProviderUsers(db, providerID, p)
+	if err != nil {
+		return nil, fmt.Errorf("list provider users: %w", err)
+	}
+	return users, nil
+}

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -64,7 +64,7 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 		}
 		addIDs = append(addIDs, item)
 	}
-	if rows.Err() != nil {
+	if err := rows.Err(); err != nil {
 		return err
 	}
 
@@ -105,7 +105,7 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 			}
 			ids = append(ids, item)
 		}
-		if rows.Err() != nil {
+		if err := rows.Err(); err != nil {
 			return err
 		}
 

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -69,6 +69,7 @@ func migrations() []*migrator.Migration {
 		addIdentityVerifiedFields(),
 		cleanCrossOrgGroupMemberships(),
 		fixProviderUserIndex(),
+		addProviderUserSCIMFields(),
 		// next one here
 	}
 }
@@ -690,6 +691,24 @@ ALTER TABLE provider_users DROP CONSTRAINT IF EXISTS provider_users_pkey;
 ALTER TABLE provider_users ADD CONSTRAINT
     provider_users_pkey PRIMARY KEY (provider_id, identity_id);
 `
+			_, err := tx.Exec(stmt)
+			return err
+		},
+	}
+}
+
+func addProviderUserSCIMFields() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-09-28T13:00",
+		Migrate: func(tx migrator.DB) error {
+			stmt := `
+				ALTER TABLE provider_users
+				ADD COLUMN IF NOT EXISTS given_name text,
+				ADD COLUMN IF NOT EXISTS family_name text,
+				ADD COLUMN IF NOT EXISTS active boolean DEFAULT true;
+
+				CREATE UNIQUE INDEX IF NOT EXISTS idx_emails_providers ON provider_users (email, provider_id);
+			`
 			_, err := tx.Exec(stmt)
 			return err
 		},

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -728,6 +728,12 @@ DELETE FROM settings WHERE id=24567;
 				// schema changes are tested with schema comparison
 			},
 		},
+		{
+			label: testCaseLine("2022-09-28T13:00"),
+			expected: func(t *testing.T, db WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -52,7 +52,7 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 	for _, p := range toDelete {
 		ids = append(ids, p.ID)
 
-		providerUsers, err := listProviderUsers(db, p.ID)
+		providerUsers, err := ListProviderUsers(db, p.ID, nil)
 		if err != nil {
 			return fmt.Errorf("listing provider users: %w", err)
 		}

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -93,29 +93,60 @@ func UpdateProviderUser(tx WriteTxn, providerUser *models.ProviderUser) error {
 	return handleError(err)
 }
 
-func listProviderUsers(tx ReadTxn, providerID uid.ID) ([]models.ProviderUser, error) {
+func ListProviderUsers(tx ReadTxn, providerID uid.ID, p *SCIMParameters) ([]models.ProviderUser, error) {
 	table := &providerUserTable{}
 	query := querybuilder.New("SELECT")
 	query.B(columnsForSelect(table))
 	query.B("FROM")
 	query.B(table.Table())
 	query.B("WHERE provider_id = ?", providerID)
+
+	query.B("ORDER BY email ASC")
+
+	if p != nil {
+		// apply scim parameters
+		if p.Count != 0 {
+			query.B("LIMIT ?", p.Count)
+		}
+		if p.StartIndex != 0 {
+			query.B("OFFSET ?", p.StartIndex)
+		}
+	}
+
 	rows, err := tx.Query(query.String(), query.Args...)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	var result []models.ProviderUser
 	for rows.Next() {
 		var pu models.ProviderUser
 
 		if err := rows.Scan((*providerUserTable)(&pu).ScanFields()...); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		result = append(result, pu)
 	}
-	return result, rows.Err()
+
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if p != nil {
+		row := tx.QueryRow(`SELECT count(identity_id) FROM provider_users WHERE provider_id = ?`, providerID)
+		var count int
+		if err := row.Scan(&count); err != nil {
+			return nil, err
+		}
+		p.TotalCount = count
+	}
+
+	return result, nil
 }
 
 type DeleteProviderUsersOptions struct {
@@ -187,4 +218,11 @@ func SyncProviderUser(ctx context.Context, tx GormTxn, user *models.Identity, pr
 	}
 
 	return nil
+}
+
+type SCIMParameters struct {
+	Count      int // the number of items to return
+	StartIndex int // the offset to start counting from
+	TotalCount int
+	// TODO: filter query param
 }

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -198,7 +198,10 @@ CREATE TABLE provider_users (
     redirect_url text,
     access_token text,
     refresh_token text,
-    expires_at timestamp with time zone
+    expires_at timestamp with time zone,
+    given_name text,
+    family_name text,
+    active boolean DEFAULT true
 );
 
 CREATE TABLE providers (
@@ -281,6 +284,8 @@ CREATE UNIQUE INDEX idx_access_keys_name ON access_keys USING btree (organizatio
 CREATE UNIQUE INDEX idx_credentials_identity_id ON credentials USING btree (organization_id, identity_id) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_destinations_unique_id ON destinations USING btree (organization_id, unique_id) WHERE (deleted_at IS NULL);
+
+CREATE UNIQUE INDEX idx_emails_providers ON provider_users USING btree (email, provider_id);
 
 CREATE UNIQUE INDEX idx_encryption_keys_key_id ON encryption_keys USING btree (key_id);
 

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -10,6 +10,7 @@ const (
 	InfraAdminRole        = "admin"
 	InfraViewRole         = "view"
 	InfraConnectorRole    = "connector"
+	InfraSCIMRole         = "scim"
 )
 
 // BasePermissionConnect is the first-principle permission that all other permissions are defined from.

--- a/internal/server/models/provideruser.go
+++ b/internal/server/models/provideruser.go
@@ -34,6 +34,10 @@ func (pu *ProviderUser) ToAPI() *api.SCIMUser {
 		Schemas:  []string{api.UserSchema},
 		ID:       pu.IdentityID.String(),
 		UserName: pu.Email,
+		Name: api.SCIMUserName{
+			GivenName:  pu.GivenName,
+			FamilyName: pu.FamilyName,
+		},
 		Emails: []api.SCIMUserEmail{
 			{
 				Primary: true,

--- a/internal/server/models/provideruser.go
+++ b/internal/server/models/provideruser.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -12,6 +13,8 @@ type ProviderUser struct {
 	ProviderID uid.ID `gorm:"primaryKey"`
 
 	Email      string
+	GivenName  string
+	FamilyName string
 	Groups     CommaSeparatedStrings
 	LastUpdate time.Time
 
@@ -20,6 +23,26 @@ type ProviderUser struct {
 	AccessToken  EncryptedAtRest
 	RefreshToken EncryptedAtRest
 	ExpiresAt    time.Time
+
+	Active bool
 }
 
 func (ProviderUser) IsAModel() {}
+
+func (pu *ProviderUser) ToAPI() *api.SCIMUser {
+	return &api.SCIMUser{
+		Schemas:  []string{api.UserSchema},
+		ID:       pu.IdentityID.String(),
+		UserName: pu.Email,
+		Emails: []api.SCIMUserEmail{
+			{
+				Primary: true,
+				Value:   pu.Email,
+			},
+		},
+		Active: pu.Active,
+		Meta: api.SCIMMetadata{
+			ResourceType: "User",
+		},
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin"
 
+	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
@@ -97,6 +98,16 @@ func (s *Server) GenerateRoutes() Routes {
 
 	post(a, authn, "/api/tokens", a.CreateToken)
 	post(a, authn, "/api/logout", a.Logout)
+
+	// SCIM inbound provisioning
+	add(a, authn, http.MethodGet, "/api/scim/v2/Users", route[api.SCIMParametersRequest, *api.ListProviderUsersResponse]{
+		handler: a.ListProviderUsers,
+		routeSettings: routeSettings{
+			omitFromTelemetry:          true,
+			omitFromDocs:               true,
+			infraVersionHeaderOptional: true,
+		},
+	})
 
 	put(a, authn, "/api/settings", a.UpdateSettings)
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -12,7 +12,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin"
 
-	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
@@ -100,14 +99,7 @@ func (s *Server) GenerateRoutes() Routes {
 	post(a, authn, "/api/logout", a.Logout)
 
 	// SCIM inbound provisioning
-	add(a, authn, http.MethodGet, "/api/scim/v2/Users", route[api.SCIMParametersRequest, *api.ListProviderUsersResponse]{
-		handler: a.ListProviderUsers,
-		routeSettings: routeSettings{
-			omitFromTelemetry:          true,
-			omitFromDocs:               true,
-			infraVersionHeaderOptional: true,
-		},
-	})
+	add(a, authn, http.MethodGet, "/api/scim/v2/Users", listProviderUsersRoute)
 
 	put(a, authn, "/api/settings", a.UpdateSettings)
 

--- a/internal/server/scim.go
+++ b/internal/server/scim.go
@@ -10,8 +10,20 @@ import (
 	"github.com/infrahq/infra/internal/server/data"
 )
 
-func (a *API) ListProviderUsers(c *gin.Context, r *api.SCIMParametersRequest) (*api.ListProviderUsersResponse, error) {
-	p := SCIMParametersFromRequest(r)
+var listProviderUsersRoute = route[api.SCIMParametersRequest, *api.ListProviderUsersResponse]{
+	handler: ListProviderUsers,
+	routeSettings: routeSettings{
+		omitFromTelemetry:          true,
+		omitFromDocs:               true,
+		infraVersionHeaderOptional: true,
+	},
+}
+
+func ListProviderUsers(c *gin.Context, r *api.SCIMParametersRequest) (*api.ListProviderUsersResponse, error) {
+	p := data.SCIMParameters{
+		StartIndex: r.StartIndex,
+		Count:      r.Count,
+	}
 	providerID := getRequestContext(c).Authenticated.AccessKey.IssuedFor // TODO: ability to create tokens for providers
 	if providerID == 0 {
 		// should not happen
@@ -35,21 +47,4 @@ func (a *API) ListProviderUsers(c *gin.Context, r *api.SCIMParametersRequest) (*
 	}
 
 	return result, nil
-}
-
-func SCIMParametersFromRequest(f *api.SCIMParametersRequest) data.SCIMParameters {
-	startIndex, count := 0, 100
-
-	if f.StartIndex != 0 {
-		startIndex = f.StartIndex
-	}
-
-	if f.Count != 0 {
-		count = f.Count
-	}
-
-	return data.SCIMParameters{
-		StartIndex: startIndex,
-		Count:      count,
-	}
 }

--- a/internal/server/scim_test.go
+++ b/internal/server/scim_test.go
@@ -1,0 +1,246 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+func TestAPI_ListProviderUsers(t *testing.T) {
+	type testCase struct {
+		name   string
+		setup  func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse)
+		verify func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder)
+	}
+
+	testCases := []testCase{
+		{
+			name: "valid, no parameters",
+			setup: func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse) {
+				s := setupServer(t, withAdminUser)
+				bearer, users, routes := createTestSCIMProvider(t, s)
+				expectedUsers := []api.SCIMUser{}
+				for _, u := range users {
+					expectedUsers = append(expectedUsers, *u.ToAPI())
+				}
+
+				expected = api.ListProviderUsersResponse{
+					Schemas:      []string{api.ListResponseSchema},
+					Resources:    expectedUsers,
+					TotalResults: 1,
+					StartIndex:   0,
+					ItemsPerPage: 100,
+				}
+
+				return bearer, "", routes, expected
+			},
+			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+				var response api.ListProviderUsersResponse
+				err := json.Unmarshal(resp.Body.Bytes(), &response)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, expected, response)
+			},
+		},
+		{
+			name: "scim role is required",
+			setup: func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse) {
+				s := setupServer(t, withAdminUser)
+				// setup the users and permissions as needed
+				bearer, users, routes := createTestSCIMProvider(t, s)
+
+				// then remove the grant for the SCIM provider
+				opts := data.DeleteGrantsOptions{
+					BySubject: uid.NewIdentityPolymorphicID(users[0].IdentityID),
+				}
+				err := data.DeleteGrants(s.DB(), opts)
+				assert.NilError(t, err)
+
+				return bearer, "", routes, api.ListProviderUsersResponse{}
+			},
+			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusForbidden, resp.Code)
+			},
+		},
+		{
+			name: "access key issued for non-existent provider results in an empty response",
+			setup: func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse) {
+				s := setupServer(t, withAdminUser)
+				// setup the users and permissions as needed
+				_, users, routes := createTestSCIMProvider(t, s, "another")
+				key := &models.AccessKey{
+					OrganizationMember: s.db.DefaultOrgSettings.OrganizationMember,
+					IssuedFor:          users[0].IdentityID,
+					IssuedForName:      "another",
+					Name:               fmt.Sprintf("%s-123", "another"),
+					ProviderID:         data.InfraProvider(s.DB()).ID,
+				}
+				bearer, err := data.CreateAccessKey(s.DB(), key)
+				assert.NilError(t, err)
+
+				err = data.CreateGrant(s.DB(),
+					&models.Grant{
+						Subject:   uid.NewIdentityPolymorphicID(users[0].IdentityID),
+						Privilege: models.InfraSCIMRole,
+						Resource:  "infra",
+					},
+				)
+				assert.NilError(t, err)
+
+				return bearer, "", routes, api.ListProviderUsersResponse{Schemas: []string{api.ListResponseSchema}, ItemsPerPage: 100}
+			},
+			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code)
+				var response api.ListProviderUsersResponse
+				err := json.Unmarshal(resp.Body.Bytes(), &response)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, expected, response)
+			},
+		},
+		{
+			name: "2 users, 1 count",
+			setup: func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse) {
+				s := setupServer(t, withAdminUser)
+				bearer, users, routes := createTestSCIMProvider(t, s, "a")
+
+				expected = api.ListProviderUsersResponse{
+					Schemas:      []string{api.ListResponseSchema},
+					Resources:    []api.SCIMUser{*users[0].ToAPI()}, // this user has the "a" email, so they return first alphabetically
+					TotalResults: 2,
+					StartIndex:   0,
+					ItemsPerPage: 1,
+				}
+
+				return bearer, "?count=1", routes, expected
+			},
+			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+				var response api.ListProviderUsersResponse
+				err := json.Unmarshal(resp.Body.Bytes(), &response)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, expected, response)
+			},
+		},
+		{
+			name: "2 users, 3 count",
+			setup: func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse) {
+				s := setupServer(t, withAdminUser)
+				bearer, users, routes := createTestSCIMProvider(t, s, "a")
+
+				expectedUsers := []api.SCIMUser{}
+				for _, u := range users {
+					expectedUsers = append(expectedUsers, *u.ToAPI())
+				}
+
+				expected = api.ListProviderUsersResponse{
+					Schemas:      []string{api.ListResponseSchema},
+					Resources:    expectedUsers,
+					TotalResults: 2,
+					StartIndex:   0,
+					ItemsPerPage: 3,
+				}
+
+				return bearer, "?count=3", routes, expected
+			},
+			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+				var response api.ListProviderUsersResponse
+				err := json.Unmarshal(resp.Body.Bytes(), &response)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, expected, response)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		bearer, params, routes, exp := tc.setup(t)
+		// nolint:noctx
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/scim/v2/Users%s", params), nil)
+		assert.NilError(t, err)
+
+		req.Header.Add("Authorization", "Bearer "+bearer)
+		req.Header.Add("Infra-Version", apiVersionLatest)
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+
+		tc.verify(t, exp, resp)
+	}
+}
+
+func createTestSCIMProvider(t *testing.T, s *Server, extraUserNames ...string) (bearer string, users []models.ProviderUser, routes Routes) {
+	testProvider := &models.Provider{
+		Model: models.Model{
+			ID: 1234,
+		},
+		Name:    "mockta",
+		Kind:    models.ProviderKindOkta,
+		AuthURL: "https://example.com/v1/auth",
+		Scopes:  []string{"openid", "email"},
+	}
+
+	err := data.CreateProvider(s.DB(), testProvider)
+	assert.NilError(t, err)
+
+	testProviderUser := createTestSCIMUserIdentity(t, s.DB(), testProvider, 1234, "test@example.com") // intentionally the same ID as the test provider as a workaround until provider access keys are supported
+	users = append(users, *testProviderUser)
+	for i, name := range extraUserNames {
+		testProviderUser := createTestSCIMUserIdentity(t, s.DB(), testProvider, uid.ID(i), name) // intentionally the same ID as the test provider as a workaround until provider access keys are supported
+		users = append(users, *testProviderUser)
+	}
+
+	// sort users by email, this is to match expected result
+	sort.Slice(users, func(i, j int) bool {
+		return users[i].Email < users[j].Email
+	})
+
+	key := &models.AccessKey{
+		OrganizationMember: s.db.DefaultOrgSettings.OrganizationMember,
+		IssuedFor:          testProvider.ID,
+		IssuedForName:      testProvider.Name,
+		Name:               fmt.Sprintf("%s-123", testProvider.Name),
+		ProviderID:         data.InfraProvider(s.DB()).ID,
+	}
+	bearer, err = data.CreateAccessKey(s.DB(), key)
+	assert.NilError(t, err)
+
+	err = data.CreateGrant(s.DB(),
+		&models.Grant{
+			Subject:   uid.NewIdentityPolymorphicID(testProviderUser.IdentityID),
+			Privilege: models.InfraSCIMRole,
+			Resource:  "infra",
+		},
+	)
+	assert.NilError(t, err)
+
+	return bearer, users, s.GenerateRoutes()
+}
+
+func createTestSCIMUserIdentity(t *testing.T, db data.GormTxn, provider *models.Provider, id uid.ID, name string) *models.ProviderUser {
+	testIdentity := &models.Identity{
+		Model: models.Model{
+			ID: id,
+		},
+		Name: name,
+	}
+	err := data.CreateIdentity(db, testIdentity)
+	assert.NilError(t, err)
+
+	testProviderUser, err := data.CreateProviderUser(db, provider, testIdentity)
+	assert.NilError(t, err)
+
+	return testProviderUser
+}

--- a/internal/server/scim_test.go
+++ b/internal/server/scim_test.go
@@ -39,7 +39,7 @@ func TestAPI_ListProviderUsers(t *testing.T) {
 					Resources:    expectedUsers,
 					TotalResults: 1,
 					StartIndex:   0,
-					ItemsPerPage: 100,
+					ItemsPerPage: 1,
 				}
 
 				return bearer, "", routes, expected
@@ -98,7 +98,7 @@ func TestAPI_ListProviderUsers(t *testing.T) {
 				)
 				assert.NilError(t, err)
 
-				return bearer, "", routes, api.ListProviderUsersResponse{Schemas: []string{api.ListResponseSchema}, ItemsPerPage: 100}
+				return bearer, "", routes, api.ListProviderUsersResponse{Schemas: []string{api.ListResponseSchema}, ItemsPerPage: 0}
 			},
 			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, http.StatusOK, resp.Code)


### PR DESCRIPTION
- add SCIM list users endpoint
- add SCIM role

## Summary
This change adds the necessary logic for a SCIM identity provider to list the users it has associated with it. 

It does not include the changes necessary to create an access key for an identity provider (which this functionality will rely on) so the code path can't be accessed yet.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Part of #3378 
