### PR TITLE
Add endpoint-specific fields to API request log

### DIFF
--- a/internal/access/request.go
+++ b/internal/access/request.go
@@ -3,6 +3,8 @@ package access
 import (
 	"net/http"
 
+	"github.com/rs/zerolog"
+
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
@@ -20,6 +22,10 @@ type RequestContext struct {
 	// start transactions. Most routes should use DBTxn and should not use
 	// DataDB directly.
 	DataDB *data.DB
+
+	// Response is a mutable field. It can be modified by API handlers to add
+	// new response metadata.
+	Response *ResponseMetadata
 }
 
 // Authenticated stores data about the authenticated user. If the AccessKey or
@@ -28,4 +34,28 @@ type Authenticated struct {
 	AccessKey    *models.AccessKey
 	User         *models.Identity
 	Organization *models.Organization
+}
+
+// ResponseMetadata is accumulated by API endpoints and used for logging and
+// reporting.
+type ResponseMetadata struct {
+	// logFields is a slice of function that can add fields to the API
+	// request log entry.
+	logFields []func(event *zerolog.Event)
+}
+
+func (r *ResponseMetadata) AddLogFields(fn func(event *zerolog.Event)) {
+	if r == nil {
+		return
+	}
+	r.logFields = append(r.logFields, fn)
+}
+
+func (r *ResponseMetadata) ApplyLogFields(event *zerolog.Event) {
+	if r == nil {
+		return
+	}
+	for _, fn := range r.logFields {
+		fn(event)
+	}
 }

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -264,28 +264,6 @@ func initialize(db *DB) error {
 	return tx.Commit()
 }
 
-func get[T models.Modelable](tx GormTxn, selectors ...SelectorFunc) (*T, error) {
-	db := tx.GormDB()
-	for _, selector := range selectors {
-		db = selector(db)
-	}
-
-	result := new(T)
-	if isOrgMember(result) {
-		db = ByOrgID(tx.OrganizationID())(db)
-	}
-
-	if err := db.Model((*T)(nil)).First(result).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, internal.ErrNotFound
-		}
-
-		return nil, err
-	}
-
-	return result, nil
-}
-
 // setOrg checks if model is an organization member, and sets the organizationID
 // from the transaction when it is an organization member.
 func setOrg(tx ReadTxn, model any) {

--- a/internal/server/logging.go
+++ b/internal/server/logging.go
@@ -72,6 +72,7 @@ func loggingMiddleware(enableSampling bool) gin.HandlerFunc {
 		if org := rCtx.Authenticated.Organization; org != nil {
 			event = event.Str("orgID", org.ID.String())
 		}
+		rCtx.Response.ApplyLogFields(event)
 
 		event.Dur("elapsed", time.Since(begin)).
 			Int("statusCode", status).

--- a/internal/server/logging_test.go
+++ b/internal/server/logging_test.go
@@ -42,6 +42,7 @@ func TestLoggingMiddleware(t *testing.T) {
 					User:         &models.Identity{Model: models.Model{ID: 12345}},
 					Organization: &models.Organization{Model: models.Model{ID: 2323}},
 				},
+				Response: &access.ResponseMetadata{},
 			})
 		})
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -246,6 +246,7 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 			DBTxn:         tx,
 			Authenticated: authned,
 			DataDB:        a.server.db,
+			Response:      &access.ResponseMetadata{},
 		}
 		c.Set(access.RequestContextKey, rCtx)
 


### PR DESCRIPTION
## Summary

This PR introduces a hook for adding fields to the API request log. It also uses the new hook in list grants to add a `lastUpdatedIndex` and `numGrants` fields. I think we may also want to use this with SCIM endpoints, so that we can track which provider is using which fields. I'm sure we'll find other use cases for adding fields to the request log as we add new endpoints.

I think maybe we can find a better way to include these fields, but this seemed to work for now. If anyone has a suggestion for a better interface, I'd be happy to incorporate it.