### PR TITLE
feat(connector): create destination as soon as possible

### DIFF
--- a/api/destination.go
+++ b/api/destination.go
@@ -30,7 +30,7 @@ type DestinationConnection struct {
 
 func (r DestinationConnection) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		validate.Required("url", r.URL),
+		validate.Required("ca", r.CA),
 	}
 }
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -90,9 +90,10 @@ func TestUse(t *testing.T) {
 				destinations := api.ListResponse[api.Destination]{
 					Items: []api.Destination{
 						{
-							ID:       destinationID,
-							UniqueID: "uniqueID",
-							Name:     "cluster",
+							ID:        destinationID,
+							UniqueID:  "uniqueID",
+							Name:      "cluster",
+							Connected: true,
 							Connection: api.DestinationConnection{
 								URL: "kubernetes.docker.local",
 								CA:  destinationCA,

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	DestinationStatusConnected    = "Connected"
+	DestinationStatusPending      = "Pending"
 	DestinationStatusDisconnected = "Disconnected"
 )
 
@@ -79,8 +80,13 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 
 				var rows []row
 				for _, d := range destinations {
-					status := DestinationStatusDisconnected
-					if d.Connected {
+					var status string
+					switch {
+					case !d.Connected:
+						status = DestinationStatusDisconnected
+					case d.Connection.URL == "":
+						status = DestinationStatusPending
+					default:
 						status = DestinationStatusConnected
 					}
 

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -108,13 +108,14 @@ func writeKubeconfig(user *api.User, destinations []api.Destination, grants []ap
 		)
 
 		for _, d := range destinations {
-			// eg resource:  "foo.bar"
-			// eg dest name: "foo"
-			if strings.HasPrefix(g.Resource, d.Name) {
+			if !isResourceForDestination(g.Resource, d.Name) {
+				continue
+			}
+
+			if isDestinationAvailable(d) {
 				url = d.Connection.URL
 				ca = []byte(d.Connection.CA)
 				exists = true
-
 				break
 			}
 		}

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -25,16 +25,32 @@ func TestWriteKubeconfig(t *testing.T) {
 	user := api.User{Name: "user"}
 	destinations := []api.Destination{
 		{
-			Name: "cluster",
+			Name:      "connected",
+			Connected: true,
 			Connection: api.DestinationConnection{
-				URL: "cluster.example.com",
+				URL: "connected.example.com",
+				CA:  destinationCA,
+			},
+		},
+		{
+			Name:      "pending",
+			Connected: true,
+			Connection: api.DestinationConnection{
+				CA: destinationCA,
+			},
+		},
+		{
+			Name:      "disconnected",
+			Connected: false,
+			Connection: api.DestinationConnection{
+				URL: "disconnected.example.com",
 				CA:  destinationCA,
 			},
 		},
 	}
 	grants := []api.Grant{
 		{
-			Resource: "cluster",
+			Resource: "connected",
 		},
 	}
 
@@ -43,15 +59,15 @@ func TestWriteKubeconfig(t *testing.T) {
 
 	expected := clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"infra:cluster": {
-				Server:                   "https://cluster.example.com",
+			"infra:connected": {
+				Server:                   "https://connected.example.com",
 				CertificateAuthorityData: []byte(destinationCA),
 			},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
-			"infra:cluster": {
+			"infra:connected": {
 				AuthInfo: "user",
-				Cluster:  "infra:cluster",
+				Cluster:  "infra:connected",
 			},
 		},
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
@@ -110,7 +126,8 @@ func TestWriteKubeconfig_UserNamespaceOverride(t *testing.T) {
 	user := api.User{Name: "user"}
 	destinations := []api.Destination{
 		{
-			Name: "cluster",
+			Name:      "cluster",
+			Connected: true,
 			Connection: api.DestinationConnection{
 				URL: "cluster.example.com",
 				CA:  destinationCA,
@@ -164,7 +181,8 @@ func TestWriteKubeconfig_UserNamespaceOverrideResetNamespacedContext(t *testing.
 	user := api.User{Name: "user"}
 	destinations := []api.Destination{
 		{
-			Name: "cluster",
+			Name:      "cluster",
+			Connected: true,
 			Connection: api.DestinationConnection{
 				URL: "cluster.example.com",
 				CA:  destinationCA,

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -46,6 +46,7 @@ func list(cli *CLI) error {
 		if isResourceForDestination(g.Resource, "infra") {
 			continue
 		}
+
 		if !destinationForResourceExists(g.Resource, destinations) {
 			continue
 		}
@@ -94,11 +95,18 @@ func list(cli *CLI) error {
 
 func destinationForResourceExists(resource string, destinations []api.Destination) bool {
 	for _, d := range destinations {
-		if isResourceForDestination(resource, d.Name) {
-			return true
+		if !isResourceForDestination(resource, d.Name) {
+			continue
 		}
+
+		return isDestinationAvailable(d)
 	}
+
 	return false
+}
+
+func isDestinationAvailable(destination api.Destination) bool {
+	return destination.Connected && destination.Connection.URL != ""
 }
 
 func isResourceForDestination(resource string, destination string) bool {

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
@@ -74,6 +75,19 @@ func TestListCmd(t *testing.T) {
 		},
 	})
 	assert.NilError(t, err)
+
+	for _, uniqueID := range []string{"space", "moon", "maintain"} {
+		// set client.Headers so each destination becomes connected
+		c.Headers = http.Header{
+			"Infra-Destination": {uniqueID},
+		}
+
+		_, err := c.ListGrants(api.ListGrantsRequest{})
+		assert.NilError(t, err)
+	}
+
+	// reset client.Headers
+	c.Headers = http.Header{}
 
 	users, err := c.ListUsers(api.ListUsersRequest{})
 	assert.NilError(t, err)

--- a/internal/server/destination_test.go
+++ b/internal/server/destination_test.go
@@ -92,7 +92,7 @@ func TestAPI_CreateDestination(t *testing.T) {
 				assert.NilError(t, err)
 
 				expected := []api.FieldError{
-					{FieldName: "connection.url", Errors: []string{"is required"}},
+					{FieldName: "connection.ca", Errors: []string{"is required"}},
 					{FieldName: "name", Errors: []string{"is required"}},
 					{FieldName: "uniqueID", Errors: []string{"is required"}},
 				}

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -146,7 +146,7 @@
               }
             },
             "required": [
-              "url"
+              "ca"
             ],
             "type": "object"
           },
@@ -403,7 +403,7 @@
                     }
                   },
                   "required": [
-                    "url"
+                    "ca"
                   ],
                   "type": "object"
                 },
@@ -1671,7 +1671,7 @@
                       }
                     },
                     "required": [
-                      "url"
+                      "ca"
                     ],
                     "type": "object"
                   },
@@ -2010,7 +2010,7 @@
                       }
                     },
                     "required": [
-                      "url"
+                      "ca"
                     ],
                     "type": "object"
                   },

--- a/ui/pages/destinations/index.js
+++ b/ui/pages/destinations/index.js
@@ -113,12 +113,18 @@ export default function Destinations() {
                 <div
                   className={`h-2 w-2 flex-none rounded-full border ${
                     info.getValue()
-                      ? ' border-teal-500/50 bg-teal-400'
+                      ? info.row.original.connection.url === ''
+                        ? 'animate-pulse border-yellow-600 bg-yellow-500'
+                        : 'border-teal-500/50 bg-teal-400'
                       : 'border-gray-300 bg-gray-200'
                   }`}
                 />
                 <span className='flex-none px-2'>
-                  {info.getValue() ? 'Connected' : 'Disconnected'}
+                  {info.getValue()
+                    ? info.row.original.connection.url === ''
+                      ? 'Pending'
+                      : 'Connected'
+                    : 'Disconnected'}
                 </span>
               </div>
             ),


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Update the connector to create itself as quickly as possible instead of waiting for a valid connection. This is mainly due to LoadBalancer potentially taking a significant amount of time to initialize. Creating the destination quickly allows the user to continue without waiting.

Update UI and CLI to output status == "Pending" when the destination is disconnected and does not have a connection URL. Omit pending and disconnected destinations when syncing kubeconfig