### PR TITLE
Start adding context.Context to api.Client methods

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -79,8 +79,14 @@ func ErrorStatusCode(err error) int32 {
 	return 0
 }
 
-func (c *Client) buildRequest(method string, path string, query Query, body io.Reader) (*http.Request, error) {
-	req, err := http.NewRequest(method, fmt.Sprintf("%s%s", c.URL, path), body)
+func (c *Client) buildRequest(
+	ctx context.Context,
+	method string,
+	path string,
+	query Query,
+	body io.Reader,
+) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("%s%s", c.URL, path), body)
 	if err != nil {
 		return nil, err
 	}
@@ -159,8 +165,8 @@ type readsResponseHeader interface {
 	setValuesFromHeader(header http.Header) error
 }
 
-func get[Res any](client Client, path string, query Query) (*Res, error) {
-	req, err := client.buildRequest(http.MethodGet, path, query, nil)
+func get[Res any](ctx context.Context, client Client, path string, query Query) (*Res, error) {
+	req, err := client.buildRequest(ctx, http.MethodGet, path, query, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +178,8 @@ func post[Req, Res any](client Client, path string, req *Req) (*Res, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpReq, err := client.buildRequest(http.MethodPost, path, nil, body)
+	ctx := context.TODO()
+	httpReq, err := client.buildRequest(ctx, http.MethodPost, path, nil, body)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +202,8 @@ func put[Req, Res any](client Client, path string, req *Req) (*Res, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpReq, err := client.buildRequest(http.MethodPut, path, nil, body)
+	ctx := context.TODO()
+	httpReq, err := client.buildRequest(ctx, http.MethodPut, path, nil, body)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +215,8 @@ func patch[Req, Res any](client Client, path string, req *Req) (*Res, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpReq, err := client.buildRequest(http.MethodPatch, path, nil, body)
+	ctx := context.TODO()
+	httpReq, err := client.buildRequest(ctx, http.MethodPatch, path, nil, body)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +224,8 @@ func patch[Req, Res any](client Client, path string, req *Req) (*Res, error) {
 }
 
 func delete(client Client, path string, query Query) error {
-	httpReq, err := client.buildRequest(http.MethodDelete, path, query, nil)
+	ctx := context.TODO()
+	httpReq, err := client.buildRequest(ctx, http.MethodDelete, path, query, nil)
 	if err != nil {
 		return err
 	}
@@ -227,16 +237,17 @@ func (c Client) ListUsers(req ListUsersRequest) (*ListResponse[User], error) {
 	ids := slice.Map[uid.ID, string](req.IDs, func(id uid.ID) string {
 		return id.String()
 	})
-	return get[ListResponse[User]](c, "/api/users",
-		Query{
-			"name": {req.Name}, "group": {req.Group.String()}, "ids": ids,
-			"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
-			"showSystem": {strconv.FormatBool(req.ShowSystem)},
-		})
+	ctx := context.TODO()
+	return get[ListResponse[User]](ctx, c, "/api/users", Query{
+		"name": {req.Name}, "group": {req.Group.String()}, "ids": ids,
+		"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
+		"showSystem": {strconv.FormatBool(req.ShowSystem)},
+	})
 }
 
 func (c Client) GetUser(id uid.ID) (*User, error) {
-	return get[User](c, fmt.Sprintf("/api/users/%s", id), Query{})
+	ctx := context.TODO()
+	return get[User](ctx, c, fmt.Sprintf("/api/users/%s", id), Query{})
 }
 
 func (c Client) CreateUser(req *CreateUserRequest) (*CreateUserResponse, error) {
@@ -262,14 +273,16 @@ func (c Client) PollDeviceFlow(req *PollDeviceFlowRequest) (*DevicePollResponse,
 }
 
 func (c Client) ListGroups(req ListGroupsRequest) (*ListResponse[Group], error) {
-	return get[ListResponse[Group]](c, "/api/groups", Query{
+	ctx := context.TODO()
+	return get[ListResponse[Group]](ctx, c, "/api/groups", Query{
 		"name": {req.Name}, "userID": {req.UserID.String()},
 		"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
 	})
 }
 
 func (c Client) GetGroup(id uid.ID) (*Group, error) {
-	return get[Group](c, fmt.Sprintf("/api/groups/%s", id), Query{})
+	ctx := context.TODO()
+	return get[Group](ctx, c, fmt.Sprintf("/api/groups/%s", id), Query{})
 }
 
 func (c Client) CreateGroup(req *CreateGroupRequest) (*Group, error) {
@@ -286,21 +299,23 @@ func (c Client) UpdateUsersInGroup(req *UpdateUsersInGroupRequest) error {
 }
 
 func (c Client) ListProviders(req ListProvidersRequest) (*ListResponse[Provider], error) {
-	return get[ListResponse[Provider]](c, "/api/providers",
-		Query{
-			"name": {req.Name},
-			"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
-		})
+	ctx := context.TODO()
+	return get[ListResponse[Provider]](ctx, c, "/api/providers", Query{
+		"name": {req.Name},
+		"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
+	})
 }
 
 func (c Client) ListOrganizations(req ListOrganizationsRequest) (*ListResponse[Organization], error) {
-	return get[ListResponse[Organization]](c, "/api/organizations", Query{
+	ctx := context.TODO()
+	return get[ListResponse[Organization]](ctx, c, "/api/organizations", Query{
 		"name": {req.Name},
 	})
 }
 
 func (c Client) GetOrganization(id uid.ID) (*Organization, error) {
-	return get[Organization](c, fmt.Sprintf("/api/organizations/%s", id), Query{})
+	ctx := context.TODO()
+	return get[Organization](ctx, c, fmt.Sprintf("/api/organizations/%s", id), Query{})
 }
 
 func (c Client) CreateOrganization(req *CreateOrganizationRequest) (*Organization, error) {
@@ -312,7 +327,8 @@ func (c Client) DeleteOrganization(id uid.ID) error {
 }
 
 func (c Client) GetProvider(id uid.ID) (*Provider, error) {
-	return get[Provider](c, fmt.Sprintf("/api/providers/%s", id), Query{})
+	ctx := context.TODO()
+	return get[Provider](ctx, c, fmt.Sprintf("/api/providers/%s", id), Query{})
 }
 
 func (c Client) CreateProvider(req *CreateProviderRequest) (*Provider, error) {
@@ -332,7 +348,8 @@ func (c Client) DeleteProvider(id uid.ID) error {
 }
 
 func (c Client) ListGrants(req ListGrantsRequest) (*ListResponse[Grant], error) {
-	return get[ListResponse[Grant]](c, "/api/grants", Query{
+	ctx := context.TODO()
+	return get[ListResponse[Grant]](ctx, c, "/api/grants", Query{
 		"user":          {req.User.String()},
 		"group":         {req.Group.String()},
 		"resource":      {req.Resource},
@@ -353,7 +370,8 @@ func (c Client) DeleteGrant(id uid.ID) error {
 }
 
 func (c Client) ListDestinations(req ListDestinationsRequest) (*ListResponse[Destination], error) {
-	return get[ListResponse[Destination]](c, "/api/destinations", Query{
+	ctx := context.TODO()
+	return get[ListResponse[Destination]](ctx, c, "/api/destinations", Query{
 		"name":      {req.Name},
 		"unique_id": {req.UniqueID},
 		"page":      {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
@@ -373,7 +391,8 @@ func (c Client) DeleteDestination(id uid.ID) error {
 }
 
 func (c Client) ListAccessKeys(req ListAccessKeysRequest) (*ListResponse[AccessKey], error) {
-	return get[ListResponse[AccessKey]](c, "/api/access-keys", Query{
+	ctx := context.TODO()
+	return get[ListResponse[AccessKey]](ctx, c, "/api/access-keys", Query{
 		"user_id":      {req.UserID.String()},
 		"name":         {req.Name},
 		"show_expired": {fmt.Sprint(req.ShowExpired)},
@@ -411,11 +430,13 @@ func (c Client) Signup(req *SignupRequest) (*SignupResponse, error) {
 }
 
 func (c Client) GetServerVersion() (*Version, error) {
-	return get[Version](c, "/api/version", Query{})
+	ctx := context.TODO()
+	return get[Version](ctx, c, "/api/version", Query{})
 }
 
 func (c Client) GetSettings() (*Settings, error) {
-	return get[Settings](c, "/api/settings", Query{})
+	ctx := context.TODO()
+	return get[Settings](ctx, c, "/api/settings", Query{})
 }
 
 func (c Client) UpdateSettings(req *Settings) (*Settings, error) {

--- a/api/client.go
+++ b/api/client.go
@@ -233,11 +233,10 @@ func delete(client Client, path string, query Query) error {
 	return err
 }
 
-func (c Client) ListUsers(req ListUsersRequest) (*ListResponse[User], error) {
+func (c Client) ListUsers(ctx context.Context, req ListUsersRequest) (*ListResponse[User], error) {
 	ids := slice.Map[uid.ID, string](req.IDs, func(id uid.ID) string {
 		return id.String()
 	})
-	ctx := context.TODO()
 	return get[ListResponse[User]](ctx, c, "/api/users", Query{
 		"name": {req.Name}, "group": {req.Group.String()}, "ids": ids,
 		"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
@@ -272,8 +271,7 @@ func (c Client) PollDeviceFlow(req *PollDeviceFlowRequest) (*DevicePollResponse,
 	})
 }
 
-func (c Client) ListGroups(req ListGroupsRequest) (*ListResponse[Group], error) {
-	ctx := context.TODO()
+func (c Client) ListGroups(ctx context.Context, req ListGroupsRequest) (*ListResponse[Group], error) {
 	return get[ListResponse[Group]](ctx, c, "/api/groups", Query{
 		"name": {req.Name}, "userID": {req.UserID.String()},
 		"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
@@ -298,16 +296,14 @@ func (c Client) UpdateUsersInGroup(req *UpdateUsersInGroupRequest) error {
 	return err
 }
 
-func (c Client) ListProviders(req ListProvidersRequest) (*ListResponse[Provider], error) {
-	ctx := context.TODO()
+func (c Client) ListProviders(ctx context.Context, req ListProvidersRequest) (*ListResponse[Provider], error) {
 	return get[ListResponse[Provider]](ctx, c, "/api/providers", Query{
 		"name": {req.Name},
 		"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
 	})
 }
 
-func (c Client) ListOrganizations(req ListOrganizationsRequest) (*ListResponse[Organization], error) {
-	ctx := context.TODO()
+func (c Client) ListOrganizations(ctx context.Context, req ListOrganizationsRequest) (*ListResponse[Organization], error) {
 	return get[ListResponse[Organization]](ctx, c, "/api/organizations", Query{
 		"name": {req.Name},
 	})
@@ -347,8 +343,7 @@ func (c Client) DeleteProvider(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/api/providers/%s", id), Query{})
 }
 
-func (c Client) ListGrants(req ListGrantsRequest) (*ListResponse[Grant], error) {
-	ctx := context.TODO()
+func (c Client) ListGrants(ctx context.Context, req ListGrantsRequest) (*ListResponse[Grant], error) {
 	return get[ListResponse[Grant]](ctx, c, "/api/grants", Query{
 		"user":          {req.User.String()},
 		"group":         {req.Group.String()},
@@ -369,8 +364,7 @@ func (c Client) DeleteGrant(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/api/grants/%s", id), Query{})
 }
 
-func (c Client) ListDestinations(req ListDestinationsRequest) (*ListResponse[Destination], error) {
-	ctx := context.TODO()
+func (c Client) ListDestinations(ctx context.Context, req ListDestinationsRequest) (*ListResponse[Destination], error) {
 	return get[ListResponse[Destination]](ctx, c, "/api/destinations", Query{
 		"name":      {req.Name},
 		"unique_id": {req.UniqueID},
@@ -390,8 +384,7 @@ func (c Client) DeleteDestination(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/api/destinations/%s", id), Query{})
 }
 
-func (c Client) ListAccessKeys(req ListAccessKeysRequest) (*ListResponse[AccessKey], error) {
-	ctx := context.TODO()
+func (c Client) ListAccessKeys(ctx context.Context, req ListAccessKeysRequest) (*ListResponse[AccessKey], error) {
 	return get[ListResponse[AccessKey]](ctx, c, "/api/access-keys", Query{
 		"user_id":      {req.UserID.String()},
 		"name":         {req.Name},

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -96,8 +97,10 @@ func TestGet(t *testing.T) {
 		"User-Agent":      []string{fmt.Sprintf("Infra/%v (testing version; %v/%v)", apiVersion, runtime.GOOS, runtime.GOARCH)},
 	}
 
+	ctx := context.Background()
+
 	t.Run("success request", func(t *testing.T) {
-		_, err := get[stubResponse](c, "/good", Query{})
+		_, err := get[stubResponse](ctx, c, "/good", Query{})
 		assert.NilError(t, err)
 		req := <-requestCh
 		assert.Equal(t, req.Method, http.MethodGet)
@@ -106,7 +109,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("bad request", func(t *testing.T) {
-		_, err := get[stubResponse](c, "/bad", Query{})
+		_, err := get[stubResponse](ctx, c, "/bad", Query{})
 		assert.Error(t, err, `bad request: it failed because`)
 		req := <-requestCh
 		assert.Equal(t, req.Method, http.MethodGet)
@@ -115,7 +118,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("server error", func(t *testing.T) {
-		_, err := get[stubResponse](c, "/invalid", Query{})
+		_, err := get[stubResponse](ctx, c, "/invalid", Query{})
 		assert.Error(t, err, `500 internal server error`)
 		req := <-requestCh
 		assert.Equal(t, req.Method, http.MethodGet)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -188,8 +188,10 @@ func TestListGrants(t *testing.T) {
 		AccessKey: "the-access-key",
 	}
 
+	ctx := context.Background()
+
 	t.Run("sets value from Last-Update-Index header", func(t *testing.T) {
-		resp, err := c.ListGrants(ListGrantsRequest{Resource: "anything"})
+		resp, err := c.ListGrants(ctx, ListGrantsRequest{Resource: "anything"})
 		assert.NilError(t, err)
 
 		assert.Equal(t, resp.LastUpdateIndex.Index, int64(10010))

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -141,12 +141,12 @@ func TestDelete(t *testing.T) {
 	}
 
 	expected := http.Header{
-		"Accept-Encoding": []string{"gzip"},
-		"Authorization":   []string{"Bearer access-key"},
-		"Content-Type":    []string{"application/json"},
-		"Accept":          []string{"application/json"},
-		"Infra-Version":   []string{apiVersion},
-		"User-Agent":      []string{fmt.Sprintf("Infra/%v (testing version; %v/%v)", apiVersion, runtime.GOOS, runtime.GOARCH)},
+		"Accept-Encoding": {"gzip"},
+		"Authorization":   {"Bearer access-key"},
+		"Content-Type":    {"application/json"},
+		"Accept":          {"application/json"},
+		"Infra-Version":   {apiVersion},
+		"User-Agent":      {fmt.Sprintf("Infra/%v (testing version; %v/%v)", apiVersion, runtime.GOOS, runtime.GOARCH)},
 	}
 
 	t.Run("headers", func(t *testing.T) {

--- a/api/types.go
+++ b/api/types.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -13,7 +14,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-type Query map[string][]string
+type Query url.Values
 
 type Resource struct {
 	ID uid.ID `uri:"id"`

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -51,8 +52,10 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
+			ctx := context.Background()
+
 			logging.Debugf("call server: list destinations")
-			destinations, err := listAll(client.ListDestinations, api.ListDestinationsRequest{})
+			destinations, err := listAll(ctx, client.ListDestinations, api.ListDestinationsRequest{})
 			if err != nil {
 				return err
 			}
@@ -127,8 +130,10 @@ func newDestinationsRemoveCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
+			ctx := context.Background()
+
 			logging.Debugf("call server: list destinations named %q", name)
-			destinations, err := client.ListDestinations(api.ListDestinationsRequest{Name: name})
+			destinations, err := client.ListDestinations(ctx, api.ListDestinationsRequest{Name: name})
 			if err != nil {
 				if api.ErrorStatusCode(err) == 403 {
 					logging.Debugf("%s", err.Error())

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"text/tabwriter"
@@ -36,6 +37,8 @@ func info(cli *CLI) error {
 		return err
 	}
 
+	ctx := context.Background()
+
 	user, err := client.GetUser(config.UserID)
 	if err != nil {
 		if api.ErrorStatusCode(err) == 401 {
@@ -65,7 +68,7 @@ func info(cli *CLI) error {
 		fmt.Fprintf(w, "Identity Provider:\t %s (%s)\n", provider.Name, provider.URL)
 	}
 
-	userGroups, err := listAll(client.ListGroups, api.ListGroupsRequest{UserID: config.UserID})
+	userGroups, err := listAll(ctx, client.ListGroups, api.ListGroupsRequest{UserID: config.UserID})
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -188,6 +189,8 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
+			ctx := context.Background()
+
 			var keys []api.AccessKey
 			var userID uid.ID
 			if options.UserName != "" {
@@ -214,7 +217,7 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 			}
 
 			logging.Debugf("call server: list access keys")
-			keys, err = listAll(client.ListAccessKeys, api.ListAccessKeysRequest{ShowExpired: options.ShowExpired, UserID: userID})
+			keys, err = listAll(ctx, client.ListAccessKeys, api.ListAccessKeysRequest{ShowExpired: options.ShowExpired, UserID: userID})
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -57,7 +58,8 @@ func kubernetesSetContext(cluster, namespace string) error {
 }
 
 func updateKubeConfig(client *api.Client, id uid.ID) error {
-	destinations, err := listAll(client.ListDestinations, api.ListDestinationsRequest{})
+	ctx := context.TODO()
+	destinations, err := listAll(ctx, client.ListDestinations, api.ListDestinationsRequest{})
 	if err != nil {
 		return err
 	}
@@ -67,7 +69,7 @@ func updateKubeConfig(client *api.Client, id uid.ID) error {
 		return err
 	}
 
-	grants, err := listAll(client.ListGrants, api.ListGrantsRequest{User: id, ShowInherited: true})
+	grants, err := listAll(ctx, client.ListGrants, api.ListGrantsRequest{User: id, ShowInherited: true})
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -114,6 +115,8 @@ func isResourceForDestination(resource string, destination string) bool {
 }
 
 func getUserDestinationGrants(client *api.Client) (*api.User, []api.Destination, []api.Grant, error) {
+	ctx := context.TODO()
+
 	config, err := currentHostConfig()
 	if err != nil {
 		return nil, nil, nil, err
@@ -128,12 +131,12 @@ func getUserDestinationGrants(client *api.Client) (*api.User, []api.Destination,
 		return nil, nil, nil, err
 	}
 
-	grants, err := listAll(client.ListGrants, api.ListGrantsRequest{User: config.UserID, ShowInherited: true})
+	grants, err := listAll(ctx, client.ListGrants, api.ListGrantsRequest{User: config.UserID, ShowInherited: true})
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	destinations, err := listAll(client.ListDestinations, api.ListDestinationsRequest{})
+	destinations, err := listAll(ctx, client.ListDestinations, api.ListDestinationsRequest{})
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -82,14 +82,14 @@ func TestListCmd(t *testing.T) {
 			"Infra-Destination": {uniqueID},
 		}
 
-		_, err := c.ListGrants(api.ListGrantsRequest{})
+		_, err := c.ListGrants(ctx, api.ListGrantsRequest{})
 		assert.NilError(t, err)
 	}
 
 	// reset client.Headers
 	c.Headers = http.Header{}
 
-	users, err := c.ListUsers(api.ListUsersRequest{})
+	users, err := c.ListUsers(ctx, api.ListUsersRequest{})
 	assert.NilError(t, err)
 
 	userMap := usersToMap(users.Items)

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -344,7 +344,7 @@ func oidcflow(provider *api.Provider) (string, error) {
 
 // Given the provider name, directs user to its OIDC login page, then saves the auth code (to later login to infra)
 func loginToProviderN(client *api.Client, providerName string) (*api.LoginRequestOIDC, error) {
-	provider, err := GetProviderByName(client, providerName)
+	provider, err := GetProviderByName(context.TODO(), client, providerName)
 	if err != nil {
 		return nil, err
 	}
@@ -589,7 +589,8 @@ func promptLocalLogin(cli *CLI) (*api.LoginRequestPasswordCredentials, error) {
 }
 
 func listProviders(client *api.Client) ([]api.Provider, error) {
-	providers, err := client.ListProviders(api.ListProvidersRequest{})
+	ctx := context.TODO()
+	providers, err := client.ListProviders(ctx, api.ListProvidersRequest{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/pagination.go
+++ b/internal/cmd/pagination.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/logging"
 )
@@ -8,8 +10,11 @@ import (
 // listAll is a helper function that handles pagination and calls the given list request function.
 // listItems is the corresponding function in the API client that handles the Request "req".
 // handleError is a function that handles the error returned by the API client.
-func listAll[Item any, Req api.Paginatable](listItems func(Req) (*api.ListResponse[Item], error), req Req) ([]Item, error) {
-
+func listAll[Item any, Req api.Paginatable](
+	ctx context.Context,
+	listItems func(context.Context, Req) (*api.ListResponse[Item], error),
+	req Req,
+) ([]Item, error) {
 	logging.Debugf("call server: page 1")
 
 	req, ok := req.SetPage(1).(Req)
@@ -17,7 +22,7 @@ func listAll[Item any, Req api.Paginatable](listItems func(Req) (*api.ListRespon
 		panic("SetPage returned a different request type than expected")
 	}
 
-	res, err := listItems(req)
+	res, err := listItems(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +36,7 @@ func listAll[Item any, Req api.Paginatable](listItems func(Req) (*api.ListRespon
 		}
 
 		logging.Debugf("call server: page %d", page)
-		res, err = listItems(req)
+		res, err = listItems(ctx, req)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmd/pagination_test.go
+++ b/internal/cmd/pagination_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -10,16 +11,17 @@ import (
 )
 
 func TestListAll(t *testing.T) {
+	ctx := context.Background()
 
 	t.Run("empty", func(t *testing.T) {
-		users, err := listAll(mockListUsers, api.ListUsersRequest{Name: "empty"})
+		users, err := listAll(ctx, mockListUsers, api.ListUsersRequest{Name: "empty"})
 		assert.NilError(t, err)
 
 		assert.DeepEqual(t, users, []api.User{})
 	})
 
 	t.Run("one", func(t *testing.T) {
-		users, err := listAll(mockListUsers, api.ListUsersRequest{Name: "one"})
+		users, err := listAll(ctx, mockListUsers, api.ListUsersRequest{Name: "one"})
 		assert.NilError(t, err)
 
 		assert.DeepEqual(t, users, []api.User{
@@ -28,7 +30,7 @@ func TestListAll(t *testing.T) {
 	})
 
 	t.Run("two", func(t *testing.T) {
-		users, err := listAll(mockListUsers, api.ListUsersRequest{Name: "two"})
+		users, err := listAll(ctx, mockListUsers, api.ListUsersRequest{Name: "two"})
 		assert.NilError(t, err)
 
 		assert.DeepEqual(t, users, []api.User{{Name: "1@test.com"}, {Name: "2@test.com"}})
@@ -36,7 +38,7 @@ func TestListAll(t *testing.T) {
 	})
 
 	t.Run("five", func(t *testing.T) {
-		users, err := listAll(mockListUsers, api.ListUsersRequest{Name: "five"})
+		users, err := listAll(ctx, mockListUsers, api.ListUsersRequest{Name: "five"})
 		assert.NilError(t, err)
 
 		assert.DeepEqual(t, users, []api.User{
@@ -46,13 +48,13 @@ func TestListAll(t *testing.T) {
 	})
 
 	t.Run("error", func(t *testing.T) {
-		_, err := listAll(mockListUsers, api.ListUsersRequest{Name: "error"})
+		_, err := listAll(ctx, mockListUsers, api.ListUsersRequest{Name: "error"})
 		assert.Error(t, err, "default error")
 	})
 
 }
 
-func mockListUsers(req api.ListUsersRequest) (*api.ListResponse[api.User], error) {
+func mockListUsers(_ context.Context, req api.ListUsersRequest) (*api.ListResponse[api.User], error) {
 	switch req.Name {
 	case "empty":
 		return &api.ListResponse[api.User]{

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -131,8 +132,10 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
+			ctx := context.Background()
+
 			logging.Debugf("call server: list providers")
-			providers, err := listAll(client.ListProviders, api.ListProvidersRequest{})
+			providers, err := listAll(ctx, client.ListProviders, api.ListProvidersRequest{})
 			if err != nil {
 				return err
 			}
@@ -294,7 +297,9 @@ func updateProvider(cli *CLI, name string, opts providerEditOptions) error {
 		return err
 	}
 
-	res, err := client.ListProviders(api.ListProvidersRequest{Name: name})
+	ctx := context.Background()
+
+	res, err := client.ListProviders(ctx, api.ListProvidersRequest{Name: name})
 	if err != nil {
 		return err
 	}
@@ -392,8 +397,10 @@ func newProvidersRemoveCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
+			ctx := context.Background()
+
 			logging.Debugf("call server: list providers named %q", args[0])
-			providers, err := client.ListProviders(api.ListProvidersRequest{Name: args[0]})
+			providers, err := client.ListProviders(ctx, api.ListProvidersRequest{Name: args[0]})
 			if err != nil {
 				return err
 			}
@@ -427,9 +434,9 @@ func newProvidersRemoveCmd(cli *CLI) *cobra.Command {
 	return cmd
 }
 
-func GetProviderByName(client *api.Client, name string) (*api.Provider, error) {
+func GetProviderByName(ctx context.Context, client *api.Client, name string) (*api.Provider, error) {
 	logging.Debugf("call server: list providers named %q", name)
-	providers, err := client.ListProviders(api.ListProvidersRequest{Name: name})
+	providers, err := client.ListProviders(ctx, api.ListProvidersRequest{Name: name})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -143,6 +144,8 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 
+			ctx := context.Background()
+
 			type row struct {
 				Name       string `header:"Name"`
 				LastSeenAt string `header:"Last Seen"`
@@ -152,7 +155,7 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 			var rows []row
 
 			logging.Debugf("call server: list users")
-			users, err := listAll(client.ListUsers, api.ListUsersRequest{})
+			users, err := listAll(ctx, client.ListUsers, api.ListUsersRequest{})
 			if err != nil {
 				return err
 			}
@@ -212,8 +215,10 @@ $ infra users remove janedoe@example.com`,
 				return err
 			}
 
+			ctx := context.Background()
+
 			logging.Debugf("call server: list users named %q", name)
-			users, err := client.ListUsers(api.ListUsersRequest{Name: name})
+			users, err := client.ListUsers(ctx, api.ListUsersRequest{Name: name})
 			if err != nil {
 				if api.ErrorStatusCode(err) == 403 {
 					logging.Debugf("%s", err.Error())
@@ -355,7 +360,9 @@ func getUserByNameOrID(client *api.Client, name string) (*api.User, error) {
 		showSystem = true
 	}
 
-	users, err := client.ListUsers(api.ListUsersRequest{Name: name, ShowSystem: showSystem})
+	ctx := context.TODO()
+
+	users, err := client.ListUsers(ctx, api.ListUsersRequest{Name: name, ShowSystem: showSystem})
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +460,8 @@ func createUser(client *api.Client, name string) (*api.CreateUserResponse, error
 // check if the user has permissions to reset passwords for another user.
 // This might be handy for customizing error messages
 func hasAccessToChangePasswordsForOtherUsers(client *api.Client, config *ClientHostConfig) (bool, error) {
-	grants, err := client.ListGrants(api.ListGrantsRequest{
+	ctx := context.TODO()
+	grants, err := client.ListGrants(ctx, api.ListGrantsRequest{
 		User:          config.UserID,
 		Privilege:     api.InfraAdminRole,
 		Resource:      "infra",


### PR DESCRIPTION
## Summary

To test blocking requests we need to be able to cancel the blocking operation, which requires that the `api.Client` method accepts a `context.Context`. I need this for the connector tests in #3444

This PR starts the work of adding a `context.Context` argument to all `api.Client` methods.

The first commits prepares for the new argument by splitting up `api.request`. This function already had more than enough arguments. Splitting up into `buildRequest`, `encodeRequestBody`, and `request` allows us to reduce the number of arguments to each, and make `buildRequest` a method on `Client`.

The second commit adds the `context.Context` argument to `buildRequest` and the http method helper functions, using `context.TODO` as a placeholder.

The last commit adds the `context.Context` argument to all `List` methods. We have to do all of these together because of the `listAll` helper that deals with required pagination in the CLI.  The only blocking request we have right now is `ListGrants`, so it's primarily list operations that need this, although technically all requests do benefit from cancellation.

In follow up PRs I think we can add the `context.Context` argument to the rest of the `Get` operations, and then to all the write and delete operations.

I've added `context.Background` where it seems reasonable to start a new context. In a bunch of places I used `context.TODO` to avoid having to change multiple functions to pass along a context. We can fix those in follow up PRs.  