### PR TITLE
draft: Improve the runtime of tests that use the database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,14 @@ tools:
 
 postgres:
 	docker run -d --name=postgres-dev --rm \
-		-e POSTGRES_PASSWORD=password123 \
 		--tmpfs=/var/lib/postgresql/data \
+		-e POSTGRES_HOST_AUTH_METHOD=trust \
 		-p 127.0.0.1:15432:5432 \
 		postgres:14-alpine -c fsync=off -c full_page_writes=off \
 			-c max_connections=100
 	@echo
 	@echo Copy the line below into the shell used to run tests
-	@echo 'export POSTGRESQL_CONNECTION="host=localhost port=15432 user=postgres dbname=postgres password=password123"'
+	@echo 'export POSTGRESQL_CONNECTION="host=localhost port=15432 user=postgres dbname=postgres"'
 
 
 LINT_ARGS ?= --fix

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,9 @@ tools:
 
 postgres:
 	docker run -d --name=postgres-dev --rm \
-		--tmpfs=/var/lib/postgresql/data \
+		--tmpfs=/var/lib/postgresql/tmpfs \
 		-e POSTGRES_HOST_AUTH_METHOD=trust \
+		-e PGDATA=/var/lib/postgresql/tmpfs \
 		-p 127.0.0.1:15432:5432 \
 		postgres:14-alpine -c fsync=off -c full_page_writes=off \
 			-c max_connections=100

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -5,29 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal"
-	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/internal/testing/database"
-	"github.com/infrahq/infra/internal/testing/patch"
 	"github.com/infrahq/infra/uid"
 )
-
-func setupDB(t *testing.T) *DB {
-	t.Helper()
-	patch.ModelsSymmetricKey(t)
-
-	db, err := NewDB(NewDBOptions{DSN: database.PostgresDriver(t, "_data").DSN})
-	assert.NilError(t, err)
-
-	logging.PatchLogger(t, zerolog.NewTestWriter(t))
-
-	return db
-}
 
 func txnForTestCase(t *testing.T, db *DB, orgID uid.ID) *Transaction {
 	t.Helper()

--- a/internal/server/data/main_test.go
+++ b/internal/server/data/main_test.go
@@ -1,0 +1,79 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/testing/database"
+)
+
+var dbBufferPool *dbBuffer
+
+func TestMain(m *testing.M) {
+	models.SkipSymmetricKey = true
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dbBufferPool = &dbBuffer{
+		items: make(chan dbBufferItem, 10),
+		done:  make(chan struct{}),
+	}
+	go dbBufferPool.fill(ctx)
+
+	code := m.Run()
+	cancel()
+	<-dbBufferPool.done // wait on cleanup
+	os.Exit(code)
+}
+
+func setupDB(t *testing.T) *DB {
+	t.Helper()
+	return dbBufferPool.Get(t)
+}
+
+type dbBuffer struct {
+	items chan dbBufferItem
+	done  chan struct{}
+}
+
+type dbBufferItem struct {
+	db    *DB
+	mainT *database.MainT
+}
+
+func (b *dbBuffer) Get(t *testing.T) *DB {
+	item := <-b.items
+	t.Cleanup(func() {
+		item.mainT.RunCleanup()
+	})
+	return item.db
+}
+
+func (b *dbBuffer) fill(ctx context.Context) {
+	var count int
+	for {
+		mainT := &database.MainT{}
+		schema := fmt.Sprintf("_data%d", count)
+		count++
+		db, err := NewDB(NewDBOptions{DSN: database.PostgresDriver(mainT, schema).DSN})
+		assert.NilError(mainT, err)
+
+		select {
+		case b.items <- dbBufferItem{db: db, mainT: mainT}:
+			fmt.Printf("BUF: adding item %d\n", count)
+		case <-ctx.Done():
+			close(b.items)
+
+			mainT.RunCleanup()
+			for item := range b.items {
+				item.mainT.RunCleanup()
+			}
+			close(b.done)
+			return
+		}
+	}
+}

--- a/internal/testing/database/maint.go
+++ b/internal/testing/database/maint.go
@@ -1,0 +1,47 @@
+package database
+
+import (
+	"fmt"
+	"os"
+)
+
+type MainT struct {
+	cleanup []func()
+}
+
+func (t *MainT) Cleanup(f func()) {
+	// prepend so that they run in the correct order
+	t.cleanup = append([]func(){f}, t.cleanup...)
+}
+
+func (t *MainT) RunCleanup() {
+	for _, fn := range t.cleanup {
+		fn()
+	}
+}
+
+func (t MainT) Fatal(a ...any) {
+	t.Log(a...)
+	t.FailNow()
+}
+
+func (t MainT) Skip(a ...any) {
+	panic("skip not supported")
+}
+
+func (t MainT) Helper() {}
+
+// FailNow exits with a non-zero code
+func (t MainT) FailNow() {
+	os.Exit(1)
+}
+
+// Fail exits with a non-zero code
+func (t MainT) Fail() {
+	os.Exit(2)
+}
+
+// Log args by printing them to stdout
+func (t MainT) Log(args ...interface{}) {
+	fmt.Println(args...)
+}


### PR DESCRIPTION
## Summary

This PR attempts to reduce the runtime of the `data` package tests.

The first commit changes `make postgres` to run a container that trusts connections. A CPU profile of the test run showed that a significant portion of the CPU time was spent calculating the sha256 hash of the postgres password. By trusting all connections we reduce the runtime by a couple seconds (~13%). I recently updated the container to only listen on `127.0.0.1`, and the password is easy to guess, so removing the password shouldn't be too risky.

The second commit sets up databases in a goroutine before they are used by a test. I think we can probably adjust the number of buffered databases, but with the current settings this also reduces the test runtime by another 2-3 seconds (~15%). The problem with setting up the database in advance is that we have a package-level variable for the data encryption key.  This PR disables the encryption, but that's probably not what we want. Another option would be to use a hard-coded key for all tests. That should allow us to setup the DB instances in parallel with other tests, without the operations conflicting.

Making this a draft until I address the problem with the data encryption key. 