### PR TITLE
Improve blocking requests and add more test coverage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,8 @@ issues:
       text: "\"io/ioutil\" has been deprecated"
     - linters: [errcheck]
       text: "tx\\.Rollback"
+    - linters: [noctx]
+      path: "_test\\.go"
 
 linters:
   enable:

--- a/api/grant.go
+++ b/api/grant.go
@@ -79,7 +79,6 @@ func (r ListGrantsRequest) validateLastUpdateIndex() *validate.Failure {
 	// query parameters can be set
 	switch {
 	case r.Destination != "":
-		// TODO: require limit=-1
 		if fields := r.fieldsWithValues("destination", "lastUpdateIndex"); len(fields) > 0 {
 			return validate.Fail("lastUpdateIndex",
 				fmt.Sprintf("can not be used with %v parameter(s)", strings.Join(fields, ",")))

--- a/api/grant.go
+++ b/api/grant.go
@@ -35,14 +35,14 @@ func (r *CreateGrantResponse) StatusCode() int {
 }
 
 type ListGrantsRequest struct {
-	User            uid.ID `form:"user"`
-	Group           uid.ID `form:"group"`
-	Resource        string `form:"resource" example:"production.namespace"`
-	Destination     string `form:"destination" example:"production"`
-	Privilege       string `form:"privilege" example:"view"`
-	ShowInherited   bool   `form:"showInherited" note:"if true, this field includes grants that the user inherits through groups"`
-	ShowSystem      bool   `form:"showSystem" note:"if true, this shows the connector and other internal grants"`
-	LastUpdateIndex int64  `form:"lastUpdateIndex" note:"set this to the value of the Last-Update-Index response header to block until the list results have changed"`
+	User          uid.ID `form:"user"`
+	Group         uid.ID `form:"group"`
+	Resource      string `form:"resource" example:"production.namespace"`
+	Destination   string `form:"destination" example:"production"`
+	Privilege     string `form:"privilege" example:"view"`
+	ShowInherited bool   `form:"showInherited" note:"if true, this field includes grants that the user inherits through groups"`
+	ShowSystem    bool   `form:"showSystem" note:"if true, this shows the connector and other internal grants"`
+	BlockingRequest
 	PaginationRequest
 }
 

--- a/api/types.go
+++ b/api/types.go
@@ -167,6 +167,18 @@ func (l *LastUpdateIndex) setValuesFromHeader(header http.Header) error {
 	return nil
 }
 
+// BlockingRequest is used to identify the last update index that was
+// visible to the client. The API endpoint will block until there is a
+// new updated index for the query.
+// BlockingRequests use a longer request timeout than a standard request.
+type BlockingRequest struct {
+	LastUpdateIndex int64 `form:"lastUpdateIndex" note:"set this to the value of the Last-Update-Index response header to block until the list results have changed"`
+}
+
+func (r BlockingRequest) IsBlockingRequest() bool {
+	return r.LastUpdateIndex != 0
+}
+
 // PEM is a base64 encoded string, commonly used to store certificates and
 // private keys. PEM values will be normalized to remove any leading whitespace
 // and all but a single trailing newline.

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -91,7 +91,7 @@ func ListGrants(c *gin.Context, opts data.ListGrantsOptions, lastUpdateIndex int
 		return result, nil
 	}
 
-	_, err = listener.WaitForNotification(rCtx.Request.Context())
+	err = listener.WaitForNotification(rCtx.Request.Context())
 	if err != nil {
 		return result, fmt.Errorf("waiting for notify: %w", err)
 	}

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -111,6 +111,11 @@ func defaultServerOptions(infraDir string) server.Options {
 		Redis: redis.Options{
 			Port: 6379,
 		},
+
+		API: server.APIOptions{
+			RequestTimeout:         time.Minute,
+			BlockingRequestTimeout: 5 * time.Minute,
+		},
 	}
 }
 

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -192,6 +192,11 @@ redis:
   host: myredis
   username: myuser
   password: mypassword
+
+api:
+  requestTimeout: 2m
+  blockingRequestTimeout: 4m
+
 `
 
 				dir := fs.NewDir(t, t.Name(),
@@ -296,6 +301,11 @@ redis:
 						Port:     6379,
 						Username: "myuser",
 						Password: "mypassword",
+					},
+
+					API: server.APIOptions{
+						RequestTimeout:         2 * time.Minute,
+						BlockingRequestTimeout: 4 * time.Minute,
 					},
 				}
 			},

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -43,11 +43,9 @@ func txnForTestCase(t *testing.T, db *DB, orgID uid.ID) *Transaction {
 // Set POSTGRESQL_CONNECTION to a postgresql connection string to run tests
 // against postgresql.
 func runDBTests(t *testing.T, run func(t *testing.T, db *DB)) {
-	t.Run("postgres", func(t *testing.T) {
-		db := setupDB(t)
-		run(t, db)
-		db.Rollback()
-	})
+	db := setupDB(t)
+	run(t, db)
+	db.Rollback()
 }
 
 func TestSnowflakeIDSerialization(t *testing.T) {

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -597,3 +597,15 @@ func FuzzListenForGrantsNotify(f *testing.F) {
 		assert.NilError(t, l.Release(ctx))
 	})
 }
+
+func TestGrantsMaxUpdateIndex(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		t.Run("no results match the query", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			idx, err := GrantsMaxUpdateIndex(tx, GrantsMaxUpdateIndexOptions{ByDestination: "nope"})
+			assert.NilError(t, err)
+			assert.Equal(t, idx, int64(1))
+		})
+	})
+}

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -3,20 +3,14 @@ package data
 import (
 	"context"
 	"errors"
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/infrahq/infra/internal"
-	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/internal/testing/database"
-	"github.com/infrahq/infra/internal/testing/patch"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -109,9 +103,8 @@ func TestCreateGrant(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 			defer cancel()
-			notification, err := listener.WaitForNotification(ctx)
+			err = listener.WaitForNotification(ctx)
 			assert.NilError(t, err)
-			assert.Equal(t, notification.Channel, "grants_by_destination_1000_match")
 		})
 	})
 }
@@ -235,9 +228,8 @@ func TestDeleteGrants(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 			t.Cleanup(cancel)
 
-			notification, err := listener.WaitForNotification(ctx)
+			err = listener.WaitForNotification(ctx)
 			assert.NilError(t, err)
-			assert.Equal(t, notification.Channel, "grants_by_destination_1000_match")
 		})
 	})
 }
@@ -550,51 +542,6 @@ func TestListGrants(t *testing.T) {
 			expected := []models.Grant{*grant1, *grant2, *grant3, *grant5}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
 		})
-	})
-}
-
-func FuzzListenForGrantsNotify(f *testing.F) {
-	patch.ModelsSymmetricKey(f)
-	logging.PatchLogger(f, zerolog.NewTestWriter(f))
-
-	// Fuzz runs multiple processes, and we don't want the schemas to conflict,
-	// so use the pid as part of the schema name.
-	suffix := fmt.Sprintf("_data_%d", os.Getpid())
-	db, err := NewDB(NewDBOptions{
-		DSN: database.PostgresDriver(f, suffix).DSN,
-		// Limit the number of connections to prevent connection errors. This
-		// number must be at most postgres.max_connections / n_workers.
-		MaxOpenConnections: 10,
-		// Must be non-zero to avoid closing the connection and exhausting all
-		// the ports on the host.
-		MaxIdleConnections: 10,
-	})
-	assert.NilError(f, err)
-
-	testCases := []string{
-		"okname",
-		"--",
-		"; bogus --",
-		"'; bogus --",
-		"; drop table organizations; --",
-		"\x99", "\x00",
-		"0", "@", ";", "'", `"`,
-	}
-	for _, tc := range testCases {
-		f.Add(tc)
-	}
-	f.Fuzz(func(t *testing.T, name string) {
-		if name == "" {
-			return
-		}
-
-		ctx := context.Background()
-		l, err := ListenForGrantsNotify(ctx, db, ListenForGrantsOptions{
-			OrgID:         db.DefaultOrg.ID,
-			ByDestination: name,
-		})
-		assert.NilError(t, err)
-		assert.NilError(t, l.Release(ctx))
 	})
 }
 

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
@@ -555,4 +556,160 @@ func TestGrantsMaxUpdateIndex(t *testing.T) {
 			assert.Equal(t, idx, int64(1))
 		})
 	})
