### PR TITLE
feat: SCIM list provider users

### DIFF
--- a/api/scim.go
+++ b/api/scim.go
@@ -1,0 +1,67 @@
+package api
+
+import "github.com/infrahq/infra/internal/validate"
+
+type SCIMUserName struct {
+	GivenName  string `json:"givenName"`
+	FamilyName string `json:"familyName"`
+}
+
+type SCIMUserEmail struct {
+	Primary bool   `json:"primary"`
+	Value   string `json:"value"`
+}
+
+func (r SCIMUserEmail) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.Required("value", r.Value),
+		validate.Email("value", r.Value),
+	}
+}
+
+const UserSchema = "urn:ietf:params:scim:schemas:core:2.0:User"
+
+type SCIMMetadata struct {
+	ResourceType string `json:"resourceType"`
+}
+
+type SCIMUser struct {
+	Schemas  []string        `json:"schemas"`
+	ID       string          `json:"id"`
+	UserName string          `json:"userName"`
+	Name     SCIMUserName    `json:"name"`
+	Emails   []SCIMUserEmail `json:"emails"`
+	Active   bool            `json:"active"`
+	Meta     SCIMMetadata    `json:"meta"`
+}
+
+type SCIMParametersRequest struct {
+	// these pagination parameters must conform to the SCIM spec, rather than our standard pagination
+	StartIndex int `form:"startIndex"`
+	Count      int `form:"count"`
+}
+
+func (r SCIMParametersRequest) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.IntRule{
+			Name:  "startIndex",
+			Value: r.StartIndex,
+			Min:   validate.Int(0),
+		},
+		validate.IntRule{
+			Name:  "count",
+			Value: r.Count,
+			Min:   validate.Int(0),
+		},
+	}
+}
+
+const ListResponseSchema = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+
+type ListProviderUsersResponse struct {
+	Schemas      []string   `json:"schemas"`
+	TotalResults int        `json:"totalResults"`
+	Resources    []SCIMUser `json:"Resources"` // intentionally capitalized
+	StartIndex   int        `json:"startIndex"`
+	ItemsPerPage int        `json:"itemsPerPage"`
+}

--- a/internal/access/scim.go
+++ b/internal/access/scim.go
@@ -1,0 +1,20 @@
+package access
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func ListProviderUsers(c *gin.Context, p *data.SCIMParameters) ([]models.ProviderUser, error) {
+	// this can only be run by an access key issued for an identity provider
+	ctx := GetRequestContext(c)
+	users, err := data.ListProviderUsers(ctx.DBTxn, ctx.Authenticated.AccessKey.IssuedFor, p)
+	if err != nil {
+		return nil, fmt.Errorf("list provider users: %w", err)
+	}
+	return users, nil
+}

