### PR TITLE
fix: do not allow dots in destination names

### DIFF
--- a/api/destination.go
+++ b/api/destination.go
@@ -59,7 +59,7 @@ type CreateDestinationRequest struct {
 func (r CreateDestinationRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.Required("uniqueID", r.UniqueID),
-		ValidateName(r.Name),
+		validateDestinationName(r.Name),
 		validate.Required("name", r.Name),
 	}
 }
@@ -80,7 +80,7 @@ func (r UpdateDestinationRequest) ValidationRules() []validate.ValidationRule {
 		validate.Required("uniqueID", r.UniqueID),
 		validate.Required("id", r.ID),
 		validate.Required("name", r.Name),
-		ValidateName(r.Name),
+		validateDestinationName(r.Name),
 	}
 }
 
@@ -88,4 +88,18 @@ func (req ListDestinationsRequest) SetPage(page int) Paginatable {
 	req.PaginationRequest.Page = page
 
 	return req
+}
+
+func validateDestinationName(value string) validate.StringRule {
+	rule := ValidateName(value)
+	// dots are not allowed in destination name, because it would make grants
+	// ambiguous. We use dots to separate destination name from resource name in
+	// the Grant.Resource field.
+	rule.CharacterRanges = []validate.CharRange{
+		validate.AlphabetLower,
+		validate.AlphabetUpper,
+		validate.Numbers,
+		validate.Dash, validate.Underscore,
+	}
+	return rule
 }

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -728,6 +728,31 @@ DELETE FROM settings WHERE id=24567;
 				// schema changes are tested with schema comparison
 			},
 		},
+		{
+			label: testCaseLine("2022-10-04T11:44"),
+			setup: func(t *testing.T, db WriteTxn) {
+				_, err := db.Exec(`
+					INSERT INTO destinations(id, name) VALUES
+					(10009, 'with.dot.no.more'),
+					(10010, 'no-dots')`)
+				assert.NilError(t, err)
+
+			},
+			cleanup: func(t *testing.T, db WriteTxn) {
+				_, err := db.Exec("DELETE FROM destinations")
+				assert.NilError(t, err)
+			},
+			expected: func(t *testing.T, db WriteTxn) {
+				row := db.QueryRow("SELECT name from destinations where id=?", 10009)
+				var name string
+				assert.NilError(t, row.Scan(&name))
+				assert.Equal(t, name, "with_dot_no_more")
+
+				row = db.QueryRow("SELECT name from destinations where id=?", 10010)
+				assert.NilError(t, row.Scan(&name))
+				assert.Equal(t, name, "no-dots")
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -1676,7 +1676,7 @@
                     "type": "object"
                   },
                   "name": {
-                    "format": "[a-zA-Z0-9\\-_.]",
+                    "format": "[a-zA-Z0-9\\-_]",
                     "maxLength": 256,
                     "minLength": 2,
                     "type": "string"
@@ -2015,7 +2015,7 @@
                     "type": "object"
                   },
                   "name": {
-                    "format": "[a-zA-Z0-9\\-_.]",
+                    "format": "[a-zA-Z0-9\\-_]",
                     "maxLength": 256,
                     "minLength": 2,
                     "type": "string"


### PR DESCRIPTION
A dot in a destination name makes all grants for that destination ambiguous. They could refer to multiple destinations.

For example a grant with `resource=kubernetes.dev` could mean the default namespace for a destination named `kubernetes.dev`, or it could mean the `dev` namespace for a destination named `kubernetes`.

We could decide to separate destination from the resource on the grant, which would allow us to support dots in destination names. That's a much larger change, so until we decide we need that, we have to exclude dots from destination names.

We don't have any telemetry for destination names. I think we need to make this change regardless, but we should be careful to call this out in the release notes as a potentially breaking change.  We may want to combine this with the change to the connector helm chart, and the change to add a unique constraint to destination names.