### PR TITLE
Populate names in device flow status API response

### DIFF
--- a/internal/access/deviceflow.go
+++ b/internal/access/deviceflow.go
@@ -20,8 +20,6 @@ func FindDeviceFlowAuthRequest(ctx RequestContext, deviceCode string) (*models.D
 		return nil, err
 	}
 
-	// TODO: do these lookups in the data function when data.GetDeviceFlowAuthRequest
-	// is converted to SQL
 	if dfar.AccessKeyID > 0 {
 		dfar.AccessKey, err = data.GetAccessKey(ctx.DBTxn, data.GetAccessKeysOptions{ByID: dfar.AccessKeyID})
 		if err != nil {

--- a/internal/access/deviceflow.go
+++ b/internal/access/deviceflow.go
@@ -20,9 +20,17 @@ func FindDeviceFlowAuthRequest(ctx RequestContext, deviceCode string) (*models.D
 		return nil, err
 	}
 
-	// TODO: do this in the data function
+	// TODO: do these lookups in the data function when data.GetDeviceFlowAuthRequest
+	// is converted to SQL
 	if dfar.AccessKeyID > 0 {
 		dfar.AccessKey, err = data.GetAccessKey(ctx.DBTxn, data.GetAccessKeysOptions{ByID: dfar.AccessKeyID})
+		if err != nil {
+			return nil, err
+		}
+
+		dfar.Organization, err = data.GetOrganization(ctx.DBTxn, data.GetOrganizationOptions{
+			ByID: dfar.AccessKey.OrganizationID,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -244,7 +244,12 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 	})
 
 	t.Run("delete by name", func(t *testing.T) {
-		key := &models.AccessKey{Name: "delete me", IssuedFor: 1, ProviderID: provider.ID, ExpiresAt: time.Now().Add(5 * time.Minute)}
+		key := &models.AccessKey{
+			Name:       "delete me",
+			IssuedFor:  user.ID,
+			ProviderID: provider.ID,
+			ExpiresAt:  time.Now().Add(5 * time.Minute),
+		}
 		_, err := data.CreateAccessKey(srv.db, key)
 		assert.NilError(t, err)
 

--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -112,7 +112,7 @@ func (a *API) ApproveDeviceAdd(c *gin.Context, req *api.ApproveDeviceFlowRequest
 		return nil, internal.ErrExpired
 	}
 
-	if dfar.AccessKey != nil {
+	if dfar.AccessKeyID != 0 {
 		// already approved, do nothing
 		return nil, nil
 	}

--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -84,11 +84,11 @@ func (a *API) GetDeviceFlowStatus(c *gin.Context, req *api.DeviceFlowStatusReque
 			Status:     "confirmed",
 			DeviceCode: dfar.DeviceCode,
 			LoginResponse: &api.LoginResponse{
-				UserID:    dfar.AccessKey.IssuedFor,
-				Name:      dfar.AccessKey.IssuedForName,
-				AccessKey: string(dfar.AccessKeyToken),
-				Expires:   api.Time(dfar.AccessKey.ExpiresAt),
-				// TODO: set OrganizationName for consistency with other login methods
+				UserID:           dfar.AccessKey.IssuedFor,
+				Name:             dfar.AccessKey.IssuedForName,
+				AccessKey:        string(dfar.AccessKeyToken),
+				Expires:          api.Time(dfar.AccessKey.ExpiresAt),
+				OrganizationName: dfar.Organization.Name,
 			},
 		}, nil
 	}

--- a/internal/server/deviceflow_test.go
+++ b/internal/server/deviceflow_test.go
@@ -49,6 +49,7 @@ func TestDeviceFlow(t *testing.T) {
 	key := accessKey.Token()
 
 	doPost := func(t *testing.T, accessKey, path string, reqObj any, respObj any) *httptest.ResponseRecorder {
+		t.Helper()
 		req := httptest.NewRequest(http.MethodPost, path, jsonBody(t, reqObj))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 		if len(accessKey) > 0 {
@@ -109,6 +110,35 @@ func TestDeviceFlow(t *testing.T) {
 	newKey := statusResp.LoginResponse.AccessKey
 	assert.Assert(t, len(newKey) > 0)
 	assert.Assert(t, strings.Contains(newKey, "."))
+
+	t.Run("attempting to claim the code again should do nothing", func(t *testing.T) {
+		tx := txnForTestCase(t, srv.db, org.ID)
+		otherUser := &models.Identity{Name: "other@example.com"}
+		err = data.CreateIdentity(tx, otherUser)
+		assert.NilError(t, err)
+
+		otherKey := &models.AccessKey{
+			Name:          "Other key",
+			IssuedFor:     otherUser.ID,
+			IssuedForName: otherUser.Name,
+			ProviderID:    data.InfraProvider(tx).ID,
+			ExpiresAt:     time.Now().Add(10 * time.Minute),
+			Scopes:        models.CommaSeparatedStrings{models.ScopeAllowCreateAccessKey},
+		}
+		_, err = data.CreateAccessKey(tx, otherKey)
+		assert.NilError(t, err)
+		assert.NilError(t, tx.Commit())
+
+		doPost(t, otherKey.Token(), "http://"+org.Domain+"/api/device/approve", api.ApproveDeviceFlowRequest{
+			UserCode: dfResp.UserCode,
+		}, nil)
+
+		doPost(t, "", "http://"+org.Domain+"/api/device/status", api.DeviceFlowStatusRequest{
+			DeviceCode: dfResp.DeviceCode,
+		}, statusResp)
+
+		assert.Equal(t, statusResp.LoginResponse.UserID, user.ID)
+	})
 }
 
 func TestAPI_StartDeviceFlow(t *testing.T) {

--- a/internal/server/models/deviceflowauthrequest.go
+++ b/internal/server/models/deviceflowauthrequest.go
@@ -20,4 +20,7 @@ type DeviceFlowAuthRequest struct {
 
 	// AccessKey will be populated by some queries, but is never used on writes.
 	AccessKey *AccessKey `db:"-"`
+
+	// Organization will be populated by some queries, but is never used on writes.
+	Organization *Organization `db:"-"`
 }


### PR DESCRIPTION
## Summary

This PR adds the user name and organization name to the device flow login response, so that all the fields in the response are correctly populated.

Previously the `GetAccessKey` operation did not populate the `IssusedForName`. This PR fixes the function to populate that field.

Also adds a lookup of the organization from the `AccessKey.OrganizationID`, so that we can include the name in the response.