### PR TITLE
maintain: automatically add grant when cluster added

### DIFF
--- a/ui/pages/destinations/add.js
+++ b/ui/pages/destinations/add.js
@@ -104,23 +104,6 @@ export default function DestinationsAdd() {
     setSubmitted(true)
   }
 
-  async function finish() {
-    // grant the person that added this cluster 'cluster-admin' access automatically
-    await fetch('/api/grants', {
-      method: 'POST',
-      body: JSON.stringify({
-        user: user.id,
-        privilege: 'cluster-admin',
-        resource: name,
-      }),
-    })
-    mutate()
-    // redirect to the root destinations page
-    router.replace({
-      pathname: '/destinations',
-    })
-  }
-
   const command = `helm repo add infrahq https://helm.infrahq.com \nhelm repo update \nhelm upgrade --install infra-connector infrahq/infra --set connector.config.server=${window.location.host} --set connector.config.name=${name} --set connector.config.accessKey=${accessKey}`
 
   if (!isAdmin) {
@@ -257,7 +240,23 @@ export default function DestinationsAdd() {
           )}
           <button
             className='inline-flex items-center rounded-md border border-transparent bg-black px-4 py-2 text-2xs font-medium text-white shadow-sm hover:cursor-pointer hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-30'
-            onClick={finish}
+            type='button'
+            onClick={async () => {
+              // grant the person that added this cluster 'cluster-admin' access automatically
+              await fetch('/api/grants', {
+                method: 'POST',
+                body: JSON.stringify({
+                  user: user.id,
+                  privilege: 'cluster-admin',
+                  resource: name,
+                }),
+              })
+              mutate()
+              // redirect to the root destinations page
+              router.replace({
+                pathname: '/destinations',
+              })
+            }}
           >
             Finish
           </button>

--- a/ui/pages/destinations/add.js
+++ b/ui/pages/destinations/add.js
@@ -256,11 +256,11 @@ export default function DestinationsAdd() {
             </div>
           )}
           <button
-              className='inline-flex items-center rounded-md border border-transparent bg-black px-4 py-2 text-2xs font-medium text-white shadow-sm hover:cursor-pointer hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-30'
-              onClick={finish}
-            >
-              Finish
-            </button>
+            className='inline-flex items-center rounded-md border border-transparent bg-black px-4 py-2 text-2xs font-medium text-white shadow-sm hover:cursor-pointer hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-30'
+            onClick={finish}
+          >
+            Finish
+          </button>
         </section>
       </div>
       <Confetti

--- a/ui/pages/destinations/add.js
+++ b/ui/pages/destinations/add.js
@@ -247,7 +247,7 @@ export default function DestinationsAdd() {
                 method: 'POST',
                 body: JSON.stringify({
                   user: user.id,
-                  privilege: 'cluster-admin',
+                  privilege: 'view',
                   resource: name,
                 }),
               })


### PR DESCRIPTION
- when an admin adds a cluster to infra through the UI automatically grant them cluster-admin access on finish

## Summary
It is confusing that someone must grant themselves access to a cluster they just added to Infra. This automatically gives a user "cluster-admin" access upon adding a cluster.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3258 
