### PR TITLE
Add bulk grant update

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -310,8 +310,8 @@ func (c Client) ListGrants(req ListGrantsRequest) (*ListResponse[Grant], error) 
 	})
 }
 
-func (c Client) CreateGrant(req *CreateGrantRequest) (*CreateGrantResponse, error) {
-	return post[CreateGrantRequest, CreateGrantResponse](c, "/api/grants", req)
+func (c Client) CreateGrant(req *GrantRequest) (*CreateGrantResponse, error) {
+	return post[GrantRequest, CreateGrantResponse](c, "/api/grants", req)
 }
 
 func (c Client) DeleteGrant(id uid.ID) error {

--- a/api/grant.go
+++ b/api/grant.go
@@ -142,14 +142,15 @@ func (r ListGrantsRequest) SetPage(page int) Paginatable {
 	return r
 }
 
-type CreateGrantRequest struct {
+// GrantRequest defines a grant request which can be used for creating or deleting grants
+type GrantRequest struct {
 	User      uid.ID `json:"user"`
 	Group     uid.ID `json:"group"`
 	Privilege string `json:"privilege" example:"view" note:"a role or permission"`
 	Resource  string `json:"resource" example:"production" note:"a resource name in Infra's Universal Resource Notation"`
 }
 
-func (r CreateGrantRequest) ValidationRules() []validate.ValidationRule {
+func (r GrantRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.RequireOneOf(
 			validate.Field{Name: "user", Value: r.User},
@@ -161,6 +162,6 @@ func (r CreateGrantRequest) ValidationRules() []validate.ValidationRule {
 }
 
 type UpdateGrantsRequest struct {
-	GrantsToAdd    []CreateGrantRequest `json:"grantsToAdd"`
-	GrantsToRemove []CreateGrantRequest `json:"grantsToRemove"`
+	GrantsToAdd    []GrantRequest `json:"grantsToAdd"`
+	GrantsToRemove []GrantRequest `json:"grantsToRemove"`
 }

--- a/api/grant.go
+++ b/api/grant.go
@@ -159,3 +159,8 @@ func (r CreateGrantRequest) ValidationRules() []validate.ValidationRule {
 		validate.Required("resource", r.Resource),
 	}
 }
+
+type UpdateGrantsRequest struct {
+	GrantsToAdd    []CreateGrantRequest `json:"grantsToAdd"`
+	GrantsToRemove []CreateGrantRequest `json:"grantsToRemove"`
+}

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -181,18 +181,8 @@ func DeleteGrant(c *gin.Context, id uid.ID) error {
 func UpdateGrants(c *gin.Context, addGrants, rmGrants []*models.Grant) error {
 	db, err := RequireInfraRole(c, models.InfraAdminRole)
 	if err != nil {
-		return HandleAuthErr(err, "grant", "create", "")
+		return HandleAuthErr(err, "grant", "update", "")
 	}
 
-	err = data.CreateGrants(db, addGrants)
-	if err != nil {
-		return err
-	}
-
-	err = data.DeleteGrantsBulk(db, rmGrants)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return data.UpdateGrants(db, addGrants, rmGrants)
 }

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -178,13 +178,18 @@ func DeleteGrant(c *gin.Context, id uid.ID) error {
 	return data.DeleteGrants(db, data.DeleteGrantsOptions{ByID: id})
 }
 
-func UpdateGrants(c *gin.Context, grants []*models.Grant) error {
+func UpdateGrants(c *gin.Context, addGrants, rmGrants []*models.Grant) error {
 	db, err := RequireInfraRole(c, models.InfraAdminRole)
 	if err != nil {
 		return HandleAuthErr(err, "grant", "create", "")
 	}
 
-	err = data.CreateGrants(db, grants)
+	err = data.CreateGrants(db, addGrants)
+	if err != nil {
+		return err
+	}
+
+	err = data.DeleteGrantsBulk(db, rmGrants)
 	if err != nil {
 		return err
 	}

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -177,3 +177,17 @@ func DeleteGrant(c *gin.Context, id uid.ID) error {
 
 	return data.DeleteGrants(db, data.DeleteGrantsOptions{ByID: id})
 }
+
+func UpdateGrants(c *gin.Context, grants []*models.Grant) error {
+	db, err := RequireInfraRole(c, models.InfraAdminRole)
+	if err != nil {
+		return HandleAuthErr(err, "grant", "create", "")
+	}
+
+	err = data.CreateGrants(db, grants)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -407,7 +407,7 @@ func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 		}
 	}
 
-	createGrantReq := &api.CreateGrantRequest{
+	createGrantReq := &api.GrantRequest{
 		User:      userID,
 		Group:     groupID,
 		Privilege: cmdOptions.Role,

--- a/internal/cmd/grants_test.go
+++ b/internal/cmd/grants_test.go
@@ -20,8 +20,8 @@ func TestGrantsAddCmd(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home) // for windows
 
-	setup := func(t *testing.T) chan api.CreateGrantRequest {
-		requestCh := make(chan api.CreateGrantRequest, 1)
+	setup := func(t *testing.T) chan api.GrantRequest {
+		requestCh := make(chan api.GrantRequest, 1)
 
 		handler := func(resp http.ResponseWriter, req *http.Request) {
 			query := req.URL.Query()
@@ -73,7 +73,7 @@ func TestGrantsAddCmd(t *testing.T) {
 			}
 
 			defer close(requestCh)
-			var createReq api.CreateGrantRequest
+			var createReq api.GrantRequest
 			err := json.NewDecoder(req.Body).Decode(&createReq)
 			assert.Check(t, err)
 
@@ -96,7 +96,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		assert.NilError(t, err)
 
 		createReq := <-ch
-		expected := api.CreateGrantRequest{
+		expected := api.GrantRequest{
 			User:      3000,
 			Privilege: "connect",
 			Resource:  "the-destination",
@@ -110,7 +110,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		assert.NilError(t, err)
 
 		createReq := <-ch
-		expected := api.CreateGrantRequest{
+		expected := api.GrantRequest{
 			User:      3000,
 			Privilege: "connect",
 			Resource:  "the-destination.default",
@@ -124,7 +124,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		assert.NilError(t, err)
 
 		createReq := <-ch
-		expected := api.CreateGrantRequest{
+		expected := api.GrantRequest{
 			User:      3000,
 			Privilege: "role",
 			Resource:  "the-destination",
@@ -140,7 +140,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		assert.NilError(t, err)
 
 		createReq := <-ch
-		expected := api.CreateGrantRequest{
+		expected := api.GrantRequest{
 			Group:     4000,
 			Privilege: "role",
 			Resource:  "the-destination",
@@ -166,7 +166,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		assert.NilError(t, err)
 
 		actual := <-ch
-		expected := api.CreateGrantRequest{
+		expected := api.GrantRequest{
 			User:      3002,
 			Privilege: "connect",
 			Resource:  "destination",
@@ -181,7 +181,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		assert.NilError(t, err)
 
 		actual := <-ch
-		expected := api.CreateGrantRequest{
+		expected := api.GrantRequest{
 			Group:     4001,
 			Privilege: "connect",
 			Resource:  "destination",
@@ -217,7 +217,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		assert.NilError(t, err)
 
 		actual := <-ch
-		expected := api.CreateGrantRequest{
+		expected := api.GrantRequest{
 			User:      3000,
 			Privilege: "connect",
 			Resource:  "nonexistent",
@@ -232,7 +232,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		assert.NilError(t, err)
 
 		actual := <-ch
-		expected := api.CreateGrantRequest{
+		expected := api.GrantRequest{
 			User:      3000,
 			Privilege: "connect",
 			Resource:  "the-destination.nonexistent",
@@ -247,7 +247,7 @@ func TestGrantsAddCmd(t *testing.T) {
 		assert.NilError(t, err)
 
 		actual := <-ch
-		expected := api.CreateGrantRequest{
+		expected := api.GrantRequest{
 			User:      3000,
 			Privilege: "nonexistent",
 			Resource:  "the-destination",

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -446,10 +446,12 @@ func createGrantsBulk(tx WriteTxn, grants []*models.Grant) error {
 	query.B(", update_index")
 	query.B(") VALUES")
 
-	columnTemplate := "(" + placeholderForColumns(table) + ", nextval('seq_update_index') )"
 	for i, g := range grants {
 		gt := (*grantsTable)(g)
-		query.B(columnTemplate, gt.Values()...)
+		query.B("(")
+		query.B(placeholderForColumns(table), gt.Values()...)
+		query.B(", nextval('seq_update_index')")
+		query.B(")")
 		if i+1 != len(grants) {
 			query.B(",")
 		}

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -439,7 +439,7 @@ func createGrantsBulk(tx WriteTxn, grants []*models.Grant) error {
 		setOrg(tx, g)
 	}
 
-	table := (*grantsTable)(grants[0])
+	table := &grantsTable{}
 	query := querybuilder.New("INSERT INTO grants")
 	query.B("(")
 	query.B(columnsForInsert(table))

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -246,8 +246,8 @@ func TestUpdateGrants(t *testing.T) {
 			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 
 			addGrants := []*models.Grant{
-				&models.Grant{Subject: "i:7654321", Privilege: "view", Resource: "foo", CreatedBy: uid.ID(1091)},
-				&models.Grant{Subject: "i:1234567", Privilege: "admin", Resource: "foo", CreatedBy: uid.ID(1091)},
+				{Subject: "i:7654321", Privilege: "view", Resource: "foo", CreatedBy: uid.ID(1091)},
+				{Subject: "i:1234567", Privilege: "admin", Resource: "foo", CreatedBy: uid.ID(1091)},
 			}
 			rmGrants := []*models.Grant{}
 
@@ -256,7 +256,7 @@ func TestUpdateGrants(t *testing.T) {
 			assert.Assert(t, addGrants[0].ID != 0)
 
 			expected := []models.Grant{
-				models.Grant{
+				{
 					Model: models.Model{
 						ID:        uid.ID(999),
 						CreatedAt: time.Now(),
@@ -269,7 +269,7 @@ func TestUpdateGrants(t *testing.T) {
 					CreatedBy:          uid.ID(1091),
 					UpdateIndex:        startUpdateIndex + 1,
 				},
-				models.Grant{
+				{
 					Model: models.Model{
 						ID:        uid.ID(999),
 						CreatedAt: time.Now(),
@@ -337,13 +337,13 @@ func TestUpdateGrants(t *testing.T) {
 			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 
 			addGrants := []*models.Grant{
-				&models.Grant{Subject: "i:7654321", Privilege: "view", Resource: "foo", CreatedBy: uid.ID(1091)},
-				&models.Grant{Subject: "i:1234567", Privilege: "admin", Resource: "foo", CreatedBy: uid.ID(1091)},
+				{Subject: "i:7654321", Privilege: "view", Resource: "foo", CreatedBy: uid.ID(1091)},
+				{Subject: "i:1234567", Privilege: "admin", Resource: "foo", CreatedBy: uid.ID(1091)},
 			}
 			rmGrants := []*models.Grant{
-				&models.Grant{Subject: "i:7654321", Privilege: "view", Resource: "foo", CreatedBy: uid.ID(1091)},
-				&models.Grant{Subject: "i:any1", Privilege: "view", Resource: "foo"},
-				&models.Grant{Subject: "i:any1", Privilege: "edit", Resource: "foo"},
+				{Subject: "i:7654321", Privilege: "view", Resource: "foo", CreatedBy: uid.ID(1091)},
+				{Subject: "i:any1", Privilege: "view", Resource: "foo"},
+				{Subject: "i:any1", Privilege: "edit", Resource: "foo"},
 			}
 
 			err := UpdateGrants(tx, addGrants, rmGrants)
@@ -352,7 +352,7 @@ func TestUpdateGrants(t *testing.T) {
 			actual, err := ListGrants(tx, ListGrantsOptions{ByDestination: "foo"})
 			assert.NilError(t, err)
 			expected := []models.Grant{
-				models.Grant{
+				{
 					Model: models.Model{
 						ID:        uid.ID(999),
 						CreatedAt: time.Now(),

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -235,6 +235,142 @@ func TestDeleteGrants(t *testing.T) {
 	})
 }
 
+func TestUpdateGrants(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		otherOrg := &models.Organization{Name: "other", Domain: "other.example.org"}
+		assert.NilError(t, CreateOrganization(db, otherOrg))
+
+		var startUpdateIndex int64 = 10001
+
+		t.Run("success add", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			addGrants := []*models.Grant{
+				&models.Grant{Subject: "i:7654321", Privilege: "view", Resource: "foo", CreatedBy: uid.ID(1091)},
+				&models.Grant{Subject: "i:1234567", Privilege: "admin", Resource: "foo", CreatedBy: uid.ID(1091)},
+			}
+			rmGrants := []*models.Grant{}
+
+			err := UpdateGrants(tx, addGrants, rmGrants)
+			assert.NilError(t, err)
+			assert.Assert(t, addGrants[0].ID != 0)
+
+			expected := []models.Grant{
+				models.Grant{
+					Model: models.Model{
+						ID:        uid.ID(999),
+						CreatedAt: time.Now(),
+						UpdatedAt: time.Now(),
+					},
+					OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrganizationID},
+					Subject:            "i:7654321",
+					Privilege:          "view",
+					Resource:           "foo",
+					CreatedBy:          uid.ID(1091),
+					UpdateIndex:        startUpdateIndex + 1,
+				},
+				models.Grant{
+					Model: models.Model{
+						ID:        uid.ID(999),
+						CreatedAt: time.Now(),
+						UpdatedAt: time.Now(),
+					},
+					OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrganizationID},
+					Subject:            "i:1234567",
+					Privilege:          "admin",
+					Resource:           "foo",
+					CreatedBy:          uid.ID(1091),
+					UpdateIndex:        startUpdateIndex + 2,
+				},
+			}
+
+			actual, err := ListGrants(tx, ListGrantsOptions{ByDestination: "foo"})
+			assert.NilError(t, err)
+			assert.DeepEqual(t, actual, expected, cmpModel)
+
+			// check for idempotency
+			err = UpdateGrants(tx, addGrants, rmGrants)
+			assert.NilError(t, err)
+			actual, err = ListGrants(tx, ListGrantsOptions{ByDestination: "foo"})
+			assert.NilError(t, err)
+			assert.DeepEqual(t, actual, expected, cmpModel)
+
+		})
+		t.Run("success delete", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			grant1 := &models.Grant{Subject: "i:any1", Privilege: "view", Resource: "foo"}
+			grant2 := &models.Grant{Subject: "i:any1", Privilege: "edit", Resource: "foo"}
+			toKeep := &models.Grant{Subject: "i:any2", Privilege: "view", Resource: "foo"}
+			createGrants(t, tx, grant1, grant2, toKeep)
+
+			otherOrgGrant := &models.Grant{Subject: "i:any1", Privilege: "view", Resource: "foo"}
+			createGrants(t, tx.WithOrgID(otherOrg.ID), otherOrgGrant)
+
+			addGrants := []*models.Grant{}
+			rmGrants := []*models.Grant{grant1, grant2}
+
+			err := UpdateGrants(tx, addGrants, rmGrants)
+			assert.NilError(t, err)
+
+			actual, err := ListGrants(tx, ListGrantsOptions{ByDestination: "foo"})
+			assert.NilError(t, err)
+			expected := []models.Grant{
+				{Model: models.Model{ID: toKeep.ID}},
+			}
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+
+			// check for idempotency
+			err = UpdateGrants(tx, addGrants, rmGrants)
+			assert.NilError(t, err)
+
+			actual, err = ListGrants(tx, ListGrantsOptions{ByDestination: "foo"})
+			assert.NilError(t, err)
+			assert.DeepEqual(t, actual, expected, cmpModelByID)
+
+			// other org still has the grant
+			actual, err = ListGrants(tx.WithOrgID(otherOrg.ID), ListGrantsOptions{ByDestination: "foo"})
+			assert.NilError(t, err)
+			assert.Equal(t, len(actual), 1)
+		})
+		t.Run("success create and delete", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			addGrants := []*models.Grant{
+				&models.Grant{Subject: "i:7654321", Privilege: "view", Resource: "foo", CreatedBy: uid.ID(1091)},
+				&models.Grant{Subject: "i:1234567", Privilege: "admin", Resource: "foo", CreatedBy: uid.ID(1091)},
+			}
+			rmGrants := []*models.Grant{
+				&models.Grant{Subject: "i:7654321", Privilege: "view", Resource: "foo", CreatedBy: uid.ID(1091)},
+				&models.Grant{Subject: "i:any1", Privilege: "view", Resource: "foo"},
+				&models.Grant{Subject: "i:any1", Privilege: "edit", Resource: "foo"},
+			}
+
+			err := UpdateGrants(tx, addGrants, rmGrants)
+			assert.NilError(t, err)
+
+			actual, err := ListGrants(tx, ListGrantsOptions{ByDestination: "foo"})
+			assert.NilError(t, err)
+			expected := []models.Grant{
+				models.Grant{
+					Model: models.Model{
+						ID:        uid.ID(999),
+						CreatedAt: time.Now(),
+						UpdatedAt: time.Now(),
+					},
+					OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrganizationID},
+					Subject:            "i:1234567",
+					Privilege:          "admin",
+					Resource:           "foo",
+					CreatedBy:          uid.ID(1091),
+					UpdateIndex:        startUpdateIndex + 12,
+				},
+			}
+			assert.DeepEqual(t, actual, expected, cmpModel)
+		})
+	})
+}
+
 func createGrants(t *testing.T, tx WriteTxn, grants ...*models.Grant) {
 	t.Helper()
 	for _, grant := range grants {

--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -11,7 +11,6 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
-	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -143,8 +142,6 @@ func (a *API) DeleteGrant(c *gin.Context, r *api.Resource) (*api.EmptyResponse, 
 }
 
 func (a *API) UpdateGrants(c *gin.Context, r *api.UpdateGrantsRequest) (*api.EmptyResponse, error) {
-	logging.Debugf("Updating grants")
-
 	iden := access.GetRequestContext(c).Authenticated.User
 	var addGrants []*models.Grant
 	for _, g := range r.GrantsToAdd {
@@ -158,8 +155,6 @@ func (a *API) UpdateGrants(c *gin.Context, r *api.UpdateGrantsRequest) (*api.Emp
 		grant := getGrantFromGrantRequest(g)
 		rmGrants = append(rmGrants, grant)
 	}
-
-	logging.Debugf("calling access.UpdateGrants")
 
 	return nil, access.UpdateGrants(c, addGrants, rmGrants)
 }

--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -72,7 +72,7 @@ func (a *API) GetGrant(c *gin.Context, r *api.Resource) (*api.Grant, error) {
 	return grant.ToAPI(), nil
 }
 
-func (a *API) CreateGrant(c *gin.Context, r *api.CreateGrantRequest) (*api.CreateGrantResponse, error) {
+func (a *API) CreateGrant(c *gin.Context, r *api.GrantRequest) (*api.CreateGrantResponse, error) {
 	var subject uid.PolymorphicID
 
 	switch {
@@ -153,12 +153,18 @@ func (a *API) UpdateGrants(c *gin.Context, r *api.UpdateGrantsRequest) (*api.Emp
 		addGrants = append(addGrants, grant)
 	}
 
+	var rmGrants []*models.Grant
+	for _, g := range r.GrantsToRemove {
+		grant := getGrantFromGrantRequest(g)
+		rmGrants = append(rmGrants, grant)
+	}
+
 	logging.Debugf("calling access.UpdateGrants")
 
-	return nil, access.UpdateGrants(c, addGrants)
+	return nil, access.UpdateGrants(c, addGrants, rmGrants)
 }
 
-func getGrantFromGrantRequest(r api.CreateGrantRequest) *models.Grant {
+func getGrantFromGrantRequest(r api.GrantRequest) *models.Grant {
 	var subject uid.PolymorphicID
 
 	switch {

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -1250,20 +1250,21 @@ func TestAPI_UpdateGrants(t *testing.T) {
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 
-				// leftover grant from success add
-				infraAdminGrants, err := data.ListGrants(srv.DB(), data.ListGrantsOptions{
-					ByPrivileges: []string{models.InfraAdminRole},
-					ByResource:   "some-cluster",
-				})
+				grantToAdd := models.Grant{
+					Subject:   uid.NewIdentityPolymorphicID(user.ID),
+					Privilege: models.InfraAdminRole,
+					Resource:  "another-cluster",
+				}
+
+				err := data.CreateGrant(srv.DB(), &grantToAdd)
 				assert.NilError(t, err)
-				assert.Assert(t, len(infraAdminGrants) == 1)
 			},
 			body: api.UpdateGrantsRequest{
 				GrantsToRemove: []api.GrantRequest{
 					{
 						User:      user.ID,
 						Privilege: models.InfraAdminRole,
-						Resource:  "some-cluster",
+						Resource:  "another-cluster",
 					},
 				},
 			},
@@ -1272,7 +1273,7 @@ func TestAPI_UpdateGrants(t *testing.T) {
 
 				infraAdminGrants, err := data.ListGrants(srv.DB(), data.ListGrantsOptions{
 					ByPrivileges: []string{models.InfraAdminRole},
-					ByResource:   "some-cluster",
+					ByResource:   "another-cluster",
 				})
 				assert.NilError(t, err)
 				assert.Assert(t, len(infraAdminGrants) == 0)

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -1199,8 +1199,6 @@ func TestAPI_UpdateGrants(t *testing.T) {
 	err := data.CreateIdentity(srv.DB(), user)
 	assert.NilError(t, err)
 
-	//otherOrg := createOtherOrg(t, srv.db)
-
 	type testCase struct {
 		setup    func(t *testing.T, req *http.Request)
 		expected func(t *testing.T, resp *httptest.ResponseRecorder)
@@ -1230,7 +1228,7 @@ func TestAPI_UpdateGrants(t *testing.T) {
 			},
 			body: api.UpdateGrantsRequest{
 				GrantsToAdd: []api.GrantRequest{
-					api.GrantRequest{
+					{
 						User:      user.ID,
 						Privilege: models.InfraAdminRole,
 						Resource:  "some-cluster",
@@ -1262,7 +1260,7 @@ func TestAPI_UpdateGrants(t *testing.T) {
 			},
 			body: api.UpdateGrantsRequest{
 				GrantsToRemove: []api.GrantRequest{
-					api.GrantRequest{
+					{
 						User:      user.ID,
 						Privilege: models.InfraAdminRole,
 						Resource:  "some-cluster",

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -50,7 +50,7 @@ func TestAPI_ListGrants(t *testing.T) {
 	createGrant := func(t *testing.T, user uid.ID, privilege, resource string) {
 		t.Helper()
 		var buf bytes.Buffer
-		body := api.CreateGrantRequest{
+		body := api.GrantRequest{
 			User:      user,
 			Privilege: privilege,
 			Resource:  resource,
@@ -942,7 +942,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 	type testCase struct {
 		setup    func(t *testing.T, req *http.Request)
 		expected func(t *testing.T, resp *httptest.ResponseRecorder)
-		body     api.CreateGrantRequest
+		body     api.GrantRequest
 	}
 
 	run := func(t *testing.T, tc testCase) {
@@ -966,7 +966,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 			},
-			body: api.CreateGrantRequest{},
+			body: api.GrantRequest{},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusBadRequest, resp.Body.String())
 
@@ -987,7 +987,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 				req.Host = "example.com"
 				req.Header.Set("Authorization", "Bearer "+otherOrg.AdminAccessKey)
 			},
-			body: api.CreateGrantRequest{
+			body: api.GrantRequest{
 				User:      someUser.ID,
 				Privilege: models.InfraAdminRole,
 				Resource:  "some-cluster",
@@ -1000,7 +1000,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 			},
-			body: api.CreateGrantRequest{
+			body: api.GrantRequest{
 				User:      someUser.ID,
 				Privilege: models.InfraAdminRole,
 				Resource:  "some-cluster",
@@ -1032,7 +1032,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 			},
-			body: api.CreateGrantRequest{
+			body: api.GrantRequest{
 				User:      someUser.ID,
 				Privilege: models.InfraSupportAdminRole,
 				Resource:  "infra",
@@ -1045,7 +1045,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+supportAccessKeyStr)
 			},
-			body: api.CreateGrantRequest{
+			body: api.GrantRequest{
 				User:      someUser.ID,
 				Privilege: models.InfraSupportAdminRole,
 				Resource:  "infra",

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -80,6 +80,7 @@ func (s *Server) GenerateRoutes() Routes {
 	get(a, authn, "/api/grants/:id", a.GetGrant)
 	post(a, authn, "/api/grants", a.CreateGrant)
 	del(a, authn, "/api/grants/:id", a.DeleteGrant)
+	patch(a, authn, "/api/grants", a.UpdateGrants)
 
 	post(a, authn, "/api/providers", a.CreateProvider)
 	patch(a, authn, "/api/providers/:id", a.PatchProvider)

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -150,7 +150,7 @@ func TestTrimWhitespace(t *testing.T) {
 
 	userID := uid.New()
 	// nolint:noctx
-	req, err := http.NewRequest(http.MethodPost, "/api/grants", jsonBody(t, api.CreateGrantRequest{
+	req, err := http.NewRequest(http.MethodPost, "/api/grants", jsonBody(t, api.GrantRequest{
 		User:      userID,
 		Privilege: "admin   ",
 		Resource:  " kubernetes.production.*",

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -2883,6 +2883,192 @@
           "Grants"
         ]
       },
+      "patch": {
+        "description": "UpdateGrants",
+        "operationId": "UpdateGrants",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.0.0",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "grantsToAdd": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "required": [
+                            "user"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "group"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "group": {
+                          "example": "4yJ3n3D8E2",
+                          "format": "uid",
+                          "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                          "type": "string"
+                        },
+                        "privilege": {
+                          "description": "a role or permission",
+                          "example": "view",
+                          "type": "string"
+                        },
+                        "resource": {
+                          "description": "a resource name in Infra's Universal Resource Notation",
+                          "example": "production",
+                          "type": "string"
+                        },
+                        "user": {
+                          "example": "4yJ3n3D8E2",
+                          "format": "uid",
+                          "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "privilege",
+                        "resource"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "grantsToRemove": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "required": [
+                            "user"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "group"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "group": {
+                          "example": "4yJ3n3D8E2",
+                          "format": "uid",
+                          "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                          "type": "string"
+                        },
+                        "privilege": {
+                          "description": "a role or permission",
+                          "example": "view",
+                          "type": "string"
+                        },
+                        "resource": {
+                          "description": "a resource name in Infra's Universal Resource Notation",
+                          "example": "production",
+                          "type": "string"
+                        },
+                        "user": {
+                          "example": "4yJ3n3D8E2",
+                          "format": "uid",
+                          "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "privilege",
+                        "resource"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptyResponse"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "UpdateGrants",
+        "tags": [
+          "Grants"
+        ]
+      },
       "post": {
         "description": "CreateGrant",
         "operationId": "CreateGrant",

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -2897,6 +2897,17 @@
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "description": "Bearer followed by your access key",
+              "example": "Bearer ACCESSKEY",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {


### PR DESCRIPTION
## Summary

This PR adds a new `PATCH` method for the `/api/grants` endpoint. It allows API callers to simultaneously add and remove multiple grants instead of having to make multiple calls.

## Checklist

- [x] Wrote appropriate unit tests* 
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades

* some additional unit tests should be added for "un-happy" path in the server, however there are some tests in the data package.

