### PR TITLE
maintain: convert get and list groups to direct sql queries

### DIFF
--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -136,7 +136,12 @@ func logError(fn func() error, msg string) {
 }
 
 func userInGroup(db data.GormTxn, authnUserID uid.ID, groupID uid.ID) bool {
-	groups, err := data.ListGroups(db, &data.Pagination{Limit: 1}, data.ByGroupMember(authnUserID), data.ByID(groupID))
+	opts := data.ListGroupOptions{
+		Pagination: &data.Pagination{Limit: 1},
+		ByMemberID: authnUserID,
+		ByIDs:      []uid.ID{groupID},
+	}
+	groups, err := data.ListGroups(db, opts)
 	if err != nil {
 		return false
 	}

--- a/internal/access/group.go
+++ b/internal/access/group.go
@@ -66,7 +66,7 @@ func GetGroup(c *gin.Context, id uid.ID) (*models.Group, error) {
 	} else if err != nil {
 		return nil, err
 	}
-	return data.GetGroup(rCtx.DBTxn, data.ByID(id))
+	return data.GetGroup(rCtx.DBTxn, data.GetGroupOptions{ByID: id})
 }
 
 func DeleteGroup(c *gin.Context, id uid.ID) error {
@@ -114,7 +114,7 @@ func UpdateUsersInGroup(c *gin.Context, groupID uid.ID, uidsToAdd []uid.ID, uids
 		return err
 	}
 
-	_, err = data.GetGroup(db, data.ByID(groupID))
+	_, err = data.GetGroup(db, data.GetGroupOptions{ByID: groupID})
 	if err != nil {
 		return err
 	}

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -111,7 +111,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(grants), 0)
 
-	group, err = data.GetGroup(db, data.ByID(group.ID))
+	group, err = data.GetGroup(db, data.GetGroupOptions{ByID: group.ID})
 	assert.NilError(t, err)
 	assert.Equal(t, group.TotalUsers, 0)
 }

--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -206,7 +206,7 @@ func TestExchangeAuthCodeForProviderTokens(t *testing.T) {
 					assert.NilError(t, err)
 				}
 
