### PR TITLE
fix: delete users from specific identity provider

### DIFF
--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -98,6 +98,9 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	_, err = data.GetIdentity(db, data.ByID(identity.ID))
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 
+	_, err = data.GetProviderUser(db, infraProvider.ID, identity.ID)
+	assert.ErrorIs(t, err, internal.ErrNotFound)
+
 	_, err = data.GetAccessKeyByKeyID(db, keyID)
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -53,6 +53,9 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	err := data.CreateIdentity(db, identity)
 	assert.NilError(t, err)
 
+	_, err = data.CreateProviderUser(db, infraProvider, identity)
+	assert.NilError(t, err)
+
 	// create some resources for this identity
 
 	keyID := generate.MathRandom(models.AccessKeyKeyLength, generate.CharsetAlphaNumeric)

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -74,7 +74,7 @@ $ infra users add johndoe@example.com`,
 				return err
 			}
 
-			cli.Output("Added user %q", args[0])
+			cli.Output("Added user %q to Infra", args[0])
 
 			if createResp.OneTimePassword != "" {
 				cli.Output("Password: %s", createResp.OneTimePassword)
@@ -241,7 +241,7 @@ $ infra users remove janedoe@example.com`,
 					return err
 				}
 
-				cli.Output("Removed user %q", user.Name)
+				cli.Output("Removed user %q from Infra", user.Name)
 			}
 
 			return nil

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -873,7 +873,7 @@ func (s Server) loadUsers(db data.GormTxn, users []User) error {
 	}
 
 	// remove any users previously defined by config
