### PR TITLE
Remove getDB and hasAuthorization

### DIFF
--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -11,24 +11,6 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-// hasAuthorization checks if a caller is the owner of a resource before checking if they have an approprite role to access it
-func hasAuthorization(c *gin.Context, requestedResource uid.ID, isResourceOwner func(rCtx RequestContext, requestedResourceID uid.ID) (bool, error), oneOfRoles ...string) (data.GormTxn, error) {
-	rCtx := GetRequestContext(c)
-	owner, err := isResourceOwner(rCtx, requestedResource)
-	if err != nil {
-		return nil, fmt.Errorf("owner lookup: %w", err)
-	}
-
-	if owner {
-		return rCtx.DBTxn, nil
-	}
-
-	if err := IsAuthorized(rCtx, oneOfRoles...); err != nil {
-		return nil, err
-	}
-	return rCtx.DBTxn, nil
-}
-
 const ResourceInfraAPI = "infra"
 
 // RequireInfraRole checks that the identity in the context can perform an action on a resource based on their granted roles

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -53,14 +53,14 @@ func CreateCredential(c *gin.Context, user models.Identity) (string, error) {
 
 func UpdateCredential(c *gin.Context, user *models.Identity, oldPassword, newPassword string) error {
 	rCtx := GetRequestContext(c)
-	_, err := hasAuthorization(c, user.ID, isIdentitySelf, models.InfraAdminRole)
-	if err != nil {
-		return HandleAuthErr(err, "user", "update", models.InfraAdminRole)
-	}
+	isSelf := isIdentitySelf(rCtx, user.ID)
 
-	isSelf, err := isIdentitySelf(rCtx, user.ID)
-	if err != nil {
-		return err
+	// anyone can update their own credentials, so check authorization when not self
+	if !isSelf {
+		err := IsAuthorized(rCtx, models.InfraAdminRole)
+		if err != nil {
+			return HandleAuthErr(err, "user", "update", models.InfraAdminRole)
+		}
 	}
 
 	// Users have to supply their old password to change their existing password

--- a/internal/access/forgotdomain.go
+++ b/internal/access/forgotdomain.go
@@ -10,9 +10,9 @@ import (
 
 func ForgotDomainRequest(c *gin.Context, email string) ([]models.ForgottenDomain, error) {
 	// no auth required
-	db := getDB(c)
+	rCtx := GetRequestContext(c)
 
-	domains, err := data.GetForgottenDomainsForEmail(db, email)
+	domains, err := data.GetForgottenDomainsForEmail(rCtx.DBTxn, email)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -15,8 +15,8 @@ import (
 )
 
 // isIdentitySelf is used by authorization checks to see if the calling identity is requesting their own attributes
-func isIdentitySelf(c *gin.Context, userID uid.ID) (bool, error) {
-	identity := GetRequestContext(c).Authenticated.User
+func isIdentitySelf(rCtx RequestContext, userID uid.ID) (bool, error) {
+	identity := rCtx.Authenticated.User
 	return identity != nil && identity.ID == userID, nil
 }
 
@@ -41,7 +41,7 @@ func CreateIdentity(c *gin.Context, identity *models.Identity) error {
 
 func DeleteIdentity(c *gin.Context, id uid.ID) error {
 	rCtx := GetRequestContext(c)
-	self, err := isIdentitySelf(c, id)
+	self, err := isIdentitySelf(rCtx, id)
 	if err != nil {
 		return err
 	}

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -15,19 +15,23 @@ import (
 )
 
 // isIdentitySelf is used by authorization checks to see if the calling identity is requesting their own attributes
-func isIdentitySelf(rCtx RequestContext, userID uid.ID) (bool, error) {
+func isIdentitySelf(rCtx RequestContext, userID uid.ID) bool {
 	identity := rCtx.Authenticated.User
-	return identity != nil && identity.ID == userID, nil
+	return identity != nil && identity.ID == userID
 }
 
 func GetIdentity(c *gin.Context, id uid.ID) (*models.Identity, error) {
-	roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
-	db, err := hasAuthorization(c, id, isIdentitySelf, roles...)
-	if err != nil {
-		return nil, HandleAuthErr(err, "user", "get", roles...)
+	rCtx := GetRequestContext(c)
+	// anyone can get their own user data
+	if !isIdentitySelf(rCtx, id) {
+		roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
+		err := IsAuthorized(rCtx, roles...)
+		if err != nil {
+			return nil, HandleAuthErr(err, "user", "get", roles...)
+		}
 	}
 
-	return data.GetIdentity(db, data.Preload("Providers"), data.ByID(id))
+	return data.GetIdentity(rCtx.DBTxn, data.Preload("Providers"), data.ByID(id))
 }
 
 func CreateIdentity(c *gin.Context, identity *models.Identity) error {
@@ -41,12 +45,7 @@ func CreateIdentity(c *gin.Context, identity *models.Identity) error {
 
 func DeleteIdentity(c *gin.Context, id uid.ID) error {
 	rCtx := GetRequestContext(c)
-	self, err := isIdentitySelf(rCtx, id)
-	if err != nil {
-		return err
-	}
-
-	if self {
+	if isIdentitySelf(rCtx, id) {
 		return fmt.Errorf("cannot delete self: %w", internal.ErrBadRequest)
 	}
 

--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -10,10 +10,11 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-// isOrganizationSelf is used by authorization checks to see if the calling identity is requesting their own organization
-func isOrganizationSelf(c *gin.Context, orgID uid.ID) (bool, error) {
-	org := GetRequestContext(c).Authenticated.Organization
-	return org != nil && org.ID == orgID, nil
+// isOrganizationSelf is used by authorization checks to see if the calling
+// identity is requesting their own organization.
+func isOrganizationSelf(rCtx RequestContext, orgID uid.ID) (bool, error) {
+	user := rCtx.Authenticated.User
+	return user != nil && user.OrganizationID == orgID, nil
 }
 
 func ListOrganizations(c *gin.Context, name string, pg *data.Pagination) ([]models.Organization, error) {

--- a/internal/access/passwordreset.go
+++ b/internal/access/passwordreset.go
@@ -13,7 +13,8 @@ import (
 
 func PasswordResetRequest(c *gin.Context, email string, ttl time.Duration) (token string, user *models.Identity, err error) {
 	// no auth required
-	db := getDB(c)
+	rCtx := GetRequestContext(c)
+	db := rCtx.DBTxn
 
 	users, err := data.ListIdentities(db, &data.Pagination{Limit: 1}, data.ByName(email))
 	if err != nil {
@@ -40,7 +41,8 @@ func PasswordResetRequest(c *gin.Context, email string, ttl time.Duration) (toke
 
 func VerifiedPasswordReset(c *gin.Context, token, newPassword string) (*models.Identity, error) {
 	// no auth required
-	db := getDB(c)
+	rCtx := GetRequestContext(c)
+	db := rCtx.DBTxn
 
 	prt, err := data.GetPasswordResetTokenByToken(db, token)
 	if err != nil {

--- a/internal/access/provider.go
+++ b/internal/access/provider.go
@@ -21,13 +21,12 @@ func CreateProvider(c *gin.Context, provider *models.Provider) error {
 }
 
 func GetProvider(c *gin.Context, id uid.ID) (*models.Provider, error) {
-	db := getDB(c)
-
-	return data.GetProvider(db, data.ByID(id))
+	rCtx := GetRequestContext(c)
+	return data.GetProvider(rCtx.DBTxn, data.ByID(id))
 }
 
 func ListProviders(c *gin.Context, name string, excludeByKind []models.ProviderKind, p *data.Pagination) ([]models.Provider, error) {
-	db := getDB(c)
+	rCtx := GetRequestContext(c)
 
 	selectors := []data.SelectorFunc{
 		data.ByOptionalName(name),
@@ -37,7 +36,7 @@ func ListProviders(c *gin.Context, name string, excludeByKind []models.ProviderK
 		selectors = append(selectors, data.NotProviderKind(exclude))
 	}
 
-	return data.ListProviders(db, p, selectors...)
+	return data.ListProviders(rCtx.DBTxn, p, selectors...)
 }
 
 func SaveProvider(c *gin.Context, provider *models.Provider) error {

--- a/internal/access/settings.go
+++ b/internal/access/settings.go
@@ -25,8 +25,8 @@ func GetPublicJWK(c RequestContext) ([]jose.JSONWebKey, error) {
 }
 
 func GetSettings(c *gin.Context) (*models.Settings, error) {
-	db := getDB(c)
-	return data.GetSettings(db)
+	rCtx := GetRequestContext(c)
+	return data.GetSettings(rCtx.DBTxn)
 }
 
 func SaveSettings(c *gin.Context, settings *models.Settings) error {


### PR DESCRIPTION
## Summary

Best viewed by individual commit.

`getDB` was deprecated a while ago, when we added `RequestContext`. We left it for a bit to make sure we had the right interface for `RequestContext`. It seems to be working well, so now we can remove it.

We had 3 different ways to authorize a request (`hasAuthorization`, `RequireInfraRole`, and `Can` which was recently renamed to `IsAuthorized`).  We've been replacing the use of `hasAuthorization` with a check in the caller to compare the requested ID to the authorized user. This PR replaces the last few callers to use the pattern we have in other place. It also changes `isIdentitySelf` to accept a `RequestContext` and remove the error return (since it always returned `nil`).  This reduces the number of ways to authorize a request to 2. We should be able to reduce it to a single function in the future.