### PR TITLE
feat: add endpoint to get a user's own organization

### DIFF
--- a/api/organization.go
+++ b/api/organization.go
@@ -13,6 +13,10 @@ type Organization struct {
 	Domain  string `json:"domain"`
 }
 
+type GetOrganizationRequest struct {
+	ID IDOrSelf `uri:"id"`
+}
+
 type ListOrganizationsRequest struct {
 	Name string `form:"name"`
 	PaginationRequest

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -176,6 +176,10 @@ func jsonUnmarshal(t *testing.T, raw string) interface{} {
 	return out
 }
 
+var cmpAPIOrganizationJSON = gocmp.Options{
+	gocmp.FilterPath(pathMapKey(`created`, `updated`), cmpApproximateTime),
+}
+
 var cmpAPIUserJSON = gocmp.Options{
 	gocmp.FilterPath(pathMapKey(`created`, `updated`, `lastSeenAt`), cmpApproximateTime),
 	gocmp.FilterPath(pathMapKey(`id`), cmpAnyValidUID),

--- a/internal/server/models/organization.go
+++ b/internal/server/models/organization.go
@@ -15,9 +15,11 @@ type Organization struct {
 
 func (o *Organization) ToAPI() *api.Organization {
 	return &api.Organization{
-		ID:     o.ID,
-		Name:   o.Name,
-		Domain: o.Domain,
+		ID:      o.ID,
+		Name:    o.Name,
+		Created: api.Time(o.CreatedAt),
+		Updated: api.Time(o.UpdatedAt),
+		Domain:  o.Domain,
 	}
 }
 

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -1,16 +1,20 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func createOrgs(t *testing.T, db data.GormTxn, orgs ...*models.Organization) {
@@ -19,6 +23,158 @@ func createOrgs(t *testing.T, db data.GormTxn, orgs ...*models.Organization) {
 		err := data.CreateOrganization(db, orgs[i])
 		assert.NilError(t, err, orgs[i].Name)
 	}
+}
+
+func TestAPI_GetOrganization(t *testing.T) {
+	srv := setupServer(t, withAdminUser, withSupportAdminGrant, withMultiOrgEnabled)
+	routes := srv.GenerateRoutes()
+
+	var (
+		first = models.Organization{Name: "first", Domain: "first.com"}
+	)
+
+	createOrgs(t, srv.DB(), &first)
+	createID := func(t *testing.T, name string) uid.ID {
+		t.Helper()
+		var buf bytes.Buffer
+		body := api.CreateUserRequest{Name: name}
+		err := json.NewEncoder(&buf).Encode(body)
+		assert.NilError(t, err)
+
+		// nolint:noctx
+		req, err := http.NewRequest(http.MethodPost, "/api/users", &buf)
+		assert.NilError(t, err)
+		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+		req.Header.Set("Infra-Version", apiVersionLatest)
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+		assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
+		respObj := &api.CreateUserResponse{}
+		err = json.Unmarshal(resp.Body.Bytes(), respObj)
+		assert.NilError(t, err)
+		return respObj.ID
+	}
+	idMe := createID(t, "me@example.com")
+
+	token := &models.AccessKey{
+		IssuedFor:  idMe,
+		ProviderID: data.InfraProvider(srv.DB()).ID,
+		ExpiresAt:  time.Now().Add(10 * time.Second),
+	}
+
+	accessKeyMe, err := data.CreateAccessKey(srv.DB(), token)
+	assert.NilError(t, err)
+
+	type testCase struct {
+		urlPath  string
+		setup    func(t *testing.T, req *http.Request)
+		expected func(t *testing.T, resp *httptest.ResponseRecorder)
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		req, err := http.NewRequest(http.MethodGet, tc.urlPath, nil)
+		assert.NilError(t, err)
+		req.Header.Add("Infra-Version", "0.15.2")
+
+		if tc.setup != nil {
+			tc.setup(t, req)
+		}
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+
+		tc.expected(t, resp)
+	}
+
+	testCases := map[string]testCase{
+		"not authenticated": {
+			urlPath: "/api/organizations/" + first.ID.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Del("Authorization")
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusUnauthorized)
+			},
+		},
+		"not authorized": {
+			urlPath: "/api/organizations/" + first.ID.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				key, _ := createAccessKey(t, srv.DB(), "someonenew@example.com")
+				req.Header.Set("Authorization", "Bearer "+key)
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusForbidden)
+			},
+		},
+		"organization by ID for default org": {
+			urlPath: "/api/organizations/" + srv.db.DefaultOrg.ID.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+accessKeyMe)
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK)
+			},
+		},
+		"organization by ID for a different org": {
+			urlPath: "/api/organizations/" + first.ID.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+accessKeyMe)
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusForbidden)
+			},
+		},
+		"organization by ID for a different org by support admin": {
+			urlPath: "/api/organizations/" + first.ID.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK)
+			},
+		},
+		"organization by self": {
+			urlPath: "/api/organizations/self",
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+accessKeyMe)
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK)
+			},
+		},
+		"JSON response": {
+			urlPath: "/api/organizations/" + srv.db.DefaultOrg.ID.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+accessKeyMe)
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK)
+
+				expected := jsonUnmarshal(t, fmt.Sprintf(`
+					{
+						"id": "%[1]v",
+						"name": "%[2]v",
+						"created": "%[3]v",
+						"updated": "%[3]v",
+						"domain": "%[4]v"
+					}`,
+					srv.db.DefaultOrg.ID.String(),
+					srv.db.DefaultOrg.Name,
+					time.Now().UTC().Format(time.RFC3339),
+					srv.db.DefaultOrg.Domain,
+				))
+				actual := jsonUnmarshal(t, resp.Body.String())
+				assert.DeepEqual(t, actual, expected, cmpAPIOrganizationJSON)
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+
 }
 
 func TestAPI_ListOrganizations(t *testing.T) {

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -3809,9 +3809,10 @@
             "name": "id",
             "required": true,
             "schema": {
+              "description": "a uid or the literal self",
               "example": "4yJ3n3D8E2",
-              "format": "uid",
-              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+              "format": "uid|self",
+              "pattern": "[\\da-zA-HJ-NP-Z]{1,11}|self",
               "type": "string"
             }
           }


### PR DESCRIPTION
## Summary

This change modifies the `GET /api/organizations/:id` endpoint to now support `GET /api/organizations/self` similar to how `GET /api/identities/self` works. The user does not need to be an infra support admin to retrieve their own organization details.

Additionally, the `created` and `updated` fields inside of the JSON response are now being properly updated (instead of returning `null` values), and a unit test for the endpoint has been added.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


