### PR TITLE
data: add helper for scanning rows into a slice

### DIFF
--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -153,22 +153,13 @@ func ListAccessKeys(tx ReadTxn, opts ListAccessKeyOptions) ([]models.AccessKey, 
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	var result []models.AccessKey
-	for rows.Next() {
-		var key models.AccessKey
-
-		fields := append((*accessKeyTable)(&key).ScanFields(), &key.IssuedForName)
+	return scanRows(rows, func(key *models.AccessKey) []any {
+		fields := append((*accessKeyTable)(key).ScanFields(), &key.IssuedForName)
 		if opts.Pagination != nil {
 			fields = append(fields, &opts.Pagination.TotalCount)
 		}
-		if err := rows.Scan(fields...); err != nil {
-			return nil, err
-		}
-		result = append(result, key)
-	}
-	return result, rows.Err()
+		return fields
+	})
 }
 
 type GetAccessKeysOptions struct {

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -138,22 +138,13 @@ func ListDestinations(tx ReadTxn, opts ListDestinationsOptions) ([]models.Destin
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	var result []models.Destination
-	for rows.Next() {
-		var dest models.Destination
-
-		fields := (*destinationsTable)(&dest).ScanFields()
+	return scanRows(rows, func(d *models.Destination) []any {
+		fields := (*destinationsTable)(d).ScanFields()
 		if opts.Pagination != nil {
 			fields = append(fields, &opts.Pagination.TotalCount)
 		}
-		if err := rows.Scan(fields...); err != nil {
-			return nil, err
-		}
-		result = append(result, dest)
-	}
-	return result, rows.Err()
+		return fields
+	})
 }
 
 func DeleteDestination(tx WriteTxn, id uid.ID) error {
@@ -187,16 +178,7 @@ func CountDestinationsByConnectedVersion(tx ReadTxn) ([]DestinationsCount, error
 		return nil, err
 
 	}
-	defer rows.Close()
-
-	var result []DestinationsCount
-	for rows.Next() {
-		var item DestinationsCount
-		if err := rows.Scan(&item.Version, &item.Connected, &item.Count); err != nil {
-			return nil, err
-		}
-		result = append(result, item)
-	}
-
-	return result, rows.Err()
+	return scanRows(rows, func(item *DestinationsCount) []any {
+		return []any{&item.Version, &item.Connected, &item.Count}
+	})
 }

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -173,22 +173,13 @@ func ListGrants(tx ReadTxn, opts ListGrantsOptions) ([]models.Grant, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	var result []models.Grant
-	for rows.Next() {
-		var grant models.Grant
-
-		fields := (*grantsTable)(&grant).ScanFields()
+	return scanRows(rows, func(grant *models.Grant) []any {
+		fields := (*grantsTable)(grant).ScanFields()
 		if opts.Pagination != nil {
 			fields = append(fields, &opts.Pagination.TotalCount)
 		}
-		if err := rows.Scan(fields...); err != nil {
-			return nil, err
-		}
-		result = append(result, grant)
-	}
-	return result, rows.Err()
+		return fields
+	})
 }
 
 type DeleteGrantsOptions struct {

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -49,22 +49,16 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 		ID   uid.ID
 		Name string
 	}
-	var addIDs []idNamePair
 
 	stmt := `SELECT id, name FROM groups WHERE deleted_at is null AND name IN (?) AND organization_id = ?`
 	rows, err := tx.Query(stmt, groupsToBeAdded, tx.OrganizationID())
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var item idNamePair
-		if err := rows.Scan(&item.ID, &item.Name); err != nil {
-			return err
-		}
-		addIDs = append(addIDs, item)
-	}
-	if rows.Err() != nil {
+	addIDs, err := scanRows(rows, func(item *idNamePair) []any {
+		return []any{&item.ID, &item.Name}
+	})
+	if err != nil {
 		return err
 	}
 
@@ -91,21 +85,14 @@ func AssignIdentityToGroups(tx GormTxn, user *models.Identity, provider *models.
 			groupID = group.ID
 		}
 
-		var ids []uid.ID
 		rows, err := tx.Query("SELECT identity_id FROM identities_groups WHERE identity_id = ? AND group_id = ?", user.ID, groupID)
 		if err != nil {
 			return err
 		}
-
-		for rows.Next() {
-			var item uid.ID
-			if err := rows.Scan(&item); err != nil {
-				rows.Close()
-				return err
-			}
-			ids = append(ids, item)
-		}
-		if rows.Err() != nil {
+		ids, err := scanRows(rows, func(item *uid.ID) []any {
+			return []any{item}
+		})
+		if err != nil {
 			return err
 		}
 

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -644,18 +644,11 @@ func cleanCrossOrgGroupMemberships() *migrator.Migration {
 				GroupID    uid.ID
 			}
 
-			var idGroups []identityGroup
-			for rows.Next() {
-				var idGroup identityGroup
-				if err := rows.Scan(&idGroup.IdentityID, &idGroup.GroupID); err != nil {
-					return fmt.Errorf("scan identity and group: %w", err)
-				}
-
-				idGroups = append(idGroups, idGroup)
-			}
-
-			if err := rows.Close(); err != nil {
-				return fmt.Errorf("close read identity group rows: %w", err)
+			idGroups, err := scanRows(rows, func(idGroup *identityGroup) []any {
+				return []any{&idGroup.IdentityID, &idGroup.GroupID}
+			})
+			if err != nil {
+				return fmt.Errorf("read identity group rows: %w", err)
 			}
 
 			for _, idGroup := range idGroups {
@@ -712,16 +705,10 @@ func removeDotFromDestinationName() *migrator.Migration {
 			if err != nil {
 				return err
 			}
-			defer rows.Close()
-			var toRename []idName
-			for rows.Next() {
-				pair := idName{}
-				if err := rows.Scan(&pair.id, &pair.name); err != nil {
-					return err
-				}
-				toRename = append(toRename, pair)
-			}
-			if err := rows.Err(); err != nil {
+			toRename, err := scanRows(rows, func(pair *idName) []any {
+				return []any{&pair.id, &pair.name}
+			})
+			if err != nil {
 				return err
 			}
 			for _, item := range toRename {

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -459,13 +459,10 @@ DELETE FROM settings WHERE id=24567;
 				rows, err := db.Query(stmt)
 				assert.NilError(t, err)
 
-				var orgs []models.Organization
-				for rows.Next() {
-					org := models.Organization{}
-					err := rows.Scan(&org.ID, &org.Name, &org.CreatedAt, &org.UpdatedAt)
-					assert.NilError(t, err)
-					orgs = append(orgs, org)
-				}
+				orgs, err := scanRows(rows, func(org *models.Organization) []any {
+					return []any{&org.ID, &org.Name, &org.CreatedAt, &org.UpdatedAt}
+				})
+				assert.NilError(t, err)
 
 				now := time.Now()
 				expected := []models.Organization{

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -104,18 +104,9 @@ func listProviderUsers(tx ReadTxn, providerID uid.ID) ([]models.ProviderUser, er
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	var result []models.ProviderUser
-	for rows.Next() {
-		var pu models.ProviderUser
-
-		if err := rows.Scan((*providerUserTable)(&pu).ScanFields()...); err != nil {
-			return nil, err
-		}
-		result = append(result, pu)
-	}
-	return result, rows.Err()
+	return scanRows(rows, func(pu *models.ProviderUser) []any {
+		return (*providerUserTable)(pu).ScanFields()
+	})
 }
 
 type DeleteProviderUsersOptions struct {


### PR DESCRIPTION
## Summary

I've noticed we end up having a lot of boilerplate for reading the rows from `tx.Query` into a slice. Using generics , this new `scanRows` removes the need to repeat the common parts.

I converted a bunch of queries in this PR to show how it works, but there are a few more places that have not been converted yet. I might look to do that in a follow up, or leave it until we make some other change to the code.