### PR TITLE
feat: create access keys for idp scim

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -640,6 +640,7 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
       --client-id string                OIDC client ID
       --client-secret string            OIDC client secret
       --kind string                     The identity provider kind. One of 'oidc, okta, azure, or google' (default "oidc")
+      --scim                            Create an access key for SCIM provisioning
       --service-account-email string    The email assigned to the Infra service client in Google
       --service-account-key filepath    The private key used to make authenticated requests to Google's API, can be a file or the key string directly
       --url string                      Base URL of the domain of the OIDC identity provider (eg. acme.okta.com)
@@ -675,6 +676,7 @@ $ infra providers edit google --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1V
 
 ```console
       --client-secret string            Set a new client secret
+      --scim                            Create a new access key for SCIM provisioning
       --service-account-email string    The email assigned to the Infra service client in Google
       --service-account-key filepath    The private key used to make authenticated requests to Google's API
       --workspace-domain-admin string   The email of your Google workspace domain admin

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -49,10 +49,6 @@ func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey) (body string, 
 		}
 	}
 
-	if accessKey.ProviderID == 0 {
-		accessKey.ProviderID = data.InfraProvider(rCtx.DBTxn).ID
-	}
-
 	body, err = data.CreateAccessKey(rCtx.DBTxn, accessKey)
 	if err != nil {
 		return "", fmt.Errorf("create token: %w", err)

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -65,16 +66,17 @@ func (o providerAPIOptions) Validate(providerKind string) error {
 
 type providerEditOptions struct {
 	ClientSecret       string
+	SCIM               bool
 	ProviderAPIOptions providerAPIOptions
 }
 
 func (o providerEditOptions) Validate(providerKind string) error {
-	if o.ClientSecret == "" && o.ProviderAPIOptions.PrivateKey == "" && o.ProviderAPIOptions.ClientEmail == "" && o.ProviderAPIOptions.WorkspaceDomainAdminEmail == "" {
-		return fmt.Errorf("Please specify a field to update.'\n\n%s", newProvidersEditCmd(nil).UsageString())
+	if !o.SCIM && o.ClientSecret == "" {
+		return fmt.Errorf("scim or client-secret flag are required for updates")
 	}
 
-	if providerKind != "google" && o.ClientSecret == "" {
-		return fmt.Errorf("Client secret flag must be specified when updating an identity provider that isn't of kind Google")
+	if o.ClientSecret == "" && o.ProviderAPIOptions.PrivateKey == "" && o.ProviderAPIOptions.ClientEmail == "" && o.ProviderAPIOptions.WorkspaceDomainAdminEmail == "" {
+		return fmt.Errorf("client secret, private key, client email, and workspace domain admin email are required.'\n\n%s", newProvidersEditCmd(nil).UsageString())
 	}
 
 	return o.ProviderAPIOptions.Validate(providerKind)
@@ -92,13 +94,14 @@ $ infra providers edit okta --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq
 # Connect Google to Infra with group sync
 $ infra providers edit google --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --service-account-key ~/client-123.json --service-account-email hello@example.com --workspace-domain-admin admin@example.com
 `,
-		Args: ExactArgs(1),
+		Args: MaxArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateProvider(cli, args[0], opts)
 		},
 	}
 
 	cmd.Flags().StringVar(&opts.ClientSecret, "client-secret", "", "Set a new client secret")
+	cmd.Flags().BoolVar(&opts.SCIM, "scim", false, "Create a new access key for SCIM provisioning")
 	cmd.Flags().Var((*types.StringOrFile)(&opts.ProviderAPIOptions.PrivateKey), "service-account-key", "The private key used to make authenticated requests to Google's API")
 	cmd.Flags().StringVar(&opts.ProviderAPIOptions.ClientEmail, "service-account-email", "", "The email assigned to the Infra service client in Google")
 	cmd.Flags().StringVar(&opts.ProviderAPIOptions.WorkspaceDomainAdminEmail, "workspace-domain-admin", "", "The email of your Google workspace domain admin")
@@ -168,6 +171,7 @@ type providerAddOptions struct {
 	ClientID           string
 	ClientSecret       string
 	Kind               string
+	SCIM               bool
 	ProviderAPIOptions providerAPIOptions
 }
 
@@ -222,7 +226,7 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 			}
 
 			logging.Debugf("call server: create provider named %q", args[0])
