### PR TITLE
Remove transaction TableName method

### DIFF
--- a/internal/server/data/migrator/helpers.go
+++ b/internal/server/data/migrator/helpers.go
@@ -17,10 +17,6 @@ func HasTable(tx DB, name string) bool {
 		WHERE table_schema = CURRENT_SCHEMA()
 		AND table_name = ? AND table_type = 'BASE TABLE'
 	`
-	if tx.DriverName() == "sqlite" {
-		stmt = `SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?`
-	}
-
 	if err := tx.QueryRow(stmt, name).Scan(&count); err != nil {
 		logging.L.Warn().Err(err).Msg("failed to check if table exists")
 		return false
@@ -40,17 +36,6 @@ func HasColumn(tx DB, table string, column string) bool {
 		WHERE table_schema = CURRENT_SCHEMA()
 		AND table_name = ? AND column_name = ?
 	`
-
-	if tx.DriverName() == "sqlite" {
-		stmt = `
-			SELECT count(*)
-			FROM sqlite_master
-			WHERE type = 'table' AND name = ?
-			AND sql LIKE ?
-		`
-		column = "% " + column + " %"
-	}
-
 	if err := tx.QueryRow(stmt, table, column).Scan(&count); err != nil {
 		logging.L.Warn().Err(err).Msg("failed to check if column exists")
 		return false
@@ -69,16 +54,6 @@ func HasConstraint(tx DB, table string, constraint string) bool {
 		WHERE table_schema = CURRENT_SCHEMA()
 		AND table_name = ? AND constraint_name = ?
 	`
-	if tx.DriverName() == "sqlite" {
-		stmt = `
-			SELECT count(*)
-			FROM sqlite_master
-			WHERE type = 'table' AND tbl_name = ?
-			AND sql LIKE ?
-		`
-		constraint = "%CONSTRAINT `" + constraint + "`%"
-	}
-
 	if err := tx.QueryRow(stmt, table, constraint).Scan(&count); err != nil {
 		logging.L.Warn().Err(err).Msg("failed to check if constraint exists")
 		return false

--- a/internal/server/data/migrator/helpers_test.go
+++ b/internal/server/data/migrator/helpers_test.go
@@ -8,9 +8,6 @@ import (
 
 func setupExampleTable(t *testing.T, db DB) {
 	t.Helper()
-	if db.DriverName() == "sqlite" {
-		t.Skip("does not work with sqlite")
-	}
 
 	_, _ = db.Exec("DROP TABLE example")
 

--- a/internal/server/data/migrator/migrator.go
+++ b/internal/server/data/migrator/migrator.go
@@ -34,9 +34,6 @@ type Migration struct {
 }
 
 type DB interface {
-	// DriverName returns the name of the database driver.
-	DriverName() string
-
 	Exec(stmt string, args ...any) (sql.Result, error)
 	Query(query string, args ...any) (*sql.Rows, error)
 	QueryRow(query string, args ...any) *sql.Row

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -9,6 +9,20 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+// ReadTxn can perform read queries and contains metadata about the request.
+type ReadTxn interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+
+	OrganizationID() uid.ID
+}
+
+// WriteTxn extends ReadTxn by adding write queries.
+type WriteTxn interface {
+	ReadTxn
+	Exec(sql string, values ...interface{}) (sql.Result, error)
+}
+
 type Table interface {
 	Table() string
 	// Columns returns the names of the table's columns. Columns must return


### PR DESCRIPTION
This PR removes the `TableName` method from `ReadTxn` and `WriteTxn`. We've removed sqlite support, so we don't need this method anymore. Also cleans up all the uses of the method.

Also moves `ReadTxn` and `WriteTxn` to `query.go`, so that `query.go` is a convenient entrypoint for learning how the `data` package works.