### PR TITLE
Remove duplicate OrganizationID in RequestContext

### DIFF
--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -116,7 +116,7 @@ func listGrantsWithMaxUpdateIndex(rCtx RequestContext, opts data.ListGrantsOptio
 		return ListGrantsResponse{}, err
 	}
 	defer logError(tx.Rollback, "failed to rollback transaction")
-	tx = tx.WithOrgID(rCtx.DBTxn.OrganizationID())
+	tx = tx.WithMetadata(rCtx.DBTxn.OrganizationID())
 
 	result, err := data.ListGrants(tx, opts)
 	if err != nil {

--- a/internal/access/request.go
+++ b/internal/access/request.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 const RequestContextKey = "requestContext"
@@ -28,4 +29,11 @@ type Authenticated struct {
 	AccessKey    *models.AccessKey
 	User         *models.Identity
 	Organization *models.Organization
+}
+
+func (n Authenticated) OrganizationID() uid.ID {
+	if org := n.Organization; org != nil {
+		return org.ID
+	}
+	return 0
 }

--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -31,9 +31,8 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details S
 		return nil, "", fmt.Errorf("create org on sign-up: %w", err)
 	}
 
-	db = db.WithOrgID(details.Org.ID)
-	rCtx.DBTxn = db
 	rCtx.Authenticated.Organization = details.Org