-				g, err := data.GetGroup(db, data.ByName("Foo"))
+				g, err := data.GetGroup(db, data.GetGroupOptions{ByName: "Foo"})
 				assert.NilError(t, err)
 				assert.Assert(t, g != nil)
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -797,7 +797,7 @@ func (Server) loadGrant(db data.GormTxn, input Grant) (*models.Grant, error) {
 		id = uid.NewIdentityPolymorphicID(user.ID)
 
 	case input.Group != "":
-		group, err := data.GetGroup(db, data.ByName(input.Group))
+		group, err := data.GetGroup(db, data.GetGroupOptions{ByName: input.Group})
 		if err != nil {
 			if !errors.Is(err, internal.ErrNotFound) {
 				return nil, err

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -71,7 +71,7 @@ func TestGetGroup(t *testing.T) {
 
 		createGroups(t, db, &everyone, &engineers, &product)
 
-		group, err := GetGroup(db, ByName(everyone.Name))
+		group, err := GetGroup(db, GetGroupOptions{ByName: everyone.Name})
 		assert.NilError(t, err)
 		assert.Assert(t, 0 != group.ID)
 	})
@@ -164,19 +164,19 @@ func TestDeleteGroup(t *testing.T) {
 		createGroups(t, tx.WithOrgID(otherOrg.ID), otherOrgGroup)
 
 		t.Run("success", func(t *testing.T) {
-			_, err := GetGroup(tx, ByID(everyone.ID))
+			_, err := GetGroup(tx, GetGroupOptions{ByID: everyone.ID})
 			assert.NilError(t, err)
 
 			err = DeleteGroup(tx, everyone.ID)
 			assert.NilError(t, err)
 
-			_, err = GetGroup(tx, ByID(everyone.ID))
+			_, err = GetGroup(tx, GetGroupOptions{ByID: everyone.ID})
 			assert.Error(t, err, "record not found")
 
 			// deleting a group should not delete unrelated groups
-			_, err = GetGroup(tx, ByID(engineers.ID))
+			_, err = GetGroup(tx, GetGroupOptions{ByID: engineers.ID})
 			assert.NilError(t, err)
-			_, err = GetGroup(tx.WithOrgID(otherOrg.ID), ByID(otherOrgGroup.ID))
+			_, err = GetGroup(tx.WithOrgID(otherOrg.ID), GetGroupOptions{ByID: otherOrgGroup.ID})
 			assert.NilError(t, err)
 
 			// grants and group membership should also be removed.

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -98,7 +98,7 @@ func TestListGroups(t *testing.T) {
 		createIdentities(t, db, &firstUser, &secondUser)
 
 		t.Run("all", func(t *testing.T) {
-			actual, err := ListGroups(db, nil)
+			actual, err := ListGroups(db, ListGroupOptions{})
 			assert.NilError(t, err)
 			expected := []models.Group{
 				{Name: "Engineering"},
@@ -109,7 +109,7 @@ func TestListGroups(t *testing.T) {
 		})
 
 		t.Run("filter by name", func(t *testing.T) {
-			actual, err := ListGroups(db, nil, ByName(engineers.Name))
+			actual, err := ListGroups(db, ListGroupOptions{ByName: engineers.Name})
 			assert.NilError(t, err)
 			expected := []models.Group{
 				{Name: "Engineering"},
@@ -118,7 +118,7 @@ func TestListGroups(t *testing.T) {
 		})
 
 		t.Run("filter by identity membership", func(t *testing.T) {
-			actual, err := ListGroups(db, nil, ByGroupMember(firstUser.ID))
+			actual, err := ListGroups(db, ListGroupOptions{ByMemberID: firstUser.ID})
 			assert.NilError(t, err)
 			expected := []models.Group{
 				{Name: "Engineering"},

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -146,9 +146,6 @@ type GetIdentityOptions struct {
 }
 
 func GetIdentity(tx GormTxn, opts GetIdentityOptions) (*models.Identity, error) {
-	if opts.ByID == 0 && opts.ByName == "" {
-		return nil, fmt.Errorf("GetIdentity must specify id or name")
-	}
 	identity := &identitiesTable{}
 	query := querybuilder.New("SELECT")
 	query.B(columnsForSelect(identity))

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -167,7 +167,7 @@ func GetIdentity(tx GormTxn, opts GetIdentityOptions) (*models.Identity, error) 
 	}
 
 	if opts.LoadGroups {
-		groups, err := ListGroups(tx, nil, ByGroupMember(identity.ID))
+		groups, err := ListGroups(tx, ListGroupOptions{ByMemberID: identity.ID})
 		if err != nil {
 			return nil, fmt.Errorf("load identity groups: %w", err)
 		}
@@ -338,7 +338,7 @@ func loadIdentitiesGroups(tx GormTxn, identities []models.Identity) error {
 	}
 
 	// look-up the group entities
-	groups, err := ListGroups(tx, nil, ByIDs(maps.Keys(groupIDs)))
+	groups, err := ListGroups(tx, ListGroupOptions{ByIDs: maps.Keys(groupIDs)})
 	if err != nil {
 		return err
 	}
@@ -488,7 +488,7 @@ func deleteReferencesToIdentities(tx GormTxn, providerID uid.ID, toDelete []mode
 		}
 
 		if len(user.Providers) == 0 {
-			groups, err := ListGroups(tx, nil, ByGroupMember(i.ID))
+			groups, err := ListGroups(tx, ListGroupOptions{ByMemberID: i.ID})
 			if err != nil {
 				return []uid.ID{}, fmt.Errorf("list groups for identity: %w", err)
 			}

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -714,7 +714,7 @@ func TestAssignIdentityToGroups(t *testing.T) {
 				assert.NilError(t, err)
 
 				// check the result
-				actual, err := ListGroups(db, nil, ByGroupMember(identity.ID))
+				actual, err := ListGroups(db, ListGroupOptions{ByMemberID: identity.ID})
 				assert.NilError(t, err)
 
 				assert.DeepEqual(t, actual, test.ExpectedGroups, cmpModelsGroupShallow)

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -605,7 +605,7 @@ func TestDeleteIdentityWithGroups(t *testing.T) {
 		err = DeleteIdentities(db, opts)
 		assert.NilError(t, err)
 
-		group, err = GetGroup(db, ByID(group.ID))
+		group, err = GetGroup(db, GetGroupOptions{ByID: group.ID})
 		assert.NilError(t, err)
 		assert.Equal(t, group.TotalUsers, 2)
 	})
@@ -692,7 +692,7 @@ func TestAssignIdentityToGroups(t *testing.T) {
 
 				// setup identity's groups
 				for _, gn := range test.StartingGroups {
-					g, err := GetGroup(db, ByName(gn))
+					g, err := GetGroup(db, GetGroupOptions{ByName: gn})
 					if errors.Is(err, internal.ErrNotFound) {
 						g = &models.Group{Name: gn}
 						err = CreateGroup(db, g)

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -199,7 +199,7 @@ func TestSyncProviderUser(t *testing.T) {
 					assert.Assert(t, puGroups["Developers"])
 
 					// check that the direct user-to-group relation was updated
-					storedGroups, err := ListGroups(db, nil, ByGroupMember(pu.IdentityID))
+					storedGroups, err := ListGroups(db, ListGroupOptions{ByMemberID: pu.IdentityID})
 					assert.NilError(t, err)
 
 					userGroups := make(map[string]bool)

--- a/internal/server/data/token.go
+++ b/internal/server/data/token.go
@@ -68,7 +68,7 @@ func CreateIdentityToken(db GormTxn, identityID uid.ID) (token *models.Token, er
 		return nil, err
 	}
 
-	identityGroups, err := ListGroups(db, nil, ByGroupMember(identityID))
+	identityGroups, err := ListGroups(db, ListGroupOptions{ByMemberID: identityID})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/groups.go
+++ b/internal/server/groups.go
@@ -5,12 +5,18 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
+	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
 func (a *API) ListGroups(c *gin.Context, r *api.ListGroupsRequest) (*api.ListResponse[api.Group], error) {
 	p := PaginationFromRequest(r.PaginationRequest)
-	groups, err := access.ListGroups(c, r.Name, r.UserID, &p)
+	opts := data.ListGroupOptions{
+		Pagination: &p,
+		ByMemberID: r.UserID,
+		ByName:     r.Name,
+	}
+	groups, err := access.ListGroups(c, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -319,7 +319,7 @@ func TestAPI_DeleteGroup(t *testing.T) {
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusNoContent, resp.Body.String())
-				actual, err := data.ListGroups(srv.DB(), nil, data.ByID(humans.ID))
+				actual, err := data.ListGroups(srv.DB(), data.ListGroupOptions{ByIDs: []uid.ID{humans.ID}})
 				assert.NilError(t, err)
 				assert.Equal(t, len(actual), 0)
 			},


### PR DESCRIPTION
## Summary
While doing some updates for tracking where groups came from I had the need to update these functions to direct SQL. No functional changes in this PR, just changing to direct SQL patterns from gorm.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
