### PR TITLE
Listen and notify for grants

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -32,6 +32,18 @@ jobs:
     strategy:
       matrix:
         name: ${{ fromJson(needs.fuzz-matrix.outputs.fuzz-names) }}
+    services:
+      postgres:
+        image: postgres:14-alpine
+        env:
+          POSTGRES_PASSWORD: password123
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports: ["127.0.0.1:5432:5432"]
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -55,4 +67,5 @@ jobs:
           # fuzz won't run with ./..., so lookup the package name
           dir="$(git grep -l "^func ${name}" | xargs dirname)"
           go test -v -fuzz=${name} -fuzztime "${fuzz_time:-30m}" "./${dir}"
-
+        env:
+          POSTGRESQL_CONNECTION: "host=localhost port=5432 user=postgres dbname=postgres password=password123"

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgconn"
@@ -271,8 +272,6 @@ type ListenForGrantsOptions struct {
 //
 // If error is nil the caller must call Listener.Release to return the database
 // connection to the pool.
-//
-// TODO: fuzz this function to show it is not vulnerable to SQL injection
 func ListenForGrantsNotify(ctx context.Context, db *DB, opts ListenForGrantsOptions) (*Listener, error) {
 	if opts.OrgID == 0 {
 		return nil, fmt.Errorf("OrgID is required")
@@ -305,6 +304,8 @@ func ListenForGrantsNotify(ctx context.Context, db *DB, opts ListenForGrantsOpti
 }
 
 func channelGrantsByDestination(orgID uid.ID, destination string) string {
+	destination = strings.ToValidUTF8(destination, "")
+	destination = strings.ReplaceAll(destination, "\x00", "")
 	return fmt.Sprintf("grants_by_destination_%d_%v", orgID, destination)
 }
 

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -87,6 +87,8 @@ func TestDeleteGrants(t *testing.T) {
 		otherOrg := &models.Organization{Name: "other", Domain: "other.example.org"}
 		assert.NilError(t, CreateOrganization(db, otherOrg))
 
+		var startUpdateIndex int64 = 10001
+
 		t.Run("empty options", func(t *testing.T) {
 			err := DeleteGrants(db, DeleteGrantsOptions{})
 			assert.ErrorContains(t, err, "requires an ID to delete")
@@ -101,12 +103,15 @@ func TestDeleteGrants(t *testing.T) {
 			err := DeleteGrants(tx, DeleteGrantsOptions{ByID: grant.ID})
 			assert.NilError(t, err)
 
-			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any"})
+			var maxIndex int64
+			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any", MaxUpdateIndex: &maxIndex})
 			assert.NilError(t, err)
 			expected := []models.Grant{
 				{Model: models.Model{ID: toKeep.ID}},
 			}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
+			assert.Equal(t, maxIndex, startUpdateIndex+3) // 2 inserts, 1 delete
+			startUpdateIndex = maxIndex
 		})
 		t.Run("by subject", func(t *testing.T) {
 			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
@@ -122,12 +127,15 @@ func TestDeleteGrants(t *testing.T) {
 			err := DeleteGrants(tx, DeleteGrantsOptions{BySubject: grant1.Subject})
 			assert.NilError(t, err)
 
-			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any"})
+			var maxIndex int64
+			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any", MaxUpdateIndex: &maxIndex})
 			assert.NilError(t, err)
 			expected := []models.Grant{
 				{Model: models.Model{ID: toKeep.ID}},
 			}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
+			assert.Equal(t, maxIndex, startUpdateIndex+6) // 4 inserts, 2 deletes
+			startUpdateIndex = maxIndex
 
 			actual, err = ListGrants(tx.WithOrgID(otherOrg.ID), ListGrantsOptions{ByResource: "any"})
 			assert.NilError(t, err)
@@ -149,13 +157,16 @@ func TestDeleteGrants(t *testing.T) {
 			})
 			assert.NilError(t, err)
 
-			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any"})
+			var maxIndex int64
+			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any", MaxUpdateIndex: &maxIndex})
 			assert.NilError(t, err)
 			expected := []models.Grant{
 				{Model: models.Model{ID: toKeep1.ID}},
 				{Model: models.Model{ID: toKeep2.ID}},
 			}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
+			assert.Equal(t, maxIndex, startUpdateIndex+6) // 4 inserts, 2 deletes
+			startUpdateIndex = maxIndex
 		})
 	})
 }
@@ -232,6 +243,7 @@ func TestGetGrant(t *testing.T) {
 				Privilege:          "view",
 				Resource:           "any",
 				CreatedBy:          uid.ID(777),
+				UpdateIndex:        10001,
 			}
 			assert.DeepEqual(t, actual, expected, cmpModel)
 		})
@@ -254,6 +266,7 @@ func TestGetGrant(t *testing.T) {
 				Privilege:          "view",
 				Resource:           "any",
 				CreatedBy:          uid.ID(777),
+				UpdateIndex:        10001,
 			}
 			assert.DeepEqual(t, actual, expected, cmpModel)
 		})

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	pgxstdlib "github.com/jackc/pgx/v4/stdlib"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
@@ -82,14 +81,11 @@ func TestCreateGrant(t *testing.T) {
 			assert.NilError(t, err)
 		})
 		t.Run("notify", func(t *testing.T) {
-			sqlDB := db.SQLdb()
-			pgxConn, err := pgxstdlib.AcquireConn(sqlDB)
+			listener, err := ListenForGrantsNotify(db, ListenGrantsOptions{ByResource: "match"})
 			assert.NilError(t, err)
-			defer pgxstdlib.ReleaseConn(sqlDB, pgxConn)
-
-			ctx := context.Background()
-			_, err = pgxConn.Exec(ctx, "LISTEN grants_by_resource_match")
-			assert.NilError(t, err)
+			t.Cleanup(func() {
+				assert.NilError(t, listener.Release(context.Background()))
+			})
 
 			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 			g := models.Grant{
@@ -101,9 +97,9 @@ func TestCreateGrant(t *testing.T) {
 			assert.NilError(t, err)
 			assert.NilError(t, tx.Commit())
 
-			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
-			notification, err := pgxConn.WaitForNotification(ctx)
+			notification, err := listener.pgxConn.WaitForNotification(ctx)
 			assert.NilError(t, err)
 			assert.Equal(t, notification.Channel, "grants_by_resource_match")
 		})
@@ -204,23 +200,21 @@ func TestDeleteGrants(t *testing.T) {
 			}
 			assert.NilError(t, CreateGrant(db, &g))
 
-			sqlDB := db.SQLdb()
-			pgxConn, err := pgxstdlib.AcquireConn(sqlDB)
+			listener, err := ListenForGrantsNotify(db, ListenGrantsOptions{ByResource: "match"})
 			assert.NilError(t, err)
-			defer pgxstdlib.ReleaseConn(sqlDB, pgxConn)
-
-			ctx := context.Background()
-			_, err = pgxConn.Exec(ctx, "LISTEN grants_by_resource_match")
-			assert.NilError(t, err)
+			t.Cleanup(func() {
+				assert.NilError(t, listener.Release(context.Background()))
+			})
 
 			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 			err = DeleteGrants(tx, DeleteGrantsOptions{BySubject: "i:1234567"})
 			assert.NilError(t, err)
 			assert.NilError(t, tx.Commit())
 
-			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			defer cancel()
-			notification, err := pgxConn.WaitForNotification(ctx)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			t.Cleanup(cancel)
+
+			notification, err := listener.pgxConn.WaitForNotification(ctx)
 			assert.NilError(t, err)
 			assert.Equal(t, notification.Channel, "grants_by_resource_match")
 		})

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -131,13 +131,15 @@ func TestDeleteGrants(t *testing.T) {
 			err := DeleteGrants(tx, DeleteGrantsOptions{ByID: grant.ID})
 			assert.NilError(t, err)
 
-			var maxIndex int64
-			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any", MaxUpdateIndex: &maxIndex})
+			actual, err := ListGrants(tx, ListGrantsOptions{ByDestination: "any"})
 			assert.NilError(t, err)
 			expected := []models.Grant{
 				{Model: models.Model{ID: toKeep.ID}},
 			}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
+
+			maxIndex, err := GrantsMaxUpdateIndex(tx, GrantsMaxUpdateIndexOptions{ByDestination: "any"})
+			assert.NilError(t, err)
 			assert.Equal(t, maxIndex, startUpdateIndex+3) // 2 inserts, 1 delete
 			startUpdateIndex = maxIndex
 		})