+}
+
+func TestListenForGrantsNotify(t *testing.T) {
+	type operation struct {
+		name        string
+		run         func(t *testing.T, tx WriteTxn)
+		expectMatch bool
+	}
+	type testCase struct {
+		name string
+		opts ListenForGrantsOptions
+		ops  []operation
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runDBTests(t, func(t *testing.T, db *DB) {
+		mainOrg := &models.Organization{Name: "Main", Domain: "main.example.org"}
+		assert.NilError(t, CreateOrganization(db, mainOrg))
+
+		otherOrg := &models.Organization{Name: "Other", Domain: "other.example.org"}
+		assert.NilError(t, CreateOrganization(db, otherOrg))
+
+		run := func(t *testing.T, tc testCase) {
+			listener, err := ListenForGrantsNotify(ctx, db, tc.opts)
+			assert.NilError(t, err)
+
+			chResult := make(chan struct{})
+			g, ctx := errgroup.WithContext(ctx)
+
+			g.Go(func() error {
+				for {
+					err := listener.WaitForNotification(ctx)
+					switch {
+					case errors.Is(err, context.Canceled):
+						return nil
+					case err != nil:
+						return err
+					}
+					select {
+					case chResult <- struct{}{}:
+					case <-ctx.Done():
+						return nil
+					}
+				}
+			})
+
+			for _, op := range tc.ops {
+				t.Run(op.name, func(t *testing.T) {
+					tx, err := db.Begin(ctx, nil)
+					assert.NilError(t, err)
+					tx = tx.WithOrgID(mainOrg.ID)
+					op.run(t, tx)
+					assert.NilError(t, tx.Commit())
+
+					if op.expectMatch {
+						isNotBlocked(t, chResult)
+						return
+					}
+					isBlocked(t, chResult)
+				})
+			}
+
+			cancel()
+			assert.NilError(t, g.Wait())
+		}
+
+		testcases := []testCase{
+			{
+				name: "by destination",
+				opts: ListenForGrantsOptions{
+					ByDestination: "mydest",
+					OrgID:         mainOrg.ID,
+				},
+				ops: []operation{
+					{
+						name: "grant resource matches exactly",
+						run: func(t *testing.T, tx WriteTxn) {
+							err := CreateGrant(tx, &models.Grant{
+								Subject:   "i:geo",
+								Resource:  "mydest",
+								Privilege: "view",
+							})
+							assert.NilError(t, err)
+						},
+						expectMatch: true,
+					},
+					{
+						name: "grant resource does not match",
+						run: func(t *testing.T, tx WriteTxn) {
+							err := CreateGrant(tx, &models.Grant{
+								Subject:   "i:geo",
+								Resource:  "otherdest",
+								Privilege: "mydest",
+							})
+							assert.NilError(t, err)
+						},
+					},
+					{
+						name: "grant resource prefix match",
+						run: func(t *testing.T, tx WriteTxn) {
+							err := CreateGrant(tx, &models.Grant{
+								Subject:   "i:geo",
+								Resource:  "mydest.also.ns1",
+								Privilege: "admin",
+							})
+							assert.NilError(t, err)
+						},
+						expectMatch: true,
+					},
+					{
+						name: "different org",
+						run: func(t *testing.T, tx WriteTxn) {
+							err := CreateGrant(tx, &models.Grant{
+								OrganizationMember: models.OrganizationMember{
+									OrganizationID: otherOrg.ID,
+								},
+								Subject:   "i:geo",
+								Resource:  "mydest",
+								Privilege: "admin",
+							})
+							assert.NilError(t, err)
+						},
+					},
+				},
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				run(t, tc)
+			})
+		}
+	})
+}
+
+func isBlocked[T any](t *testing.T, ch chan T) {
+	t.Helper()
+	select {
+	case item := <-ch:
+		t.Fatalf("expected operation to be blocked, but it returned: %v", item)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func isNotBlocked[T any](t *testing.T, ch chan T) (result T) {
+	t.Helper()
+	timeout := 100 * time.Millisecond
+	select {
+	case item := <-ch:
+		return item
+	case <-time.After(timeout):
+		t.Fatalf("expected operation to not block, timeout after: %v", timeout)
+		return result
+	}
 }

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -734,7 +734,7 @@ func removeDeletedIdentityProviderUsers() *migrator.Migration {
 
 func addUpdateIndexAndGrantNotify() *migrator.Migration {
 	return &migrator.Migration{
-		ID: "2022-09-21T13:50",
+		ID: "2022-10-17T18:00",
 		Migrate: func(tx migrator.DB) error {
 			if _, err := tx.Exec(`
 				CREATE SEQUENCE IF NOT EXISTS seq_update_index
@@ -757,10 +757,8 @@ func addUpdateIndexAndGrantNotify() *migrator.Migration {
 CREATE OR REPLACE FUNCTION grants_notify() RETURNS trigger
 	LANGUAGE PLPGSQL
 	AS $$
-DECLARE
-	destination text := split_part(NEW.resource, '.', 1);
 BEGIN
-PERFORM pg_notify('grants_by_destination_' || NEW.organization_id || '_' || destination, '');
+PERFORM pg_notify(current_schema() || '.grants_' || NEW.organization_id, row_to_json(NEW)::text);
 RETURN NULL;
 END; $$;
 
@@ -781,7 +779,7 @@ CREATE OR REPLACE FUNCTION listen_on_chan(chan text) RETURNS void
 LANGUAGE PLPGSQL
 AS $$
 BEGIN
-    EXECUTE format('LISTEN %I', chan);
+    EXECUTE format('LISTEN %I', current_schema() || '.' || chan);
 END; $$;
 `
 			if _, err := tx.Exec(fn); err != nil {

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -785,7 +785,7 @@ DELETE FROM settings WHERE id=24567;
 			},
 		},
 		{
-			label: testCaseLine("2022-09-21T13:50"),
+			label: testCaseLine("2022-10-17T18:00"),
 			expected: func(t *testing.T, db WriteTxn) {
 				// schema changes are tested with schema comparison
 			},

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -7,10 +7,8 @@
 CREATE FUNCTION grants_notify() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
-DECLARE
-	destination text := split_part(NEW.resource, '.', 1);
 BEGIN
-PERFORM pg_notify('grants_by_destination_' || NEW.organization_id || '_' || destination, '');
+PERFORM pg_notify(current_schema() || '.grants_' || NEW.organization_id, row_to_json(NEW)::text);
 RETURN NULL;
 END; $$;
 
@@ -18,7 +16,7 @@ CREATE FUNCTION listen_on_chan(chan text) RETURNS void
     LANGUAGE plpgsql
     AS $$
 BEGIN
-    EXECUTE format('LISTEN %I', chan);
+    EXECUTE format('LISTEN %I', current_schema() || '.' || chan);
 END; $$;
 
 CREATE FUNCTION uidinttostr(id bigint) RETURNS text

--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -33,17 +33,20 @@ func (a *API) ListGrants(c *gin.Context, r *api.ListGrantsRequest) (*ListGrantsR
 		subject = uid.NewGroupPolymorphicID(r.Group)
 	}
 
-	p := PaginationFromRequest(r.PaginationRequest)
+	var p data.Pagination
 	opts := data.ListGrantsOptions{
 		ByResource:                 r.Resource,
 		BySubject:                  subject,
 		ByDestination:              r.Destination,
 		ExcludeConnectorGrant:      !r.ShowSystem,
 		IncludeInheritedFromGroups: r.ShowInherited,
-		Pagination:                 &p,
 	}
 	if r.Privilege != "" {
 		opts.ByPrivileges = []string{r.Privilege}
+	}
+	if !r.IsBlockingRequest() {
+		p = PaginationFromRequest(r.PaginationRequest)
+		opts.Pagination = &p
 	}
 
 	grants, err := access.ListGrants(c, opts, r.LastUpdateIndex)

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -769,7 +769,17 @@ func TestAPI_ListGrants_BlockingRequest_BlocksUntilUpdate(t *testing.T) {
 
 	isBlocked(t, respCh)
 
+	// unrelated grant
 	err := data.CreateGrant(srv.db, &models.Grant{
+		Subject:   "i:abcd",
+		Privilege: "view",
+		Resource:  "somethingelse",
+	})
+	assert.NilError(t, err)
+	isBlocked(t, respCh)
+
+	// matching grant
+	err = data.CreateGrant(srv.db, &models.Grant{
 		Subject:   "i:abcd",
 		Privilege: "view",
 		Resource:  "infra",
@@ -778,7 +788,7 @@ func TestAPI_ListGrants_BlockingRequest_BlocksUntilUpdate(t *testing.T) {
 
 	resp := isNotBlocked(t, respCh)
 	assert.Equal(t, resp.Code, http.StatusOK, (*responseDebug)(resp))
-	assert.Equal(t, resp.Result().Header.Get("Last-Update-Index"), "10002", (*responseDebug)(resp))
+	assert.Equal(t, resp.Result().Header.Get("Last-Update-Index"), "10003", (*responseDebug)(resp))
 
 	respBody := &api.ListResponse[api.Grant]{}
 	assert.NilError(t, json.NewDecoder(resp.Body).Decode(respBody))
@@ -832,7 +842,17 @@ func TestAPI_ListGrants_BlockingRequest_NotFoundBlocksUntilUpdate(t *testing.T) 
 
 	isBlocked(t, respCh)
 
+	// unrelated grant
 	err := data.CreateGrant(srv.db, &models.Grant{
+		Subject:   "i:abcd",
+		Privilege: "view",
+		Resource:  "somethingelse",
+	})
+	assert.NilError(t, err)
+	isBlocked(t, respCh)
+
+	// matching grant
+	err = data.CreateGrant(srv.db, &models.Grant{
 		Subject:   "i:abcd",
 		Privilege: "view",
 		Resource:  "deferred.ns1",
@@ -841,7 +861,7 @@ func TestAPI_ListGrants_BlockingRequest_NotFoundBlocksUntilUpdate(t *testing.T) 
 
 	resp := isNotBlocked(t, respCh)
 	assert.Equal(t, resp.Code, http.StatusOK, (*responseDebug)(resp))
-	assert.Equal(t, resp.Result().Header.Get("Last-Update-Index"), "10002", (*responseDebug)(resp))
+	assert.Equal(t, resp.Result().Header.Get("Last-Update-Index"), "10003", (*responseDebug)(resp))
 
 	respBody := &api.ListResponse[api.Grant]{}
 	assert.NilError(t, json.NewDecoder(resp.Body).Decode(respBody))

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -708,8 +708,8 @@ func TestAPI_ListGrants_ExtendedRequestTimeout(t *testing.T) {
 	}
 
 	withShortRequestTimeout := func(t *testing.T, options *Options) {
-		options.API.RequestTimeout = 50 * time.Millisecond
-		options.API.BlockingRequestTimeout = 400 * time.Millisecond
+		options.API.RequestTimeout = 250 * time.Millisecond
+		options.API.BlockingRequestTimeout = 1500 * time.Millisecond
 	}
 	srv := setupServer(t, withAdminUser, withShortRequestTimeout)
 	routes := srv.GenerateRoutes()
@@ -726,7 +726,7 @@ func TestAPI_ListGrants_ExtendedRequestTimeout(t *testing.T) {
 
 	elapsed := time.Since(start)
 	assert.Assert(t, elapsed >= srv.options.API.BlockingRequestTimeout,
-		"elapsed=%v", elapsed)
+		"elapsed=%v, resp=%#v", elapsed, resp)
 
 	assert.Equal(t, resp.Code, http.StatusGatewayTimeout, resp.Body.String())
 }

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -491,12 +491,15 @@ func TestAPI_ListGrants(t *testing.T) {
 				err = json.NewDecoder(resp.Body).Decode(&grants)
 				assert.NilError(t, err)
 
-				expected := []api.Grant{
-					{User: idInGroup, Privilege: "custom1", Resource: "res1"},
-					{User: idOther, Privilege: "custom2", Resource: "res1.ns1"},
-					{User: idOther, Privilege: "connector", Resource: "res1.ns2"},
+				expected := api.ListResponse[api.Grant]{
+					Items: []api.Grant{
+						{User: idInGroup, Privilege: "custom1", Resource: "res1"},
+						{User: idOther, Privilege: "custom2", Resource: "res1.ns1"},
+						{User: idOther, Privilege: "connector", Resource: "res1.ns2"},
+					},
+					Count: 3,
 				}
-				assert.DeepEqual(t, grants.Items, expected, cmpAPIGrantShallow)
+				assert.DeepEqual(t, grants, expected, cmpAPIGrantShallow)
 				assert.Equal(t, resp.Result().Header.Get("Last-Update-Index"), "10004")
 			},
 		},

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -29,7 +29,9 @@ import (
 func setupDB(t *testing.T) *data.DB {
 	t.Helper()
 	tpatch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_server").DSN})
+
+	schema := "_server_" + generate.MathRandom(4, "0123456789")
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, schema).DSN})
 	assert.NilError(t, err)
 	t.Cleanup(func() {
 		assert.NilError(t, db.Close())

--- a/internal/server/pagination.go
+++ b/internal/server/pagination.go
@@ -29,6 +29,9 @@ func PaginationFromRequest(pr api.PaginationRequest) data.Pagination {
 // PaginationToResponse translates an internal Pagination type into the pagination
 // response.
 func PaginationToResponse(p data.Pagination) api.PaginationResponse {
+	if p.Limit == 0 {
+		return api.PaginationResponse{}
+	}
 	return api.PaginationResponse{
 		Page:       p.Page,
 		Limit:      p.Limit,

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -218,16 +218,15 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 		}
 		defer logError(tx.Rollback, "failed to rollback request handler transaction")
 
+		if org := authned.Organization; org != nil {
+			tx = tx.WithOrgID(org.ID)
+		}
 		rCtx := access.RequestContext{
 			Request:       c.Request,
 			DBTxn:         tx,
 			Authenticated: authned,
 			DataDB:        a.server.db,
 		}
-		if org := rCtx.Authenticated.Organization; org != nil {
-			tx = tx.WithOrgID(org.ID)
-		}
-		rCtx.DBTxn = tx
 		c.Set(access.RequestContextKey, rCtx)
 
 		resp, err := route.handler(c, req)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net/http"
@@ -48,7 +49,7 @@ func (s *Server) GenerateRoutes() Routes {
 	// This group of middleware will apply to everything, including the UI
 	router.Use(
 		loggingMiddleware(s.options.EnableLogSampling),
-		TimeoutMiddleware(1*time.Minute),
+		TimeoutMiddleware(s.options.API.RequestTimeout),
 	)
 
 	// This group of middleware only applies to non-ui routes
@@ -212,6 +213,14 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 			return err
 		}
 
+		if r, ok := any(req).(isBlockingRequest); ok && r.IsBlockingRequest() {
+			ctx, cancel := newExtendedDeadlineContext(
+				c.Request.Context(),
+				a.server.options.API.BlockingRequestTimeout)
+			defer cancel()
+			c.Request = c.Request.WithContext(ctx)
+		}
+
 		tx, err := a.server.db.Begin(c.Request.Context(), route.txnOptions)
 		if err != nil {
 			return err
@@ -251,7 +260,7 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 		if respHeaders, ok := any(resp).(hasResponseHeaders); ok {
 			respHeaders.SetHeaders(c.Writer.Header())
 		}
-		if r, ok := responseIsRedirect(resp); ok {
+		if r, ok := any(resp).(isRedirect); ok {
 			c.Redirect(http.StatusPermanentRedirect, r.RedirectURL())
 		} else {
 			c.JSON(responseStatusCode(routeID.method, resp), resp)
@@ -268,13 +277,30 @@ type isRedirect interface {
 	RedirectURL() string
 }
 
-func responseIsRedirect(resp interface{}) (isRedirect, bool) {
-	r, ok := resp.(isRedirect)
-	return r, ok
-}
-
 type statusCoder interface {
 	StatusCode() int
+}
+
+type isBlockingRequest interface {
+	IsBlockingRequest() bool
+}
+
+func newExtendedDeadlineContext(base context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	return extendedContext{Context: ctx, valuesCtx: base}, cancel
+}
+
+// extendedContext can be used to create a new context where only the values
+// come from the base context. The context deadline is redefined to a new
+// (must likely longer) value. This  allows us to extend the deadline by ignoring
+// the one that was set in the base context.
+type extendedContext struct {
+	context.Context
+	valuesCtx context.Context
+}
+
+func (e extendedContext) Value(key any) any {
+	return e.valuesCtx.Value(key)
 }
 
 var reflectTypeString = reflect.TypeOf("")

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -325,8 +325,8 @@ func TestRequestTimeout(t *testing.T) {
 
 func TestGenerateRoutes_OneRequestDoesNotBlockOthers(t *testing.T) {
 	withShortRequestTimeout := func(t *testing.T, options *Options) {
-		options.API.RequestTimeout = 50 * time.Millisecond
-		options.API.BlockingRequestTimeout = 500 * time.Millisecond
+		options.API.RequestTimeout = 250 * time.Millisecond
+		options.API.BlockingRequestTimeout = 1500 * time.Millisecond
 	}
 	srv := setupServer(t, withAdminUser, withShortRequestTimeout)
 	routes := srv.GenerateRoutes()
@@ -348,7 +348,7 @@ func TestGenerateRoutes_OneRequestDoesNotBlockOthers(t *testing.T) {
 	// perform many short-lived requests with the same user
 	start := time.Now()
 	var count int
-	for time.Since(start) < srv.options.API.BlockingRequestTimeout {
+	for time.Since(start) < srv.options.API.BlockingRequestTimeout && count < 3 {
 		urlPath := "/api/grants?destination=infra"
 		req, err := http.NewRequest(http.MethodGet, urlPath, nil)
 		assert.NilError(t, err)
@@ -364,5 +364,5 @@ func TestGenerateRoutes_OneRequestDoesNotBlockOthers(t *testing.T) {
 	assert.NilError(t, g.Wait())
 	// The count is likely close to 40, but use a low threshold to prevent flakes.
 	// Anything more than 2 should indicate the requests did not block each other.
-	assert.Assert(t, count > 3, "count=%d", count)
+	assert.Assert(t, count >= 3, "count=%d", count)
 }

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/errgroup"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -320,4 +321,48 @@ func TestRequestTimeout(t *testing.T) {
 	assert.Equal(t, resp.Code, http.StatusGatewayTimeout, resp.Body.String())
 
 	assert.Assert(t, elapsed < 1500*time.Millisecond, "expected request to time out due to the timeout context, but it did not")
+}
+
+func TestGenerateRoutes_OneRequestDoesNotBlockOthers(t *testing.T) {
+	withShortRequestTimeout := func(t *testing.T, options *Options) {
+		options.API.RequestTimeout = 50 * time.Millisecond
+		options.API.BlockingRequestTimeout = 500 * time.Millisecond
+	}
+	srv := setupServer(t, withAdminUser, withShortRequestTimeout)
+	routes := srv.GenerateRoutes()
+
+	g := errgroup.Group{}
+	// start a blocking request in the background
+	g.Go(func() error {
+		urlPath := "/api/grants?destination=infra&lastUpdateIndex=10001"
+		req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+		assert.NilError(t, err)
+		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+		req.Header.Add("Infra-Version", apiVersionLatest)
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+		return nil
+	})
+
+	// perform many short-lived requests with the same user
+	start := time.Now()
+	var count int
+	for time.Since(start) < srv.options.API.BlockingRequestTimeout {
+		urlPath := "/api/grants?destination=infra"
+		req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+		assert.NilError(t, err)
+		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+		req.Header.Add("Infra-Version", apiVersionLatest)
+
+		resp := httptest.NewRecorder()
+		routes.ServeHTTP(resp, req)
+		assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
+		count++
+	}
+
+	assert.NilError(t, g.Wait())
+	// The count is likely close to 40, but use a low threshold to prevent flakes.
+	// Anything more than 2 should indicate the requests did not block each other.
+	assert.Assert(t, count > 3, "count=%d", count)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,6 +78,7 @@ type Options struct {
 	Addr ListenerOptions
 	UI   UIOptions
 	TLS  TLSOptions
+	API  APIOptions
 
 	DB data.NewDBOptions
 }
@@ -105,6 +106,11 @@ type TLSOptions struct {
 	// certificate will be requested from Let's Encrypt, which will be cached
 	// in the TLSCache.
 	ACME bool
+}
+
+type APIOptions struct {
+	RequestTimeout         time.Duration
+	BlockingRequestTimeout time.Duration
 }
 
 type Server struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -31,6 +31,10 @@ func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
 	options := Options{
 		SessionDuration:          10 * time.Minute,
 		SessionExtensionDeadline: 30 * time.Minute,
+		API: APIOptions{
+			RequestTimeout:         time.Minute,
+			BlockingRequestTimeout: 5 * time.Minute,
+		},
 	}
 	for _, op := range ops {
 		op(t, &options)
@@ -113,6 +117,7 @@ func TestServer_Run(t *testing.T) {
 			CA:           types.StringOrFile(golden.Get(t, "pki/ca.crt")),
 			CAPrivateKey: string(golden.Get(t, "pki/ca.key")),
 		},
+		API: APIOptions{RequestTimeout: time.Minute},
 	}
 
 	driver := database.PostgresDriver(t, "_server_run")
@@ -211,6 +216,7 @@ func TestServer_Run_UIProxy(t *testing.T) {
 			CA:           types.StringOrFile(golden.Get(t, "pki/ca.crt")),
 			CAPrivateKey: string(golden.Get(t, "pki/ca.key")),
 		},
+		API: APIOptions{RequestTimeout: time.Minute},
 	}
 	assert.NilError(t, opts.UI.ProxyURL.Set(uiSrv.URL))
 


### PR DESCRIPTION
## Summary

Branched from #3436 

Best viewed by individual commit. This PR makes the following changes:
* disables pagination when the request includes `lastUpdateIndex`, so that all the results are returned on an update
* extends the request timeout from 1 minute to 5 minutes for request with `lastUpdateIndex > 0`, and makes both timeouts configurable from server options
* adds a test for concurrent requests
* adds tests for blocking requests, to show they unblock on unpdate
* fixes a bug when a query for grants returned no results 