### PR TITLE
Use SQL for settings queries

### DIFF
--- a/internal/access/access_key_test.go
+++ b/internal/access/access_key_test.go
@@ -16,7 +16,6 @@ func TestAccessKeys_SelfManagement(t *testing.T) {
 	org := &models.Organization{Name: "joe's jackets", Domain: "joes-jackets"}
 	err := data.CreateOrganization(db, org)
 	assert.NilError(t, err)
-	db.OrganizationID()
 
 	user := &models.Identity{Name: "joe@example.com", OrganizationMember: models.OrganizationMember{OrganizationID: org.ID}}
 	err = data.CreateIdentity(db, user)

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -21,7 +21,7 @@ func TestSettingsPasswordRequirements(t *testing.T) {
 	_, err = CreateCredential(c, *user)
 	assert.NilError(t, err)
 
-	err = data.SaveSettings(db, &models.Settings{
+	err = data.UpdateSettings(db, &models.Settings{
 		LengthMin: 8,
 	})
 	assert.NilError(t, err)
@@ -35,7 +35,7 @@ func TestSettingsPasswordRequirements(t *testing.T) {
 	settings, err := data.GetSettings(db)
 	assert.NilError(t, err)
 	settings.LengthMin = 5
-	err = data.SaveSettings(db, settings)
+	err = data.UpdateSettings(db, settings)
 	assert.NilError(t, err)
 	t.Run("Update user credentials passes if equal than min length", func(t *testing.T) {
 		err := UpdateCredential(c, user, "", "short")
@@ -49,7 +49,7 @@ func TestSettingsPasswordRequirements(t *testing.T) {
 	// Test multiple failures
 	settings.LengthMin = 10
 	settings.SymbolMin = 1
-	err = data.SaveSettings(db, settings)
+	err = data.UpdateSettings(db, settings)
 	assert.NilError(t, err)
 	t.Run("Update user credentials fails with multiple requirement failures", func(t *testing.T) {
 		err := UpdateCredential(c, user, "", "badpw")

--- a/internal/access/settings.go
+++ b/internal/access/settings.go
@@ -35,7 +35,7 @@ func SaveSettings(c *gin.Context, settings *models.Settings) error {
 		return HandleAuthErr(err, "settings", "update", models.InfraAdminRole)
 	}
 
-	if err = data.SaveSettings(db, settings); err != nil {
+	if err = data.UpdateSettings(db, settings); err != nil {
 		return err
 	}
 	return nil

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -904,6 +904,12 @@ func parseTime(t *testing.T, s string) time.Time {
 	return v
 }
 
+func runStep(t *testing.T, name string, fn func(t *testing.T)) {
+	if !t.Run(name, fn) {
+		t.FailNow()
+	}
+}
+
 // testCaseLine is motivated by this Go proposal https://github.com/golang/go/issues/52751.
 // That issue has additional context about the problem this solves.
 func testCaseLine(name string) testCaseLabel {

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -20,9 +20,7 @@ func (o organizationsTable) Columns() []string {
 }
 
 func (o organizationsTable) Values() []any {
-	return []any{o.CreatedAt, o.CreatedBy, o.DeletedAt, o.Domain, o.ID,
-
-		o.Name, o.UpdatedAt}
+	return []any{o.CreatedAt, o.CreatedBy, o.DeletedAt, o.Domain, o.ID, o.Name, o.UpdatedAt}
 }
 
 func (o *organizationsTable) ScanFields() []any {
@@ -35,13 +33,10 @@ func CreateOrganization(tx GormTxn, org *models.Organization) error {
 	if org.Name == "" {
 		return fmt.Errorf("Organization.Name is required")
 	}
-	err := insert(tx, (*organizationsTable)(org))
-	if err != nil {
+	if err := insert(tx, (*organizationsTable)(org)); err != nil {
 		return fmt.Errorf("creating org: %w", err)
 	}
-
-	_, err = initializeSettings(tx, org.ID)
-	if err != nil {
+	if err := createSettings(tx, org.ID); err != nil {
 		return fmt.Errorf("initializing org settings: %w", err)
 	}
 
@@ -65,7 +60,7 @@ func CreateOrganization(tx GormTxn, org *models.Organization) error {
 		return fmt.Errorf("failed to create connector identity while creating org: %w", err)
 	}
 
-	err = CreateGrant(tx, &models.Grant{
+	err := CreateGrant(tx, &models.Grant{
 		Subject:            uid.NewIdentityPolymorphicID(connector.ID),
 		Privilege:          models.InfraConnectorRole,
 		Resource:           "infra",

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -68,9 +68,3 @@ func NotPrivilege(privilege string) SelectorFunc {
 		return db.Not("privilege = ?", privilege)
 	}
 }
-
-func ByDomain(host string) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("domain = ?", host)
-	}
-}

--- a/internal/server/data/settings.go
+++ b/internal/server/data/settings.go
@@ -8,26 +8,40 @@ import (
 
 	"gopkg.in/square/go-jose.v2"
 
+	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
-func initializeSettings(tx GormTxn, orgID uid.ID) (*models.Settings, error) {
-	settings, err := getSettingsForOrg(tx, orgID)
-	if settings != nil {
-		return settings, err
-	}
+type settingsTable models.Settings
 
+func (settingsTable) Table() string {
+	return "settings"
+}
+
+func (s settingsTable) Columns() []string {
+	return []string{"created_at", "deleted_at", "id", "length_min", "lowercase_min", "number_min", "organization_id", "private_jwk", "public_jwk", "symbol_min", "updated_at", "uppercase_min"}
+}
+
+func (s settingsTable) Values() []any {
+	return []any{s.CreatedAt, s.DeletedAt, s.ID, s.LengthMin, s.LowercaseMin, s.NumberMin, s.OrganizationID, s.PrivateJWK, s.PublicJWK, s.SymbolMin, s.UpdatedAt, s.UppercaseMin}
+}
+
+func (s *settingsTable) ScanFields() []any {
+	return []any{&s.CreatedAt, &s.DeletedAt, &s.ID, &s.LengthMin, &s.LowercaseMin, &s.NumberMin, &s.OrganizationID, &s.PrivateJWK, &s.PublicJWK, &s.SymbolMin, &s.UpdatedAt, &s.UppercaseMin}
+}
+
+func createSettings(tx WriteTxn, orgID uid.ID) error {
 	pubkey, seckey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	sec := jose.JSONWebKey{Key: seckey, KeyID: "", Algorithm: string(jose.ED25519), Use: "sig"}
 
 	thumb, err := sec.Thumbprint(crypto.SHA256)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	sec.KeyID = base64.URLEncoding.EncodeToString(thumb)
@@ -36,52 +50,48 @@ func initializeSettings(tx GormTxn, orgID uid.ID) (*models.Settings, error) {
 
 	secs, err := sec.MarshalJSON()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	pubs, err := pub.MarshalJSON()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	settings = &models.Settings{
+	settings := &models.Settings{
 		OrganizationMember: models.OrganizationMember{OrganizationID: orgID},
 		PrivateJWK:         models.EncryptedAtRest(secs),
 		PublicJWK:          pubs,
+		LengthMin:          8,
 	}
-
-	db := tx.GormDB()
-	db = ByOrgID(orgID)(db)
-	if err := db.FirstOrCreate(&settings).Error; err != nil {
-		return nil, err
-	}
-
-	return settings, nil
+	return insert(tx, (*settingsTable)(settings))
 }
 
-func GetSettings(db GormTxn) (*models.Settings, error) {
+func GetSettings(db ReadTxn) (*models.Settings, error) {
 	return getSettingsForOrg(db, db.OrganizationID())
 }
 
-func getSettingsForOrg(tx GormTxn, orgID uid.ID) (*models.Settings, error) {
-	db := tx.GormDB()
-	db = ByOrgID(orgID)(db)
-	var settings models.Settings
-	if err := db.First(&settings).Error; err != nil {
-		return nil, err
-	}
+func getSettingsForOrg(tx ReadTxn, orgID uid.ID) (*models.Settings, error) {
+	settings := settingsTable{}
+	query := querybuilder.New("SELECT")
+	query.B(columnsForSelect(settings))
+	query.B("FROM settings")
+	query.B("WHERE deleted_at is null AND organization_id = ?", orgID)
 
-	return &settings, nil
+	err := tx.QueryRow(query.String(), query.Args...).Scan(settings.ScanFields()...)
+	if err != nil {
+		return nil, handleError(err)
+	}
+	return (*models.Settings)(&settings), nil
 }
 
-func SaveSettings(db GormTxn, settings *models.Settings) error {
-	// TODO: clean this up by having the query use the organization_id instead of the
-	// primary key in the WHERE.
-	existing, err := GetSettings(db)
-	if err != nil {
-		return err
+func UpdateSettings(tx WriteTxn, settings *models.Settings) error {
+	if settings.ID == 0 {
+		existing, err := GetSettings(tx)
+		if err != nil {
+			return err
+		}
+		settings.ID = existing.ID
 	}
-	settings.ID = existing.ID
-
-	return save(db, settings)
+	return update(tx, (*settingsTable)(settings))
 }

--- a/internal/server/data/settings_test.go
+++ b/internal/server/data/settings_test.go
@@ -5,32 +5,64 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/uid"
 )
 
-func TestInitializeSettings(t *testing.T) {
+func TestCreateSettings(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
-		var settings *models.Settings
-		runStep(t, "first call creates new settings", func(t *testing.T) {
-			var err error
-			settings, err = initializeSettings(db, db.DefaultOrg.ID)
+		err := createSettings(db, 145)
+		assert.NilError(t, err)
+
+		settings, err := getSettingsForOrg(db, 145)
+		assert.NilError(t, err)
+		assert.Assert(t, settings.ID != 0)
+		assert.Assert(t, len(settings.PrivateJWK) != 0)
+		assert.Assert(t, len(settings.PublicJWK) != 0)
+		assert.Equal(t, settings.LengthMin, 8)
+	})
+}
+func TestGetSettings(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		t.Run("success", func(t *testing.T) {
+			tx := txnForTestCase(t, db, 181)
+
+			err := createSettings(db, 181)
 			assert.NilError(t, err)
 
-			assert.Assert(t, settings.ID != 0)
-			assert.Assert(t, len(settings.PrivateJWK) != 0)
-			assert.Assert(t, len(settings.PublicJWK) != 0)
+			settings, err := GetSettings(tx)
+			assert.NilError(t, err)
+			assert.Equal(t, settings.OrganizationID, uid.ID(181))
 		})
-
-		runStep(t, "next call returns existing settings", func(t *testing.T) {
-			nextSettings, err := initializeSettings(db, db.DefaultOrg.ID)
-			assert.NilError(t, err)
-			assert.DeepEqual(t, settings, nextSettings, cmpModel)
+		t.Run("not found", func(t *testing.T) {
+			tx := txnForTestCase(t, db, 77)
+			_, err := GetSettings(tx)
+			assert.ErrorIs(t, err, internal.ErrNotFound)
 		})
 	})
 }
 
-func runStep(t *testing.T, name string, fn func(t *testing.T)) {
-	if !t.Run(name, fn) {
-		t.FailNow()
-	}
+func TestUpdateSettings(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		tx := txnForTestCase(t, db, 181)
+
+		err := createSettings(db, 181)
+		assert.NilError(t, err)
+		orig, err := GetSettings(tx)
+		assert.NilError(t, err)
+
+		updated := *orig // shallow copy
+		updated.PrivateJWK = "primary-key"
+		updated.LengthMin = 2
+		updated.SymbolMin = 3
+
+		err = UpdateSettings(tx, &updated)
+		assert.NilError(t, err)
+
+		actual, err := GetSettings(tx)
+		assert.NilError(t, err)
+
+		assert.Assert(t, orig.UpdatedAt != actual.UpdatedAt)
+		assert.DeepEqual(t, actual, &updated, cmpModel)
+	})
 }

--- a/internal/server/data/tables_test.go
+++ b/internal/server/data/tables_test.go
@@ -23,6 +23,7 @@ var tables = []tabler{
 	organizationsTable{},
 	providersTable{},
 	providerUserTable{},
+	settingsTable{},
 }
 
 type tabler interface {

--- a/internal/server/models/settings.go
+++ b/internal/server/models/settings.go
@@ -11,11 +11,11 @@ type Settings struct {
 	PrivateJWK EncryptedAtRest
 	PublicJWK  []byte
 
-	LowercaseMin int `gorm:"default:0"`
-	UppercaseMin int `gorm:"default:0"`
-	NumberMin    int `gorm:"default:0"`
-	SymbolMin    int `gorm:"default:0"`
-	LengthMin    int `gorm:"default:8"`
+	LowercaseMin int
+	UppercaseMin int
+	NumberMin    int
+	SymbolMin    int
+	LengthMin    int
 }
 
 func (s *Settings) ToAPI() *api.Settings {


### PR DESCRIPTION
## Summary

Branched from #3540 

Convert `data` queries for settings to SQL, and add  test cases.