### PR TITLE
fix: remove provider users for deleted identities

### DIFF
--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -775,10 +775,10 @@ DELETE FROM settings WHERE id=24567;
 				assert.NilError(t, err)
 			},
 			expected: func(t *testing.T, db WriteTxn) {
-				var remainingProviderUser uid.ID
-				err := db.QueryRow(`SELECT identity_id FROM provider_users`).Scan(&remainingProviderUser)
+				var count int
+				err := db.QueryRow(`SELECT count(*) from provider_users where identity_id = 1111`).Scan(&count)
 				assert.NilError(t, err)
-				assert.Equal(t, remainingProviderUser, uid.ID(2222))
+				assert.Equal(t, count, 0)
 			},
 		},
 	}

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -736,7 +736,6 @@ DELETE FROM settings WHERE id=24567;
 					(10009, 'with.dot.no.more'),
 					(10010, 'no-dots')`)
 				assert.NilError(t, err)
-
 			},
 			cleanup: func(t *testing.T, db WriteTxn) {
 				_, err := db.Exec("DELETE FROM destinations")
@@ -757,6 +756,29 @@ DELETE FROM settings WHERE id=24567;
 			label: testCaseLine("2022-10-05T11:12"),
 			expected: func(t *testing.T, db WriteTxn) {
 				// schema changes are tested with schema comparison
+			},
+		},
+		{
+			label: testCaseLine("2022-10-05T18:00:00"),
+			setup: func(t *testing.T, db WriteTxn) {
+				_, err := db.Exec("INSERT INTO identities(id, name, deleted_at) VALUES(1111, 'hello@example.com', ?)", time.Now())
+				assert.NilError(t, err)
+				_, err = db.Exec("INSERT INTO provider_users(provider_id, identity_id, email) VALUES(9999, 1111, 'hello@example.com')")
+				assert.NilError(t, err)
+				_, err = db.Exec("INSERT INTO provider_users(provider_id, identity_id, email) VALUES(9999, 2222, 'hello@example.com')")
+				assert.NilError(t, err)
+			},
+			cleanup: func(t *testing.T, db WriteTxn) {
+				_, err := db.Exec("DELETE FROM identities")
+				assert.NilError(t, err)
+				_, err = db.Exec("DELETE FROM provider_users")
+				assert.NilError(t, err)
+			},
+			expected: func(t *testing.T, db WriteTxn) {
+				var remainingProviderUser uid.ID
+				err := db.QueryRow(`SELECT identity_id FROM provider_users`).Scan(&remainingProviderUser)
+				assert.NilError(t, err)
+				assert.Equal(t, remainingProviderUser, uid.ID(2222))
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
This should be merged after #3398
When an identity was deleted through the CLI the associated provider user was not deleted. This migration cleans up provider_user records that reference a deleted identity.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3397
