### PR TITLE
fix: remove server lookup

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -120,20 +120,6 @@ func Run(ctx context.Context, options Options) error {
 		return fmt.Errorf("invalid server url: %w", err)
 	}
 
-	// server is localhost which should never be the case. try to infer the actual host
-	// TODO: do this lookup when Host is "" instead of localhost
-	// https://github.com/infrahq/infra/issues/3380
-	if strings.HasPrefix(u.Host, "localhost") {
-		server, err := k8s.Service("server")
-		if err != nil {
-			logging.Warnf("no cluster-local infra server found for %q. check connector configurations", u.Host)
-		} else {
-			host := fmt.Sprintf("%s.%s", server.ObjectMeta.Name, server.ObjectMeta.Namespace)
-			logging.Debugf("using cluster-local infra server at %q instead of %q", host, u.Host)
-			u.Host = host
-		}
-	}
-
 	u.Scheme = "https"
 
 	destination := &api.Destination{

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -542,8 +542,8 @@ func readNamespaceFromInClusterFile() (string, error) {
 	return string(contents), nil
 }
 
-// Find the first suitable Service, filtering on infrahq.com/component
-func (k *Kubernetes) Service(component string, labels ...string) (*corev1.Service, error) {
+// Find the first suitable Service, filtering on app.infrahq.com/component
+func (k *Kubernetes) Service(labels ...string) (*corev1.Service, error) {
 	clientset, err := kubernetes.NewForConfig(k.Config)
 	if err != nil {
 		return nil, err
@@ -554,21 +554,16 @@ func (k *Kubernetes) Service(component string, labels ...string) (*corev1.Servic
 		return nil, err
 	}
 
-	selector := []string{
-		fmt.Sprintf("app.infrahq.com/component=%s", component),
-	}
-
-	selector = append(selector, labels...)
-
 	services, err := clientset.CoreV1().Services(namespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: strings.Join(selector, ","),
+		// TODO: this should use configurable label selectors instead of using pod labels or static labels
+		LabelSelector: strings.Join(append(labels, "app.infrahq.com/component=connector"), ","),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	if len(services.Items) == 0 {
-		return nil, fmt.Errorf("no service found for component %s", component)
+		return nil, fmt.Errorf("no service found for labels %v", labels)
 	}
 
 	return &services.Items[0], nil
@@ -633,7 +628,7 @@ func (k *Kubernetes) Endpoint() (string, int, error) {
 		return "", -1, err
 	}
 
-	service, err := k.Service("connector", labels...)
+	service, err := k.Service(labels...)
 	if err != nil {
 		return "", -1, err
 	}
@@ -674,7 +669,7 @@ func (k *Kubernetes) IsServiceTypeClusterIP() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	service, err := k.Service("connector", labels...)
+	service, err := k.Service(labels...)
 	if err != nil {
 		return false, err
 	}

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -643,7 +643,7 @@ func (k *Kubernetes) Endpoint() (string, int, error) {
 		return k.NodePort(service)
 	case corev1.ServiceTypeLoadBalancer:
 		if len(service.Status.LoadBalancer.Ingress) == 0 {
-			return "", -1, fmt.Errorf("load balancer has no ingress objects")
+			return "", -1, fmt.Errorf("no address available for load balancer, it may still be provisioning")
 		}
 
 		ingress := service.Status.LoadBalancer.Ingress[0]


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Remove the server lookup when server config value is `localhost`. The original use case for this was to provide a simple way to configure a in-cluster connector. This is no longer useful. Users should provide the server URL explicitly

Resolves #3380 
