### PR TITLE
maintain: add redirect for cli-reference to docs

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -111,15 +111,11 @@ module.exports = phase => ({
           permanent: true,
         }
       }),
-      ...[
-        '/docs/reference/cli-reference',
-      ].map(source => {
-        return {
-          source,
-          destination: '/docs/reference/cli',
-          permanent: true,
-        }
-      }),
+      {
+        source: '/docs/reference/cli-reference',
+        destination: '/docs/reference/cli',
+        permanent: true,
+      },
       ...[
         '/docs/getting-started/key-concepts',
         '/docs/reference/how-infra-works',

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -112,6 +112,15 @@ module.exports = phase => ({
         }
       }),
       ...[
+        '/docs/reference/cli-reference',
+      ].map(source => {
+        return {
+          source,
+          destination: '/docs/reference/cli',
+          permanent: true,
+        }
+      }),
+      ...[
         '/docs/getting-started/key-concepts',
         '/docs/reference/how-infra-works',
       ].map(source => {


### PR DESCRIPTION
Signed-off-by: Matt Williams <m@technovangelist.com>

## Summary

A month or so back, we simplified a lot of the docs. One of the changes was moving reference/cli-reference to reference/cli. I added most of the redirects, but managed to miss this one. 
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
