### PR TITLE
fix: remove authinfo for context

### DIFF
--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -176,8 +176,8 @@ func writeKubeconfig(user *api.User, destinations []api.Destination, grants []ap
 	}
 
 	// cleanup others
-	for c := range kubeConfig.Contexts {
-		parts := strings.Split(c, ":")
+	for id, ctx := range kubeConfig.Contexts {
+		parts := strings.Split(id, ":")
 
 		if len(parts) < 1 {
 			continue
@@ -187,10 +187,10 @@ func writeKubeconfig(user *api.User, destinations []api.Destination, grants []ap
 			continue
 		}
 
-		if _, ok := keep[c]; !ok {
-			delete(kubeConfig.Clusters, c)
-			delete(kubeConfig.Contexts, c)
-			delete(kubeConfig.AuthInfos, c)
+		if _, ok := keep[id]; !ok {
+			delete(kubeConfig.AuthInfos, ctx.AuthInfo)
+			delete(kubeConfig.Clusters, ctx.Cluster)
+			delete(kubeConfig.Contexts, id)
 		}
 	}
 
@@ -245,8 +245,8 @@ func clearKubeconfig() error {
 		return err
 	}
 
-	for c := range kubeConfig.Contexts {
-		parts := strings.Split(c, ":")
+	for id, ctx := range kubeConfig.Contexts {
+		parts := strings.Split(id, ":")
 
 		if len(parts) < 1 {
 			continue
@@ -256,9 +256,9 @@ func clearKubeconfig() error {
 			continue
 		}
 
-		delete(kubeConfig.Clusters, c)
-		delete(kubeConfig.Contexts, c)
-		delete(kubeConfig.AuthInfos, c)
+		delete(kubeConfig.AuthInfos, ctx.AuthInfo)
+		delete(kubeConfig.Clusters, ctx.Cluster)
+		delete(kubeConfig.Contexts, id)
 	}
 
 	if strings.HasPrefix(kubeConfig.CurrentContext, "infra:") {

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -91,6 +91,22 @@ func TestWriteKubeconfig(t *testing.T) {
 		cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"),
 		cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "Exec"),
 	)
+
+	t.Run("clearKubeconfig", func(t *testing.T) {
+		err := clearKubeconfig()
+		assert.NilError(t, err)
+
+		expected := clientcmdapi.Config{
+			Clusters:  map[string]*clientcmdapi.Cluster{},
+			Contexts:  map[string]*clientcmdapi.Context{},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{},
+		}
+
+		actual, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+
+		assert.DeepEqual(t, expected, actual, cmpopts.EquateEmpty())
+	})
 }
 
 func TestWriteKubeconfig_UserNamespaceOverride(t *testing.T) {

--- a/internal/cmd/logout_test.go
+++ b/internal/cmd/logout_test.go
@@ -80,12 +80,12 @@ func TestLogout(t *testing.T) {
 				"infra:prod":     {Server: "https://infraprod:8080"},
 			},
 			Contexts: map[string]*clientcmdapi.Context{
-				"keep:not-infra": {Cluster: "keep:not-infra"},
-				"infra:prod":     {Cluster: "infra:prod"},
+				"keep:not-infra": {Cluster: "keep:not-infra", AuthInfo: "keep:not-infra"},
+				"infra:prod":     {Cluster: "infra:prod", AuthInfo: "user@example.com"},
 			},
 			AuthInfos: map[string]*clientcmdapi.AuthInfo{
-				"keep:not-infra": {Token: "keep-token"},
-				"infra:prod":     {Token: "infra-token"},
+				"keep:not-infra":   {Token: "keep-token"},
+				"user@example.com": {Token: "infra-token"},
 			},
 		}
 		err = clientcmd.WriteToFile(kubeCfg, kubeConfigPath)
@@ -145,12 +145,12 @@ func TestLogout(t *testing.T) {
 				"infra:prod":     {Server: "https://infraprod:8080"},
 			},
 			Contexts: map[string]*clientcmdapi.Context{
-				"keep:not-infra": {Cluster: "keep:not-infra"},
-				"infra:prod":     {Cluster: "infra:prod"},
+				"keep:not-infra": {Cluster: "keep:not-infra", AuthInfo: "keep:not-infra"},
+				"infra:prod":     {Cluster: "infra:prod", AuthInfo: "user@example.com"},
 			},
 			AuthInfos: map[string]*clientcmdapi.AuthInfo{
-				"keep:not-infra": {Token: "keep-token"},
-				"infra:prod":     {Token: "infra-token"},
+				"keep:not-infra":   {Token: "keep-token"},
+				"user@example.com": {Token: "infra-token"},
 			},
 		}
 		err = clientcmd.WriteToFile(kubeCfg, kubeConfigPath)
@@ -164,13 +164,13 @@ func TestLogout(t *testing.T) {
 
 	expectedKubeCfg := clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"keep:not-infra": {Server: "https://keep:8080", LocationOfOrigin: kubeConfigPath},
+			"keep:not-infra": {Server: "https://keep:8080"},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
-			"keep:not-infra": {Cluster: "keep:not-infra", LocationOfOrigin: kubeConfigPath},
+			"keep:not-infra": {Cluster: "keep:not-infra", AuthInfo: "keep:not-infra"},
 		},
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"keep:not-infra": {Token: "keep-token", LocationOfOrigin: kubeConfigPath},
+			"keep:not-infra": {Token: "keep-token"},
 		},
 	}
 
@@ -193,7 +193,11 @@ func TestLogout(t *testing.T) {
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
 		assert.NilError(t, err)
-		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg,
+			cmpopts.EquateEmpty(),
+			cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.Context{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"))
 	})
 
 	t.Run("current infra", func(t *testing.T) {
@@ -215,7 +219,11 @@ func TestLogout(t *testing.T) {
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
 		assert.NilError(t, err)
-		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg,
+			cmpopts.EquateEmpty(),
+			cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.Context{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"))
 	})
 
 	t.Run("current non-infra", func(t *testing.T) {
@@ -240,7 +248,11 @@ func TestLogout(t *testing.T) {
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
 		assert.NilError(t, err)
-		assert.DeepEqual(t, kubeconfig, updatedKubeCfg, cmpopts.EquateEmpty())
+		assert.DeepEqual(t, kubeconfig, updatedKubeCfg,
+			cmpopts.EquateEmpty(),
+			cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.Context{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"))
 	})
 
 	t.Run("with clear", func(t *testing.T) {
@@ -258,7 +270,11 @@ func TestLogout(t *testing.T) {
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
 		assert.NilError(t, err)
-		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg,
+			cmpopts.EquateEmpty(),
+			cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.Context{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"))
 	})
 
 	t.Run("with all", func(t *testing.T) {
@@ -284,7 +300,11 @@ func TestLogout(t *testing.T) {
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
 		assert.NilError(t, err)
-		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg,
+			cmpopts.EquateEmpty(),
+			cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.Context{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"))
 	})
 
 	t.Run("with clear all", func(t *testing.T) {
@@ -302,7 +322,11 @@ func TestLogout(t *testing.T) {
 
 		updatedKubeCfg, err := clientConfig().RawConfig()
 		assert.NilError(t, err)
-		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg,
+			cmpopts.EquateEmpty(),
+			cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.Context{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"))
 	})
 
 	t.Run("with one and all", func(t *testing.T) {
@@ -347,6 +371,10 @@ func TestLogout(t *testing.T) {
 		updatedKubeCfg, err := clientConfig().RawConfig()
 		expectedKubeCfg.CurrentContext = "keep:non-infra"
 		assert.NilError(t, err)
-		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg, cmpopts.EquateEmpty())
+		assert.DeepEqual(t, expectedKubeCfg, updatedKubeCfg,
+			cmpopts.EquateEmpty(),
+			cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.Context{}, "LocationOfOrigin"),
+			cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"))
 	})
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

kubeconfig.AuthInfo no longer follows the name of the contexts so when kubeconfig entries are removed, the authinfo remains. Instead of removing entries based on the name of the contexts, use the name of the individual references, e.g. context.Cluster and context.AuthInfo