-	if err := data.DeleteIdentities(db, data.NotIDs(keep), data.CreatedBy(models.CreatedBySystem)); err != nil {
+	if err := data.DeleteIdentities(db, data.InfraProvider(db).ID, data.NotIDs(keep), data.CreatedBy(models.CreatedBySystem)); err != nil {
 		return err
 	}
 
@@ -902,6 +902,12 @@ func (s Server) loadUser(db data.GormTxn, input User) (*models.Identity, error) 
 		if err := data.CreateIdentity(db, identity); err != nil {
 			return nil, err
 		}
+
+		_, err = data.CreateProviderUser(db, data.InfraProvider(db), identity)
+		if err != nil {
+			return nil, err
+		}
+
 	}
 
 	if err := s.loadCredential(db, identity, input.Password); err != nil {

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -702,7 +702,7 @@ func TestLoadConfigPruneConfig(t *testing.T) {
 
 	err = s.db.Raw("SELECT COUNT(*) FROM provider_users").Scan(&providerUsers).Error
 	assert.NilError(t, err)
-	assert.Equal(t, int64(0), providerUsers)
+	assert.Equal(t, int64(1), providerUsers)
 
 	// previous config is cleared on new config application
 	newConfig := Config{

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -197,7 +197,7 @@ func deleteReferencesToIdentities(tx GormTxn, providerID uid.ID, toDelete []mode
 			return []uid.ID{}, fmt.Errorf("remove provider user: %w", err)
 		}
 
-		// if this identity only exists from an infra identity provider, remove all their groups and grants, then delete the user
+		// if this identity no longer exists in any identity providers then remove all their references
 		user, err := GetIdentity(tx, Preload("Providers"), ByID(i.ID))
 		if err != nil {
 			return []uid.ID{}, fmt.Errorf("check user providers: %w", err)

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -38,6 +38,8 @@ func createIdentities(t *testing.T, db GormTxn, identities ...*models.Identity) 
 	for i := range identities {
 		err := CreateIdentity(db, identities[i])
 		assert.NilError(t, err, identities[i].Name)
+		_, err = CreateProviderUser(db, InfraProvider(db), identities[i])
+		assert.NilError(t, err, identities[i].Name)
 	}
 }
 
@@ -155,14 +157,14 @@ func TestDeleteIdentity(t *testing.T) {
 		_, err := GetIdentity(db, ByName(bond.Name))
 		assert.NilError(t, err)
 
-		err = DeleteIdentities(db, ByName(bond.Name))
+		err = DeleteIdentities(db, InfraProvider(db).ID, ByName(bond.Name))
 		assert.NilError(t, err)
 
 		_, err = GetIdentity(db, ByName(bond.Name))
 		assert.Error(t, err, "record not found")
 
 		// deleting a nonexistent identity should not fail
-		err = DeleteIdentities(db, ByName(bond.Name))
+		err = DeleteIdentities(db, InfraProvider(db).ID, ByName(bond.Name))
 		assert.NilError(t, err)
 
 		// deleting a identity should not delete unrelated identities
@@ -187,7 +189,7 @@ func TestDeleteIdentityWithGroups(t *testing.T) {
 		err = AddUsersToGroup(db, group.ID, []uid.ID{bond.ID, bourne.ID, bauer.ID})
 		assert.NilError(t, err)
 
-		err = DeleteIdentities(db, ByName(bond.Name))
+		err = DeleteIdentities(db, InfraProvider(db).ID, ByName(bond.Name))
 		assert.NilError(t, err)
 
 		group, err = GetGroup(db, ByID(group.ID))
@@ -206,7 +208,7 @@ func TestReCreateIdentitySameName(t *testing.T) {
 
 		createIdentities(t, db, &bond, &bourne, &bauer)
 
-		err := DeleteIdentities(db, ByName(bond.Name))
+		err := DeleteIdentities(db, InfraProvider(db).ID, ByName(bond.Name))
 		assert.NilError(t, err)
 
 		err = CreateIdentity(db, &models.Identity{Name: bond.Name})

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -74,7 +74,7 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 		}
 
 		if len(userIDsToDelete) > 0 {
-			if err := DeleteIdentities(db, ByIDs(userIDsToDelete)); err != nil {
+			if err := DeleteIdentities(db, p.ID, ByIDs(userIDsToDelete)); err != nil {
 				return fmt.Errorf("delete users: %w", err)
 			}
 		}

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -161,6 +161,9 @@ func TestDeleteProviders(t *testing.T) {
 		t.Run("access keys issued using different provider from deleted are NOT revoked", func(t *testing.T) {
 			setup()
 
+			_, err := CreateProviderUser(db, &providerProduction, user)
+			assert.NilError(t, err)
+
 			key := &models.AccessKey{
 				Name:       "test key",
 				IssuedFor:  user.ID,
@@ -168,13 +171,17 @@ func TestDeleteProviders(t *testing.T) {
 				ExpiresAt:  time.Now().Add(5 * time.Minute),
 			}
 
-			_, err := CreateAccessKey(db, key)
+			_, err = CreateAccessKey(db, key)
 			assert.NilError(t, err)
 
 			err = DeleteProviders(db, ByOptionalName(providerDevelop.Name))
 			assert.NilError(t, err)
 
 			_, err = GetAccessKeyByKeyID(db, key.KeyID)
+			assert.NilError(t, err)
+
+			// clean up
+			err = DeleteProviders(db, ByOptionalName(providerProduction.Name))
 			assert.NilError(t, err)
 		})
 

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -336,7 +336,10 @@ export default function Users() {
               )
 
               // can only delete users that exist within Infra which are not the currently logged in user
-              if (info.row.original.id === user?.id || !info.row.original.providerNames.includes("infra")) {
+              if (
+                info.row.original.id === user?.id ||
+                !info.row.original.providerNames.includes('infra')
+              ) {
                 return null
               }
 

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -335,7 +335,8 @@ export default function Users() {
                 }
               )
 
-              if (info.row.original.id === user?.id) {
+              // can only delete users that exist within Infra which are not the currently logged in user
+              if (info.row.original.id === user?.id || !info.row.original.providerNames.includes("infra")) {
                 return null
               }
 
@@ -374,7 +375,7 @@ export default function Users() {
                                     onClick={() => setOpen(true)}
                                   >
                                     <XIcon className='mr-1 mt-px h-3.5 w-3.5' />{' '}
-                                    Remove user
+                                    Remove Infra user
                                   </button>
                                 )}
                               </Menu.Item>


### PR DESCRIPTION
- infra users command adds/removes from the infra identity provider specifically
- consolidate identity deletion logic
- delete identity when it no longer exists in any identity provider

## Summary
When a user is deleted using `infra users add` or `infra users rm` only delete the resources associated with the identity through the Infra provider. Users from other identity providers can be removed by removing the associated provider, or through SCIM (soon).

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3397
Resolves #2838
