### PR TITLE
Use SQL for organizations queries

### DIFF
--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -11,14 +11,12 @@ import (
 )
 
 func ListOrganizations(c *gin.Context, name string, pg *data.Pagination) ([]models.Organization, error) {
-	selectors := []data.SelectorFunc{}
-	if name != "" {
-		selectors = append(selectors, data.ByName(name))
-	}
-
 	db, err := RequireInfraRole(c, models.InfraSupportAdminRole)
 	if err == nil {
-		return data.ListOrganizations(db, pg, selectors...)
+		return data.ListOrganizations(db, data.ListOrganizationsOptions{
+			ByName:     name,
+			Pagination: pg,
+		})
 	}
 	err = HandleAuthErr(err, "organizations", "list", models.InfraSupportAdminRole)
 

--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -38,7 +38,7 @@ func GetOrganization(c *gin.Context, id uid.ID) (*models.Organization, error) {
 		}
 	}
 
-	return data.GetOrganization(rCtx.DBTxn, data.ByID(id))
+	return data.GetOrganization(rCtx.DBTxn, data.GetOrganizationOptions{ByID: id})
 }
 
 func CreateOrganization(c *gin.Context, org *models.Organization) error {

--- a/internal/access/organization.go
+++ b/internal/access/organization.go
@@ -58,7 +58,7 @@ func DeleteOrganization(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "organizations", "delete", models.InfraSupportAdminRole)
 	}
 