@@ -155,17 +157,20 @@ func TestDeleteGrants(t *testing.T) {
 			err := DeleteGrants(tx, DeleteGrantsOptions{BySubject: grant1.Subject})
 			assert.NilError(t, err)
 
-			var maxIndex int64
-			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any", MaxUpdateIndex: &maxIndex})
+			actual, err := ListGrants(tx, ListGrantsOptions{ByDestination: "any"})
 			assert.NilError(t, err)
 			expected := []models.Grant{
 				{Model: models.Model{ID: toKeep.ID}},
 			}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
+
+			maxIndex, err := GrantsMaxUpdateIndex(tx, GrantsMaxUpdateIndexOptions{ByDestination: "any"})
+			assert.NilError(t, err)
 			assert.Equal(t, maxIndex, startUpdateIndex+6) // 4 inserts, 2 deletes
 			startUpdateIndex = maxIndex
 
-			actual, err = ListGrants(tx.WithOrgID(otherOrg.ID), ListGrantsOptions{ByResource: "any"})
+			// other org still has the grant
+			actual, err = ListGrants(tx.WithOrgID(otherOrg.ID), ListGrantsOptions{ByDestination: "any"})
 			assert.NilError(t, err)
 			assert.Equal(t, len(actual), 1)
 		})
@@ -185,14 +190,16 @@ func TestDeleteGrants(t *testing.T) {
 			})
 			assert.NilError(t, err)
 
-			var maxIndex int64
-			actual, err := ListGrants(tx, ListGrantsOptions{ByResource: "any", MaxUpdateIndex: &maxIndex})
+			actual, err := ListGrants(tx, ListGrantsOptions{ByDestination: "any"})
 			assert.NilError(t, err)
 			expected := []models.Grant{
 				{Model: models.Model{ID: toKeep1.ID}},
 				{Model: models.Model{ID: toKeep2.ID}},
 			}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
+
+			maxIndex, err := GrantsMaxUpdateIndex(tx, GrantsMaxUpdateIndexOptions{ByDestination: "any"})
+			assert.NilError(t, err)
 			assert.Equal(t, maxIndex, startUpdateIndex+6) // 4 inserts, 2 deletes
 			startUpdateIndex = maxIndex
 		})

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -800,13 +800,14 @@ func addUpdateIndexAndGrantNotify() *migrator.Migration {
 				return err
 			}
 
