### PR TITLE
fix: include organization_id in where clause of update queries

### DIFF
--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -362,6 +362,9 @@ func list[T models.Modelable](tx GormTxn, p *Pagination, selectors ...SelectorFu
 func save[T models.Modelable](tx GormTxn, model *T) error {
 	db := tx.GormDB()
 	setOrg(tx, model)
+	if isOrgMember(model) {
+		db = ByOrgID(tx.OrganizationID())(db)
+	}
 	err := db.Save(model).Error
 	return handleError(err)
 }

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -166,9 +166,7 @@ func CountDestinationsByConnectedVersion(tx ReadTxn) ([]DestinationsCount, error
 	timeout := time.Now().Add(-5 * time.Minute)
 
 	stmt := `
-		SELECT COALESCE(version, '') as version,
-			   last_seen_at >= ? as connected,
-			   count(*)
+		SELECT COALESCE(version, '') as version, last_seen_at >= ? as connected, count(*)
 		FROM destinations
 		WHERE deleted_at IS NULL
 		GROUP BY connected, version

--- a/internal/server/data/query_test.go
+++ b/internal/server/data/query_test.go
@@ -6,6 +6,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -39,6 +40,11 @@ func (e example) OnUpdate() error {
 	return nil
 }
 
+func (e example) IsOrganizationMember() {}
+
+func (e example) SetOrganizationID(_ models.OrganizationIDSource) {
+}
+
 func TestInsert(t *testing.T) {
 	e := example{ID: 123, First: "first", Age: 111}
 	tx := &txnCapture{}
@@ -62,13 +68,17 @@ func (t *txnCapture) Exec(query string, args ...any) (sql.Result, error) {
 	return nil, nil
 }
 
+func (t *txnCapture) OrganizationID() uid.ID {
+	return 7
+}
+
 func TestUpdate(t *testing.T) {
 	e := example{ID: 123, First: "first", Age: 111}
 	tx := &txnCapture{}
 	err := update(tx, e)
 	assert.NilError(t, err)
-	expected := `UPDATE examples SET id = ?, first = ?, age = ? WHERE deleted_at is null AND id = ?; `
+	expected := `UPDATE examples SET id = ?, first = ?, age = ? WHERE deleted_at is null AND id = ? AND organization_id = ?; `
 	assert.Equal(t, tx.query, expected)
-	expectedArgs := []any{uid.ID(123), "first", 111, uid.ID(123)}
+	expectedArgs := []any{uid.ID(123), "first", 111, uid.ID(123), uid.ID(7)}
 	assert.DeepEqual(t, tx.args, expectedArgs)
 }


### PR DESCRIPTION
If someone is able to guess the ID of a row or the ID is accidentally shared it's possible a non-authorized user could update the row using the ID.

This PR fixes the bug by setting `WHERE organization_id = ?` so that only a user authorized for that org can perform updates.

Also adds a bunch more godoc for `query.go`.