--- a/internal/access/scim.go
+++ b/internal/access/scim.go
@@ -10,8 +10,10 @@ import (
 )
 
 func ListProviderUsers(c *gin.Context, p *data.SCIMParameters) ([]models.ProviderUser, error) {
-	// this can only be run by an access key issued for an identity provider
 	ctx := GetRequestContext(c)
+	// IssuedFor will match no providers if called with a regular access key. When called with
+	// a SCIM access key it will be the provider ID. This effectively restricts this endpoint to
+	// only SCIM access keys.
 	users, err := data.ListProviderUsers(ctx.DBTxn, ctx.Authenticated.AccessKey.IssuedFor, p)
 	if err != nil {
 		return nil, fmt.Errorf("list provider users: %w", err)

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -785,8 +785,8 @@ func addProviderUserSCIMFields() *migrator.Migration {
 		Migrate: func(tx migrator.DB) error {
 			stmt := `
 				ALTER TABLE provider_users
-				ADD COLUMN IF NOT EXISTS given_name text,
-				ADD COLUMN IF NOT EXISTS family_name text,
+				ADD COLUMN IF NOT EXISTS given_name text DEFAULT '',
+				ADD COLUMN IF NOT EXISTS family_name text DEFAULT '',
 				ADD COLUMN IF NOT EXISTS active boolean DEFAULT true;
 
 				CREATE UNIQUE INDEX IF NOT EXISTS idx_emails_providers ON provider_users (email, provider_id);

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -73,6 +73,7 @@ func migrations() []*migrator.Migration {
 		removeDotFromDestinationName(),
 		destinationNameUnique(),
 		removeDeletedIdentityProviderUsers(),
+		addProviderUserSCIMFields(),
 		// next one here
 	}
 }
@@ -774,6 +775,24 @@ func removeDeletedIdentityProviderUsers() *migrator.Migration {
 			}
 
 			return nil
+		},
+	}
+}
+
+func addProviderUserSCIMFields() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-09-28T13:00",
+		Migrate: func(tx migrator.DB) error {
+			stmt := `
+				ALTER TABLE provider_users
+				ADD COLUMN IF NOT EXISTS given_name text,
+				ADD COLUMN IF NOT EXISTS family_name text,
+				ADD COLUMN IF NOT EXISTS active boolean DEFAULT true;
+
+				CREATE UNIQUE INDEX IF NOT EXISTS idx_emails_providers ON provider_users (email, provider_id);
+			`
+			_, err := tx.Exec(stmt)
+			return err
 		},
 	}
 }

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -778,6 +778,12 @@ DELETE FROM settings WHERE id=24567;
 				assert.Equal(t, count, 0)
 			},
 		},
+		{
+			label: testCaseLine("2022-09-28T13:00"),
+			expected: func(t *testing.T, db WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -52,7 +52,7 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 	for _, p := range toDelete {
 		ids = append(ids, p.ID)
 
-		providerUsers, err := listProviderUsers(db, p.ID)
+		providerUsers, err := ListProviderUsers(db, p.ID, nil)
 		if err != nil {
 			return fmt.Errorf("listing provider users: %w", err)
 		}

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -21,15 +21,15 @@ func (p providerUserTable) Table() string {
 }
 
 func (p providerUserTable) Columns() []string {
-	return []string{"identity_id", "provider_id", "email", "groups", "last_update", "redirect_url", "access_token", "refresh_token", "expires_at"}
+	return []string{"identity_id", "provider_id", "email", "groups", "last_update", "redirect_url", "access_token", "refresh_token", "expires_at", "given_name", "family_name", "active"}
 }
 
 func (p providerUserTable) Values() []any {
-	return []any{p.IdentityID, p.ProviderID, p.Email, p.Groups, p.LastUpdate, p.RedirectURL, p.AccessToken, p.RefreshToken, p.ExpiresAt}
+	return []any{p.IdentityID, p.ProviderID, p.Email, p.Groups, p.LastUpdate, p.RedirectURL, p.AccessToken, p.RefreshToken, p.ExpiresAt, p.GivenName, p.FamilyName, p.Active}
 }
 
 func (p *providerUserTable) ScanFields() []any {
-	return []any{&p.IdentityID, &p.ProviderID, &p.Email, &p.Groups, &p.LastUpdate, &p.RedirectURL, &p.AccessToken, &p.RefreshToken, &p.ExpiresAt}
+	return []any{&p.IdentityID, &p.ProviderID, &p.Email, &p.Groups, &p.LastUpdate, &p.RedirectURL, &p.AccessToken, &p.RefreshToken, &p.ExpiresAt, &p.GivenName, &p.FamilyName, &p.Active}
 }
 
 func (p *providerUserTable) OnInsert() error {
@@ -66,6 +66,7 @@ func CreateProviderUser(db GormTxn, provider *models.Provider, ident *models.Ide
 		IdentityID: ident.ID,
 		Email:      ident.Name,
 		LastUpdate: time.Now().UTC(),
+		Active:     true,
 	}
 	if err := validateProviderUser(pu); err != nil {
 		return nil, err

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -215,6 +215,6 @@ func SyncProviderUser(ctx context.Context, tx GormTxn, user *models.Identity, pr
 type SCIMParameters struct {
 	Count      int // the number of items to return
 	StartIndex int // the offset to start counting from
-	TotalCount int
+	TotalCount int // the total number of items that match the query
 	// TODO: filter query param
 }

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -113,8 +113,9 @@ func ListProviderUsers(tx ReadTxn, providerID uid.ID, p *SCIMParameters) ([]mode
 		if p.Count != 0 {
 			query.B("LIMIT ?", p.Count)
 		}
-		if p.StartIndex != 0 {
-			query.B("OFFSET ?", p.StartIndex)
+		if p.StartIndex > 0 {
+			offset := p.StartIndex - 1 // start index begins at 1, not 0
+			query.B("OFFSET ?", offset)
 		}
 	}
 

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -107,6 +107,7 @@ func TestSyncProviderUser(t *testing.T) {
 						AccessToken:  "any-access-token",
 						ExpiresAt:    time.Now().Add(time.Hour).UTC(),
 						LastUpdate:   time.Now().UTC(),
+						Active:       true,
 					}
 
 					cmpProviderUser := cmp.Options{
@@ -167,6 +168,7 @@ func TestSyncProviderUser(t *testing.T) {
 						AccessToken:  "any-access-token",
 						ExpiresAt:    time.Now().Add(5 * time.Minute).UTC(),
 						LastUpdate:   time.Now().UTC(),
+						Active:       true,
 					}
 
 					cmpProviderUser := cmp.Options{

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/server/providers"
+	"github.com/infrahq/infra/uid"
 )
 
 // mockOIDC is a mock oidc identity provider
@@ -253,4 +254,120 @@ func TestDeleteProviderUser(t *testing.T) {
 		_, err = CreateProviderUser(db, provider, user)
 		assert.NilError(t, err)
 	})
+}
+
+func TestListProviderUsers(t *testing.T) {
+	type testCase struct {
+		name  string
+		setup func(t *testing.T, tx *Transaction) (providerID uid.ID, p *SCIMParameters, expected []models.ProviderUser, totalCount int)
+	}
+
+	testCases := []testCase{
+		{
+			name: "list all provider users",
+			setup: func(t *testing.T, tx *Transaction) (providerID uid.ID, p *SCIMParameters, expected []models.ProviderUser, totalCount int) {
+				provider := &models.Provider{
+					Name: "mockta",
+					Kind: models.ProviderKindOkta,
+				}
+
+				err := CreateProvider(tx, provider)
+				assert.NilError(t, err)
+
+				pu := createTestProviderUser(t, tx, provider, "david@example.com")
+				return provider.ID, nil, []models.ProviderUser{pu}, 0
+			},
+		},
+		{
+			name: "list all provider users invalid provider ID",
+			setup: func(t *testing.T, tx *Transaction) (providerID uid.ID, p *SCIMParameters, expected []models.ProviderUser, totalCount int) {
+				provider := &models.Provider{
+					Name: "mockta",
+					Kind: models.ProviderKindOkta,
+				}
+
+				err := CreateProvider(tx, provider)
+				assert.NilError(t, err)
+
+				_ = createTestProviderUser(t, tx, provider, "david@example.com")
+				return 1234, nil, nil, 0
+			},
+		},
+		{
+			name: "limit less than total",
+			setup: func(t *testing.T, tx *Transaction) (providerID uid.ID, p *SCIMParameters, expected []models.ProviderUser, totalCount int) {
+				provider := &models.Provider{
+					Name: "mockta",
+					Kind: models.ProviderKindOkta,
+				}
+
+				err := CreateProvider(tx, provider)
+				assert.NilError(t, err)
+
+				pu := createTestProviderUser(t, tx, provider, "david@example.com")
+				_ = createTestProviderUser(t, tx, provider, "lucy@example.com")
+				return provider.ID, &SCIMParameters{Count: 1}, []models.ProviderUser{pu}, 2
+			},
+		},
+		{
+			name: "offset from start",
+			setup: func(t *testing.T, tx *Transaction) (providerID uid.ID, p *SCIMParameters, expected []models.ProviderUser, totalCount int) {
+				provider := &models.Provider{
+					Name: "mockta",
+					Kind: models.ProviderKindOkta,
+				}
+
+				err := CreateProvider(tx, provider)
+				assert.NilError(t, err)
+
+				_ = createTestProviderUser(t, tx, provider, "david@example.com")
+				pu := createTestProviderUser(t, tx, provider, "lucy@example.com")
+				return provider.ID, &SCIMParameters{StartIndex: 1}, []models.ProviderUser{pu}, 2
+			},
+		},
+	}
+
+	runDBTests(t, func(t *testing.T, db *DB) {
+		org := &models.Organization{Name: "something", Domain: "example.com"}
+		assert.NilError(t, CreateOrganization(db, org))
+
+		// create some dummy data for another org to test multi-tenancy
+		stmt := `
+					INSERT INTO provider_users(identity_id, provider_id, email)
+					VALUES (?, ?, ?);
+				`
+		_, err := db.Exec(stmt, 123, 123, "otherorg@example.com")
+		assert.NilError(t, err)
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				tx := txnForTestCase(t, db, org.ID)
+
+				providerID, p, expected, totalCount := tc.setup(t, tx)
+
+				result, err := ListProviderUsers(tx, providerID, p)
+
+				assert.NilError(t, err)
+				assert.DeepEqual(t, result, expected, cmpTimeWithDBPrecision)
+				if p != nil {
+					assert.Equal(t, p.TotalCount, totalCount)
+				}
+			})
+		}
+	})
+}
+
+func createTestProviderUser(t *testing.T, tx *Transaction, provider *models.Provider, userName string) models.ProviderUser {
+	user := &models.Identity{
+		Name: userName,
+	}
+	err := CreateIdentity(tx, user)
+	assert.NilError(t, err)
+
+	pu, err := CreateProviderUser(tx, provider, user)
+	assert.NilError(t, err)
+
+	pu.Groups = models.CommaSeparatedStrings{}
+
+	return *pu
 }

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -322,9 +322,9 @@ func TestListProviderUsers(t *testing.T) {
 				err := CreateProvider(tx, provider)
 				assert.NilError(t, err)
 
-				_ = createTestProviderUser(t, tx, provider, "david@example.com")
-				pu := createTestProviderUser(t, tx, provider, "lucy@example.com")
-				return provider.ID, &SCIMParameters{StartIndex: 1}, []models.ProviderUser{pu}, 2
+				pu1 := createTestProviderUser(t, tx, provider, "david@example.com")
+				pu2 := createTestProviderUser(t, tx, provider, "lucy@example.com")
+				return provider.ID, &SCIMParameters{StartIndex: 1}, []models.ProviderUser{pu1, pu2}, 2
 			},
 		},
 	}

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -199,8 +199,8 @@ CREATE TABLE provider_users (
     access_token text,
     refresh_token text,
     expires_at timestamp with time zone,
-    given_name text,
-    family_name text,
+    given_name text DEFAULT ''::text,
+    family_name text DEFAULT ''::text,
     active boolean DEFAULT true
 );
 

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -198,7 +198,10 @@ CREATE TABLE provider_users (
     redirect_url text,
     access_token text,
     refresh_token text,
-    expires_at timestamp with time zone
+    expires_at timestamp with time zone,
+    given_name text,
+    family_name text,
+    active boolean DEFAULT true
 );
 
 CREATE TABLE providers (
@@ -283,6 +286,8 @@ CREATE UNIQUE INDEX idx_credentials_identity_id ON credentials USING btree (orga
 CREATE UNIQUE INDEX idx_destinations_name ON destinations USING btree (organization_id, name) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_destinations_unique_id ON destinations USING btree (organization_id, unique_id) WHERE (deleted_at IS NULL);
+
+CREATE UNIQUE INDEX idx_emails_providers ON provider_users USING btree (email, provider_id);
 
 CREATE UNIQUE INDEX idx_encryption_keys_key_id ON encryption_keys USING btree (key_id);
 

--- a/internal/server/models/provideruser.go
+++ b/internal/server/models/provideruser.go
@@ -3,6 +3,7 @@ package models
 import (
 	"time"
 
+	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -12,6 +13,8 @@ type ProviderUser struct {
 	ProviderID uid.ID `gorm:"primaryKey"`
 
 	Email      string
+	GivenName  string
+	FamilyName string
 	Groups     CommaSeparatedStrings
 	LastUpdate time.Time
 
@@ -20,6 +23,30 @@ type ProviderUser struct {
 	AccessToken  EncryptedAtRest
 	RefreshToken EncryptedAtRest
 	ExpiresAt    time.Time
+
+	Active bool
 }
 
 func (ProviderUser) IsAModel() {}
+
+func (pu *ProviderUser) ToAPI() *api.SCIMUser {
+	return &api.SCIMUser{
+		Schemas:  []string{api.UserSchema},
+		ID:       pu.IdentityID.String(),
+		UserName: pu.Email,
+		Name: api.SCIMUserName{
+			GivenName:  pu.GivenName,
+			FamilyName: pu.FamilyName,
+		},
+		Emails: []api.SCIMUserEmail{
+			{
+				Primary: true,
+				Value:   pu.Email,
+			},
+		},
+		Active: pu.Active,
+		Meta: api.SCIMMetadata{
+			ResourceType: "User",
+		},
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -98,6 +98,9 @@ func (s *Server) GenerateRoutes() Routes {
 	post(a, authn, "/api/tokens", a.CreateToken)
 	post(a, authn, "/api/logout", a.Logout)
 
+	// SCIM inbound provisioning
+	add(a, authn, http.MethodGet, "/api/scim/v2/Users", listProviderUsersRoute)
+
 	put(a, authn, "/api/settings", a.UpdateSettings)
 
 	add(a, authn, http.MethodGet, "/api/debug/pprof/*profile", pprofRoute)

--- a/internal/server/scim.go
+++ b/internal/server/scim.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/access"
+	"github.com/infrahq/infra/internal/server/data"
+)
+
+var listProviderUsersRoute = route[api.SCIMParametersRequest, *api.ListProviderUsersResponse]{
+	handler: ListProviderUsers,
+	routeSettings: routeSettings{
+		omitFromTelemetry:          true,
+		omitFromDocs:               true,
+		infraVersionHeaderOptional: true,
+	},
+}
+
+func ListProviderUsers(c *gin.Context, r *api.SCIMParametersRequest) (*api.ListProviderUsersResponse, error) {
+	p := data.SCIMParameters{
+		StartIndex: r.StartIndex,
+		Count:      r.Count,
+	}
+	users, err := access.ListProviderUsers(c, &p)
+	if err != nil {
+		return nil, err
+	}
+	result := &api.ListProviderUsersResponse{
+		Schemas:      []string{api.ListResponseSchema},
+		TotalResults: p.TotalCount,
+		StartIndex:   p.StartIndex,
+		ItemsPerPage: p.Count,
+	}
+	for _, user := range users {
+		result.Resources = append(result.Resources, *user.ToAPI())
+	}
+	return result, nil
+}

--- a/internal/server/scim_test.go
+++ b/internal/server/scim_test.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+func TestAPI_ListProviderUsers(t *testing.T) {
+	type testCase struct {
+		name   string
+		setup  func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse)
+		verify func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder)
+	}
+
+	testCases := []testCase{
+		{
+			name: "valid, no parameters",
+			setup: func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse) {
+				s := setupServer(t, withAdminUser)
+				bearer, users, routes := createTestSCIMProvider(t, s)
+				expectedUsers := []api.SCIMUser{}
+				for _, u := range users {
+					expectedUsers = append(expectedUsers, *u.ToAPI())
+				}
+
+				expected = api.ListProviderUsersResponse{
+					Schemas:      []string{api.ListResponseSchema},
+					Resources:    expectedUsers,
+					TotalResults: 1,
+					StartIndex:   0,
+					ItemsPerPage: 1,
+				}
+
+				return bearer, "", routes, expected
+			},
+			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+				var response api.ListProviderUsersResponse
+				err := json.Unmarshal(resp.Body.Bytes(), &response)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, expected, response)
+			},
+		},
+		{
+			name: "access key issued for non-existent provider results in an empty response",
+			setup: func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse) {
+				s := setupServer(t, withAdminUser)
+				// setup the users and permissions as needed
+				_, users, routes := createTestSCIMProvider(t, s, "another")
+				key := &models.AccessKey{
+					OrganizationMember: s.db.DefaultOrgSettings.OrganizationMember,
+					IssuedFor:          users[0].IdentityID,
+					IssuedForName:      "another",
+					Name:               fmt.Sprintf("%s-123", "another"),
+					ProviderID:         data.InfraProvider(s.DB()).ID,
+				}
+				bearer, err := data.CreateAccessKey(s.DB(), key)
+				assert.NilError(t, err)
+
+				return bearer, "", routes, api.ListProviderUsersResponse{Schemas: []string{api.ListResponseSchema}, ItemsPerPage: 0}
+			},
+			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code)
+				var response api.ListProviderUsersResponse
+				err := json.Unmarshal(resp.Body.Bytes(), &response)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, expected, response)
+			},
+		},
+		{
+			name: "2 users, 1 count",
+			setup: func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse) {
+				s := setupServer(t, withAdminUser)
+				bearer, users, routes := createTestSCIMProvider(t, s, "a")
+
+				expected = api.ListProviderUsersResponse{
+					Schemas:      []string{api.ListResponseSchema},
+					Resources:    []api.SCIMUser{*users[0].ToAPI()}, // this user has the "a" email, so they return first alphabetically
+					TotalResults: 2,
+					StartIndex:   0,
+					ItemsPerPage: 1,
+				}
+
+				return bearer, "?count=1", routes, expected
+			},
+			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+				var response api.ListProviderUsersResponse
+				err := json.Unmarshal(resp.Body.Bytes(), &response)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, expected, response)
+			},
+		},
+		{
+			name: "2 users, 3 count",
+			setup: func(t *testing.T) (bearer, params string, routes Routes, expected api.ListProviderUsersResponse) {
+				s := setupServer(t, withAdminUser)
+				bearer, users, routes := createTestSCIMProvider(t, s, "a")
+
+				expectedUsers := []api.SCIMUser{}
+				for _, u := range users {
+					expectedUsers = append(expectedUsers, *u.ToAPI())
+				}
+
+				expected = api.ListProviderUsersResponse{
+					Schemas:      []string{api.ListResponseSchema},
+					Resources:    expectedUsers,
+					TotalResults: 2,
+					StartIndex:   0,
+					ItemsPerPage: 3,
+				}
+
+				return bearer, "?count=3", routes, expected
+			},
+			verify: func(t *testing.T, expected api.ListProviderUsersResponse, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+				var response api.ListProviderUsersResponse
+				err := json.Unmarshal(resp.Body.Bytes(), &response)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, expected, response)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		bearer, params, routes, exp := tc.setup(t)
+		// nolint:noctx
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/scim/v2/Users%s", params), nil)
+		assert.NilError(t, err)
+
+		req.Header.Add("Authorization", "Bearer "+bearer)
+		req.Header.Add("Infra-Version", apiVersionLatest)
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+
+		tc.verify(t, exp, resp)
+	}
+}
+
+func createTestSCIMProvider(t *testing.T, s *Server, extraUserNames ...string) (bearer string, users []models.ProviderUser, routes Routes) {
+	testProvider := &models.Provider{
+		Model: models.Model{
+			ID: 1234,
+		},
+		Name:    "mockta",
+		Kind:    models.ProviderKindOkta,
+		AuthURL: "https://example.com/v1/auth",
+		Scopes:  []string{"openid", "email"},
+	}
+
+	err := data.CreateProvider(s.DB(), testProvider)
+	assert.NilError(t, err)
+
+	testProviderUser := createTestSCIMUserIdentity(t, s.DB(), testProvider, 1234, "test@example.com") // intentionally the same ID as the test provider as a workaround until provider access keys are supported
+	users = append(users, *testProviderUser)
+	for i, name := range extraUserNames {
+		testProviderUser := createTestSCIMUserIdentity(t, s.DB(), testProvider, uid.ID(i), name) // intentionally the same ID as the test provider as a workaround until provider access keys are supported
+		users = append(users, *testProviderUser)
+	}
+
+	// sort users by email, this is to match expected result
+	sort.Slice(users, func(i, j int) bool {
+		return users[i].Email < users[j].Email
+	})
+
+	key := &models.AccessKey{
+		OrganizationMember: s.db.DefaultOrgSettings.OrganizationMember,
+		IssuedFor:          testProvider.ID,
+		IssuedForName:      testProvider.Name,
+		Name:               fmt.Sprintf("%s-123", testProvider.Name),
+		ProviderID:         data.InfraProvider(s.DB()).ID,
+	}
+	bearer, err = data.CreateAccessKey(s.DB(), key)
+	assert.NilError(t, err)
+
+	return bearer, users, s.GenerateRoutes()
+}
+
+func createTestSCIMUserIdentity(t *testing.T, db data.GormTxn, provider *models.Provider, id uid.ID, name string) *models.ProviderUser {
+	testIdentity := &models.Identity{
+		Model: models.Model{
+			ID: id,
+		},
+		Name: name,
+	}
+	err := data.CreateIdentity(db, testIdentity)
+	assert.NilError(t, err)
+
+	testProviderUser, err := data.CreateProviderUser(db, provider, testIdentity)
+	assert.NilError(t, err)
+
+	return testProviderUser
+}


### PR DESCRIPTION
Restore #3379
- add SCIM list users endpoint
## Summary
> This change adds the necessary logic for a SCIM identity provider to list the users it has associated with it.

> It does not include the changes necessary to create an access key for an identity provider (which this functionality will rely on) so the code path can't be accessed yet.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Part of #3378
