### PR TITLE
Use SQL for credential queries

### DIFF
--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -134,7 +134,7 @@ func updateCredential(c *gin.Context, user *models.Identity, newPassword string,
 	userCredential.PasswordHash = hash
 	userCredential.OneTimePassword = !isSelf
 
-	if err := data.SaveCredential(db, userCredential); err != nil {
+	if err := data.UpdateCredential(db, userCredential); err != nil {
 		return fmt.Errorf("saving credentials: %w", err)
 	}
 

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -71,7 +71,7 @@ func UpdateCredential(c *gin.Context, user *models.Identity, oldPassword, newPas
 			return errs
 		}
 
-		userCredential, err := data.GetCredential(rCtx.DBTxn, data.ByIdentityID(user.ID))
+		userCredential, err := data.GetCredentialByUserID(rCtx.DBTxn, user.ID)
 		if err != nil {
 			return fmt.Errorf("existing credential: %w", err)
 		}
@@ -116,7 +116,7 @@ func updateCredential(c *gin.Context, user *models.Identity, newPassword string,
 		return fmt.Errorf("hash: %w", err)
 	}
 
-	userCredential, err := data.GetCredential(db, data.ByIdentityID(user.ID))
+	userCredential, err := data.GetCredentialByUserID(db, user.ID)
 	if err != nil {
 		if errors.Is(err, internal.ErrNotFound) && !isSelf {
 			if err := data.CreateCredential(db, &models.Credential{

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -71,7 +71,7 @@ func TestCreateCredential(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, oneTimePassword != "")
 
-	_, err = data.GetCredential(db, data.ByIdentityID(user.ID))
+	_, err = data.GetCredentialByUserID(db, user.ID)
 	assert.NilError(t, err)
 }
 
@@ -87,14 +87,14 @@ func TestUpdateCredentials(t *testing.T) {
 	tmpPassword, err := CreateCredential(c, *user)
 	assert.NilError(t, err)
 
-	userCreds, err := data.GetCredential(db, data.ByIdentityID(user.ID))
+	userCreds, err := data.GetCredentialByUserID(db, user.ID)
 	assert.NilError(t, err)
 
 	t.Run("Update user credentials IS single use password", func(t *testing.T) {
 		err := UpdateCredential(c, user, "", "newPassword")
 		assert.NilError(t, err)
 
-		creds, err := data.GetCredential(db, data.ByIdentityID(user.ID))
+		creds, err := data.GetCredentialByUserID(db, user.ID)
 		assert.NilError(t, err)
 		assert.Equal(t, creds.OneTimePassword, true)
 	})
@@ -110,7 +110,7 @@ func TestUpdateCredentials(t *testing.T) {
 		err = UpdateCredential(c, user, tmpPassword, "newPassword")
 		assert.NilError(t, err)
 
-		creds, err := data.GetCredential(db, data.ByIdentityID(user.ID))
+		creds, err := data.GetCredentialByUserID(db, user.ID)
 		assert.NilError(t, err)
 		assert.Equal(t, creds.OneTimePassword, false)
 	})
@@ -141,7 +141,7 @@ func TestUpdateCredentials(t *testing.T) {
 		err = UpdateCredential(c, user, tmpPassword, "newPassword")
 		assert.NilError(t, err)
 
-		creds, err := data.GetCredential(db, data.ByIdentityID(user.ID))
+		creds, err := data.GetCredentialByUserID(db, user.ID)
 		assert.NilError(t, err)
 		assert.Equal(t, creds.OneTimePassword, false)
 

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -100,7 +100,7 @@ func TestUpdateCredentials(t *testing.T) {
 	})
 
 	t.Run("Update own credentials is NOT single use password", func(t *testing.T) {
-		err := data.SaveCredential(db, userCreds)
+		err := data.UpdateCredential(db, userCreds)
 		assert.NilError(t, err)
 
 		rCtx := GetRequestContext(c)
@@ -116,7 +116,7 @@ func TestUpdateCredentials(t *testing.T) {
 	})
 
 	t.Run("Update own credentials removes password reset scope, but keeps other scopes", func(t *testing.T) {
-		err := data.SaveCredential(db, userCreds)
+		err := data.UpdateCredential(db, userCreds)
 		assert.NilError(t, err)
 
 		rCtx := GetRequestContext(c)

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -104,7 +104,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	_, err = data.GetAccessKeyByKeyID(db, keyID)
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 
-	_, err = data.GetCredential(db, data.ByIdentityID(identity.ID))
+	_, err = data.GetCredentialByUserID(db, identity.ID)
 	assert.ErrorIs(t, err, internal.ErrNotFound)
 
 	grants, err := data.ListGrants(db, data.ListGrantsOptions{BySubject: identity.PolyID()})

--- a/internal/access/passwordreset.go
+++ b/internal/access/passwordreset.go
@@ -23,7 +23,7 @@ func PasswordResetRequest(c *gin.Context, email string, ttl time.Duration) (toke
 		return "", nil, err
 	}
 
-	_, err = data.GetCredential(db, data.ByIdentityID(user.ID))
+	_, err = data.GetCredentialByUserID(db, user.ID)
 	if err != nil {
 		// if credential is not found, the user cannot reset their password.
 		return "", nil, err

--- a/internal/access/passwordreset_test.go
+++ b/internal/access/passwordreset_test.go
@@ -35,7 +35,7 @@ func TestPasswordResetFlow(t *testing.T) {
 	assert.NilError(t, err)
 
 	// check it worked
-	cred, err := data.GetCredential(db, data.ByIdentityID(user.ID))
+	cred, err := data.GetCredentialByUserID(db, user.ID)
 	assert.NilError(t, err)
 
 	err = bcrypt.CompareHashAndPassword(cred.PasswordHash, []byte("my New PassWord@$1"))

--- a/internal/server/authn/password_credentials.go
+++ b/internal/server/authn/password_credentials.go
@@ -33,7 +33,7 @@ func (a *passwordCredentialAuthn) Authenticate(ctx context.Context, db *data.Tra
 	}
 
 	// Infra users can have only one username/password combo, look it up
-	userCredential, err := data.GetCredential(db, data.ByIdentityID(identity.ID))
+	userCredential, err := data.GetCredentialByUserID(db, identity.ID)
 	if err != nil {
 		return AuthenticatedIdentity{}, fmt.Errorf("validate creds get user: %w", err)
 	}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -968,7 +968,7 @@ func (s Server) loadCredential(db data.GormTxn, identity *models.Identity, passw
 
 	credential.PasswordHash = hash
 
-	if err := data.SaveCredential(db, credential); err != nil {
+	if err := data.UpdateCredential(db, credential); err != nil {
 		return err
 	}
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -944,7 +944,7 @@ func (s Server) loadCredential(db data.GormTxn, identity *models.Identity, passw
 		return err
 	}
 
-	credential, err := data.GetCredential(db, data.ByIdentityID(identity.ID))
+	credential, err := data.GetCredentialByUserID(db, identity.ID)
 	if err != nil {
 		if !errors.Is(err, internal.ErrNotFound) {
 			return err

--- a/internal/server/data/credential.go
+++ b/internal/server/data/credential.go
@@ -37,18 +37,18 @@ func validateCredential(c *models.Credential) error {
 	return nil
 }
 
-func CreateCredential(db GormTxn, credential *models.Credential) error {
+func CreateCredential(tx WriteTxn, credential *models.Credential) error {
 	if err := validateCredential(credential); err != nil {
 		return err
 	}
-	return add(db, credential)
+	return insert(tx, (*credentialsTable)(credential))
 }
 
-func SaveCredential(db GormTxn, credential *models.Credential) error {
+func UpdateCredential(tx WriteTxn, credential *models.Credential) error {
 	if err := validateCredential(credential); err != nil {
 		return err
 	}
-	return save(db, credential)
+	return update(tx, (*credentialsTable)(credential))
 }
 
 func GetCredentialByUserID(tx ReadTxn, userID uid.ID) (*models.Credential, error) {

--- a/internal/server/data/credential.go
+++ b/internal/server/data/credential.go
@@ -2,10 +2,29 @@ package data
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
+
+type credentialsTable models.Credential
+
+func (credentialsTable) Table() string {
+	return "credentials"
+}
+
+func (c credentialsTable) Columns() []string {
+	return []string{"created_at", "deleted_at", "id", "identity_id", "one_time_password", "organization_id", "password_hash", "updated_at"}
+}
+
+func (c credentialsTable) Values() []any {
+	return []any{c.CreatedAt, c.DeletedAt, c.ID, c.IdentityID, c.OneTimePassword, c.OrganizationID, c.PasswordHash, c.UpdatedAt}
+}
+
+func (c *credentialsTable) ScanFields() []any {
+	return []any{&c.CreatedAt, &c.DeletedAt, &c.ID, &c.IdentityID, &c.OneTimePassword, &c.OrganizationID, &c.PasswordHash, &c.UpdatedAt}
+}
 
 func validateCredential(c *models.Credential) error {
 	switch {
@@ -35,6 +54,12 @@ func GetCredential(db GormTxn, selectors ...SelectorFunc) (*models.Credential, e
 	return get[models.Credential](db, selectors...)
 }
 
-func DeleteCredential(db GormTxn, id uid.ID) error {
-	return delete[models.Credential](db, id)
+func DeleteCredential(tx WriteTxn, id uid.ID) error {
+	stmt := `
+		UPDATE credentials
+		SET deleted_at = ?
+		WHERE id = ? AND organization_id = ? AND deleted_at is NULL`
+
+	_, err := tx.Exec(stmt, time.Now(), id, tx.OrganizationID())
+	return err
 }

--- a/internal/server/data/credential_test.go
+++ b/internal/server/data/credential_test.go
@@ -1,0 +1,42 @@
+package data
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func TestDeleteCredential(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		cred := &models.Credential{
+			IdentityID:   7145,
+			PasswordHash: []byte("password-hash"),
+		}
+
+		err := CreateCredential(db, cred)
+		assert.NilError(t, err)
+
+		t.Run("success", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			err := DeleteCredential(tx, cred.ID)
+			assert.NilError(t, err)
+
+			_, err = GetCredential(tx, ByIdentityID(7145))
+			assert.ErrorIs(t, err, internal.ErrNotFound)
+
+			// Delete again to check idempotence
+			err = DeleteCredential(tx, cred.ID)
+			assert.NilError(t, err)
+		})
+		t.Run("delete not found", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			err := DeleteCredential(tx, 171717)
+			assert.NilError(t, err)
+		})
+	})
+}

--- a/internal/server/data/credential_test.go
+++ b/internal/server/data/credential_test.go
@@ -2,12 +2,61 @@ package data
 
 import (
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/models"
 )
+
+func TestGetCredentialByUserID(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		cred := &models.Credential{
+			IdentityID:      7145,
+			PasswordHash:    []byte("password-hash"),
+			OneTimePassword: true,
+		}
+
+		err := CreateCredential(db, cred)
+		assert.NilError(t, err)
+
+		t.Run("success", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+			actual, err := GetCredentialByUserID(tx, 7145)
+			assert.NilError(t, err)
+
+			expected := &models.Credential{
+				Model: models.Model{
+					ID:        12345,
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				OrganizationMember: models.OrganizationMember{
+					OrganizationID: db.DefaultOrg.ID,
+				},
+				IdentityID:      7145,
+				PasswordHash:    []byte("password-hash"),
+				OneTimePassword: true,
+			}
+			assert.DeepEqual(t, actual, expected, cmpModel)
+		})
+		t.Run("not found", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+			_, err := GetCredentialByUserID(tx, 91234)
+			assert.ErrorIs(t, err, internal.ErrNotFound)
+		})
+		t.Run("deleted", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			err := DeleteCredential(tx, cred.ID)
+			assert.NilError(t, err)
+
+			_, err = GetCredentialByUserID(tx, 7145)
+			assert.ErrorIs(t, err, internal.ErrNotFound)
+		})
+	})
+}
 
 func TestDeleteCredential(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
@@ -25,7 +74,7 @@ func TestDeleteCredential(t *testing.T) {
 			err := DeleteCredential(tx, cred.ID)
 			assert.NilError(t, err)
 
-			_, err = GetCredential(tx, ByIdentityID(7145))
+			_, err = GetCredentialByUserID(tx, 7145)
 			assert.ErrorIs(t, err, internal.ErrNotFound)
 
 			// Delete again to check idempotence

--- a/internal/server/data/credential_test.go
+++ b/internal/server/data/credential_test.go
@@ -10,6 +10,83 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
+func TestCreateCredential(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		cred := &models.Credential{
+			IdentityID:      7145,
+			PasswordHash:    []byte("password-hash"),
+			OneTimePassword: true,
+		}
+
+		err := CreateCredential(db, cred)
+		assert.NilError(t, err)
+
+		created, err := GetCredentialByUserID(db, cred.IdentityID)
+		assert.NilError(t, err)
+
+		expected := &models.Credential{
+			Model: models.Model{
+				ID:        cred.ID,
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			OrganizationMember: models.OrganizationMember{
+				OrganizationID: db.DefaultOrg.ID,
+			},
+			IdentityID:      7145,
+			PasswordHash:    []byte("password-hash"),
+			OneTimePassword: true,
+		}
+		assert.DeepEqual(t, expected, created, cmpModel)
+	})
+}
+
+func TestUpdateCredential(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		past := time.Date(2022, 1, 2, 3, 4, 5, 600, time.UTC)
+		cred := &models.Credential{
+			Model: models.Model{
+				CreatedAt: past,
+				UpdatedAt: past,
+			},
+			IdentityID:      7145,
+			PasswordHash:    []byte("password-hash"),
+			OneTimePassword: true,
+		}
+
+		err := CreateCredential(db, cred)
+		assert.NilError(t, err)
+
+		t.Run("success", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			updated := *cred // shallow copy
+			updated.PasswordHash = []byte("new-hash")
+			updated.OneTimePassword = false
+
+			err := UpdateCredential(tx, &updated)
+			assert.NilError(t, err)
+
+			actual, err := GetCredentialByUserID(tx, cred.IdentityID)
+			assert.NilError(t, err)
+
+			expected := &models.Credential{
+				Model: models.Model{
+					ID:        cred.ID,
+					CreatedAt: past,
+					UpdatedAt: time.Now(),
+				},
+				OrganizationMember: models.OrganizationMember{
+					OrganizationID: db.DefaultOrg.ID,
+				},
+				IdentityID:   7145,
+				PasswordHash: []byte("new-hash"),
+			}
+			assert.DeepEqual(t, expected, actual, cmpModel)
+		})
+	})
+}
+
 func TestGetCredentialByUserID(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		cred := &models.Credential{

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -474,7 +474,7 @@ func deleteReferencesToIdentities(tx GormTxn, providerID uid.ID, toDelete []mode
 		}
 		if providerID == InfraProvider(tx).ID {
 			// if an identity does not have credentials in the Infra provider this won't be found, but we can proceed
-			credential, err := GetCredential(tx, ByIdentityID(i.ID))
+			credential, err := GetCredentialByUserID(tx, i.ID)
 			if err != nil && !errors.Is(err, internal.ErrNotFound) {
 				return nil, fmt.Errorf("get delete identity creds: %w", err)
 			}

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -359,7 +359,7 @@ func TestDeleteIdentities(t *testing.T) {
 				assert.Error(t, err, "record not found")
 
 				// when an identity has no more references its resources are cleaned up
-				_, err = GetCredential(tx, ByIdentityID(identity.ID))
+				_, err = GetCredentialByUserID(tx, identity.ID)
 				assert.Error(t, err, "record not found")
 				groupIDs, err := ListGroupIDsForUser(tx, identity.ID)
 				assert.NilError(t, err)
@@ -415,7 +415,7 @@ func TestDeleteIdentities(t *testing.T) {
 				id, err := GetIdentity(tx, GetIdentityOptions{ByName: identity.Name})
 				assert.NilError(t, err) // still exists in infra provider
 
-				_, err = GetCredential(tx, ByIdentityID(id.ID))
+				_, err = GetCredentialByUserID(tx, id.ID)
 				assert.NilError(t, err) // still exists in infra provider
 			},
 		},

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -14,12 +14,6 @@ func ByID(id uid.ID) SelectorFunc {
 	}
 }
 
-func ByIDs(ids []uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("id in (?)", ids)
-	}
-}
-
 func ByOrgID(orgID uid.ID) SelectorFunc {
 	if orgID == 0 {
 		panic("OrganizationID was not set")
@@ -32,12 +26,6 @@ func ByOrgID(orgID uid.ID) SelectorFunc {
 func ByName(name string) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where("name = ?", name)
-	}
-}
-
-func ByIdentityID(identityID uid.ID) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("identity_id = ?", identityID)
 	}
 }
 

--- a/internal/server/data/tables_test.go
+++ b/internal/server/data/tables_test.go
@@ -15,6 +15,7 @@ import (
 
 var tables = []tabler{
 	accessKeyTable{},
+	credentialsTable{},
 	destinationsTable{},
 	encryptionKeysTable{},
 	grantsTable{},

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -619,7 +619,7 @@ func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 				assert.NilError(t, err)
 				_, err = data.GetProviderUser(db, data.InfraProvider(db).ID, user.ID)
 				assert.NilError(t, err)
-				cred, err := data.GetCredential(db, data.ByIdentityID(user.ID))
+				cred, err := data.GetCredentialByUserID(db, user.ID)
 				assert.NilError(t, err)
 				assert.Equal(t, true, cred.OneTimePassword)
 			})
@@ -631,7 +631,7 @@ func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 				assert.NilError(t, err)
 
 				t.Run("I cannot set a password", func(t *testing.T) {
-					cred, err := data.GetCredential(db, data.ByIdentityID(user.ID))
+					cred, err := data.GetCredentialByUserID(db, user.ID)
 					assert.NilError(t, err)
 					if cred != nil {
 						_ = data.DeleteCredential(db, cred.ID)
@@ -648,7 +648,7 @@ func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 			t.Run("with an existing infra user", func(t *testing.T) {
 				_, _ = data.CreateProviderUser(db, data.InfraProvider(db), user)
 
-				cred, _ := data.GetCredential(db, data.ByIdentityID(user.ID))
+				cred, _ := data.GetCredentialByUserID(db, user.ID)
 				if cred != nil {
 					_ = data.DeleteCredential(db, cred.ID)
 				}


### PR DESCRIPTION
## Summary

This PR converts the `data` query functions for credentials to use SQL, and adds some test coverage for the functions.