-			_, err = client.CreateProvider(&api.CreateProviderRequest{
+			provider, err := client.CreateProvider(&api.CreateProviderRequest{
 				Name:         args[0],
 				URL:          opts.URL,
 				ClientID:     opts.ClientID,
@@ -245,6 +249,26 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 			}
 
 			cli.Output("Connected provider %q (%s) to infra", args[0], opts.URL)
+
+			if opts.SCIM {
+				key, err := client.CreateAccessKey(&api.CreateAccessKeyRequest{
+					UserID:            provider.ID,
+					Name:              fmt.Sprintf("%s-SCIM", args[0]),
+					TTL:               api.Duration(time.Hour * 87600), // 10 years
+					ExtensionDeadline: api.Duration(time.Hour * 87600), // 10 years
+				})
+				if err != nil {
+					if api.ErrorStatusCode(err) == 403 {
+						logging.Debugf("%s", err.Error())
+						return Error{
+							Message: "Cannot create SCIM key: missing privileges for CreateKey",
+						}
+					}
+					return err
+				}
+				cli.Output("Access key for SCIM provisioning: %s", key.AccessKey)
+			}
+
 			return nil
 		},
 	}
@@ -253,6 +277,7 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 	cmd.Flags().StringVar(&opts.ClientID, "client-id", "", "OIDC client ID")
 	cmd.Flags().StringVar(&opts.ClientSecret, "client-secret", "", "OIDC client secret")
 	cmd.Flags().StringVar(&opts.Kind, "kind", "oidc", "The identity provider kind. One of 'oidc, okta, azure, or google'")
+	cmd.Flags().BoolVar(&opts.SCIM, "scim", false, "Create an access key for SCIM provisioning")
 	cmd.Flags().Var((*types.StringOrFile)(&opts.ProviderAPIOptions.PrivateKey), "service-account-key", "The private key used to make authenticated requests to Google's API, can be a file or the key string directly")
 	cmd.Flags().StringVar(&opts.ProviderAPIOptions.ClientEmail, "service-account-email", "", "The email assigned to the Infra service client in Google") // this is only needed with the private key is not a file
 	cmd.Flags().StringVar(&opts.ProviderAPIOptions.WorkspaceDomainAdminEmail, "workspace-domain-admin", "", "The email of your Google Workspace domain admin")
@@ -281,34 +306,68 @@ func updateProvider(cli *CLI, name string, opts providerEditOptions) error {
 		return err
 	}
 
-	err = parsePrivateKey(&opts.ProviderAPIOptions)
-	if err != nil {
-		return err
+	if opts.SCIM {
+		// revoke the previous SCIM access key for this provider, if it exists
+		keyName := fmt.Sprintf("%s-SCIM", provider.Name)
+		err = client.DeleteAccessKeyByName(keyName)
+		if err != nil {
+			logging.Debugf("%s", err.Error())
+			if api.ErrorStatusCode(err) == 403 {
+				return Error{
+					Message: "Cannot delete key: missing privileges for DeleteKey",
+				}
+			}
+			// ignore error and proceed, key may not exist
+			err = nil
+		}
+		key, err := client.CreateAccessKey(&api.CreateAccessKeyRequest{
+			UserID:            provider.ID,
+			Name:              keyName,
+			TTL:               api.Duration(time.Hour * 87600), // 10 years
+			ExtensionDeadline: api.Duration(time.Hour * 87600), // 10 years
+		})
+		if err != nil {
+			if api.ErrorStatusCode(err) == 403 {
+				logging.Debugf("%s", err.Error())
+				return Error{
+					Message: "Cannot create SCIM key: missing privileges for CreateKey",
+				}
+			}
+			return err
+		}
+		cli.Output("New access key for SCIM provisioning: %s", key.AccessKey)
 	}
 
-	logging.Debugf("call server: update provider named %q", name)
-	_, err = client.UpdateProvider(api.UpdateProviderRequest{
-		ID:           provider.ID,
-		Name:         name,
-		URL:          provider.URL,
-		ClientID:     provider.ClientID,
-		ClientSecret: opts.ClientSecret,
-		Kind:         provider.Kind,
-		API: &api.ProviderAPICredentials{
-			PrivateKey:       api.PEM(opts.ProviderAPIOptions.PrivateKey),
-			ClientEmail:      opts.ProviderAPIOptions.ClientEmail,
-			DomainAdminEmail: opts.ProviderAPIOptions.WorkspaceDomainAdminEmail,
-		},
-	})
-
-	if err != nil {
-		if api.ErrorStatusCode(err) == 403 {
-			logging.Debugf("%v", err)
-			return Error{
-				Message: "Cannot update provider: missing privileges for UpdateProvider",
-			}
+	if opts.ClientSecret != "" {
+		err = parsePrivateKey(&opts.ProviderAPIOptions)
+		if err != nil {
+			return err
 		}
-		return err
+
+		logging.Debugf("call server: update provider named %q", name)
+		_, err = client.UpdateProvider(api.UpdateProviderRequest{
+			ID:           provider.ID,
+			Name:         name,
+			URL:          provider.URL,
+			ClientID:     provider.ClientID,
+			ClientSecret: opts.ClientSecret,
+			Kind:         provider.Kind,
+			API: &api.ProviderAPICredentials{
+				PrivateKey:       api.PEM(opts.ProviderAPIOptions.PrivateKey),
+				ClientEmail:      opts.ProviderAPIOptions.ClientEmail,
+				DomainAdminEmail: opts.ProviderAPIOptions.WorkspaceDomainAdminEmail,
+			},
+		})
+
+		if err != nil {
+			if api.ErrorStatusCode(err) == 403 {
+				logging.Debugf("%v", err)
+				return Error{
+					Message: "Cannot update provider: missing privileges for UpdateProvider",
+				}
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -85,7 +85,7 @@ func (o providerEditOptions) Validate(providerKind string) error {
 
 	if o.IsUpdatingGoogleAPIOptions(providerKind) {
 		if o.ProviderAPIOptions.PrivateKey == "" || o.ProviderAPIOptions.ClientEmail == "" || o.ProviderAPIOptions.WorkspaceDomainAdminEmail == "" {
-			return fmt.Errorf("client secret or private key, client email, and workspace domain admin email are required to update google provider.'\n\n%s", newProvidersEditCmd(nil).UsageString())
+			return fmt.Errorf("client secret or private key, client email, and workspace domain admin email are required to update google provider.\n\n%s", newProvidersEditCmd(nil).UsageString())
 		}
 	}
 

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -94,7 +94,7 @@ $ infra providers edit okta --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq
 # Connect Google to Infra with group sync
 $ infra providers edit google --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --service-account-key ~/client-123.json --service-account-email hello@example.com --workspace-domain-admin admin@example.com
 `,
-		Args: MaxArgs(5),
+		Args: MaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateProvider(cli, args[0], opts)
 		},
@@ -258,12 +258,6 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 					ExtensionDeadline: api.Duration(time.Hour * 87600), // 10 years
 				})
 				if err != nil {
-					if api.ErrorStatusCode(err) == 403 {
-						logging.Debugf("%s", err.Error())
-						return Error{
-							Message: "Cannot create SCIM key: missing privileges for CreateKey",
-						}
-					}
 					return err
 				}
 				cli.Output("Access key for SCIM provisioning: %s", key.AccessKey)

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -104,7 +104,7 @@ $ infra providers edit okta --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq
 # Connect Google to Infra with group sync
 $ infra providers edit google --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --service-account-key ~/client-123.json --service-account-email hello@example.com --workspace-domain-admin admin@example.com
 `,
-		Args: MaxArgs(1),
+		Args: ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateProvider(cli, args[0], opts)
 		},

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -90,6 +90,10 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 		if err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByProviderID: p.ID}); err != nil {
 			return fmt.Errorf("delete access keys: %w", err)
 		}
+
+		if err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByIssuedForID: p.ID}); err != nil {
+			return fmt.Errorf("delete provider access keys: %w", err)
+		}
 	}
 
 	return deleteAll[models.Provider](db, ByIDs(ids))

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -91,6 +91,7 @@ func DeleteProviders(db GormTxn, selectors ...SelectorFunc) error {
 			return fmt.Errorf("delete access keys: %w", err)
 		}
 
+		// delete any access keys used for SCIM
 		if err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByIssuedForID: p.ID}); err != nil {
 			return fmt.Errorf("delete provider access keys: %w", err)
 		}

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -22,7 +22,10 @@ type AccessKey struct {
 	Model
 	OrganizationMember
 	Name string `gorm:"uniqueIndex:idx_access_keys_name,where:deleted_at is NULL"`
-	// IssuedFor is the ID of the user that this access key was created for
+	/* IssuedFor is either:
+	1. The ID of the user that this access key was created for.
+	2. The ID of a provider that is doing SCIM provisioning using this access key.
+	*/
 	IssuedFor     uid.ID
 	IssuedForName string `db:"-"`
 	ProviderID    uid.ID


### PR DESCRIPTION
## Summary
Allow creating access keys for identity providers to make SCIM requests. This change only adds CLI support, waiting for full user SCIM support to add to the UI.

Example CLI interaction.
```
$ infra providers add okta --url dev-123.okta.com --client-id xyz --client-secret xxx --kind okta --scim
Connected provider "okta" (dev-123.okta.com) to infra
Access key for SCIM provisioning: aaaaaaaa.bbbbbbbbb

$ infra providers edit okta --scim
New access key for SCIM provisioning: aaaaaa.bbbbbbbb
```

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

Part of #3378