-			// TODO: use destination name not resource
 			fn := `
 CREATE OR REPLACE FUNCTION grants_notify() RETURNS trigger
 	LANGUAGE PLPGSQL
 	AS $$
+DECLARE
+	destination text := split_part(NEW.resource, '.', 1);
 BEGIN
-PERFORM pg_notify('grants_by_resource_' || NEW.resource, '');
+PERFORM pg_notify('grants_by_destination_' || NEW.organization_id || '_' || destination, '');
 RETURN NULL;
 END; $$;
 

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -74,7 +74,7 @@ func migrations() []*migrator.Migration {
 		destinationNameUnique(),
 		removeDeletedIdentityProviderUsers(),
 		addProviderUserSCIMFields(),
-		addUpdateIndex(),
+		addUpdateIndexAndGrantNotify(),
 		// next one here
 	}
 }
@@ -779,7 +779,7 @@ func removeDeletedIdentityProviderUsers() *migrator.Migration {
 	}
 }
 
-func addUpdateIndex() *migrator.Migration {
+func addUpdateIndexAndGrantNotify() *migrator.Migration {
 	return &migrator.Migration{
 		ID: "2022-09-21T13:50",
 		Migrate: func(tx migrator.DB) error {
@@ -800,6 +800,23 @@ func addUpdateIndex() *migrator.Migration {
 				return err
 			}
 
+			// TODO: use destination name not resource
+			fn := `
+CREATE OR REPLACE FUNCTION grants_notify() RETURNS trigger
+	LANGUAGE PLPGSQL
+	AS $$
+BEGIN
+PERFORM pg_notify('grants_by_resource_' || NEW.resource, '');
+RETURN NULL;
+END; $$;
+
+CREATE OR REPLACE TRIGGER grants_notify_trigger AFTER insert OR update
+ON grants
+FOR EACH ROW EXECUTE FUNCTION grants_notify();
+`
+			if _, err := tx.Exec(fn); err != nil {
+				return err
+			}
 			return nil
 		},
 	}

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -784,6 +784,12 @@ DELETE FROM settings WHERE id=24567;
 				// schema changes are tested with schema comparison
 			},
 		},
+		{
+			label: testCaseLine("2022-09-21T13:50"),
+			expected: func(t *testing.T, db WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -63,6 +63,7 @@ func TestCreateOrganization(t *testing.T) {
 			Privilege:          models.InfraConnectorRole,
 			Resource:           "infra",
 			CreatedBy:          models.CreatedBySystem,
+			UpdateIndex:        10001,
 		}
 		assert.DeepEqual(t, connectorGrant, expectedConnectorGrant)
 	})

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -4,6 +4,14 @@
 --     go test -run TestMigrations ./internal/server/data -update
 --
 
+CREATE FUNCTION grants_notify() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+PERFORM pg_notify('grants_by_resource_' || NEW.resource, '');
+RETURN NULL;
+END; $$;
+
 CREATE FUNCTION uidinttostr(id bigint) RETURNS text
     LANGUAGE plpgsql
     AS $$
@@ -316,3 +324,5 @@ CREATE UNIQUE INDEX idx_password_reset_tokens_token ON password_reset_tokens USI
 CREATE UNIQUE INDEX idx_providers_name ON providers USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX settings_org_id ON settings USING btree (organization_id) WHERE (deleted_at IS NULL);
+
+CREATE TRIGGER grants_notify_trigger AFTER INSERT OR UPDATE ON grants FOR EACH ROW EXECUTE FUNCTION grants_notify();

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -12,6 +12,13 @@ PERFORM pg_notify('grants_by_resource_' || NEW.resource, '');
 RETURN NULL;
 END; $$;
 
+CREATE FUNCTION listen_on_chan(chan text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    EXECUTE format('LISTEN %I', chan);
+END; $$;
+
 CREATE FUNCTION uidinttostr(id bigint) RETURNS text
     LANGUAGE plpgsql
     AS $$

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -7,8 +7,10 @@
 CREATE FUNCTION grants_notify() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
+DECLARE
+	destination text := split_part(NEW.resource, '.', 1);
 BEGIN
-PERFORM pg_notify('grants_by_resource_' || NEW.resource, '');
+PERFORM pg_notify('grants_by_destination_' || NEW.organization_id || '_' || destination, '');
 RETURN NULL;
 END; $$;
 

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -139,7 +139,8 @@ CREATE TABLE grants (
     privilege text,
     resource text,
     created_by bigint,
-    organization_id bigint
+    organization_id bigint,
+    update_index bigint
 );
 
 CREATE TABLE groups (
@@ -223,6 +224,13 @@ CREATE TABLE providers (
     organization_id bigint
 );
 
+CREATE SEQUENCE seq_update_index
+    START WITH 10000
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
 CREATE TABLE settings (
     id bigint NOT NULL,
     created_at timestamp with time zone,
@@ -292,6 +300,8 @@ CREATE UNIQUE INDEX idx_emails_providers ON provider_users USING btree (email, p
 CREATE UNIQUE INDEX idx_encryption_keys_key_id ON encryption_keys USING btree (key_id);
 
 CREATE UNIQUE INDEX idx_grant_srp ON grants USING btree (organization_id, subject, privilege, resource) WHERE (deleted_at IS NULL);
+
+CREATE INDEX idx_grants_update_index ON grants USING btree (organization_id, update_index);
 
 CREATE UNIQUE INDEX idx_groups_name ON groups USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 

--- a/internal/server/data/schema/parse.go
+++ b/internal/server/data/schema/parse.go
@@ -126,6 +126,7 @@ func parseStatementLine(line string) (table, parsed string, err error) {
 	case strings.HasPrefix(line, "CREATE UNIQUE INDEX"):
 	case strings.HasPrefix(line, "CREATE INDEX"):
 	case strings.HasPrefix(line, "CREATE FUNCTION"):
+	case strings.HasPrefix(line, "CREATE TRIGGER"):
 	default:
 		return "", "", fmt.Errorf("unexpected start of statement: %q", line)
 	}

--- a/internal/server/data/schema/parse.go
+++ b/internal/server/data/schema/parse.go
@@ -124,6 +124,7 @@ func parseStatementLine(line string) (table, parsed string, err error) {
 	case strings.HasPrefix(line, "CREATE SEQUENCE"):
 	case strings.HasPrefix(line, "ALTER SEQUENCE"):
 	case strings.HasPrefix(line, "CREATE UNIQUE INDEX"):
+	case strings.HasPrefix(line, "CREATE INDEX"):
 	case strings.HasPrefix(line, "CREATE FUNCTION"):
 	default:
 		return "", "", fmt.Errorf("unexpected start of statement: %q", line)
@@ -178,6 +179,8 @@ func TrimComments(input string) (string, error) {
 		case strings.HasPrefix(line, "SET "):
 			continue
 		case strings.HasPrefix(line, "SELECT pg_catalog.set_config"):
+			continue
+		case strings.HasPrefix(line, "SELECT pg_catalog.setval"):
 			continue
 		}
 		buf.WriteString(line + "\n")

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -42,10 +42,11 @@ type Grant struct {
 	Model
 	OrganizationMember
 
-	Subject   uid.PolymorphicID `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // usually an identity, but could be a role definition
-	Privilege string            `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // role or permission
-	Resource  string            `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // Universal Resource Notation
-	CreatedBy uid.ID
+	Subject     uid.PolymorphicID `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // usually an identity, but could be a role definition
+	Privilege   string            `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // role or permission
+	Resource    string            `gorm:"uniqueIndex:idx_grant_srp,where:deleted_at is NULL"` // Universal Resource Notation
+	CreatedBy   uid.ID
+	UpdateIndex int64 `db:"-"`
 }
 
 func (r *Grant) ToAPI() *api.Grant {


### PR DESCRIPTION
## Summary

Branched from #3396 , extracted from #3351 

This PR adds `data` package and DB support for listen/notify to be used for long-polling `ListGrants` requests.

* adds a `seq_update_index` sequence for tracking updates
* adds an `update_index` column to the `grants` table, and sets the value to the next value in the index on every insert and soft-delete
* adds a trigger and trigger function for calling `pg_notify` on queries that insert or update (soft-delete does update) grants.
* adds a function to listen and wait on notifications
* adds a `GrantsMaxUpdateIndex` for getting the max update index for a query (which must include soft-deleted rows

TODO:
* [x] add a fuzz test for the `Listen` function (more details in the TODO comment in the code)

API support will come in a follow up PR, but most of it can be seen in #3351 