### PR TITLE
fix postgres-dev to only listen on localhost

### DIFF
--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -48,7 +48,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        ports: ["5432:5432"]
+        ports: ["127.0.0.1:5432:5432"]
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,9 @@ postgres:
 	docker run -d --name=postgres-dev --rm \
 		-e POSTGRES_PASSWORD=password123 \
 		--tmpfs=/var/lib/postgresql/data \
-		-p 15432:5432 \
-		postgres:14-alpine -c fsync=off -c full_page_writes=off
+		-p 127.0.0.1:15432:5432 \
+		postgres:14-alpine -c fsync=off -c full_page_writes=off \
+			-c listen_addresses=127.0.0.1 -c max_connections=100
 	@echo
 	@echo Copy the line below into the shell used to run tests
 	@echo 'export POSTGRESQL_CONNECTION="host=localhost port=15432 user=postgres dbname=postgres password=password123"'

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -12,8 +12,8 @@ services:
       - INFRA_SERVER_TLS_CA_PRIVATE_KEY=file:internal/server/testdata/pki/ca.key
     command: server --ui-proxy-url http://ui:3000 --db-host db --db-name postgres --db-port 5432 --db-username postgres --db-password postgres --enable-signup --base-domain localhost
     ports:
-      - "80:80"
-      - "443:443"
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:443:443"
     depends_on:
       db:
         condition: service_healthy
@@ -38,7 +38,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=postgres
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - /var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Summary

The default for docker port mapping is `0.0.0.0` (all interfaces), which can be a security risk. If a developer laptop is ever connected to an untrusted network, someone on that network could connect to the database and use `COPY` and other postgres operations to read files or even run processes on the laptop.

By mapping the host port to 127.0.0.1 we ensure that no one can connect to the dev database except for the processes on the local host.

If you are using Docker for Mac I could use your help to confirm this works with that setup.