### PR TITLE
maintain: cli docgen fixes to clean up the resulting file

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,26 +2,23 @@
 title: CLI Reference
 position: 1
 ---
-
 # CLI Reference
 
-## Commands
-
-### `infra login`
+## `infra login`
 
 Login to Infra
 
-#### Description
+### Description
 
 Login to Infra and start a background agent to keep local configuration up-to-date
 
-```
+```bash
 infra login [SERVER] [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # By default, login will prompt for all required information.
 $ infra login
 
@@ -41,9 +38,9 @@ $ export INFRA_PROVIDER=google
 $ infra login
 ```
 
-#### Options
+### Options
 
-```
+```console
       --key string                       Login with an access key
       --no-agent                         Skip starting the Infra agent in the background
       --non-interactive                  Disable all prompts for input
@@ -53,88 +50,85 @@ $ infra login
       --tls-trusted-fingerprint string   SHA256 fingerprint of the server TLS certificate
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra logout`
+## `infra logout`
 
 Log out of Infra
 
-#### Description
+### Description
 
 Log out of Infra
 Note: [SERVER] and [--all] cannot be both specified. Choose either one or all servers.
 
-```
+```bash
 infra logout [SERVER] [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Log out of current server
 $ infra logout
-
+		
 # Log out of a specific server
 $ infra logout infraexampleserver.com
-
+		
 # Logout of all servers
-$ infra logout --all
-
-# Log out of current server and clear from list
+$ infra logout --all 
+		
+# Log out of current server and clear from list 
 $ infra logout --clear
-
+		
 # Log out of a specific server and clear from list
-$ infra logout infraexampleserver.com --clear
-
-# Logout and clear list of all servers
+$ infra logout infraexampleserver.com --clear 
+		
+# Logout and clear list of all servers 
 $ infra logout --all --clear
 ```
 
-#### Options
+### Options
 
-```
+```console
       --all     logout of all servers
       --clear   clear from list of servers
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra list`
+## `infra list`
 
 List accessible destinations
 
-```
+```bash
 infra list [flags]
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra use`
+## `infra use`
 
 Access a destination
 
-```
+```bash
 infra use DESTINATION [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 
 # Use a Kubernetes context
 $ infra use development
@@ -143,97 +137,94 @@ $ infra use development
 $ infra use development.kube-system
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra destinations list`
+## `infra destinations list`
 
 List connected destinations
 
-```
+```bash
 infra destinations list [flags]
 ```
 
-#### Options
+### Options
 
-```
+```console
       --format string   Output format [json|yaml]
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra destinations remove`
+## `infra destinations remove`
 
 Disconnect a destination
 
-```
+```bash
 infra destinations remove DESTINATION [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 $ infra destinations remove docker-desktop
 ```
 
-#### Options
+### Options
 
-```
+```console
       --force   Exit successfully even if destination does not exist
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra grants list`
+## `infra grants list`
 
 List grants
 
-```
+```bash
 infra grants list [flags]
 ```
 
-#### Options
+### Options
 
-```
+```console
       --destination string   Filter by destination
       --group string         Filter by group name or id
       --inherited            Include grants a user inherited through a group
+      --resource string      Filter by resource
       --role string          Filter by user role
       --user string          Filter by user name or id
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra grants add`
+## `infra grants add`
 
 Grant a user or group access to a destination
 
-```
+```bash
 infra grants add USER|GROUP DESTINATION [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Grant a user access to a destination
 $ infra grants add johndoe@example.com docker-desktop
 
@@ -248,32 +239,31 @@ $ infra grants add johndoe@example.com infra --role admin
 
 ```
 
-#### Options
+### Options
 
-```
+```console
       --force         Create grant even if requested user, destination, or role are unknown
   -g, --group         When set, creates a grant for a group instead of a user
       --role string   Type of access that the user or group will be given (default "connect")
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra grants remove`
+## `infra grants remove`
 
 Revoke a user or group's access to a destination
 
-```
+```bash
 infra grants remove USER|GROUP DESTINATION [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Remove all grants of a user in a destination
 $ infra grants remove janedoe@example.com docker-desktop
 
@@ -288,287 +278,276 @@ $ infra grants remove janedoe@example.com infra --role admin
 
 ```
 
-#### Options
+### Options
 
-```
+```console
       --force         Exit successfully even if grant does not exist
   -g, --group         Group to revoke access from
       --role string   Role to revoke
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra users add`
+## `infra users add`
 
 Create a user
 
-#### Description
+### Description
 
 Create a user.
 
 Note: A temporary password will be created. The user will be prompted to set a new password on first login.
 
-```
+```bash
 infra users add USER [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Create a user
 $ infra users add johndoe@example.com
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra users edit`
+## `infra users edit`
 
 Update a user
 
-```
+```bash
 infra users edit USER [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Set a new password for a user
 $ infra users edit janedoe@example.com --password
 ```
 
-#### Options
+### Options
 
-```
+```console
       --password   Set a new password, or if admin, set a temporary password for the user
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra users list`
+## `infra users list`
 
 List users
 
-```
+```bash
 infra users list [flags]
 ```
 
-#### Options
+### Options
 
-```
+```console
       --format string   Output format [json|yaml]
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra users remove`
+## `infra users remove`
 
 Delete a user
 
-```
+```bash
 infra users remove USER [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Delete a user
 $ infra users remove janedoe@example.com
 ```
 
-#### Options
+### Options
 
-```
+```console
       --force   Exit successfully even if user does not exist
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra groups add`
+## `infra groups add`
 
 Create a group
 
-```
+```bash
 infra groups add GROUP [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Create a group
 $ infra groups add Engineering
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra groups adduser`
+## `infra groups adduser`
 
 Add a user to a group
 
-```
+```bash
 infra groups adduser USER GROUP [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Add a user to a group
 $ infra groups adduser johndoe@example.com Engineering
 
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra groups list`
+## `infra groups list`
 
 List groups
 
-```
+```bash
 infra groups list [flags]
 ```
 
-#### Options
+### Options
 
-```
+```console
       --no-truncate     Do not truncate the list of users for each group
       --num-users int   The number of users to display in each group (default 8)
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra groups remove`
+## `infra groups remove`
 
 Delete a group
 
-```
+```bash
 infra groups remove GROUP [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Delete a group
 $ infra groups remove Engineering
 ```
 
-#### Options
+### Options
 
-```
+```console
       --force   Exit successfully even if the group does not exist
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra groups removeuser`
+## `infra groups removeuser`
 
 Remove a user from a group
 
-```
+```bash
 infra groups removeuser USER GROUP [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Remove a user from a group
 $ infra groups removeuser johndoe@example.com Engineering
 
 ```
 
-#### Options
+### Options
 
-```
+```console
       --force   Exit successfully even if the user or group does not exist
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra keys list`
+## `infra keys list`
 
 List access keys
 
-```
+```bash
 infra keys list [flags]
 ```
 
-#### Options
+### Options
 
-```
+```console
       --show-expired   Show expired access keys
       --user string    The name of a user to list access keys for
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra keys add`
+## `infra keys add`
 
 Create an access key
 
-#### Description
+### Description
 
 Create an access key for a user or a connector.
 
-```
+```bash
 infra keys add USER|connector [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 
 # Create an access key named 'example-key' for a user that expires in 12 hours
 $ infra keys add user@example.com --ttl=12h --name example-key
@@ -578,79 +557,76 @@ $ infra keys add connector
 
 ```
 
-#### Options
+### Options
 
-```
+```console
       --extension-deadline duration   A specified deadline that the access key must be used within to remain valid (default 720h0m0s)
       --name string                   The name of the access key
       --ttl duration                  The total time that the access key will be valid for (default 720h0m0s)
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra keys remove`
+## `infra keys remove`
 
 Delete an access key
 
-```
+```bash
 infra keys remove KEY [flags]
 ```
 
-#### Options
+### Options
 
-```
+```console
       --force   Exit successfully even if access key does not exist
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra providers list`
+## `infra providers list`
 
 List connected identity providers
 
-```
+```bash
 infra providers list [flags]
 ```
 
-#### Options
+### Options
 
-```
+```console
       --format string   Output format [json|yaml]
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra providers add`
+## `infra providers add`
 
 Connect an identity provider
 
-#### Description
+### Description
 
 Add an identity provider for users to authenticate.
 PROVIDER is a short unique name of the identity provider being added (eg. okta)
 
-```
+```bash
 infra providers add PROVIDER [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Connect Okta to Infra
 $ infra providers add okta --url example.okta.com --client-id 0oa3sz06o6do0muoW5d7 --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --kind okta
 
@@ -658,9 +634,9 @@ $ infra providers add okta --url example.okta.com --client-id 0oa3sz06o6do0muoW5
 $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0muoW5d7 --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --service-account-key ~/client-123.json --workspace-domain-admin admin@example.com --kind google
 ```
 
-#### Options
+### Options
 
-```
+```console
       --client-id string                OIDC client ID
       --client-secret string            OIDC client secret
       --kind string                     The identity provider kind. One of 'oidc, okta, azure, or google' (default "oidc")
@@ -670,24 +646,23 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
       --workspace-domain-admin string   The email of your Google Workspace domain admin
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra providers edit`
+## `infra providers edit`
 
 Update a provider
 
-```
+```bash
 infra providers edit PROVIDER [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 # Set a new client secret for a connected provider
 $ infra providers edit okta --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN
 
@@ -696,99 +671,94 @@ $ infra providers edit google --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1V
 
 ```
 
-#### Options
+### Options
 
-```
+```console
       --client-secret string            Set a new client secret
       --service-account-email string    The email assigned to the Infra service client in Google
       --service-account-key filepath    The private key used to make authenticated requests to Google's API
       --workspace-domain-admin string   The email of your Google workspace domain admin
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra providers remove`
+## `infra providers remove`
 
 Disconnect an identity provider
 
-```
+```bash
 infra providers remove PROVIDER [flags]
 ```
 
-#### Examples
+### Examples
 
-```
+```bash
 $ infra providers remove okta
 ```
 
-#### Options
+### Options
 
-```
+```console
       --force   Exit successfully even if provider does not exist
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra info`
+## `infra info`
 
 Display the info about the current session
 
-```
+```bash
 infra info [flags]
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra version`
+## `infra version`
 
 Display the Infra version
 
-```
+```bash
 infra version [flags]
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra about`
+## `infra about`
 
 Display information about Infra
 
-```
+```bash
 infra about [flags]
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```
-
-### `infra completion`
+## `infra completion`
 
 Generate shell auto-completion for the CLI
 
-#### Description
+### Description
 
 To load completions:
 
@@ -797,10 +767,9 @@ To load completions:
 `$ source <(infra completion bash)`
 
 To load completions for each session, execute once:
-
-- Linux:
+* Linux:
   `$ infra completion bash > /etc/bash_completion.d/infra`
-- macOS:
+* macOS:
   `$ infra completion bash > /usr/local/etc/bash_completion.d/infra`
 
 ##### Zsh:
@@ -828,13 +797,14 @@ To load completions for every new session, run:
 `PS> infra completion powershell > infra.ps1`
 and source this file from your PowerShell profile.
 
-```
+
+```bash
 infra completion
 ```
 
-#### Options inherited from parent commands
+### Options inherited from parent commands
 
-```
+```console
       --help               Display help
       --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
 ```

--- a/internal/docgen/cli.go
+++ b/internal/docgen/cli.go
@@ -28,7 +28,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	flags.SetOutput(buf)
 
 	if flags.HasAvailableFlags() {
-		buf.WriteString("#### Options\n\n```\n")
+		buf.WriteString("### Options\n\n```console\n")
 		flags.PrintDefaults()
 		buf.WriteString("```\n\n")
 	}
@@ -37,7 +37,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	parentFlags.SetOutput(buf)
 
 	if parentFlags.HasAvailableFlags() {
-		buf.WriteString("#### Options inherited from parent commands\n\n```\n")
+		buf.WriteString("### Options inherited from parent commands\n\n```console\n")
 		parentFlags.PrintDefaults()
 		buf.WriteString("```\n")
 	}
@@ -53,21 +53,21 @@ func GenMarkdown(cmd *cobra.Command, w io.Writer) error {
 	buf := new(bytes.Buffer)
 	name := cmd.CommandPath()
 
-	buf.WriteString("### `" + name + "`\n\n")
+	buf.WriteString("## `" + name + "`\n\n")
 	buf.WriteString(cmd.Short + "\n\n")
 
 	if len(cmd.Long) > 0 {
-		buf.WriteString("#### Description\n\n")
+		buf.WriteString("### Description\n\n")
 		buf.WriteString(cmd.Long + "\n\n")
 	}
 
 	if cmd.Runnable() {
-		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.UseLine()))
+		buf.WriteString(fmt.Sprintf("```bash\n%s\n```\n\n", cmd.UseLine()))
 	}
 
 	if len(cmd.Example) > 0 {
-		buf.WriteString("#### Examples\n\n")
-		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", cmd.Example))
+		buf.WriteString("### Examples\n\n")
+		buf.WriteString(fmt.Sprintf("```bash\n%s\n```\n\n", cmd.Example))
 	}
 
 	if err := printOptions(buf, cmd, name); err != nil {
@@ -126,7 +126,7 @@ position: 1
 		return err
 	}
 
-	if _, err := io.WriteString(f, "# CLI Reference\n\n## Commands\n\n"); err != nil {
+	if _, err := io.WriteString(f, "# CLI Reference"); err != nil {
 		return err
 	}
 

--- a/internal/docgen/main.go
+++ b/internal/docgen/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	f, err := os.Create("./docs/reference/cli-reference.md")
+	f, err := os.Create("./docs/reference/cli.md")
 	if err != nil {
 		log.Println(err.Error())
 		return


### PR DESCRIPTION

Signed-off-by: Matt Williams <m@technovangelist.com>

## Summary

The docgen process was generating cli-reference.md, but all the docs point to cli.md after renaming a month or so back. So this update generates the right doc, and cleans up the generated doc a bit.

<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
