### PR TITLE
api: add support to list grants by destination

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -204,11 +204,6 @@ func (c Client) DeleteUser(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/api/users/%s", id), Query{})
 }
 
-// Deprecated: use ListGrants
-func (c Client) ListUserGrants(id uid.ID) (*ListResponse[Grant], error) {
-	return get[ListResponse[Grant]](c, fmt.Sprintf("/api/users/%s/grants", id), Query{})
-}
-
 func (c Client) ListGroups(req ListGroupsRequest) (*ListResponse[Group], error) {
 	return get[ListResponse[Group]](c, "/api/groups", Query{
 		"name": {req.Name}, "userID": {req.UserID.String()},
@@ -231,11 +226,6 @@ func (c Client) DeleteGroup(id uid.ID) error {
 func (c Client) UpdateUsersInGroup(req *UpdateUsersInGroupRequest) error {
 	_, err := patch[UpdateUsersInGroupRequest, EmptyResponse](c, fmt.Sprintf("/api/groups/%s/users", req.GroupID), req)
 	return err
-}
-
-// Deprecated: use ListGrants
-func (c Client) ListGroupGrants(id uid.ID) (*ListResponse[Grant], error) {
-	return get[ListResponse[Grant]](c, fmt.Sprintf("/api/groups/%s/grants", id), Query{})
 }
 
 func (c Client) ListProviders(req ListProvidersRequest) (*ListResponse[Provider], error) {
@@ -289,6 +279,7 @@ func (c Client) ListGrants(req ListGrantsRequest) (*ListResponse[Grant], error) 
 		"user":          {req.User.String()},
 		"group":         {req.Group.String()},
 		"resource":      {req.Resource},
+		"destination":   {req.Destination},
 		"privilege":     {req.Privilege},
 		"showInherited": {strconv.FormatBool(req.ShowInherited)},
 		"showSystem":    {strconv.FormatBool(req.ShowSystem)},

--- a/api/grant.go
+++ b/api/grant.go
@@ -35,7 +35,8 @@ func (r *CreateGrantResponse) StatusCode() int {
 type ListGrantsRequest struct {
 	User          uid.ID `form:"user"`
 	Group         uid.ID `form:"group"`
-	Resource      string `form:"resource" example:"production"`
+	Resource      string `form:"resource" example:"production.namespace"`
+	Destination   string `form:"destination" example:"production"`
 	Privilege     string `form:"privilege" example:"view"`
 	ShowInherited bool   `form:"showInherited" note:"if true, this field includes grants that the user inherits through groups"`
 	ShowSystem    bool   `form:"showSystem" note:"if true, this shows the connector and other internal grants"`
@@ -48,6 +49,10 @@ func (r ListGrantsRequest) ValidationRules() []validate.ValidationRule {
 			validate.Field{Name: "user", Value: r.User},
 			validate.Field{Name: "group", Value: r.Group},
 		),
+		validate.MutuallyExclusive(
+			validate.Field{Name: "resource", Value: r.Resource},
+			validate.Field{Name: "destination", Value: r.Destination},
+		),
 		validate.ValidatorFunc(func() *validate.Failure {
 			if r.ShowInherited && r.User == 0 {
 				return &validate.Failure{
@@ -58,6 +63,11 @@ func (r ListGrantsRequest) ValidationRules() []validate.ValidationRule {
 			return nil
 		}),
 	}
+}
+
+func (r ListGrantsRequest) SetPage(page int) Paginatable {
+	r.PaginationRequest.Page = page
+	return r
 }
 
 type CreateGrantRequest struct {
@@ -76,10 +86,4 @@ func (r CreateGrantRequest) ValidationRules() []validate.ValidationRule {
 		validate.Required("privilege", r.Privilege),
 		validate.Required("resource", r.Resource),
 	}
-}
-
-func (req ListGrantsRequest) SetPage(page int) Paginatable {
-	req.PaginationRequest.Page = page
-
-	return req
 }

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -19,8 +19,9 @@ func GetGrant(c *gin.Context, id uid.ID) (*models.Grant, error) {
 	return data.GetGrant(db, data.GetGrantOptions{ByID: id})
 }
 
-func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, privilege string, inherited bool, showSystem bool, p *data.Pagination) ([]models.Grant, error) {
+func ListGrants(c *gin.Context, opts data.ListGrantsOptions) ([]models.Grant, error) {
 	rCtx := GetRequestContext(c)
+	subject := opts.BySubject
 
 	roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
 	_, err := RequireInfraRole(c, roles...)
@@ -40,17 +41,6 @@ func ListGrants(c *gin.Context, subject uid.PolymorphicID, resource string, priv
 		}
 	} else if err != nil {
 		return nil, err
-	}
-
-	opts := data.ListGrantsOptions{
-		ByResource:                 resource,
-		BySubject:                  subject,
-		ExcludeConnectorGrant:      !showSystem,
-		IncludeInheritedFromGroups: inherited,
-		Pagination:                 p,
-	}
-	if privilege != "" {
-		opts.ByPrivileges = []string{privilege}
 	}
 	return data.ListGrants(rCtx.DBTxn, opts)
 }

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -15,12 +15,13 @@ import (
 )
 
 type grantsCmdOptions struct {
-	UserName  string
-	GroupName string
-	Resource  string
-	Role      string
-	Force     bool
-	Inherited bool
+	UserName    string
+	GroupName   string
+	Resource    string
+	Destination string
+	Role        string
+	Force       bool
+	Inherited   bool
 }
 
 func newGrantsCmd(cli *CLI) *cobra.Command {
@@ -60,6 +61,7 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 			listReq := api.ListGrantsRequest{
 				Privilege:     options.Role,
 				Resource:      options.Resource,
+				Destination:   options.Destination,
 				ShowInherited: options.Inherited,
 			}
 
@@ -114,7 +116,8 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&options.Resource, "destination", "", "Filter by destination")
+	cmd.Flags().StringVar(&options.Destination, "destination", "", "Filter by destination")
+	cmd.Flags().StringVar(&options.Resource, "resource", "", "Filter by resource")
 	cmd.Flags().StringVar(&options.GroupName, "group", "", "Filter by group name or id")
 	cmd.Flags().StringVar(&options.UserName, "user", "", "Filter by user name or id")
 	cmd.Flags().BoolVar(&options.Inherited, "inherited", false, "Include grants a user inherited through a group")

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -404,27 +404,10 @@ func getEndpointHostPort(k8s *kubernetes.Kubernetes, opts Options) (types.HostPo
 }
 
 func syncWithServer(con connector) error {
-	grants, err := con.client.ListGrants(api.ListGrantsRequest{Resource: con.destination.Name})
+	grants, err := con.client.ListGrants(api.ListGrantsRequest{Destination: con.destination.Name})
 	if err != nil {
 		logging.Errorf("error listing grants: %v", err)
 		return nil
-	}
-
-	namespaces, err := con.k8s.Namespaces()
-	if err != nil {
-		logging.Errorf("could not get kubernetes namespaces: %v", err)
-		return nil
-	}
-
-	// TODO(https://github.com/infrahq/infra/issues/2422): support wildcard resource searches
-	for _, n := range namespaces {
-		g, err := con.client.ListGrants(api.ListGrantsRequest{Resource: fmt.Sprintf("%s.%s", con.destination.Name, n)})
-		if err != nil {
-			logging.Errorf("error listing grants: %v", err)
-			return nil
-		}
-
-		grants.Items = append(grants.Items, g.Items...)
 	}
 
 	err = updateRoles(con.client, con.k8s, grants.Items)

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -105,9 +105,10 @@ func GetGrant(tx ReadTxn, opts GetGrantOptions) (*models.Grant, error) {
 }
 
 type ListGrantsOptions struct {
-	BySubject    uid.PolymorphicID
-	ByPrivileges []string
-	ByResource   string
+	BySubject     uid.PolymorphicID
+	ByPrivileges  []string
+	ByResource    string
+	ByDestination string
 
 	// IncludeInheritedFromGroups instructs ListGrants to include grants from
 	// groups where the user is a member. This option can only be used when
@@ -159,6 +160,9 @@ func ListGrants(tx ReadTxn, opts ListGrantsOptions) ([]models.Grant, error) {
 	}
 	if opts.ByResource != "" {
 		query.B("AND resource = ?", opts.ByResource)
+	}
+	if opts.ByDestination != "" {
+		query.B("AND (resource = ? OR resource LIKE ?)", opts.ByDestination, opts.ByDestination+".%")
 	}
 	if opts.ExcludeConnectorGrant {
 		query.B("AND NOT (privilege = 'connector' AND resource = 'infra')")

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -2256,9 +2256,18 @@
             }
           },
           {
-            "example": "production",
+            "example": "production.namespace",
             "in": "query",
             "name": "resource",
+            "schema": {
+              "example": "production.namespace",
+              "type": "string"
+            }
+          },
+          {
+            "example": "production",
+            "in": "query",
+            "name": "destination",
             "schema": {
               "example": "production",
               "type": "string"


### PR DESCRIPTION
## Summary

Both the UI and the connector would like to list grants by destination. 

This PR adds a new `destination` query parameter to `ListGrants`, and updates the connector to use this new parameter. In #3351 the connector will change once again to wait on updates to that query.

For now this query uses an `OR` clause. In the future we will likely want to save the destination name as a column, so that we can remove the `OR`.