### PR TITLE
fix: only remove password reset scope on cred update

### DIFF
--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -112,7 +112,7 @@ func updateCredential(c *gin.Context, user *models.Identity, newPassword string,
 		if raw, ok := c.Get(RequestContextKey); ok {
 			if rCtx, ok := raw.(RequestContext); ok {
 				if accessKey := rCtx.Authenticated.AccessKey; accessKey != nil {
-					accessKey.Scopes = models.CommaSeparatedStrings{}
+					accessKey.Scopes = sliceWithoutElement(accessKey.Scopes, models.ScopePasswordReset)
 					if err = data.UpdateAccessKey(db, accessKey); err != nil {
 						return fmt.Errorf("updating access key: %w", err)
 					}
@@ -122,6 +122,16 @@ func updateCredential(c *gin.Context, user *models.Identity, newPassword string,
 	}
 
 	return nil
+}
+
+func sliceWithoutElement(s []string, without string) []string {
+	result := []string{}
+	for _, v := range s {
+		if v != without {
+			result = append(result, v)
+		}
+	}
+	return result
 }
 
 func GetRequestContext(c *gin.Context) RequestContext {

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -131,7 +131,7 @@ func TestUpdateCredentials(t *testing.T) {
 
 		updatedKey, err := data.GetAccessKeyByKeyID(db, key.KeyID)
 		assert.NilError(t, err)
-		assert.Equal(t, updatedKey.Scopes, models.CommaSeparatedStrings{models.ScopeAllowCreateAccessKey})
+		assert.DeepEqual(t, updatedKey.Scopes, models.CommaSeparatedStrings{models.ScopeAllowCreateAccessKey})
 	})
 }
 

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -107,6 +107,32 @@ func TestUpdateCredentials(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, creds.OneTimePassword, false)
 	})
+
+	t.Run("Update own credentials removes password reset scope, but keeps other scopes", func(t *testing.T) {
+		rCtx := GetRequestContext(c)
+		rCtx.Authenticated.User = user
+
+		key := &models.AccessKey{
+			IssuedFor:  user.ID,
+			ProviderID: data.InfraProvider(db).ID,
+			Scopes:     []string{models.ScopeAllowCreateAccessKey, models.ScopePasswordReset},
+		}
+		_, err = CreateAccessKey(c, key)
+		assert.NilError(t, err)
+		rCtx.Authenticated.AccessKey = key
+		c.Set(RequestContextKey, rCtx)
+
+		err := UpdateCredential(c, user, "newPassword")
+		assert.NilError(t, err)
+
+		creds, err := data.GetCredential(db, data.ByIdentityID(user.ID))
+		assert.NilError(t, err)
+		assert.Equal(t, creds.OneTimePassword, false)
+
+		updatedKey, err := data.GetAccessKeyByKeyID(db, key.KeyID)
+		assert.NilError(t, err)
+		assert.Equal(t, updatedKey.Scopes, models.CommaSeparatedStrings{models.ScopeAllowCreateAccessKey})
+	})
 }
 
 func TestLowercaseRequirements(t *testing.T) {


### PR DESCRIPTION
## Summary
When a credential is update the access key needs to have the "password reset required" scope removed, but keep the ability to create access keys. This change ensures that the key has the only the "password reset required scope" removed so any scopes we add in the future will also continue to work.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3348