+	db.MetadataSource = rCtx.Authenticated
 	c.Set(RequestContextKey, rCtx)
 
 	identity := &models.Identity{

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -30,7 +30,7 @@ func txnForTestCase(t *testing.T, db *data.DB, orgID uid.ID) *data.Transaction {
 	t.Cleanup(func() {
 		_ = tx.Rollback()
 	})
-	return tx.WithOrgID(orgID)
+	return tx.WithMetadata(orgID)
 }
 
 func TestLogin(t *testing.T) {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -611,7 +611,7 @@ func (s Server) loadConfig(config Config) error {
 		return err
 	}
 	defer logError(tx.Rollback, "failed to rollback loadConfig transaction")
-	tx = tx.WithOrgID(org.ID)
+	tx = tx.WithMetadata(org.ID)
 
 	if config.DefaultOrganizationDomain != org.Domain {
 		org.Domain = config.DefaultOrganizationDomain

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -273,7 +273,7 @@ func ValidateRequestAccessKey(tx *Transaction, authnKey string) (*models.AccessK
 	if err != nil {
 		return nil, fmt.Errorf("%w: could not get access key from database, it may not exist", err)
 	}
-	tx = tx.WithOrgID(t.OrganizationID)
+	tx = tx.WithMetadata(t.OrganizationID)
 
 	sum := secretChecksum(secret)
 

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -149,7 +149,8 @@ type GormTxn interface {
 
 // MetadataSource provides metadata for Transaction.
 //
-// TODO: change Transaction.WithOrgID to WithMetadata.
+// IMPORTANT: any new methods on this struct also need to be added as args to
+// Transaction.WithMetadata, and the metadata struct.
 type MetadataSource interface {
 	OrganizationID() uid.ID
 }
@@ -206,12 +207,12 @@ func (t *Transaction) Commit() error {
 	return err
 }
 
-// WithOrgID returns a shallow copy of the Transaction with the OrganizationID
-// set to orgID. Note that the underlying database transaction and commit state
+// WithMetadata returns a shallow copy of the Transaction with the MetadataSource
+// update to the new values.
+// Note that the underlying database transaction and commit state
 // is shared with the new copy.
-func (t *Transaction) WithOrgID(orgID uid.ID) *Transaction {
+func (t *Transaction) WithMetadata(orgID uid.ID) *Transaction {
 	newTxn := *t
-	// TODO: copy other fields from existing MetadataSource if not nil.
 	newTxn.MetadataSource = metadata{orgID: orgID}
 	return &newTxn
 }

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -131,7 +131,7 @@ func TestCreateTransactionError(t *testing.T) {
 	// on creation error (such as conflict) the database transaction should still be usable
 	runDBTests(t, func(t *testing.T, db *DB) {
 		err := db.Transaction(func(txDB *gorm.DB) error {
-			tx := &Transaction{DB: txDB, orgID: 12345}
+			tx := &Transaction{DB: txDB, MetadataSource: metadata{orgID: 12345}}
 
 			g := &models.Grant{}
 			err := add(tx, g)
@@ -155,7 +155,7 @@ func TestCreateTransactionError(t *testing.T) {
 func TestSetOrg(t *testing.T) {
 	model := &models.AccessKey{}
 
-	tx := &Transaction{orgID: 123456}
+	tx := &Transaction{MetadataSource: metadata{orgID: 123456}}
 	setOrg(tx, model)
 	assert.Equal(t, model.OrganizationID, uid.ID(123456))
 }

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -36,7 +36,7 @@ func txnForTestCase(t *testing.T, db *DB, orgID uid.ID) *Transaction {
 	t.Cleanup(func() {
 		_ = tx.Rollback()
 	})
-	return tx.WithOrgID(orgID)
+	return tx.WithMetadata(orgID)
 }
 
 // runDBTests against all supported databases.
@@ -176,7 +176,7 @@ func TestDB_Begin(t *testing.T) {
 			ctx := context.Background()
 			tx, err := db.Begin(ctx, nil)
 			assert.NilError(t, err)
-			tx = tx.WithOrgID(db.DefaultOrg.ID)
+			tx = tx.WithMetadata(db.DefaultOrg.ID)
 
 			user := &models.Identity{Name: "something@example.com"}
 			err = CreateIdentity(tx, user)
@@ -196,7 +196,7 @@ func TestDB_Begin(t *testing.T) {
 			ctx := context.Background()
 			tx, err := db.Begin(ctx, nil)
 			assert.NilError(t, err)
-			tx = tx.WithOrgID(db.DefaultOrg.ID)
+			tx = tx.WithMetadata(db.DefaultOrg.ID)
 
 			user := &models.Identity{Name: "something@example.com"}
 			err = CreateIdentity(tx, user)

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -152,7 +152,7 @@ func TestDeleteGrants(t *testing.T) {
 			createGrants(t, tx, grant1, grant2, toKeep)
 
 			otherOrgGrant := &models.Grant{Subject: "i:any1", Privilege: "view", Resource: "any"}
-			createGrants(t, tx.WithOrgID(otherOrg.ID), otherOrgGrant)
+			createGrants(t, tx.WithMetadata(otherOrg.ID), otherOrgGrant)
 
 			err := DeleteGrants(tx, DeleteGrantsOptions{BySubject: grant1.Subject})
 			assert.NilError(t, err)
@@ -170,7 +170,7 @@ func TestDeleteGrants(t *testing.T) {
 			startUpdateIndex = maxIndex
 
 			// other org still has the grant
-			actual, err = ListGrants(tx.WithOrgID(otherOrg.ID), ListGrantsOptions{ByDestination: "any"})
+			actual, err = ListGrants(tx.WithMetadata(otherOrg.ID), ListGrantsOptions{ByDestination: "any"})
 			assert.NilError(t, err)
 			assert.Equal(t, len(actual), 1)
 		})
@@ -263,7 +263,7 @@ func TestGetGrant(t *testing.T) {
 		otherOrg := &models.Organization{Name: "other", Domain: "other.example.org"}
 		assert.NilError(t, CreateOrganization(tx, otherOrg))
 		other := &models.Grant{Subject: "i:any1", Privilege: "view", Resource: "any"}
-		createGrants(t, tx.WithOrgID(otherOrg.ID), other)
+		createGrants(t, tx.WithMetadata(otherOrg.ID), other)
 
 		t.Run("default options", func(t *testing.T) {
 			_, err := GetGrant(tx, GetGrantOptions{})
@@ -421,7 +421,7 @@ func TestListGrants(t *testing.T) {
 			CreatedBy:          uid.ID(778),
 			OrganizationMember: models.OrganizationMember{OrganizationID: otherOrg.ID},
 		}
-		createGrants(t, tx.WithOrgID(otherOrg.ID), otherOrgGrant)
+		createGrants(t, tx.WithMetadata(otherOrg.ID), otherOrgGrant)
 
 		connectorUser := InfraConnectorIdentity(db)
 
@@ -608,7 +608,7 @@ func TestListenForGrantsNotify(t *testing.T) {
 				t.Run(op.name, func(t *testing.T) {
 					tx, err := db.Begin(ctx, nil)
 					assert.NilError(t, err)
-					tx = tx.WithOrgID(mainOrg.ID)
+					tx = tx.WithMetadata(mainOrg.ID)
 					op.run(t, tx)
 					assert.NilError(t, tx.Commit())
 

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -161,7 +161,7 @@ func TestDeleteGroup(t *testing.T) {
 		createGrants(t, tx, groupGrant)
 
 		otherOrgGroup := &models.Group{Name: "Everyone"}
-		createGroups(t, tx.WithOrgID(otherOrg.ID), otherOrgGroup)
+		createGroups(t, tx.WithMetadata(otherOrg.ID), otherOrgGroup)
 
 		t.Run("success", func(t *testing.T) {
 			_, err := GetGroup(tx, ByID(everyone.ID))
@@ -176,7 +176,7 @@ func TestDeleteGroup(t *testing.T) {
 			// deleting a group should not delete unrelated groups
 			_, err = GetGroup(tx, ByID(engineers.ID))
 			assert.NilError(t, err)
-			_, err = GetGroup(tx.WithOrgID(otherOrg.ID), ByID(otherOrgGroup.ID))
+			_, err = GetGroup(tx.WithMetadata(otherOrg.ID), ByID(otherOrgGroup.ID))
 			assert.NilError(t, err)
 
 			// grants and group membership should also be removed.

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -16,7 +16,7 @@ func TestCreateOrganization(t *testing.T) {
 		err := CreateOrganization(db, org)
 		assert.NilError(t, err)
 
-		tx := &Transaction{DB: db.DB, orgID: org.ID}
+		tx := &Transaction{DB: db.DB, MetadataSource: metadata{orgID: org.ID}}
 
 		// org is created
 		readOrg, err := GetOrganization(db, ByID(org.ID))

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -99,7 +99,7 @@ func txnForTestCase(t *testing.T, db *data.DB, orgID uid.ID) *data.Transaction {
 	t.Cleanup(func() {
 		assert.NilError(t, tx.Rollback())
 	})
-	return tx.WithOrgID(orgID)
+	return tx.WithMetadata(orgID)
 }
 
 func jsonBody(t *testing.T, body interface{}) *bytes.Buffer {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -95,7 +95,7 @@ func authenticateRequest(c *gin.Context, route routeSettings, srv *Server) (acce
 
 	if authned.User != nil {
 		if uniqueID := c.Request.Header.Get(headerInfraDestination); uniqueID != "" {
-			tx = tx.WithOrgID(authned.Organization.ID)
+			tx.MetadataSource = authned
 			rCtx := access.RequestContext{DBTxn: tx, Authenticated: authned}
 			if err := handleInfraDestinationHeader(rCtx, uniqueID); err != nil {
 				return authned, err

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -174,8 +174,8 @@ func requireAccessKey(c *gin.Context, db *data.Transaction, srv *Server) (access
 
 	// now that the org is loaded scope all db calls to that org
 	// TODO: set the orgID explicitly in the options passed to GetIdentity to
-	// remove the need for this WithOrgID.
-	db = db.WithOrgID(org.ID)
+	// remove the need for this WithMetadata.
+	db = db.WithMetadata(org.ID)
 
 	// either this access key was issued for a user or for an identity provider to do SCIM
 	if accessKey.IssuedFor == accessKey.ProviderID {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -429,7 +429,7 @@ func TestAuthenticateRequest(t *testing.T) {
 
 	tx, err := srv.db.Begin(context.Background(), nil)
 	assert.NilError(t, err)
-	tx = tx.WithOrgID(org.ID)
+	tx = tx.WithMetadata(org.ID)
 
 	user := &models.Identity{
 		Name:               "userone@example.com",
@@ -624,7 +624,7 @@ func TestValidateRequestOrganization(t *testing.T) {
 
 	tx, err := srv.db.Begin(context.Background(), nil)
 	assert.NilError(t, err)
-	tx = tx.WithOrgID(org.ID)
+	tx = tx.WithMetadata(org.ID)
 
 	provider := &models.Provider{
 		Name:               "electric",

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -237,9 +237,7 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 		}
 		defer logError(tx.Rollback, "failed to rollback request handler transaction")
 
-		if org := authned.Organization; org != nil {
-			tx = tx.WithOrgID(org.ID)
-		}
+		tx.MetadataSource = authned
 		rCtx := access.RequestContext{
 			Request:       c.Request,
 			DBTxn:         tx,

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -228,7 +228,7 @@ func TestAPI_Signup(t *testing.T) {
 				assert.Equal(t, userResp.ID, respBody.User.ID)
 
 				// check the user is an admin
-				tx := (&data.Transaction{DB: srv.db.DB}).WithOrgID(orgID)
+				tx := (&data.Transaction{DB: srv.db.DB}).WithMetadata(orgID)
 				_, err = data.GetGrant(tx, data.GetGrantOptions{
 					BySubject:   uid.NewIdentityPolymorphicID(userID),
 					ByResource:  access.ResourceInfraAPI,


### PR DESCRIPTION
One of the unfortunate trade-offs with `RequestContext` was that we end up storing the OrganizationID in two places. Once at `Authenticated.Organization.ID`, and the other at `DBTxn.OrganizationID()`.

I attempted to resolve this previously, but ran into problems because a transaction needs to exist in packages that don't have access to `RequestContext`, or before the Organization ID is known.

This is another attempt to address this problem. The first commit allows a transaction to accept a `MetadataSource` to provide the metadata, which is implemented by `access.Authenticated`. This way we end up using the same field to provide the value in both places.

The second commit renames `WithOrgID` to `WithMetadata` so that we don't forget to add additional parameters when we add more metadata.