### PR TITLE
Extend the threshold for Destination.LastSeenAt connected

### DIFF
--- a/internal/server/models/destination.go
+++ b/internal/server/models/destination.go
@@ -24,9 +24,7 @@ type Destination struct {
 
 func (d *Destination) ToAPI() *api.Destination {
 	connected := false
-	// TODO: this should be configurable
-	// https://github.com/infrahq/infra/issues/2505
-	if time.Since(d.LastSeenAt) < 5*time.Minute {
+	if time.Since(d.LastSeenAt) < 6*time.Minute {
 		connected = true
 	}
 


### PR DESCRIPTION
Long polling timeout is 5 minutes, so we need a bit more time to keep the destination showing as connected between long polling requests.