### PR TITLE
Add unique constraint to destination name

### DIFF
--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -753,6 +753,12 @@ DELETE FROM settings WHERE id=24567;
 				assert.Equal(t, name, "no-dots")
 			},
 		},
+		{
+			label: testCaseLine("2022-10-05T11:12"),
+			expected: func(t *testing.T, db WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -280,6 +280,8 @@ CREATE UNIQUE INDEX idx_access_keys_name ON access_keys USING btree (organizatio
 
 CREATE UNIQUE INDEX idx_credentials_identity_id ON credentials USING btree (organization_id, identity_id) WHERE (deleted_at IS NULL);
 
+CREATE UNIQUE INDEX idx_destinations_name ON destinations USING btree (organization_id, name) WHERE (deleted_at IS NULL);
+
 CREATE UNIQUE INDEX idx_destinations_unique_id ON destinations USING btree (organization_id, unique_id) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_encryption_keys_key_id ON encryption_keys USING btree (key_id);


### PR DESCRIPTION
Branched from #3276 

This PR adds a unique constraint to destination name. The destination name must be unique because it is referred to be both grants in the `resource` field, and by users when running `infra use`. A non-unique name makes both the grants and the `use` ambiguous and will likely cause problems.