### PR TITLE
Throttle database updates for LastSeenAt and ExtensionDeadline

### DIFF
--- a/internal/server/authn/authn_method.go
+++ b/internal/server/authn/authn_method.go
@@ -20,7 +20,7 @@ type AuthenticatedIdentity struct {
 }
 
 type LoginMethod interface {
-	Authenticate(ctx context.Context, db data.GormTxn, requestedExpiry time.Time) (AuthenticatedIdentity, error)
+	Authenticate(ctx context.Context, db *data.Transaction, requestedExpiry time.Time) (AuthenticatedIdentity, error)
 	Name() string // Name returns the name of the authentication method used
 }
 
@@ -38,7 +38,7 @@ type LoginResult struct {
 
 func Login(
 	ctx context.Context,
-	db data.GormTxn,
+	db *data.Transaction,
 	loginMethod LoginMethod,
 	requestedExpiry time.Time,
 	keyExtension time.Duration,

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -30,7 +30,7 @@ func txnForTestCase(t *testing.T, db *data.DB, orgID uid.ID) *data.Transaction {
 	t.Cleanup(func() {
 		_ = tx.Rollback()
 	})
-	return tx.WithMetadata(orgID)
+	return tx.WithOrgID(orgID)
 }
 
 func TestLogin(t *testing.T) {

--- a/internal/server/authn/key_exchange.go
+++ b/internal/server/authn/key_exchange.go
@@ -20,7 +20,7 @@ func NewKeyExchangeAuthentication(requestingAccessKey string) LoginMethod {
 	}
 }
 
-func (a *keyExchangeAuthn) Authenticate(_ context.Context, db data.GormTxn, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
+func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *data.Transaction, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
 	validatedRequestKey, err := data.ValidateRequestAccessKey(db, a.RequestingAccessKey)
 	if err != nil {
 		return AuthenticatedIdentity{}, fmt.Errorf("invalid access key in exchange: %w", err)

--- a/internal/server/authn/oidc.go
+++ b/internal/server/authn/oidc.go
@@ -29,7 +29,7 @@ func NewOIDCAuthentication(providerID uid.ID, redirectURL string, code string, o
 	}
 }
 
-func (a *oidcAuthn) Authenticate(ctx context.Context, db data.GormTxn, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
+func (a *oidcAuthn) Authenticate(ctx context.Context, db *data.Transaction, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
 	provider, err := data.GetProvider(db, data.ByID(a.ProviderID))
 	if err != nil {
 		return AuthenticatedIdentity{}, err

--- a/internal/server/authn/password_credentials.go
+++ b/internal/server/authn/password_credentials.go
@@ -23,7 +23,7 @@ func NewPasswordCredentialAuthentication(username, password string) LoginMethod 
 	}
 }
 
-func (a *passwordCredentialAuthn) Authenticate(_ context.Context, db data.GormTxn, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
+func (a *passwordCredentialAuthn) Authenticate(ctx context.Context, db *data.Transaction, requestedExpiry time.Time) (AuthenticatedIdentity, error) {
 	if a.Username == "" {
 		return AuthenticatedIdentity{}, fmt.Errorf("username required for password authentication")
 	}

--- a/internal/server/authn/password_credentials_test.go
+++ b/internal/server/authn/password_credentials_test.go
@@ -16,14 +16,14 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 	db := setupDB(t)
 
 	type testCase struct {
-		setup       func(t *testing.T, db data.GormTxn) LoginMethod
+		setup       func(t *testing.T, db *data.Transaction) LoginMethod
 		expectedErr string
 		expected    func(t *testing.T, authnIdentity AuthenticatedIdentity)
 	}
 
 	cases := map[string]testCase{
 		"UsernameAndOneTimePasswordFirstUse": {
-			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
+			setup: func(t *testing.T, db *data.Transaction) LoginMethod {
 				username := "goku@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -51,7 +51,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			},
 		},
 		"UsernameAndPassword": {
-			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
+			setup: func(t *testing.T, db *data.Transaction) LoginMethod {
 				username := "bulma@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -79,7 +79,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			},
 		},
 		"UsernameAndPasswordReuse": {
-			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
+			setup: func(t *testing.T, db *data.Transaction) LoginMethod {
 				username := "cell@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -112,7 +112,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			},
 		},
 		"ValidUsernameAndNoPasswordFails": {
-			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
+			setup: func(t *testing.T, db *data.Transaction) LoginMethod {
 				username := "krillin@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -123,7 +123,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			expectedErr: "record not found",
 		},
 		"UsernameAndInvalidPasswordFails": {
-			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
+			setup: func(t *testing.T, db *data.Transaction) LoginMethod {
 				username := "po@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -147,7 +147,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			expectedErr: "hashedPassword is not the hash of the given password",
 		},
 		"UsernameAndEmptyPasswordFails": {
-			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
+			setup: func(t *testing.T, db *data.Transaction) LoginMethod {
 				username := "gohan@example.com"
 				user := &models.Identity{Name: username}
 				err := data.CreateIdentity(db, user)
@@ -171,7 +171,7 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 			expectedErr: "hashedPassword is not the hash of the given password",
 		},
 		"EmptyUsernameAndPasswordFails": {
-			setup: func(t *testing.T, db data.GormTxn) LoginMethod {
+			setup: func(t *testing.T, db *data.Transaction) LoginMethod {
 				return NewPasswordCredentialAuthentication("", "whatever")
 			},
 			expectedErr: "username required for password authentication",

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -246,7 +246,7 @@ func DeleteAccessKeys(tx WriteTxn, opts DeleteAccessKeysOptions) error {
 }
 
 // TODO: move this to access package?
-func ValidateRequestAccessKey(tx WriteTxn, authnKey string) (*models.AccessKey, error) {
+func ValidateRequestAccessKey(tx *Transaction, authnKey string) (*models.AccessKey, error) {
 	keyID, secret, ok := strings.Cut(authnKey, ".")
 	if !ok {
 		return nil, fmt.Errorf("invalid access key format")
@@ -256,6 +256,7 @@ func ValidateRequestAccessKey(tx WriteTxn, authnKey string) (*models.AccessKey, 
 	if err != nil {
 		return nil, fmt.Errorf("%w: could not get access key from database, it may not exist", err)
 	}
+	tx = tx.WithOrgID(t.OrganizationID)
 
 	sum := secretChecksum(secret)
 

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -907,7 +908,8 @@ func TestAPI_CreateGrant(t *testing.T) {
 	srv := setupServer(t, withAdminUser, withMultiOrgEnabled)
 	routes := srv.GenerateRoutes()
 
-	accessKey, err := data.ValidateRequestAccessKey(srv.DB(), adminAccessKey(srv))
+	keyID, _, _ := strings.Cut(adminAccessKey(srv), ".")
+	accessKey, err := data.GetAccessKeyByKeyID(srv.DB(), keyID)
 	assert.NilError(t, err)
 
 	someUser := models.Identity{Name: "someone@example.com"}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -92,14 +92,14 @@ func loginAs(tx *data.Transaction, user *models.Identity) *gin.Context {
 	return ctx
 }
 
-func txnForTestCase(t *testing.T, db *data.DB) *data.Transaction {
+func txnForTestCase(t *testing.T, db *data.DB, orgID uid.ID) *data.Transaction {
 	t.Helper()
 	tx, err := db.Begin(context.Background(), nil)
 	assert.NilError(t, err)
 	t.Cleanup(func() {
 		assert.NilError(t, tx.Rollback())
 	})
-	return tx.WithOrgID(db.DefaultOrg.ID)
+	return tx.WithOrgID(orgID)
 }
 
 func jsonBody(t *testing.T, body interface{}) *bytes.Buffer {
@@ -200,7 +200,7 @@ func createOtherOrg(t *testing.T, db *data.DB) organizationData {
 	otherOrg := &models.Organization{Name: "Other", Domain: "other.example.org"}
 	assert.NilError(t, data.CreateOrganization(db, otherOrg))
 
-	tx := txnForTestCase(t, db).WithOrgID(otherOrg.ID)
+	tx := txnForTestCase(t, db, otherOrg.ID)
 	admin := createAdmin(t, tx)
 
 	token := &models.AccessKey{
@@ -235,7 +235,7 @@ func TestWellKnownJWKs(t *testing.T) {
 	err = defaultKey.UnmarshalJSON(settings.PublicJWK)
 	assert.NilError(t, err)
 
-	otherOrgTx := txnForTestCase(t, srv.db).WithOrgID(otherOrg.ID)
+	otherOrgTx := txnForTestCase(t, srv.db, otherOrg.ID)
 	settings, err = data.GetSettings(otherOrgTx)
 	assert.NilError(t, err)
 

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -574,7 +574,7 @@ func TestAPI_CreateUser(t *testing.T) {
 // Note this test is the result of a long conversation, don't change lightly.
 func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 	srv := &Server{db: setupDB(t)}
-	db := txnForTestCase(t, srv.db)
+	db := txnForTestCase(t, srv.db, srv.db.DefaultOrg.ID)
 
 	a := &API{server: srv}
 	admin := createAdmin(t, db)


### PR DESCRIPTION
## Summary

This approach was first used by @mxyng for the `Destination.LastSeenAt`. This PR adopts the approach for `Identity.LastSeenAt`, and `AccessKey.ExtensionDeadline`.  All 3 of these values may be updated on every authenticated request.

If a user makes many requests in a short period of time, each of the requests ends up blocking while the middleware transaction runs. While testing in development with 100 concurrent requests I noticed database queries blocking for over a minute.

This PR throttles the updates, so that we only update each of these values once every 2 seconds. Previously we used 1 second, but I'd like to increase that a bit to throttle more. It means that a `LastSeenAt` value could be stale by up to 2 seconds.

Also fixes updates of access key extension deadline, which broke in #3439