### PR TITLE
Update the connector to use blocking requests for ListGrants

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -345,14 +345,16 @@ func (c Client) DeleteProvider(id uid.ID) error {
 
 func (c Client) ListGrants(ctx context.Context, req ListGrantsRequest) (*ListResponse[Grant], error) {
 	return get[ListResponse[Grant]](ctx, c, "/api/grants", Query{
-		"user":          {req.User.String()},
-		"group":         {req.Group.String()},
-		"resource":      {req.Resource},
-		"destination":   {req.Destination},
-		"privilege":     {req.Privilege},
-		"showInherited": {strconv.FormatBool(req.ShowInherited)},
-		"showSystem":    {strconv.FormatBool(req.ShowSystem)},
-		"page":          {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
+		"user":            {req.User.String()},
+		"group":           {req.Group.String()},
+		"resource":        {req.Resource},
+		"destination":     {req.Destination},
+		"privilege":       {req.Privilege},
+		"showInherited":   {strconv.FormatBool(req.ShowInherited)},
+		"showSystem":      {strconv.FormatBool(req.ShowSystem)},
+		"page":            {strconv.Itoa(req.Page)},
+		"limit":           {strconv.Itoa(req.Limit)},
+		"lastUpdateIndex": {strconv.FormatInt(req.LastUpdateIndex, 10)},
 	})
 }
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -27,6 +27,7 @@ import (
 	"github.com/infrahq/infra/internal/kubernetes"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/metrics"
+	"github.com/infrahq/infra/uid"
 )
 
 type Options struct {
@@ -78,10 +79,23 @@ type KubernetesOptions struct {
 // connector stores all the dependencies for the connector operations.
 type connector struct {
 	k8s         *kubernetes.Kubernetes
-	client      *api.Client
+	client      apiClient
 	destination *api.Destination
 	certCache   *CertCache
 	options     Options
+}
+
+type apiClient interface {
+	ListGrants(ctx context.Context, req api.ListGrantsRequest) (*api.ListResponse[api.Grant], error)
+	ListDestinations(ctx context.Context, req api.ListDestinationsRequest) (*api.ListResponse[api.Destination], error)
+	CreateDestination(req *api.CreateDestinationRequest) (*api.Destination, error)
+	UpdateDestination(req api.UpdateDestinationRequest) (*api.Destination, error)
+
+	// GetGroup and GetUser are used to retrieve the name of the group or user.
+	// TODO: we can remove these calls to GetGroup and GetUser by including
+	// the name of the group or user in the ListGrants response.
+	GetGroup(id uid.ID) (*api.Group, error)
+	GetUser(id uid.ID) (*api.User, error)
 }
 
 func Run(ctx context.Context, options Options) error {
@@ -188,14 +202,7 @@ func Run(ctx context.Context, options Options) error {
 		options:     options,
 	}
 	group.Go(func() error {
-		for {
-			if err := syncWithServer(ctx, con); err != nil {
-				return err
-			}
-			if err := wait(ctx, 30*time.Second); err != nil {
-				return err
-			}
-		}
+		return syncWithServer(ctx, con)
 	})
 	group.Go(func() error {
 		for {
@@ -404,22 +411,55 @@ func getEndpointHostPort(k8s *kubernetes.Kubernetes, opts Options) (types.HostPo
 }
 
 func syncWithServer(ctx context.Context, con connector) error {
-	grants, err := con.client.ListGrants(ctx, api.ListGrantsRequest{Destination: con.destination.Name})
-	if err != nil {
-		logging.Errorf("error listing grants: %v", err)
+	var latestIndex int64 = 1
+
+	sync := func() error {
+		grants, err := con.client.ListGrants(ctx, api.ListGrantsRequest{
+			Destination:     con.destination.Name,
+			BlockingRequest: api.BlockingRequest{LastUpdateIndex: latestIndex},
+		})
+		var apiError api.Error
+		switch {
+		case errors.As(err, &apiError) && apiError.Code == http.StatusGatewayTimeout:
+			// a timeout is expected when there are no changes
+			logging.L.Info().
+				Int64("updateIndex", latestIndex).
+				Msgf("no updated grants from server")
+			return nil
+		case err != nil:
+			return fmt.Errorf("list grants: %w", err)
+		}
+		logging.L.Info().
+			Int64("updateIndex", latestIndex).
+			Int("numGrants", len(grants.Items)).
+			Msgf("received grants from server")
+
+		err = updateRoles(con.client, con.k8s, grants.Items)
+		if err != nil {
+			return fmt.Errorf("update roles: %w", err)
+		}
+
+		// Only update latestIndex once the entire operation was a success
+		latestIndex = grants.LastUpdateIndex.Index
 		return nil
 	}
 
-	err = updateRoles(con.client, con.k8s, grants.Items)
-	if err != nil {
-		logging.Errorf("error updating grants: %v", err)
-		return nil
+	for {
+		if err := sync(); err != nil {
+			logging.L.Error().Err(err).Msg("sync grants with kubernetes")
+		}
+		// TODO: exponential backoff when there are errors.
+
+		// sleep for a short duration between updates to allow batches of
+		// updates to apply before querying again.
+		if err := wait(ctx, 2*time.Second); err != nil {
+			return err
+		}
 	}
-	return nil
 }
 
 // UpdateRoles converts infra grants to role-bindings in the current cluster
-func updateRoles(c *api.Client, k *kubernetes.Kubernetes, grants []api.Grant) error {
+func updateRoles(c apiClient, k *kubernetes.Kubernetes, grants []api.Grant) error {
 	logging.Debugf("syncing local grants from infra configuration")
 
 	crSubjects := make(map[string][]rbacv1.Subject)                           // cluster-role: subject
@@ -491,7 +531,7 @@ func updateRoles(c *api.Client, k *kubernetes.Kubernetes, grants []api.Grant) er
 }
 
 // createOrUpdateDestination creates a destination in the infra server if it does not exist and updates it if it does
-func createOrUpdateDestination(ctx context.Context, client *api.Client, local *api.Destination) error {
+func createOrUpdateDestination(ctx context.Context, client apiClient, local *api.Destination) error {
 	if local.ID != 0 {
 		return updateDestination(client, local)
 	}
@@ -525,7 +565,7 @@ func createOrUpdateDestination(ctx context.Context, client *api.Client, local *a
 }
 
 // updateDestination updates a destination in the infra server
-func updateDestination(client *api.Client, local *api.Destination) error {
+func updateDestination(client apiClient, local *api.Destination) error {
 	logging.Debugf("updating information at server")
 
 	request := api.UpdateDestinationRequest{


### PR DESCRIPTION
## Summary

This PR updates the connector to use blocking requests for `ListGrants`. The connector will block until there is an update or timeout. Also adds log messages for the sync operation.