### PR TITLE
Return 304 on blocking request timeout, and add label for blocking request

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -172,6 +172,9 @@ func (l *LastUpdateIndex) setValuesFromHeader(header http.Header) error {
 // visible to the client. The API endpoint will block until there is a
 // new updated index for the query.
 // BlockingRequests use a longer request timeout than a standard request.
+//
+// Important: metrics.Middleware relies on the name lastUpdateIndex. If that
+// changes the middleware will need to be updated as well.
 type BlockingRequest struct {
 	LastUpdateIndex int64 `form:"lastUpdateIndex" note:"set this to the value of the Last-Update-Index response header to block until the list results have changed"`
 }

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -92,7 +93,10 @@ func ListGrants(c *gin.Context, opts data.ListGrantsOptions, lastUpdateIndex int
 	}
 
 	err = listener.WaitForNotification(rCtx.Request.Context())
-	if err != nil {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return result, internal.ErrNotModified
+	case err != nil:
 		return result, fmt.Errorf("waiting for notify: %w", err)
 	}
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -447,8 +447,8 @@ func syncGrantsToKubeBindings(ctx context.Context, con connector, waiter waiter)
 		})
 		var apiError api.Error
 		switch {
-		case errors.As(err, &apiError) && apiError.Code == http.StatusGatewayTimeout:
-			// a timeout is expected when there are no changes
+		case errors.As(err, &apiError) && apiError.Code == http.StatusNotModified:
+			// not modified is expected when there are no changes
 			logging.L.Info().
 				Int64("updateIndex", latestIndex).
 				Msg("no updated grants from server")

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -299,7 +299,7 @@ func TestSyncGrantsToKubeBindings(t *testing.T) {
 		{
 			name: "api blocking request timeout",
 			fakeAPI: &fakeAPIClient{
-				listGrantsError: api.Error{Code: http.StatusGatewayTimeout},
+				listGrantsError: api.Error{Code: http.StatusNotModified},
 			},
 			expectedListGrantIndexes: []int64{1, 1},
 			successCount:             2,

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -14,6 +14,7 @@ var (
 
 	ErrInternalServerError = fmt.Errorf("internal server error")
 	ErrNotFound            = fmt.Errorf("record not found")
+	ErrNotModified         = fmt.Errorf("not modified")
 	ErrBadRequest          = fmt.Errorf("bad request")
 	ErrNotImplemented      = fmt.Errorf("not implemented")
 	ErrExpired             = fmt.Errorf("expired")

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -89,6 +89,10 @@ func sendAPIError(c *gin.Context, err error) {
 		resp.Code = http.StatusNotImplemented
 		resp.Message = internal.ErrNotImplemented.Error()
 
+	case errors.Is(err, internal.ErrNotModified):
+		resp.Code = http.StatusNotModified
+		resp.Message = err.Error()
+
 	case errors.Is(err, internal.ErrBadGateway):
 		resp.Code = http.StatusBadGateway
 		resp.Message = err.Error()

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -20,8 +20,9 @@ import (
 
 func TestSendAPIError(t *testing.T) {
 	tests := []struct {
-		err    error
-		result api.Error
+		err               error
+		result            api.Error
+		emptyResponseBody bool
 	}{
 		{
 			err:    internal.ErrBadRequest,
@@ -106,6 +107,11 @@ func TestSendAPIError(t *testing.T) {
 				},
 			},
 		},
+		{
+			err:               internal.ErrNotModified,
+			result:            api.Error{Code: http.StatusNotModified},
+			emptyResponseBody: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -121,6 +127,12 @@ func TestSendAPIError(t *testing.T) {
 			sendAPIError(c, test.err)
 
 			assert.Equal(t, test.result.Code, int32(resp.Result().StatusCode))
+
+			if test.emptyResponseBody {
+				assert.Equal(t, resp.Body.Len(), 0)
+				return
+			}
+
 			actual := &api.Error{}
 			err := json.NewDecoder(resp.Body).Decode(actual)
 			assert.NilError(t, err)

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -730,7 +730,7 @@ func TestAPI_ListGrants_ExtendedRequestTimeout(t *testing.T) {
 	assert.Assert(t, elapsed >= srv.options.API.BlockingRequestTimeout,
 		"elapsed=%v %v", elapsed, (*responseDebug)(resp))
 
-	assert.Equal(t, resp.Code, http.StatusGatewayTimeout, (*responseDebug)(resp))
+	assert.Equal(t, resp.Code, http.StatusNotModified, (*responseDebug)(resp))
 }
 
 func TestAPI_ListGrants_ExtendedRequestTimeout_CancelledByClient(t *testing.T) {
@@ -763,7 +763,7 @@ func TestAPI_ListGrants_ExtendedRequestTimeout_CancelledByClient(t *testing.T) {
 	assert.Assert(t, elapsed < time.Second,
 		"elapsed=%v %v", elapsed, (*responseDebug)(resp))
 
-	assert.Equal(t, resp.Code, http.StatusGatewayTimeout, (*responseDebug)(resp))
+	assert.Equal(t, resp.Code, http.StatusNotModified, (*responseDebug)(resp))
 }
 
 type responseDebug httptest.ResponseRecorder


### PR DESCRIPTION
## Summary

This PR addresses two problems with monitoring of blocking API requests:

1. changes the http response status code from 504 gateway timeout, to 304 not modified, when a blocking request times out
2. add a `blocking` label to both HTTP metrics, so that we can filter out `blocking=true` in the monitors for API request latency

Best viewed by individual commit.