### PR TITLE
fixes auth header around open api docs

### DIFF
--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1179,7 +1179,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -1280,7 +1280,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -1417,7 +1417,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -1553,7 +1553,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -1660,7 +1660,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -1787,7 +1787,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -1938,7 +1938,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -2043,7 +2043,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -2148,7 +2148,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -2395,7 +2395,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -2714,7 +2714,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -2905,7 +2905,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -3050,7 +3050,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3155,7 +3155,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3262,7 +3262,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3392,7 +3392,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -3505,7 +3505,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3610,7 +3610,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3717,7 +3717,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -4007,7 +4007,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -4103,7 +4103,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -4223,7 +4223,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -4343,7 +4343,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -4448,7 +4448,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -4879,7 +4879,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -5037,7 +5037,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -5132,17 +5132,6 @@
               "description": "Version of the API being requested",
               "example": "99.99.99999",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "schema": {
-              "description": "Bearer followed by your access key",
-              "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
               "type": "string"
             }
           },
@@ -5247,7 +5236,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -5371,7 +5360,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -5709,7 +5698,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -5968,7 +5957,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -6064,7 +6053,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -6216,7 +6205,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -6330,7 +6319,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -6435,7 +6424,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -6541,7 +6530,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -179,12 +179,12 @@ func add[Req, Res any](a *API, group *routeGroup, method, urlPath string, route 
 		path:   path.Join(group.BasePath(), urlPath),
 	}
 
+	route.authenticationOptional = group.noAuthentication
+	route.organizationOptional = group.noOrgRequired
+
 	if !route.omitFromDocs {
 		a.register(openAPIRouteDefinition(routeID, route))
 	}
-
-	route.authenticationOptional = group.noAuthentication
-	route.organizationOptional = group.noOrgRequired
 
 	handler := func(c *gin.Context) {
 		if err := wrapRoute(a, routeID, route)(c); err != nil {

--- a/internal/server/testdata/openapi3.json
+++ b/internal/server/testdata/openapi3.json
@@ -1179,7 +1179,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -1280,7 +1280,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -1417,7 +1417,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -1553,7 +1553,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -1660,7 +1660,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -1787,7 +1787,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -1938,7 +1938,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -2043,7 +2043,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -2148,7 +2148,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -2395,7 +2395,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -2714,7 +2714,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -2905,7 +2905,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -3050,7 +3050,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3155,7 +3155,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3262,7 +3262,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3392,7 +3392,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -3505,7 +3505,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3610,7 +3610,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -3717,7 +3717,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -4007,7 +4007,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -4103,7 +4103,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -4223,7 +4223,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -4343,7 +4343,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -4448,7 +4448,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -4879,7 +4879,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -5037,7 +5037,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -5132,17 +5132,6 @@
               "description": "Version of the API being requested",
               "example": "0.0.0",
               "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
-              "type": "string"
-            }
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "schema": {
-              "description": "Bearer followed by your access key",
-              "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
               "type": "string"
             }
           },
@@ -5247,7 +5236,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -5371,7 +5360,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -5709,7 +5698,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -5968,7 +5957,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -6064,7 +6053,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -6216,7 +6205,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           }
@@ -6330,7 +6319,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -6435,7 +6424,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },
@@ -6541,7 +6530,7 @@
             "schema": {
               "description": "Bearer followed by your access key",
               "example": "Bearer ACCESSKEY",
-              "format": "Bearer\\s[\\d|a-z]{10}.[\\d|a-z]{24}",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
               "type": "string"
             }
           },


### PR DESCRIPTION
## Summary

Auth header in openapi docs was a manual list that needed to be edited. this updates it so that it's detected and generated automatically, so impossible to screw up.
also fixed:
- regex for auth tokens
- this resolved a bug with one endpoint saying it needed auth which it did not.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #
