### PR TITLE
fix: postgres-dev container listen address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ postgres:
 		--tmpfs=/var/lib/postgresql/data \
 		-p 127.0.0.1:15432:5432 \
 		postgres:14-alpine -c fsync=off -c full_page_writes=off \
-			-c listen_addresses=127.0.0.1 -c max_connections=100
+			-c max_connections=100
 	@echo
 	@echo Copy the line below into the shell used to run tests
 	@echo 'export POSTGRESQL_CONNECTION="host=localhost port=15432 user=postgres dbname=postgres password=password123"'


### PR DESCRIPTION
## Summary

Fixes a problem introduced in #3403 (just merged)

While [the postgres default for `listen_addresses` is localhost](https://www.postgresql.org/docs/current/runtime-config-connection.html#RUNTIME-CONFIG-CONNECTION-SETTINGS), the docker container apparently sets a default of `0.0.0.0`. I must have changed this at the last minute without testing, assuming the default was still localhost.

Setting `listen_address` to localhost does not work. The docker port mapping isn't able to map to the localhost port. This PR reverts setting `-c listen_addresses`, so that the default is used. This fixes the docker port mapping.