### PR TITLE
Require oldpassword

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -57,8 +57,9 @@ type CreateUserResponse struct {
 }
 
 type UpdateUserRequest struct {
-	ID       uid.ID `uri:"id" json:"-"`
-	Password string `json:"password"`
+	ID          uid.ID `uri:"id" json:"-"`
+	OldPassword string `json:"oldPassword"`
+	Password    string `json:"password"`
 }
 
 func (r UpdateUserRequest) ValidationRules() []validate.ValidationRule {

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -26,7 +26,7 @@ func TestSettingsPasswordRequirements(t *testing.T) {
 	})
 	assert.NilError(t, err)
 	t.Run("Update user credentials fails if less than min length", func(t *testing.T) {
-		err := UpdateCredential(c, user, "short")
+		err := UpdateCredential(c, user, "", "short")
 		assert.ErrorContains(t, err, "validation failed: password")
 		assert.ErrorContains(t, err, "needs minimum length of 8")
 	})
@@ -38,11 +38,11 @@ func TestSettingsPasswordRequirements(t *testing.T) {
 	err = data.SaveSettings(db, settings)
 	assert.NilError(t, err)
 	t.Run("Update user credentials passes if equal than min length", func(t *testing.T) {
-		err := UpdateCredential(c, user, "short")
+		err := UpdateCredential(c, user, "", "short")
 		assert.NilError(t, err)
 	})
 	t.Run("Update user credentials passes if equal than min length", func(t *testing.T) {
-		err := UpdateCredential(c, user, "longer")
+		err := UpdateCredential(c, user, "", "longer")
 		assert.NilError(t, err)
 	})
 
@@ -52,7 +52,7 @@ func TestSettingsPasswordRequirements(t *testing.T) {
 	err = data.SaveSettings(db, settings)
 	assert.NilError(t, err)
 	t.Run("Update user credentials fails with multiple requirement failures", func(t *testing.T) {
-		err := UpdateCredential(c, user, "badpw")
+		err := UpdateCredential(c, user, "", "badpw")
 		assert.ErrorContains(t, err, "validation failed: password:")
 		assert.ErrorContains(t, err, "needs minimum 1 symbols")
 		assert.ErrorContains(t, err, "needs minimum length of 10")
@@ -80,14 +80,18 @@ func TestUpdateCredentials(t *testing.T) {
 
 	username := "bruce@example.com"
 	user := &models.Identity{Name: username}
+
 	err := data.CreateIdentity(db, user)
 	assert.NilError(t, err)
 
-	_, err = CreateCredential(c, *user)
+	tmpPassword, err := CreateCredential(c, *user)
+	assert.NilError(t, err)
+
+	userCreds, err := data.GetCredential(db, data.ByIdentityID(user.ID))
 	assert.NilError(t, err)
 
 	t.Run("Update user credentials IS single use password", func(t *testing.T) {
-		err := UpdateCredential(c, user, "newPassword")
+		err := UpdateCredential(c, user, "", "newPassword")
 		assert.NilError(t, err)
 
 		creds, err := data.GetCredential(db, data.ByIdentityID(user.ID))
@@ -96,11 +100,14 @@ func TestUpdateCredentials(t *testing.T) {
 	})
 
 	t.Run("Update own credentials is NOT single use password", func(t *testing.T) {
+		err := data.SaveCredential(db, userCreds)
+		assert.NilError(t, err)
+
 		rCtx := GetRequestContext(c)
 		rCtx.Authenticated.User = user
 		c.Set(RequestContextKey, rCtx)
 
-		err := UpdateCredential(c, user, "newPassword")
+		err = UpdateCredential(c, user, tmpPassword, "newPassword")
 		assert.NilError(t, err)
 
 		creds, err := data.GetCredential(db, data.ByIdentityID(user.ID))
@@ -109,6 +116,9 @@ func TestUpdateCredentials(t *testing.T) {
 	})
 
 	t.Run("Update own credentials removes password reset scope, but keeps other scopes", func(t *testing.T) {
+		err := data.SaveCredential(db, userCreds)
+		assert.NilError(t, err)
+
 		rCtx := GetRequestContext(c)
 		rCtx.Authenticated.User = user
 
@@ -122,7 +132,10 @@ func TestUpdateCredentials(t *testing.T) {
 		rCtx.Authenticated.AccessKey = key
 		c.Set(RequestContextKey, rCtx)
 
-		err := UpdateCredential(c, user, "newPassword")
+		err = UpdateCredential(c, user, "somePassword", "newPassword")
+		assert.ErrorContains(t, err, "invalid oldPassword")
+
+		err = UpdateCredential(c, user, tmpPassword, "newPassword")
 		assert.NilError(t, err)
 
 		creds, err := data.GetCredential(db, data.ByIdentityID(user.ID))

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -132,8 +132,11 @@ func TestUpdateCredentials(t *testing.T) {
 		rCtx.Authenticated.AccessKey = key
 		c.Set(RequestContextKey, rCtx)
 
+		err = UpdateCredential(c, user, "", "newPassword")
+		assert.ErrorContains(t, err, "oldPassword: is required")
+
 		err = UpdateCredential(c, user, "somePassword", "newPassword")
-		assert.ErrorContains(t, err, "invalid oldPassword")
+		assert.ErrorContains(t, err, "oldPassword: invalid oldPassword")
 
 		err = UpdateCredential(c, user, tmpPassword, "newPassword")
 		assert.NilError(t, err)

--- a/internal/access/passwordreset.go
+++ b/internal/access/passwordreset.go
@@ -59,7 +59,7 @@ func VerifiedPasswordReset(c *gin.Context, token, newPassword string) (*models.I
 		}
 	}
 
-	if err := updateCredential(c, user, "", newPassword, true, false); err != nil {
+	if err := updateCredential(c, user, newPassword, true); err != nil {
 		return nil, err
 	}
 

--- a/internal/access/passwordreset.go
+++ b/internal/access/passwordreset.go
@@ -59,7 +59,7 @@ func VerifiedPasswordReset(c *gin.Context, token, newPassword string) (*models.I
 		}
 	}
 
-	if err := updateCredential(c, user, newPassword, true); err != nil {
+	if err := updateCredential(c, user, "", newPassword, true, false); err != nil {
 		return nil, err
 	}
 

--- a/internal/server/authn_test.go
+++ b/internal/server/authn_test.go
@@ -43,7 +43,7 @@ func TestServerLimitsAccessWithTemporaryPassword(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp1.Code)
 
 	// change password
-	changePassword(t, routes, key, loginResp.UserID, "balloons")
+	changePassword(t, routes, key, loginResp.UserID, resp.OneTimePassword, "balloons")
 
 	// can access other urls.
 	resp2 := tryOtherURL()
@@ -77,9 +77,10 @@ func createUser(t *testing.T, srv *Server, routes Routes, email string) *api.Cre
 	return result
 }
 
-func changePassword(t *testing.T, routes Routes, accessKey string, id uid.ID, password string) *api.User {
+func changePassword(t *testing.T, routes Routes, accessKey string, id uid.ID, oldPassword, password string) *api.User {
 	r := &api.UpdateUserRequest{
-		Password: password,
+		OldPassword: oldPassword,
+		Password:    password,
 	}
 	body, err := json.Marshal(r)
 	assert.NilError(t, err)

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -5791,6 +5791,9 @@
             "application/json": {
               "schema": {
                 "properties": {
+                  "oldPassword": {
+                    "type": "string"
+                  },
                   "password": {
                     "type": "string"
                   }

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -112,7 +112,7 @@ func (a *API) UpdateUser(c *gin.Context, r *api.UpdateUserRequest) (*api.User, e
 		return nil, err
 	}
 
-	err = access.UpdateCredential(c, identity, r.Password)
+	err = access.UpdateCredential(c, identity, r.OldPassword, r.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/ui/pages/account/index.js
+++ b/ui/pages/account/index.js
@@ -7,6 +7,7 @@ import Dashboard from '../../components/layouts/dashboard'
 import Notification from '../../components/notification'
 
 function PasswordReset({ user, onReset = () => {} }) {
+  const [oldPassword, setOldPassword] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState('')
@@ -32,6 +33,7 @@ function PasswordReset({ user, onReset = () => {} }) {
         method: 'PUT',
         body: JSON.stringify({
           ...user,
+          oldPassword: oldPassword,
           password: confirmPassword,
         }),
       })
@@ -44,6 +46,7 @@ function PasswordReset({ user, onReset = () => {} }) {
         throw data
       }
 
+      setOldPassword('')
       setPassword('')
       setConfirmPassword('')
       onReset()
@@ -64,6 +67,31 @@ function PasswordReset({ user, onReset = () => {} }) {
 
   return (
     <form onSubmit={onSubmit} className='flex flex-col'>
+      <div className='relative my-2 w-full'>
+        <label
+          htmlFor='old-password'
+          className='text-2xs font-medium text-gray-700'
+        >
+          Old Password
+        </label>
+        <input
+          required
+          name='oldPassword'
+          type='password'
+          value={oldPassword}
+          onChange={e => {
+            setOldPassword(e.target.value)
+            setErrors({})
+            setError('')
+          }}
+          className={`mt-1 block w-full rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm ${
+            errors.oldPassword ? 'border-red-500' : 'border-gray-300'
+          }`}
+        />
+        {errors.oldPassword && (
+          <p className='my-1 text-xs text-red-500'>{errors.oldPassword}</p>
+        )}
+      </div>
       <div className='relative my-2 w-full'>
         <label
           htmlFor='password'


### PR DESCRIPTION
## Summary

When a user changes their password, they need to specify their old password in addition to their new password. This doesn't modify the forgot password screen which validates a user's identity by sending them a password reset link email.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