-	return data.DeleteOrganizations(db, data.ByID(id))
+	return data.DeleteOrganization(db, id)
 }
 
 func SanitizedDomain(subDomain, serverBaseDomain string) string {

--- a/internal/server/authn/authn_method.go
+++ b/internal/server/authn/authn_method.go
@@ -75,7 +75,7 @@ func Login(
 		return LoginResult{}, fmt.Errorf("login failed to update last seen: %w", err)
 	}
 
-	org, err := data.GetOrganization(db, data.ByID(accessKey.OrganizationID))
+	org, err := data.GetOrganization(db, data.GetOrganizationOptions{ByID: accessKey.OrganizationID})
 	if err != nil {
 		return LoginResult{}, err
 	}

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -434,7 +434,7 @@ func TestLoadConfigWithProviders(t *testing.T) {
 
 	defaultOrg := s.db.DefaultOrg
 
-	updatedOrg, err := data.GetOrganization(s.db, data.ByID(defaultOrg.ID))
+	updatedOrg, err := data.GetOrganization(s.db, data.GetOrganizationOptions{ByID: defaultOrg.ID})
 	assert.NilError(t, err)
 	assert.Equal(t, updatedOrg.Domain, "super.example.com")
 

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -242,7 +242,7 @@ func initialize(db *DB) error {
 	}
 	defer tx.Rollback()
 
-	org, err := GetOrganization(tx, ByID(defaultOrganizationID))
+	org, err := GetOrganization(tx, GetOrganizationOptions{ByID: defaultOrganizationID})
 	switch {
 	case errors.Is(err, internal.ErrNotFound):
 		org = &models.Organization{

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -164,7 +164,7 @@ func TestNewDB(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		assert.Equal(t, db.DefaultOrg.ID, uid.ID(defaultOrganizationID))
 
-		org, err := GetOrganization(db, ByID(defaultOrganizationID))
+		org, err := GetOrganization(db, GetOrganizationOptions{ByID: defaultOrganizationID})
 		assert.NilError(t, err)
 		assert.DeepEqual(t, org, db.DefaultOrg, cmpTimeWithDBPrecision)
 	})

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -97,7 +97,7 @@ func GetOrganization(tx ReadTxn, opts GetOrganizationOptions) (*models.Organizat
 	case opts.ByDomain != "":
 		query.B("AND domain = ?", opts.ByDomain)
 	default:
-		return nil, fmt.Errorf("an ID is required to get organization")
+		return nil, fmt.Errorf("an ID or domain is required to get organization")
 	}
 
 	err := tx.QueryRow(query.String(), query.Args...).Scan(org.ScanFields()...)

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -85,15 +86,16 @@ func ListOrganizations(db GormTxn, p *Pagination, selectors ...SelectorFunc) ([]
 	return list[models.Organization](db, p, selectors...)
 }
 
-func DeleteOrganizations(db GormTxn, selectors ...SelectorFunc) error {
-	toDelete, err := GetOrganization(db, selectors...)
-	if err != nil {
-		return err
-	}
-
+func DeleteOrganization(tx WriteTxn, id uid.ID) error {
 	// TODO: delete everything in the organization
 
-	return delete[models.Organization](db, toDelete.ID)
+	stmt := `
+		UPDATE organizations
+		SET deleted_at = ?
+		WHERE id = ? AND deleted_at is NULL`
+
+	_, err := tx.Exec(stmt, time.Now(), id)
+	return err
 }
 
 func UpdateOrganization(tx WriteTxn, org *models.Organization) error {

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -117,7 +117,7 @@ func TestGetOrganization(t *testing.T) {
 
 		t.Run("default options", func(t *testing.T) {
 			_, err := GetOrganization(tx, GetOrganizationOptions{})
-			assert.ErrorContains(t, err, "an ID is required")
+			assert.ErrorContains(t, err, "an ID or domain is required")
 		})
 		t.Run("by id", func(t *testing.T) {
 			actual, err := GetOrganization(tx, GetOrganizationOptions{ByID: first.ID})

--- a/internal/server/data/tables_test.go
+++ b/internal/server/data/tables_test.go
@@ -20,6 +20,7 @@ var tables = []tabler{
 	grantsTable{},
 	groupsTable{},
 	identitiesTable{},
+	organizationsTable{},
 	providersTable{},
 	providerUserTable{},
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -167,7 +167,7 @@ func requireAccessKey(c *gin.Context, db *data.Transaction, srv *Server) (access
 		}
 	}
 
-	org, err := data.GetOrganization(db, data.ByID(accessKey.OrganizationID))
+	org, err := data.GetOrganization(db, data.GetOrganizationOptions{ByID: accessKey.OrganizationID})
 	if err != nil {
 		return u, fmt.Errorf("access key org lookup: %w", err)
 	}
@@ -235,7 +235,7 @@ func getOrgFromRequest(req *http.Request, tx data.GormTxn) (*models.Organization
 	}
 
 hostLookup:
-	org, err := data.GetOrganization(tx, data.ByDomain(host))
+	org, err := data.GetOrganization(tx, data.GetOrganizationOptions{ByDomain: host})
 	if err != nil {
 		if errors.Is(err, internal.ErrNotFound) {
 			logging.Debugf("Host not found: %s", host)

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -13,6 +13,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -383,9 +384,8 @@ func TestAPI_DeleteOrganization(t *testing.T) {
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusNoContent, resp.Body.String())
-				actual, err := data.ListOrganizations(srv.DB(), &data.Pagination{}, data.ByID(first.ID))
-				assert.NilError(t, err)
-				assert.Equal(t, len(actual), 0)
+				_, err := data.GetOrganization(srv.DB(), data.ByID(first.ID))
+				assert.ErrorIs(t, err, internal.ErrNotFound)
 			},
 		},
 	}

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -384,7 +384,7 @@ func TestAPI_DeleteOrganization(t *testing.T) {
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusNoContent, resp.Body.String())
-				_, err := data.GetOrganization(srv.DB(), data.ByID(first.ID))
+				_, err := data.GetOrganization(srv.DB(), data.GetOrganizationOptions{ByID: first.ID})
 				assert.ErrorIs(t, err, internal.ErrNotFound)
 			},
 		},

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -99,7 +99,9 @@ func TestAPI_Signup(t *testing.T) {
 				assert.DeepEqual(t, respBody.FieldErrors, expected)
 
 				// the org should have been rolled back
-				_, err = data.GetOrganization(srv.DB(), data.ByDomain("hello.exampledomain.com"))
+				_, err = data.GetOrganization(srv.DB(), data.GetOrganizationOptions{
+					ByDomain: "hello.exampledomain.com",
+				})
 				assert.ErrorIs(t, err, internal.ErrNotFound)
 			},
 		},
@@ -202,7 +204,9 @@ func TestAPI_Signup(t *testing.T) {
 				orgID := respBody.Organization.ID
 
 				// the organization exists
-				org, err := data.GetOrganization(srv.DB(), data.ByDomain("acme-co.exampledomain.com"))
+				org, err := data.GetOrganization(srv.DB(), data.GetOrganizationOptions{
+					ByDomain: "acme-co.exampledomain.com",
+				})
 				assert.NilError(t, err)
 				assert.Equal(t, org.ID, respBody.Organization.ID)
 


### PR DESCRIPTION
## Summary

This PR converts the `data` query functions for organizations to SQL, and adds test coverage for the functions.