### PR TITLE
fix: add http connector service to serve health check

### DIFF
--- a/helm/charts/infra/templates/connector/deployment.yaml
+++ b/helm/charts/infra/templates/connector/deployment.yaml
@@ -61,6 +61,9 @@ spec:
 {{- toYaml .Values.connector.volumeMounts | nindent 12 }}
 {{- end }}
           ports:
+            - name: http
+              containerPort: {{ .Values.connector.config.addr.http }}
+              protocol: TCP
             - name: https
               containerPort: {{ .Values.connector.config.addr.https }}
               protocol: TCP
@@ -70,8 +73,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: https
-              scheme: HTTPS
+              port: http
             successThreshold: {{ .Values.connector.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.connector.livenessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.connector.livenessProbe.initialDelaySeconds }}
@@ -80,8 +82,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: https
-              scheme: HTTPS
+              port: http
             successThreshold: {{ .Values.connector.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.connector.readinessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.connector.readinessProbe.initialDelaySeconds }}

--- a/helm/charts/infra/templates/connector/service.yaml
+++ b/helm/charts/infra/templates/connector/service.yaml
@@ -26,6 +26,13 @@ spec:
   sessionAffinity: {{ .Values.connector.service.sessionAffinity }}
 {{- end }}
   ports:
+    - port: {{ .Values.connector.service.port }}
+      name: {{ .Values.connector.service.portName }}
+      targetPort: http
+      protocol: TCP
+{{- if eq .Values.connector.service.type "NodePort" }}
+      nodePort: {{ .Values.connector.service.nodePort }}
+{{- end }}
     - port: {{ .Values.connector.service.securePort }}
       name: {{ .Values.connector.service.securePortName }}
       targetPort: https

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -1061,6 +1061,7 @@ connector:
 
     ## Connector container service ports
     addr:
+      http: 9080
       https: 9443
       metrics: 9091
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -340,6 +340,7 @@ var runConnector = connector.Run
 func defaultConnectorOptions() connector.Options {
 	return connector.Options{
 		Addr: connector.ListenerOptions{
+			HTTP:    ":80",
 			HTTPS:   ":443",
 			Metrics: ":9090",
 		},

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -403,6 +403,7 @@ name: the-name
 caCert: /path/to/cert
 caKey: /path/to/key
 addr:
+  http: localhost:84
   https: localhost:414
   metrics: 127.0.0.1:8000
 `,
@@ -410,6 +411,7 @@ addr:
 				return connector.Options{
 					Name: "the-name",
 					Addr: connector.ListenerOptions{
+						HTTP:    "localhost:84",
 						HTTPS:   "localhost:414",
 						Metrics: "127.0.0.1:8000",
 					},

--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -79,6 +79,7 @@ func TestConnector_Run(t *testing.T) {
 			CA:        types.StringOrFile(certs.PEMEncodeCertificate(kubeSrv.Certificate().Raw)),
 		},
 		Addr: connector.ListenerOptions{
+			HTTP:    "127.0.0.1:0",
 			HTTPS:   "127.0.0.1:0",
 			Metrics: "127.0.0.1:0",
 		},

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -337,6 +337,9 @@ func Run(ctx context.Context, options Options) error {
 	if err := tlsServer.Shutdown(shutdownCtx); err != nil {
 		logging.L.Warn().Err(err).Msgf("shutdown proxy server")
 	}
+	if err := plaintextServer.Close(); err != nil {
+		logging.L.Warn().Err(err).Msgf("shutdown plaintext server")
+	}
 	if err := metricsServer.Close(); err != nil {
 		logging.L.Warn().Err(err).Msgf("shutdown metrics server")
 	}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The connector has a single HTTPS service which is problematic for most health checkers as they tend to default to TCP. This causes an incomplete TLS handshake which shows up in logs as `http: TLS handshake error from <addr>:<port>: EOF`. Adding a HTTP service mitigates this since the health checker does not attempt an TLS handshake