### PR TITLE
Add context.Context argument to api.Client methods - part 2

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -197,12 +197,11 @@ func encodeRequestBody(req any) (io.Reader, error) {
 	return bytes.NewReader(b), nil
 }
 
-func put[Req, Res any](client Client, path string, req *Req) (*Res, error) {
+func put[Res any](ctx context.Context, client Client, path string, req any) (*Res, error) {
 	body, err := encodeRequestBody(req)
 	if err != nil {
 		return nil, err
 	}
-	ctx := context.TODO()
 	httpReq, err := client.buildRequest(ctx, http.MethodPut, path, nil, body)
 	if err != nil {
 		return nil, err
@@ -210,12 +209,11 @@ func put[Req, Res any](client Client, path string, req *Req) (*Res, error) {
 	return request[Res](client, httpReq)
 }
 
-func patch[Req, Res any](client Client, path string, req *Req) (*Res, error) {
+func patch[Res any](ctx context.Context, client Client, path string, req any) (*Res, error) {
 	body, err := encodeRequestBody(req)
 	if err != nil {
 		return nil, err
 	}
-	ctx := context.TODO()
 	httpReq, err := client.buildRequest(ctx, http.MethodPatch, path, nil, body)
 	if err != nil {
 		return nil, err
@@ -252,8 +250,8 @@ func (c Client) CreateUser(req *CreateUserRequest) (*CreateUserResponse, error) 
 	return post[CreateUserRequest, CreateUserResponse](c, "/api/users", req)
 }
 
-func (c Client) UpdateUser(req *UpdateUserRequest) (*User, error) {
-	return put[UpdateUserRequest, User](c, fmt.Sprintf("/api/users/%s", req.ID.String()), req)
+func (c Client) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*User, error) {
+	return put[User](ctx, c, fmt.Sprintf("/api/users/%s", req.ID.String()), req)
 }
 
 func (c Client) DeleteUser(id uid.ID) error {
@@ -289,8 +287,8 @@ func (c Client) DeleteGroup(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/api/groups/%s", id), Query{})
 }
 
-func (c Client) UpdateUsersInGroup(req *UpdateUsersInGroupRequest) error {
-	_, err := patch[UpdateUsersInGroupRequest, EmptyResponse](c, fmt.Sprintf("/api/groups/%s/users", req.GroupID), req)
+func (c Client) UpdateUsersInGroup(ctx context.Context, req *UpdateUsersInGroupRequest) error {
+	_, err := patch[EmptyResponse](ctx, c, fmt.Sprintf("/api/groups/%s/users", req.GroupID), req)
 	return err
 }
 
@@ -327,12 +325,12 @@ func (c Client) CreateProvider(req *CreateProviderRequest) (*Provider, error) {
 	return post[CreateProviderRequest, Provider](c, "/api/providers", req)
 }
 
-func (c Client) PatchProvider(req PatchProviderRequest) (*Provider, error) {
-	return patch[PatchProviderRequest, Provider](c, fmt.Sprintf("/api/providers/%s", req.ID.String()), &req)
+func (c Client) PatchProvider(ctx context.Context, req PatchProviderRequest) (*Provider, error) {
+	return patch[Provider](ctx, c, fmt.Sprintf("/api/providers/%s", req.ID.String()), &req)
 }
 
-func (c Client) UpdateProvider(req UpdateProviderRequest) (*Provider, error) {
-	return put[UpdateProviderRequest, Provider](c, fmt.Sprintf("/api/providers/%s", req.ID.String()), &req)
+func (c Client) UpdateProvider(ctx context.Context, req UpdateProviderRequest) (*Provider, error) {
+	return put[Provider](ctx, c, fmt.Sprintf("/api/providers/%s", req.ID.String()), &req)
 }
 
 func (c Client) DeleteProvider(id uid.ID) error {
@@ -374,8 +372,8 @@ func (c Client) CreateDestination(req *CreateDestinationRequest) (*Destination, 
 	return post[CreateDestinationRequest, Destination](c, "/api/destinations", req)
 }
 
-func (c Client) UpdateDestination(req UpdateDestinationRequest) (*Destination, error) {
-	return put[UpdateDestinationRequest, Destination](c, fmt.Sprintf("/api/destinations/%s", req.ID.String()), &req)
+func (c Client) UpdateDestination(ctx context.Context, req UpdateDestinationRequest) (*Destination, error) {
+	return put[Destination](ctx, c, fmt.Sprintf("/api/destinations/%s", req.ID.String()), &req)
 }
 
 func (c Client) DeleteDestination(id uid.ID) error {
@@ -428,8 +426,8 @@ func (c Client) GetSettings(ctx context.Context) (*Settings, error) {
 	return get[Settings](ctx, c, "/api/settings", Query{})
 }
 
-func (c Client) UpdateSettings(req *Settings) (*Settings, error) {
-	return put[Settings, Settings](c, "/api/settings", req)
+func (c Client) UpdateSettings(ctx context.Context, req *Settings) (*Settings, error) {
+	return put[Settings](ctx, c, "/api/settings", req)
 }
 
 func partialText(body []byte, limit int) string {

--- a/api/client.go
+++ b/api/client.go
@@ -244,8 +244,7 @@ func (c Client) ListUsers(ctx context.Context, req ListUsersRequest) (*ListRespo
 	})
 }
 
-func (c Client) GetUser(id uid.ID) (*User, error) {
-	ctx := context.TODO()
+func (c Client) GetUser(ctx context.Context, id uid.ID) (*User, error) {
 	return get[User](ctx, c, fmt.Sprintf("/api/users/%s", id), Query{})
 }
 
@@ -278,8 +277,7 @@ func (c Client) ListGroups(ctx context.Context, req ListGroupsRequest) (*ListRes
 	})
 }
 
-func (c Client) GetGroup(id uid.ID) (*Group, error) {
-	ctx := context.TODO()
+func (c Client) GetGroup(ctx context.Context, id uid.ID) (*Group, error) {
 	return get[Group](ctx, c, fmt.Sprintf("/api/groups/%s", id), Query{})
 }
 
@@ -309,8 +307,7 @@ func (c Client) ListOrganizations(ctx context.Context, req ListOrganizationsRequ
 	})
 }
 
-func (c Client) GetOrganization(id uid.ID) (*Organization, error) {
-	ctx := context.TODO()
+func (c Client) GetOrganization(ctx context.Context, id uid.ID) (*Organization, error) {
 	return get[Organization](ctx, c, fmt.Sprintf("/api/organizations/%s", id), Query{})
 }
 
@@ -322,8 +319,7 @@ func (c Client) DeleteOrganization(id uid.ID) error {
 	return delete(c, fmt.Sprintf("/api/organizations/%s", id), Query{})
 }
 
-func (c Client) GetProvider(id uid.ID) (*Provider, error) {
-	ctx := context.TODO()
+func (c Client) GetProvider(ctx context.Context, id uid.ID) (*Provider, error) {
 	return get[Provider](ctx, c, fmt.Sprintf("/api/providers/%s", id), Query{})
 }
 
@@ -424,13 +420,11 @@ func (c Client) Signup(req *SignupRequest) (*SignupResponse, error) {
 	return post[SignupRequest, SignupResponse](c, "/api/signup", req)
 }
 
-func (c Client) GetServerVersion() (*Version, error) {
-	ctx := context.TODO()
+func (c Client) GetServerVersion(ctx context.Context) (*Version, error) {
 	return get[Version](ctx, c, "/api/version", Query{})
 }
 
-func (c Client) GetSettings() (*Settings, error) {
-	ctx := context.TODO()
+func (c Client) GetSettings(ctx context.Context) (*Settings, error) {
 	return get[Settings](ctx, c, "/api/settings", Query{})
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -173,12 +173,11 @@ func get[Res any](ctx context.Context, client Client, path string, query Query) 
 	return request[Res](client, req)
 }
 
-func post[Req, Res any](client Client, path string, req *Req) (*Res, error) {
+func post[Res any](ctx context.Context, client Client, path string, req any) (*Res, error) {
 	body, err := encodeRequestBody(req)
 	if err != nil {
 		return nil, err
 	}
-	ctx := context.TODO()
 	httpReq, err := client.buildRequest(ctx, http.MethodPost, path, nil, body)
 	if err != nil {
 		return nil, err
@@ -245,8 +244,8 @@ func (c Client) GetUser(ctx context.Context, id uid.ID) (*User, error) {
 	return get[User](ctx, c, fmt.Sprintf("/api/users/%s", id), Query{})
 }
 
-func (c Client) CreateUser(req *CreateUserRequest) (*CreateUserResponse, error) {
-	return post[CreateUserRequest, CreateUserResponse](c, "/api/users", req)
+func (c Client) CreateUser(ctx context.Context, req *CreateUserRequest) (*CreateUserResponse, error) {
+	return post[CreateUserResponse](ctx, c, "/api/users", req)
 }
 
 func (c Client) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*User, error) {
@@ -257,14 +256,12 @@ func (c Client) DeleteUser(ctx context.Context, id uid.ID) error {
 	return delete(ctx, c, fmt.Sprintf("/api/users/%s", id), Query{})
 }
 
-func (c Client) StartDeviceFlow() (*DeviceFlowResponse, error) {
-	return post[EmptyRequest, DeviceFlowResponse](c, "/api/device", nil)
+func (c Client) StartDeviceFlow(ctx context.Context) (*DeviceFlowResponse, error) {
+	return post[DeviceFlowResponse](ctx, c, "/api/device", nil)
 }
 
-func (c Client) GetDeviceFlowStatus(req *DeviceFlowStatusRequest) (*DeviceFlowStatusResponse, error) {
-	return post[DeviceFlowStatusRequest, DeviceFlowStatusResponse](c, "/api/device/status", &DeviceFlowStatusRequest{
-		DeviceCode: req.DeviceCode,
-	})
+func (c Client) GetDeviceFlowStatus(ctx context.Context, req *DeviceFlowStatusRequest) (*DeviceFlowStatusResponse, error) {
+	return post[DeviceFlowStatusResponse](ctx, c, "/api/device/status", req)
 }
 
 func (c Client) ListGroups(ctx context.Context, req ListGroupsRequest) (*ListResponse[Group], error) {
@@ -278,8 +275,8 @@ func (c Client) GetGroup(ctx context.Context, id uid.ID) (*Group, error) {
 	return get[Group](ctx, c, fmt.Sprintf("/api/groups/%s", id), Query{})
 }
 
-func (c Client) CreateGroup(req *CreateGroupRequest) (*Group, error) {
-	return post[CreateGroupRequest, Group](c, "/api/groups", req)
+func (c Client) CreateGroup(ctx context.Context, req *CreateGroupRequest) (*Group, error) {
+	return post[Group](ctx, c, "/api/groups", req)
 }
 
 func (c Client) DeleteGroup(ctx context.Context, id uid.ID) error {
@@ -308,8 +305,8 @@ func (c Client) GetOrganization(ctx context.Context, id uid.ID) (*Organization, 
 	return get[Organization](ctx, c, fmt.Sprintf("/api/organizations/%s", id), Query{})
 }
 
-func (c Client) CreateOrganization(req *CreateOrganizationRequest) (*Organization, error) {
-	return post[CreateOrganizationRequest, Organization](c, "/api/organizations", req)
+func (c Client) CreateOrganization(ctx context.Context, req *CreateOrganizationRequest) (*Organization, error) {
+	return post[Organization](ctx, c, "/api/organizations", req)
 }
 
 func (c Client) DeleteOrganization(ctx context.Context, id uid.ID) error {
@@ -320,8 +317,8 @@ func (c Client) GetProvider(ctx context.Context, id uid.ID) (*Provider, error) {
 	return get[Provider](ctx, c, fmt.Sprintf("/api/providers/%s", id), Query{})
 }
 
-func (c Client) CreateProvider(req *CreateProviderRequest) (*Provider, error) {
-	return post[CreateProviderRequest, Provider](c, "/api/providers", req)
+func (c Client) CreateProvider(ctx context.Context, req *CreateProviderRequest) (*Provider, error) {
+	return post[Provider](ctx, c, "/api/providers", req)
 }
 
 func (c Client) PatchProvider(ctx context.Context, req PatchProviderRequest) (*Provider, error) {
@@ -351,8 +348,8 @@ func (c Client) ListGrants(ctx context.Context, req ListGrantsRequest) (*ListRes
 	})
 }
 
-func (c Client) CreateGrant(req *GrantRequest) (*CreateGrantResponse, error) {
-	return post[GrantRequest, CreateGrantResponse](c, "/api/grants", req)
+func (c Client) CreateGrant(ctx context.Context, req *GrantRequest) (*CreateGrantResponse, error) {
+	return post[CreateGrantResponse](ctx, c, "/api/grants", req)
 }
 
 func (c Client) DeleteGrant(ctx context.Context, id uid.ID) error {
@@ -367,8 +364,8 @@ func (c Client) ListDestinations(ctx context.Context, req ListDestinationsReques
 	})
 }
 
-func (c Client) CreateDestination(req *CreateDestinationRequest) (*Destination, error) {
-	return post[CreateDestinationRequest, Destination](c, "/api/destinations", req)
+func (c Client) CreateDestination(ctx context.Context, req *CreateDestinationRequest) (*Destination, error) {
+	return post[Destination](ctx, c, "/api/destinations", req)
 }
 
 func (c Client) UpdateDestination(ctx context.Context, req UpdateDestinationRequest) (*Destination, error) {
@@ -388,8 +385,8 @@ func (c Client) ListAccessKeys(ctx context.Context, req ListAccessKeysRequest) (
 	})
 }
 
-func (c Client) CreateAccessKey(req *CreateAccessKeyRequest) (*CreateAccessKeyResponse, error) {
-	return post[CreateAccessKeyRequest, CreateAccessKeyResponse](c, "/api/access-keys", req)
+func (c Client) CreateAccessKey(ctx context.Context, req *CreateAccessKeyRequest) (*CreateAccessKeyResponse, error) {
+	return post[CreateAccessKeyResponse](ctx, c, "/api/access-keys", req)
 }
 
 func (c Client) DeleteAccessKey(ctx context.Context, id uid.ID) error {
@@ -400,21 +397,21 @@ func (c Client) DeleteAccessKeyByName(ctx context.Context, name string) error {
 	return delete(ctx, c, "/api/access-keys", Query{"name": []string{name}})
 }
 
-func (c Client) CreateToken() (*CreateTokenResponse, error) {
-	return post[EmptyRequest, CreateTokenResponse](c, "/api/tokens", &EmptyRequest{})
+func (c Client) CreateToken(ctx context.Context) (*CreateTokenResponse, error) {
+	return post[CreateTokenResponse](ctx, c, "/api/tokens", &EmptyRequest{})
 }
 
-func (c Client) Login(req *LoginRequest) (*LoginResponse, error) {
-	return post[LoginRequest, LoginResponse](c, "/api/login", req)
+func (c Client) Login(ctx context.Context, req *LoginRequest) (*LoginResponse, error) {
+	return post[LoginResponse](ctx, c, "/api/login", req)
 }
 
-func (c Client) Logout() error {
-	_, err := post[EmptyRequest, EmptyResponse](c, "/api/logout", &EmptyRequest{})
+func (c Client) Logout(ctx context.Context) error {
+	_, err := post[EmptyResponse](ctx, c, "/api/logout", &EmptyRequest{})
 	return err
 }
 
-func (c Client) Signup(req *SignupRequest) (*SignupResponse, error) {
-	return post[SignupRequest, SignupResponse](c, "/api/signup", req)
+func (c Client) Signup(ctx context.Context, req *SignupRequest) (*SignupResponse, error) {
+	return post[SignupResponse](ctx, c, "/api/signup", req)
 }
 
 func (c Client) GetServerVersion(ctx context.Context) (*Version, error) {

--- a/api/client.go
+++ b/api/client.go
@@ -221,8 +221,7 @@ func patch[Res any](ctx context.Context, client Client, path string, req any) (*
 	return request[Res](client, httpReq)
 }
 
-func delete(client Client, path string, query Query) error {
-	ctx := context.TODO()
+func delete(ctx context.Context, client Client, path string, query Query) error {
 	httpReq, err := client.buildRequest(ctx, http.MethodDelete, path, query, nil)
 	if err != nil {
 		return err
@@ -254,8 +253,8 @@ func (c Client) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*User, 
 	return put[User](ctx, c, fmt.Sprintf("/api/users/%s", req.ID.String()), req)
 }
 
-func (c Client) DeleteUser(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/api/users/%s", id), Query{})
+func (c Client) DeleteUser(ctx context.Context, id uid.ID) error {
+	return delete(ctx, c, fmt.Sprintf("/api/users/%s", id), Query{})
 }
 
 func (c Client) StartDeviceFlow() (*DeviceFlowResponse, error) {
@@ -283,8 +282,8 @@ func (c Client) CreateGroup(req *CreateGroupRequest) (*Group, error) {
 	return post[CreateGroupRequest, Group](c, "/api/groups", req)
 }
 
-func (c Client) DeleteGroup(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/api/groups/%s", id), Query{})
+func (c Client) DeleteGroup(ctx context.Context, id uid.ID) error {
+	return delete(ctx, c, fmt.Sprintf("/api/groups/%s", id), Query{})
 }
 
 func (c Client) UpdateUsersInGroup(ctx context.Context, req *UpdateUsersInGroupRequest) error {
@@ -313,8 +312,8 @@ func (c Client) CreateOrganization(req *CreateOrganizationRequest) (*Organizatio
 	return post[CreateOrganizationRequest, Organization](c, "/api/organizations", req)
 }
 
-func (c Client) DeleteOrganization(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/api/organizations/%s", id), Query{})
+func (c Client) DeleteOrganization(ctx context.Context, id uid.ID) error {
+	return delete(ctx, c, fmt.Sprintf("/api/organizations/%s", id), Query{})
 }
 
 func (c Client) GetProvider(ctx context.Context, id uid.ID) (*Provider, error) {
@@ -333,8 +332,8 @@ func (c Client) UpdateProvider(ctx context.Context, req UpdateProviderRequest) (
 	return put[Provider](ctx, c, fmt.Sprintf("/api/providers/%s", req.ID.String()), &req)
 }
 
-func (c Client) DeleteProvider(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/api/providers/%s", id), Query{})
+func (c Client) DeleteProvider(ctx context.Context, id uid.ID) error {
+	return delete(ctx, c, fmt.Sprintf("/api/providers/%s", id), Query{})
 }
 
 func (c Client) ListGrants(ctx context.Context, req ListGrantsRequest) (*ListResponse[Grant], error) {
@@ -356,8 +355,8 @@ func (c Client) CreateGrant(req *GrantRequest) (*CreateGrantResponse, error) {
 	return post[GrantRequest, CreateGrantResponse](c, "/api/grants", req)
 }
 
-func (c Client) DeleteGrant(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/api/grants/%s", id), Query{})
+func (c Client) DeleteGrant(ctx context.Context, id uid.ID) error {
+	return delete(ctx, c, fmt.Sprintf("/api/grants/%s", id), Query{})
 }
 
 func (c Client) ListDestinations(ctx context.Context, req ListDestinationsRequest) (*ListResponse[Destination], error) {
@@ -376,8 +375,8 @@ func (c Client) UpdateDestination(ctx context.Context, req UpdateDestinationRequ
 	return put[Destination](ctx, c, fmt.Sprintf("/api/destinations/%s", req.ID.String()), &req)
 }
 
-func (c Client) DeleteDestination(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/api/destinations/%s", id), Query{})
+func (c Client) DeleteDestination(ctx context.Context, id uid.ID) error {
+	return delete(ctx, c, fmt.Sprintf("/api/destinations/%s", id), Query{})
 }
 
 func (c Client) ListAccessKeys(ctx context.Context, req ListAccessKeysRequest) (*ListResponse[AccessKey], error) {
@@ -393,12 +392,12 @@ func (c Client) CreateAccessKey(req *CreateAccessKeyRequest) (*CreateAccessKeyRe
 	return post[CreateAccessKeyRequest, CreateAccessKeyResponse](c, "/api/access-keys", req)
 }
 
-func (c Client) DeleteAccessKey(id uid.ID) error {
-	return delete(c, fmt.Sprintf("/api/access-keys/%s", id), Query{})
+func (c Client) DeleteAccessKey(ctx context.Context, id uid.ID) error {
+	return delete(ctx, c, fmt.Sprintf("/api/access-keys/%s", id), Query{})
 }
 
-func (c Client) DeleteAccessKeyByName(name string) error {
-	return delete(c, "/api/access-keys", Query{"name": []string{name}})
+func (c Client) DeleteAccessKeyByName(ctx context.Context, name string) error {
+	return delete(ctx, c, "/api/access-keys", Query{"name": []string{name}})
 }
 
 func (c Client) CreateToken() (*CreateTokenResponse, error) {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -128,6 +128,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	ctx := context.Background()
 	ch := make(chan *http.Request, 1)
 	handler := func(rw http.ResponseWriter, r *http.Request) {
 		ch <- r
@@ -153,7 +154,7 @@ func TestDelete(t *testing.T) {
 	}
 
 	t.Run("headers", func(t *testing.T) {
-		err := delete(c, "/good", Query{})
+		err := delete(ctx, c, "/good", Query{})
 		assert.NilError(t, err)
 
 		r := <-ch

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -151,7 +151,7 @@ func newDestinationsRemoveCmd(cli *CLI) *cobra.Command {
 			logging.Debugf("deleting %d destinations named %q...", destinations.Count, name)
 			for _, d := range destinations.Items {
 				logging.Debugf("...call server: delete destination %s", d.ID)
-				err := client.DeleteDestination(d.ID)
+				err := client.DeleteDestination(ctx, d.ID)
 				if err != nil {
 					if api.ErrorStatusCode(err) == 403 {
 						logging.Debugf("%s", err.Error())

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -378,7 +378,7 @@ func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 	}
 
 	if userID == 0 && cmdOptions.UserName != "" {
-		user, err := createUser(client, cmdOptions.UserName)
+		user, err := createUser(ctx, client, cmdOptions.UserName)
 		if err != nil {
 			if api.ErrorStatusCode(err) == 403 {
 				logging.Debugf("%s", err.Error())
@@ -393,9 +393,8 @@ func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 		userID = user.ID
 
 	} else if groupID == 0 && cmdOptions.GroupName != "" {
-		group, err := createGroup(client, cmdOptions.GroupName)
+		group, err := client.CreateGroup(ctx, &api.CreateGroupRequest{Name: cmdOptions.GroupName})
 		if err != nil {
-
 			if api.ErrorStatusCode(err) == 403 {
 				logging.Debugf("%s", err.Error())
 				return Error{
@@ -422,7 +421,7 @@ func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 		Resource:  cmdOptions.Resource,
 	}
 	logging.Debugf("call server: create grant %#v", createGrantReq)
-	response, err := client.CreateGrant(createGrantReq)
+	response, err := client.CreateGrant(ctx, createGrantReq)
 	if err != nil {
 		if api.ErrorStatusCode(err) == 403 {
 			logging.Debugf("%s", err.Error())

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -292,7 +292,7 @@ func removeGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 
 	for _, g := range grants.Items {
 		logging.Debugf("call server: delete grant %s", g.ID)
-		err := client.DeleteGrant(g.ID)
+		err := client.DeleteGrant(ctx, g.ID)
 		if err != nil {
 			if api.ErrorStatusCode(err) == 403 {
 				logging.Debugf("%s", err.Error())

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -202,7 +202,7 @@ $ infra groups remove Engineering`,
 			}
 
 			for _, group := range groups.Items {
-				if err := client.DeleteGroup(group.ID); err != nil {
+				if err := client.DeleteGroup(ctx, group.ID); err != nil {
 					return err
 				}
 

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -229,6 +229,8 @@ $ infra groups adduser johndoe@example.com Engineering
 			userName := args[0]
 			groupName := args[1]
 
+			ctx := context.Background()
+
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err
@@ -254,7 +256,7 @@ $ infra groups adduser johndoe@example.com Engineering
 				GroupID:      group.ID,
 				UserIDsToAdd: []uid.ID{user.ID},
 			}
-			err = client.UpdateUsersInGroup(req)
+			err = client.UpdateUsersInGroup(ctx, req)
 			if err != nil {
 				return err
 			}
@@ -279,6 +281,8 @@ $ infra groups removeuser johndoe@example.com Engineering
 		RunE: func(cmd *cobra.Command, args []string) error {
 			userName := args[0]
 			groupName := args[1]
+
+			ctx := context.Background()
 
 			client, err := defaultAPIClient()
 			if err != nil {
@@ -311,7 +315,7 @@ $ infra groups removeuser johndoe@example.com Engineering
 				GroupID:         group.ID,
 				UserIDsToRemove: []uid.ID{user.ID},
 			}
-			err = client.UpdateUsersInGroup(req)
+			err = client.UpdateUsersInGroup(ctx, req)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -39,16 +39,6 @@ func getGroupByNameOrID(client *api.Client, name string) (*api.Group, error) {
 	return &groups.Items[0], nil
 }
 
-// createGroup creates a group with the requested name
-func createGroup(client *api.Client, name string) (*api.Group, error) {
-	group, err := client.CreateGroup(&api.CreateGroupRequest{Name: name})
-	if err != nil {
-		return nil, err
-	}
-
-	return group, nil
-}
-
 func newGroupsCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "groups",
@@ -156,12 +146,13 @@ func newGroupsAddCmd(cli *CLI) *cobra.Command {
 		Example: `# Create a group
 $ infra groups add Engineering`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err
 			}
 
-			_, err = client.CreateGroup(&api.CreateGroupRequest{Name: args[0]})
+			_, err = client.CreateGroup(ctx, &api.CreateGroupRequest{Name: args[0]})
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -13,15 +13,17 @@ import (
 )
 
 func getGroupByNameOrID(client *api.Client, name string) (*api.Group, error) {
+	ctx := context.TODO()
+
 	req := api.ListGroupsRequest{Name: name}
-	groups, err := client.ListGroups(context.TODO(), req)
+	groups, err := client.ListGroups(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if groups.Count == 0 {
 		if id, err := uid.Parse([]byte(name)); err == nil {
-			g, err := client.GetGroup(id)
+			g, err := client.GetGroup(ctx, id)
 			if err == nil {
 				return g, nil
 			}

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -39,7 +39,7 @@ func info(cli *CLI) error {
 
 	ctx := context.Background()
 
-	user, err := client.GetUser(config.UserID)
+	user, err := client.GetUser(ctx, config.UserID)
 	if err != nil {
 		if api.ErrorStatusCode(err) == 401 {
 			return Error{Message: "Session is not valid for this server; run 'infra login' to start a new session"}
@@ -60,7 +60,7 @@ func info(cli *CLI) error {
 	fmt.Fprintf(w, "User:\t %s (%s)\n", user.Name, user.ID)
 
 	if config.ProviderID != 0 {
-		provider, err := client.GetProvider(config.ProviderID)
+		provider, err := client.GetProvider(ctx, config.ProviderID)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -58,6 +58,7 @@ $ infra keys add connector
 `,
 		Args: ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
 			userName := args[0]
 
 			if options.Name != "" {
@@ -94,7 +95,7 @@ $ infra keys add connector
 			}
 
 			logging.Debugf("call server: create access key named %q", options.Name)
-			resp, err := client.CreateAccessKey(&api.CreateAccessKeyRequest{
+			resp, err := client.CreateAccessKey(ctx, &api.CreateAccessKeyRequest{
 				UserID:            userID,
 				Name:              options.Name,
 				TTL:               api.Duration(options.TTL),

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -143,12 +143,13 @@ func newKeysRemoveCmd(cli *CLI) *cobra.Command {
 		Short:   "Delete an access key",
 		Args:    ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err
 			}
 
-			err = client.DeleteAccessKeyByName(args[0])
+			err = client.DeleteAccessKeyByName(ctx, args[0])
 			if err != nil {
 				if api.ErrorStatusCode(err) == 403 {
 					logging.Debugf("%s", err.Error())

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -64,7 +64,7 @@ func updateKubeConfig(client *api.Client, id uid.ID) error {
 		return err
 	}
 
-	user, err := client.GetUser(id)
+	user, err := client.GetUser(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -126,7 +126,7 @@ func getUserDestinationGrants(client *api.Client) (*api.User, []api.Destination,
 		return nil, nil, nil, fmt.Errorf("no active identity")
 	}
 
-	user, err := client.GetUser(config.UserID)
+	user, err := client.GetUser(ctx, config.UserID)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -46,7 +46,7 @@ func TestListCmd(t *testing.T) {
 	httpTransport := httpTransportForHostConfig(&ClientHostConfig{SkipTLSVerify: true})
 	c := apiClient(srv.Addrs.HTTPS.String(), "0000000001.adminadminadminadmin1234", httpTransport)
 
-	_, err = c.CreateDestination(&api.CreateDestinationRequest{
+	_, err = c.CreateDestination(ctx, &api.CreateDestinationRequest{
 		UniqueID: "space",
 		Name:     "space",
 		Connection: api.DestinationConnection{
@@ -56,7 +56,7 @@ func TestListCmd(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	_, err = c.CreateDestination(&api.CreateDestinationRequest{
+	_, err = c.CreateDestination(ctx, &api.CreateDestinationRequest{
 		UniqueID: "moon",
 		Name:     "moon",
 		Connection: api.DestinationConnection{
@@ -66,7 +66,7 @@ func TestListCmd(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	_, err = c.CreateDestination(&api.CreateDestinationRequest{
+	_, err = c.CreateDestination(ctx, &api.CreateDestinationRequest{
 		UniqueID: "maintain",
 		Name:     "infra-this-is-not",
 		Connection: api.DestinationConnection{

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -99,6 +99,7 @@ $ infra login`,
 }
 
 func login(cli *CLI, options loginCmdOptions) error {
+	ctx := context.Background()
 	config, err := readConfig()
 	if err != nil {
 		return err
@@ -181,7 +182,7 @@ func login(cli *CLI, options loginCmdOptions) error {
 				return err
 			}
 		case deviceLogin:
-			resp, err := deviceFlowLogin(lc.APIClient, cli)
+			resp, err := deviceFlowLogin(ctx, lc.APIClient, cli)
 			if err != nil {
 				return err
 			}
@@ -208,7 +209,7 @@ func equalHosts(x, y string) bool {
 
 func loginToInfra(cli *CLI, lc loginClient, loginReq *api.LoginRequest, noAgent bool) error {
 	ctx := context.TODO()
-	loginRes, err := lc.APIClient.Login(loginReq)
+	loginRes, err := lc.APIClient.Login(ctx, loginReq)
 	if err != nil {
 		if api.ErrorStatusCode(err) == http.StatusUnauthorized || api.ErrorStatusCode(err) == http.StatusNotFound {
 			switch {
@@ -505,8 +506,8 @@ func attemptTLSRequest(options loginCmdOptions) error {
 
 const spinChars = `\|/-`
 
-func deviceFlowLogin(client *api.Client, cli *CLI) (*api.LoginResponse, error) {
-	resp, err := client.StartDeviceFlow()
+func deviceFlowLogin(ctx context.Context, client *api.Client, cli *CLI) (*api.LoginResponse, error) {
+	resp, err := client.StartDeviceFlow(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +539,7 @@ func deviceFlowLogin(client *api.Client, cli *CLI) (*api.LoginResponse, error) {
 			return nil, api.ErrDeviceLoginTimeout
 		case <-poll.C:
 			// check to see if user is authed yet
-			pollResp, err := client.GetDeviceFlowStatus(&api.DeviceFlowStatusRequest{DeviceCode: resp.DeviceCode})
+			pollResp, err := client.GetDeviceFlowStatus(ctx, &api.DeviceFlowStatusRequest{DeviceCode: resp.DeviceCode})
 			if err != nil {
 				return nil, err
 			}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -207,6 +207,7 @@ func equalHosts(x, y string) bool {
 }
 
 func loginToInfra(cli *CLI, lc loginClient, loginReq *api.LoginRequest, noAgent bool) error {
+	ctx := context.TODO()
 	loginRes, err := lc.APIClient.Login(loginReq)
 	if err != nil {
 		if api.ErrorStatusCode(err) == http.StatusUnauthorized || api.ErrorStatusCode(err) == http.StatusNotFound {
@@ -235,7 +236,7 @@ func loginToInfra(cli *CLI, lc loginClient, loginReq *api.LoginRequest, noAgent 
 		}
 
 		logging.Debugf("call server: update user %s", loginRes.UserID)
-		if _, err := lc.APIClient.UpdateUser(&api.UpdateUserRequest{ID: loginRes.UserID, Password: password}); err != nil {
+		if _, err := lc.APIClient.UpdateUser(ctx, &api.UpdateUserRequest{ID: loginRes.UserID, Password: password}); err != nil {
 			if passwordError(cli, err) {
 				goto PROMPTLOGIN
 			}

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -63,6 +64,7 @@ $ infra logout --all --clear`,
 }
 
 func logoutOfServer(hostConfig *ClientHostConfig) (success bool) {
+	ctx := context.TODO()
 	client := apiClient(hostConfig.Host, hostConfig.AccessKey, httpTransportForHostConfig(hostConfig))
 
 	defer func() {
@@ -73,7 +75,7 @@ func logoutOfServer(hostConfig *ClientHostConfig) (success bool) {
 	}()
 
 	if hostConfig.isLoggedIn() {
-		err := client.Logout()
+		err := client.Logout(ctx)
 		switch {
 		case api.ErrorStatusCode(err) == http.StatusUnauthorized:
 			logging.Debugf("err: %s", err)

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -354,7 +354,7 @@ func updateProvider(cli *CLI, name string, opts providerEditOptions) error {
 		}
 
 		logging.Debugf("call server: update provider named %q", name)
-		_, err = client.UpdateProvider(api.UpdateProviderRequest{
+		_, err = client.UpdateProvider(ctx, api.UpdateProviderRequest{
 			ID:           provider.ID,
 			Name:         name,
 			URL:          provider.URL,

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -220,6 +220,7 @@ $ infra providers add okta --url example.okta.com --client-id 0oa3sz06o6do0muoW5
 $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0muoW5d7 --client-secret VT_oXtkEDaT7UFY-C3DSRWYb00qyKZ1K1VCq7YzN --service-account-key ~/client-123.json --workspace-domain-admin admin@example.com --kind google`,
 		Args: ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
 			if err := cliopts.DefaultsFromEnv("INFRA_PROVIDER", cmd.Flags()); err != nil {
 				return err
 			}
@@ -239,7 +240,7 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 			}
 
 			logging.Debugf("call server: create provider named %q", args[0])
-			provider, err := client.CreateProvider(&api.CreateProviderRequest{
+			provider, err := client.CreateProvider(ctx, &api.CreateProviderRequest{
 				Name:         args[0],
 				URL:          opts.URL,
 				ClientID:     opts.ClientID,
@@ -264,7 +265,7 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 			cli.Output("Connected provider %q (%s) to infra", args[0], opts.URL)
 
 			if opts.SCIM {
-				key, err := client.CreateAccessKey(&api.CreateAccessKeyRequest{
+				key, err := client.CreateAccessKey(ctx, &api.CreateAccessKeyRequest{
 					UserID:            provider.ID,
 					Name:              fmt.Sprintf("%s-SCIM", args[0]),
 					TTL:               api.Duration(time.Hour * 87600), // 10 years
@@ -329,7 +330,7 @@ func updateProvider(cli *CLI, name string, opts providerEditOptions) error {
 			// ignore error and proceed, key may not exist
 			err = nil
 		}
-		key, err := client.CreateAccessKey(&api.CreateAccessKeyRequest{
+		key, err := client.CreateAccessKey(ctx, &api.CreateAccessKeyRequest{
 			UserID:            provider.ID,
 			Name:              keyName,
 			TTL:               api.Duration(time.Hour * 87600), // 10 years

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -318,7 +318,7 @@ func updateProvider(cli *CLI, name string, opts providerEditOptions) error {
 	if opts.SCIM {
 		// revoke the previous SCIM access key for this provider, if it exists
 		keyName := fmt.Sprintf("%s-SCIM", provider.Name)
-		err = client.DeleteAccessKeyByName(keyName)
+		err = client.DeleteAccessKeyByName(ctx, keyName)
 		if err != nil {
 			logging.Debugf("%s", err.Error())
 			if api.ErrorStatusCode(err) == 403 {
@@ -412,7 +412,7 @@ func newProvidersRemoveCmd(cli *CLI) *cobra.Command {
 			logging.Debugf("deleting %d providers named %q...", providers.Count, args[0])
 			for _, provider := range providers.Items {
 				logging.Debugf("...call server: delete provider %s", provider.ID)
-				if err := client.DeleteProvider(provider.ID); err != nil {
+				if err := client.DeleteProvider(ctx, provider.ID); err != nil {
 					if api.ErrorStatusCode(err) == 403 {
 						logging.Debugf("%s", err.Error())
 						return Error{

--- a/internal/cmd/tokens.go
+++ b/internal/cmd/tokens.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -39,12 +40,13 @@ func newTokensAddCmd(cli *CLI) *cobra.Command {
 }
 
 func tokensCreate(cli *CLI) error {
+	ctx := context.Background()
 	client, err := defaultAPIClient()
 	if err != nil {
 		return err
 	}
 
-	token, err := client.CreateToken()
+	token, err := client.CreateToken(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -369,7 +369,7 @@ func getUserByNameOrID(client *api.Client, name string) (*api.User, error) {
 
 	if users.Count == 0 {
 		if id, err := uid.Parse([]byte(name)); err == nil {
-			if u, err := client.GetUser(id); err == nil {
+			if u, err := client.GetUser(ctx, id); err == nil {
 				return u, nil
 			}
 		}

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -236,7 +236,7 @@ $ infra users remove janedoe@example.com`,
 			logging.Debugf("deleting %d users named %q...", users.Count, name)
 			for _, user := range users.Items {
 				logging.Debugf("...call server: delete user %s", user.ID)
-				if err := client.DeleteUser(user.ID); err != nil {
+				if err := client.DeleteUser(ctx, user.ID); err != nil {
 					if api.ErrorStatusCode(err) == 403 {
 						logging.Debugf("%s", err.Error())
 						return Error{

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -59,12 +59,14 @@ $ infra users add johndoe@example.com`,
 				return fmt.Errorf("username must be a valid email")
 			}
 
+			ctx := context.Background()
+
 			client, err := defaultAPIClient()
 			if err != nil {
 				return err
 			}
 
-			createResp, err := createUser(client, args[0])
+			createResp, err := createUser(ctx, client, args[0])
 			if err != nil {
 				if api.ErrorStatusCode(err) == 403 {
 					logging.Debugf("%s", err.Error())
@@ -258,22 +260,6 @@ $ infra users remove janedoe@example.com`,
 	return cmd
 }
 
-// CreateUser creates an user within Infra
-func CreateUser(req *api.CreateUserRequest) (*api.CreateUserResponse, error) {
-	client, err := defaultAPIClient()
-	if err != nil {
-		return nil, err
-	}
-
-	logging.Debugf("call server: create users named %q", req.Name)
-	resp, err := client.CreateUser(req)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
-}
-
 func updateUser(cli *CLI, name string) error {
 	ctx := context.Background()
 
@@ -449,14 +435,9 @@ func isUserSelf(name string) (bool, error) {
 }
 
 // createUser creates a user with the requested name
-func createUser(client *api.Client, name string) (*api.CreateUserResponse, error) {
+func createUser(ctx context.Context, client *api.Client, name string) (*api.CreateUserResponse, error) {
 	logging.Debugf("call server: create user named %q", name)
-	user, err := client.CreateUser(&api.CreateUserRequest{Name: name})
-	if err != nil {
-		return nil, err
-	}
-
-	return user, nil
+	return client.CreateUser(ctx, &api.CreateUserRequest{Name: name})
 }
 
 // check if the user has permissions to reset passwords for another user.

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -275,6 +275,8 @@ func CreateUser(req *api.CreateUserRequest) (*api.CreateUserResponse, error) {
 }
 
 func updateUser(cli *CLI, name string) error {
+	ctx := context.Background()
+
 	client, err := defaultAPIClient()
 	if err != nil {
 		return err
@@ -302,7 +304,7 @@ func updateUser(cli *CLI, name string) error {
 		}
 
 		logging.Debugf("call server: update user %s", req.ID)
-		if _, err := client.UpdateUser(req); err != nil {
+		if _, err := client.UpdateUser(ctx, req); err != nil {
 			if passwordError(cli, err) {
 				goto PROMPT
 			}
@@ -341,7 +343,7 @@ func updateUser(cli *CLI, name string) error {
 		return err
 	}
 
-	if _, err := client.UpdateUser(&api.UpdateUserRequest{
+	if _, err := client.UpdateUser(ctx, &api.UpdateUserRequest{
 		ID:       user.ID,
 		Password: tmpPassword,
 	}); err != nil {

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"text/tabwriter"
@@ -24,6 +25,8 @@ func newVersionCmd(cli *CLI) *cobra.Command {
 }
 
 func version(cli *CLI) error {
+	ctx := context.Background()
+
 	w := tabwriter.NewWriter(cli.Stdout, 0, 0, 1, ' ', tabwriter.AlignRight)
 	defer w.Flush()
 
@@ -51,7 +54,7 @@ func version(cli *CLI) error {
 		return nil
 	}
 
-	version, err := client.GetServerVersion()
+	version, err := client.GetServerVersion(ctx)
 	if err != nil {
 		fmt.Fprintln(w, "Server:\t", "disconnected")
 		logging.Debugf("%s", err.Error())

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -90,7 +90,7 @@ type connector struct {
 type apiClient interface {
 	ListGrants(ctx context.Context, req api.ListGrantsRequest) (*api.ListResponse[api.Grant], error)
 	ListDestinations(ctx context.Context, req api.ListDestinationsRequest) (*api.ListResponse[api.Destination], error)
-	CreateDestination(req *api.CreateDestinationRequest) (*api.Destination, error)
+	CreateDestination(ctx context.Context, req *api.CreateDestinationRequest) (*api.Destination, error)
 	UpdateDestination(ctx context.Context, req api.UpdateDestinationRequest) (*api.Destination, error)
 
 	// GetGroup and GetUser are used to retrieve the name of the group or user.
@@ -584,7 +584,7 @@ func createOrUpdateDestination(ctx context.Context, client apiClient, local *api
 		Roles:      local.Roles,
 	}
 
-	destination, err := client.CreateDestination(request)
+	destination, err := client.CreateDestination(ctx, request)
 	if err != nil {
 		return fmt.Errorf("error creating destination: %w", err)
 	}

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -371,11 +371,11 @@ func (f *fakeAPIClient) ListGrants(ctx context.Context, req api.ListGrantsReques
 	return f.listGrantsResult, f.listGrantsError
 }
 
-func (f *fakeAPIClient) GetGroup(id uid.ID) (*api.Group, error) {
+func (f *fakeAPIClient) GetGroup(ctx context.Context, id uid.ID) (*api.Group, error) {
 	return &api.Group{Name: "the-group"}, nil
 }
 
-func (f *fakeAPIClient) GetUser(id uid.ID) (*api.User, error) {
+func (f *fakeAPIClient) GetUser(ctx context.Context, id uid.ID) (*api.User, error) {
 	return &api.User{Name: "theuser@example.com"}, nil
 }
 


### PR DESCRIPTION
## Summary

Branched from #3492

This PR adds the `ctx context.Context` argument to the remaining `get` methods, and all the `put`, `patch`, `post`, and `delete` methods.

This PR also removes the generic `Req any` type parameter to `put`, `post`, and `patch`. We're passing that value to json marshal, which accepts `any`, so we don't need the type parameter.