### PR TITLE
feat: ui generate scim access key for provider

### DIFF
--- a/ui/components/scim-key.js
+++ b/ui/components/scim-key.js
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import copy from 'copy-to-clipboard'
+import Link from 'next/link'
+import { CheckIcon, DuplicateIcon } from '@heroicons/react/outline'
+
+export default function SCIMKey({ accessKey, errorMsg }) {
+  const [keyCopied, setKeyCopied] = useState(false)
+
+  return (
+    <div className='w-full 2xl:m-auto'>
+      <h1 className='py-1 font-display text-lg font-medium'>SCIM Access Key</h1>
+      <div className='space-y-4'>
+        <section>
+          {errorMsg === '' ? (
+            <>
+              <div className='mb-2'>
+                <p className='mt-1 text-sm text-gray-500'>
+                  Use this access key to configure your identity provider for
+                  inbound SCIM provisioning
+                </p>
+              </div>
+              <div className='group relative my-4 flex'>
+                <pre className='w-full overflow-auto rounded-lg bg-gray-50 px-5 py-4 text-xs leading-normal text-gray-800'>
+                  {accessKey}
+                </pre>
+                <button
+                  className='absolute right-2 top-2 rounded-md border border-black/10 bg-white px-2 py-2 text-black/40 backdrop-blur-xl hover:text-black/70'
+                  type='button'
+                  onClick={() => {
+                    copy(accessKey)
+                    setKeyCopied(true)
+                    setTimeout(() => setKeyCopied(false), 2000)
+                  }}
+                >
+                  {keyCopied ? (
+                    <CheckIcon className='h-4 w-4 text-green-500' />
+                  ) : (
+                    <DuplicateIcon className='h-4 w-4' />
+                  )}
+                </button>
+              </div>
+            </>
+          ) : (
+            <div
+              class='mb-4 rounded-lg bg-red-100 p-4 text-sm text-red-700'
+              role='alert'
+            >
+              <span class='font-medium'>Error:</span> {errorMsg}
+            </div>
+          )}
+        </section>
+
+        {/* Finish */}
+        <section className='my-10 flex justify-end'>
+          <Link href='/providers'>
+            <a className='flex-none items-center self-center rounded-md border border-transparent bg-black px-4 py-2 text-2xs font-medium text-white shadow-sm hover:bg-gray-800'>
+              Finish
+            </a>
+          </Link>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/ui/pages/providers/[id].js
+++ b/ui/pages/providers/[id].js
@@ -11,7 +11,7 @@ import RemoveButton from '../../components/remove-button'
 import Notification from '../../components/notification'
 import SCIMKey from '../../components/scim-key'
 
-function SCIMKeyDialog(props) {
+function SCIMKeyDialog({ provider, setOpen }) {
   const [scimAccessKey, setSCIMAccessKey] = useState('')
   const [error, setError] = useState('')
 
@@ -20,7 +20,7 @@ function SCIMKeyDialog(props) {
     setError('')
 
     try {
-      const keyName = props.provider.name + '-scim'
+      const keyName = provider.name + '-scim'
 
       // delete any existing access key for this provider
       await fetch(`/api/access-keys?name=${keyName}`, {
@@ -31,7 +31,7 @@ function SCIMKeyDialog(props) {
       const res = await fetch('/api/access-keys', {
         method: 'POST',
         body: JSON.stringify({
-          userID: props.provider.id,
+          userID: provider.id,
           name: keyName,
           ttl: '87600h',
           extensionDeadline: '720h',
@@ -59,7 +59,7 @@ function SCIMKeyDialog(props) {
                 <div className='relative mt-4'>
                   <h2 className='mt-5 text-sm'>
                     Generating a new SCIM access key will revoke any existing
-                    SCIM access key for this identity provider.
+                    SCIM access keys for this identity provider.
                   </h2>
                   <h2 className='mt-5 text-sm'>Do you wish to continue?</h2>
                 </div>
@@ -67,7 +67,7 @@ function SCIMKeyDialog(props) {
               <div className='flex flex-row items-center justify-end space-x-3'>
                 <button
                   type='button'
-                  onClick={() => props.setOpen(false)}
+                  onClick={() => setOpen(false)}
                   className='inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-100'
                 >
                   Cancel
@@ -206,7 +206,7 @@ export default function ProvidersEditDetails() {
               <Dialog
                 as='div'
                 className='relative z-50'
-                onClose={() => router.replace('/providers')}
+                onClose={() => setKeyDialogOpen(false)}
               >
                 <Transition.Child
                   as={Fragment}
@@ -279,7 +279,11 @@ export default function ProvidersEditDetails() {
                 className='px-6 py-5 text-left first:pr-6 first:pl-0'
               >
                 <div className='text-2xs text-gray-400'>{g.label}</div>
-                <span className='text-sm font-medium text-gray-800'>
+                <span
+                  className={`text-sm ${
+                    g.font ? g.font : 'font-medium'
+                  } text-gray-800`}
+                >
                   {g.value}
                 </span>
               </div>

--- a/ui/pages/providers/[id].js
+++ b/ui/pages/providers/[id].js
@@ -100,7 +100,7 @@ function SCIMKeyDialog(props) {
                 <button
                   className={`absolute right-2 top-2 rounded-md border border-black/10 bg-white px-2 py-2 text-black/40 backdrop-blur-xl hover:text-black/70`}
                   onClick={() => {
-                    copy(key)
+                    copy(scimAccessKey)
                     setKeyCopied(true)
                     setTimeout(() => setKeyCopied(false), 2000)
                   }}

--- a/ui/pages/providers/[id].js
+++ b/ui/pages/providers/[id].js
@@ -39,11 +39,7 @@ function SCIMKeyDialog(props) {
         }),
       })
 
-      const data = await res.json()
-
-      if (!res.ok) {
-        throw data
-      }
+      const data = await jsonBody(res)
 
       setSCIMAccessKey(data.accessKey)
     } catch (e) {

--- a/ui/pages/providers/[id].js
+++ b/ui/pages/providers/[id].js
@@ -1,27 +1,26 @@
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { Transition, Dialog } from '@headlessui/react'
 import { useRouter } from 'next/router'
-import copy from 'copy-to-clipboard'
 import Head from 'next/head'
 import Link from 'next/link'
 import useSWR, { useSWRConfig } from 'swr'
-import { DuplicateIcon, CheckIcon } from '@heroicons/react/outline'
 import dayjs from 'dayjs'
 
 import Dashboard from '../../components/layouts/dashboard'
 import RemoveButton from '../../components/remove-button'
 import Notification from '../../components/notification'
+import SCIMKey from '../../components/scim-key'
 
 function SCIMKeyDialog(props) {
   const [scimAccessKey, setSCIMAccessKey] = useState('')
   const [error, setError] = useState('')
-  const [keyCopied, setKeyCopied] = useState(false)
 
   async function onSubmit(e) {
     e.preventDefault()
+    setError('')
 
     try {
-      let keyName = props.provider.name + '-scim'
+      const keyName = props.provider.name + '-scim'
 
       // delete any existing access key for this provider
       await fetch(`/api/access-keys?name=${keyName}`, {
@@ -49,9 +48,11 @@ function SCIMKeyDialog(props) {
 
   return (
     <div className='w-full 2xl:m-auto'>
-      <h1 className='py-1 font-display text-lg font-medium'>SCIM Access Key</h1>
-      <div className='space-y-4'>
-        {scimAccessKey === '' && error === '' ? (
+      {scimAccessKey === '' && error === '' ? (
+        <>
+          <h1 className='py-1 font-display text-lg font-medium'>
+            SCIM Access Key
+          </h1>
           <section>
             <form onSubmit={onSubmit} className='flex flex-col space-y-4'>
               <div className='mb-4 flex flex-col'>
@@ -80,47 +81,10 @@ function SCIMKeyDialog(props) {
               </div>
             </form>
           </section>
-        ) : (
-          <>
-            <section>
-              <div className='mb-2'>
-                <p className='mt-1 text-sm text-gray-500'>
-                  Use this access key to configure your identity provider for
-                  inbound SCIM provisioning
-                </p>
-              </div>
-              <div className='group relative my-4 flex'>
-                <pre className='w-full overflow-auto rounded-lg bg-gray-50 px-5 py-4 text-xs leading-normal text-gray-800'>
-                  {scimAccessKey}
-                </pre>
-                <button
-                  className={`absolute right-2 top-2 rounded-md border border-black/10 bg-white px-2 py-2 text-black/40 backdrop-blur-xl hover:text-black/70`}
-                  onClick={() => {
-                    copy(scimAccessKey)
-                    setKeyCopied(true)
-                    setTimeout(() => setKeyCopied(false), 2000)
-                  }}
-                >
-                  {keyCopied ? (
-                    <CheckIcon className='h-4 w-4 text-green-500' />
-                  ) : (
-                    <DuplicateIcon className='h-4 w-4' />
-                  )}
-                </button>
-              </div>
-            </section>
-
-            {/* Finish */}
-            <section className={`my-10 flex justify-between`}>
-              <Link href='/providers'>
-                <a className='flex-none items-center self-center rounded-md border border-transparent bg-black px-4 py-2 text-2xs font-medium text-white shadow-sm hover:bg-gray-800'>
-                  Finish
-                </a>
-              </Link>
-            </section>
-          </>
-        )}
-      </div>
+        </>
+      ) : (
+        <SCIMKey accessKey={scimAccessKey} errorMsg={error} />
+      )}
     </div>
   )
 }
@@ -283,6 +247,7 @@ export default function ProvidersEditDetails() {
             <button
               onClick={() => setKeyDialogOpen(true)}
               className='inline-flex items-center rounded-md border border-transparent bg-black px-4 py-2 text-xs font-medium text-white shadow-sm hover:cursor-pointer hover:bg-gray-800'
+              type='button'
             >
               Generate SCIM Access Key
             </button>
@@ -314,11 +279,7 @@ export default function ProvidersEditDetails() {
                 className='px-6 py-5 text-left first:pr-6 first:pl-0'
               >
                 <div className='text-2xs text-gray-400'>{g.label}</div>
-                <span
-                  className={`text-sm ${
-                    g.font ? g.font : 'font-medium'
-                  } text-gray-800`}
-                >
+                <span className='text-sm font-medium text-gray-800'>
                   {g.value}
                 </span>
               </div>
@@ -361,7 +322,7 @@ export default function ProvidersEditDetails() {
                 type='text'
                 value={provider?.url}
                 readOnly
-                className={`mt-1 block w-full rounded-md border-gray-300 bg-gray-200 text-gray-600 shadow-sm focus:border-gray-300 focus:ring-0 sm:text-sm`}
+                className='mt-1 block w-full rounded-md border-gray-300 bg-gray-200 text-gray-600 shadow-sm focus:border-gray-300 focus:ring-0 sm:text-sm'
               />
             </div>
 
@@ -373,7 +334,7 @@ export default function ProvidersEditDetails() {
                 readOnly
                 type='text'
                 value={provider?.clientID}
-                className={`mt-1 block w-full rounded-md border-gray-300 bg-gray-200 text-gray-600 shadow-sm focus:border-gray-300 focus:ring-0 sm:text-sm`}
+                className='mt-1 block w-full rounded-md border-gray-300 bg-gray-200 text-gray-600 shadow-sm focus:border-gray-300 focus:ring-0 sm:text-sm'
               />
             </div>
 

--- a/ui/pages/providers/add.js
+++ b/ui/pages/providers/add.js
@@ -199,11 +199,7 @@ export default function ProvidersAddDetails() {
         }),
       })
 
-      const data = await res.json()
-
-      if (!res.ok) {
-        throw data
-      }
+      const data = await jsonBody(res)
 
       setSCIMAccessKey(data.accessKey)
     } catch (e) {

--- a/ui/pages/providers/add.js
+++ b/ui/pages/providers/add.js
@@ -1,80 +1,16 @@
 import { Fragment, useEffect, useState } from 'react'
 import { Transition, Dialog } from '@headlessui/react'
 import { useRouter } from 'next/router'
-import copy from 'copy-to-clipboard'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useSWRConfig } from 'swr'
 import Tippy from '@tippyjs/react'
-import {
-  DuplicateIcon,
-  CheckIcon,
-  InformationCircleIcon,
-  XIcon,
-} from '@heroicons/react/outline'
+import { InformationCircleIcon, XIcon } from '@heroicons/react/outline'
 
 import { providers } from '../../lib/providers'
 
 import Dashboard from '../../components/layouts/dashboard'
-
-function SCIMKeyDialog(props) {
-  const [keyCopied, setKeyCopied] = useState(false)
-
-  return (
-    <div className='w-full 2xl:m-auto'>
-      <h1 className='py-1 font-display text-lg font-medium'>SCIM Access Key</h1>
-      <div className='space-y-4'>
-        <section>
-          {props.errorMsg === '' ? (
-            <>
-              <div className='mb-2'>
-                <p className='mt-1 text-sm text-gray-500'>
-                  Use this access key to configure your identity provider for
-                  inbound SCIM provisioning
-                </p>
-              </div>
-              <div className='group relative my-4 flex'>
-                <pre className='w-full overflow-auto rounded-lg bg-gray-50 px-5 py-4 text-xs leading-normal text-gray-800'>
-                  {props.accessKey}
-                </pre>
-                <button
-                  className={`absolute right-2 top-2 rounded-md border border-black/10 bg-white px-2 py-2 text-black/40 backdrop-blur-xl hover:text-black/70`}
-                  onClick={() => {
-                    copy(props.accessKey)
-                    setKeyCopied(true)
-                    setTimeout(() => setKeyCopied(false), 2000)
-                  }}
-                >
-                  {keyCopied ? (
-                    <CheckIcon className='h-4 w-4 text-green-500' />
-                  ) : (
-                    <DuplicateIcon className='h-4 w-4' />
-                  )}
-                </button>
-              </div>
-            </>
-          ) : (
-            <div
-              class='mb-4 rounded-lg bg-red-100 p-4 text-sm text-red-700 dark:bg-red-200 dark:text-red-800'
-              role='alert'
-            >
-              <span class='font-medium'>Error:</span> {props.errorMsg}
-            </div>
-          )}
-        </section>
-
-        {/* Finish */}
-        <section className={`my-10 flex justify-between`}>
-          <Link href='/providers'>
-            <a className='flex-none items-center self-center rounded-md border border-transparent bg-black px-4 py-2 text-2xs font-medium text-white shadow-sm hover:bg-gray-800'>
-              Finish
-            </a>
-          </Link>
-        </section>
-      </div>
-    </div>
-  )
-}
+import SCIMKey from '../../components/scim-key'
 
 function Provider({ kind, name, currentKind }) {
   return (
@@ -116,7 +52,7 @@ export default function ProvidersAddDetails() {
   const [error, setError] = useState('')
   const [errors, setErrors] = useState({})
   const [name, setName] = useState('')
-  const [scimAccessKey, setSCIMAccessKey] = useState('')
+  const [scimAccessKey, setSCIMAccessKey] = useState()
   const [keyDialogOpen, setKeyDialogOpen] = useState(false)
 
   useEffect(() => {
@@ -160,7 +96,9 @@ export default function ProvidersAddDetails() {
 
           const data = await jsonBody(res)
 
-          createSCIMAccessKey(data.id, data.name)
+          if (enableSCIM) {
+            createSCIMAccessKey(data.id, data.name)
+          }
 
           return { items: [...providers, data] }
         }
@@ -280,7 +218,7 @@ export default function ProvidersAddDetails() {
                   leaveTo='opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
                 >
                   <Dialog.Panel className='relative w-full transform overflow-hidden rounded-xl border border-gray-100 bg-white p-8 text-left shadow-xl shadow-gray-300/10 transition-all sm:my-8 sm:max-w-lg'>
-                    <SCIMKeyDialog accessKey={scimAccessKey} errorMsg={error} />
+                    <SCIMKey accessKey={scimAccessKey} errorMsg={error} />
                   </Dialog.Panel>
                 </Transition.Child>
               </div>
@@ -440,7 +378,7 @@ export default function ProvidersAddDetails() {
                   id='scim-checkbox'
                   type='checkbox'
                   value=''
-                  class='h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800 dark:focus:ring-blue-600'
+                  class='h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:ring-2 focus:ring-blue-500'
                   onChange={() => {
                     setEnableSCIM(!enableSCIM)
                   }}

--- a/ui/pages/providers/add.js
+++ b/ui/pages/providers/add.js
@@ -5,7 +5,6 @@ import copy from 'copy-to-clipboard'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useSWRConfig } from 'swr'
-import { InformationCircleIcon, XIcon } from '@heroicons/react/outline'
 import Tippy from '@tippyjs/react'
 import {
   DuplicateIcon,
@@ -41,7 +40,7 @@ function SCIMKeyDialog(props) {
                 <button
                   className={`absolute right-2 top-2 rounded-md border border-black/10 bg-white px-2 py-2 text-black/40 backdrop-blur-xl hover:text-black/70`}
                   onClick={() => {
-                    copy(key)
+                    copy(props.accessKey)
                     setKeyCopied(true)
                     setTimeout(() => setKeyCopied(false), 2000)
                   }}

--- a/ui/pages/providers/index.js
+++ b/ui/pages/providers/index.js
@@ -24,7 +24,7 @@ export default function Providers() {
         <h1 className='py-1 font-display text-xl font-medium'>Providers</h1>
         <Link href='/providers/add'>
           <a className='inline-flex items-center rounded-md border border-transparent bg-black px-4 py-2 text-xs font-medium text-white shadow-sm hover:cursor-pointer hover:bg-gray-800'>
-            Connect provider
+            Connect Provider
           </a>
         </Link>
       </header>

--- a/ui/pages/providers/index.js
+++ b/ui/pages/providers/index.js
@@ -24,7 +24,7 @@ export default function Providers() {
         <h1 className='py-1 font-display text-xl font-medium'>Providers</h1>
         <Link href='/providers/add'>
           <a className='inline-flex items-center rounded-md border border-transparent bg-black px-4 py-2 text-xs font-medium text-white shadow-sm hover:cursor-pointer hover:bg-gray-800'>
-            Connect Provider
+            Connect provider
           </a>
         </Link>
       </header>


### PR DESCRIPTION
## Summary
Create an access key that a provider can use for SCIM in the UI.

<img width="1440" alt="Screen Shot 2022-10-20 at 6 10 14 PM" src="https://user-images.githubusercontent.com/5853428/197059347-a1ce9459-d4b4-421e-b922-3da854483676.png">
<img width="1440" alt="Screen Shot 2022-10-20 at 6 11 32 PM" src="https://user-images.githubusercontent.com/5853428/197059350-ec7dd106-97ac-4dd6-a7dd-199469137f89.png">
<img width="1440" alt="Screen Shot 2022-10-20 at 6 11 42 PM" src="https://user-images.githubusercontent.com/5853428/197059353-f7c1cb6f-59fc-467b-81de-65c9f21797ab.png">
<img width="1440" alt="Screen Shot 2022-10-20 at 6 11 50 PM" src="https://user-images.githubusercontent.com/5853428/197059359-d173eea0-39d7-4859-bc1f-5fbe3055e32b.png">


## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3378
