### PR TITLE
Fix context cancellation in blocking requests

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -19,23 +18,6 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/server/redis"
 )
-
-// TimeoutMiddleware adds a timeout to the request context within the Gin context.
-// To correctly abort long-running requests, this depends on the users of the context to
-// stop working when the context cancels.
-// Note: The goroutine for the request is never halted; if the context is not
-// passed down to lower packages and long-running tasks, then the app will not
-// magically stop working on the request. No effort should be made to write
-// an early http response here; it's up to the users of the context to watch for
-// c.Request.Context().Err() or <-c.Request.Context().Done()
-func TimeoutMiddleware(timeout time.Duration) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
-		defer cancel()
-		c.Request = c.Request.WithContext(ctx)
-		c.Next()
-	}
-}
 
 func handleInfraDestinationHeader(rCtx access.RequestContext, uniqueID string) error {
 	if uniqueID == "" {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -59,30 +59,6 @@ func issueToken(t *testing.T, db data.GormTxn, identityName string, sessionDurat
 	return body
 }
 
-func TestRequestTimeoutError(t *testing.T) {
-	router := gin.New()
-	router.Use(TimeoutMiddleware(100 * time.Millisecond))
-	router.GET("/", func(c *gin.Context) {
-		time.Sleep(110 * time.Millisecond)
-
-		assert.ErrorIs(t, c.Request.Context().Err(), context.DeadlineExceeded)
-
-		c.Status(200)
-	})
-	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
-}
-
-func TestRequestTimeoutSuccess(t *testing.T) {
-	router := gin.New()
-	router.Use(TimeoutMiddleware(60 * time.Second))
-	router.GET("/", func(c *gin.Context) {
-		assert.NilError(t, c.Request.Context().Err())
-
-		c.Status(200)
-	})
-	router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
-}
-
 func TestRequireAccessKey(t *testing.T) {
 	type testCase struct {
 		setup    func(t *testing.T, db data.GormTxn) *http.Request

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -187,9 +187,7 @@ func TestTrimWhitespace(t *testing.T) {
 }
 
 func TestWrapRoute_TxnRollbackOnError(t *testing.T) {
-	srv := newServer(Options{})
-	srv.db = setupDB(t)
-
+	srv := setupServer(t)
 	router := gin.New()
 
 	r := route[api.EmptyRequest, *api.EmptyResponse]{
@@ -229,9 +227,7 @@ func TestWrapRoute_TxnRollbackOnError(t *testing.T) {
 }
 
 func TestWrapRoute_HandleErrorOnCommit(t *testing.T) {
-	srv := newServer(Options{})
-	srv.db = setupDB(t)
-
+	srv := setupServer(t)
 	router := gin.New()
 
 	r := route[api.EmptyRequest, *api.EmptyResponse]{
@@ -288,12 +284,13 @@ func TestRequestTimeout(t *testing.T) {
 		t.Skip("too slow for short run")
 	}
 	srv := setupServer(t)
+	srv.options.API.RequestTimeout = time.Second
 	routes := srv.GenerateRoutes()
 	router, ok := routes.Handler.(*gin.Engine)
 	assert.Assert(t, ok)
 	a := &API{server: srv}
 
-	group := &routeGroup{RouterGroup: router.Group("/", TimeoutMiddleware(1*time.Second)), noAuthentication: true, noOrgRequired: true}
+	group := &routeGroup{RouterGroup: router.Group("/"), noAuthentication: true, noOrgRequired: true}
 	add(a, group, http.MethodGet, "/sleep", route[api.EmptyRequest, *api.EmptyResponse]{
 		handler: func(c *gin.Context, req *api.EmptyRequest) (*api.EmptyResponse, error) {
 			ctx := getRequestContext(c)


### PR DESCRIPTION
## Summary

I noticed this problem while testing blocking requests in dev.

PR #3443 tried one approach for using a longer timeout in blocking requests using `extendedContext`. That worked to extend the deadline, but breaks regular cancellation (ex: when a client disconnects).

This PR takes a different approach. By removing the `TimeoutMiddleware` and moving that timeout into `wrapWroute` we can capture the original context set on the request by `http.Server`.  This allows us to create a new context without losing cancellation on the original context.

With this approach we get both a longer deadline, and proper cancellation when a client disconnects.