### PR TITLE
fix: set default device flow url

### DIFF
--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -51,7 +51,7 @@ retry:
 	}
 	if host == "" {
 		// Default to the request hostname when in single tenant mode
-		host = rctx.Request.URL.Host
+		host = rctx.Request.Host
 	}
 
 	return &api.DeviceFlowResponse{

--- a/internal/server/deviceflow_test.go
+++ b/internal/server/deviceflow_test.go
@@ -102,22 +102,20 @@ func TestAPI_StartDeviceFlow(t *testing.T) {
 		srv := setupServer(t, withAdminUser)
 		routes := srv.GenerateRoutes()
 
-		u := "https://api.example.com:2020/api/device"
-		req, err := http.NewRequest(http.MethodPost, u, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/device", nil)
 		req.Header.Set("Infra-Version", apiVersionLatest)
 		resp := httptest.NewRecorder()
 		routes.ServeHTTP(resp, req)
 
 		flowResp := &api.DeviceFlowResponse{}
-		err = json.NewDecoder(resp.Body).Decode(flowResp)
+		err := json.NewDecoder(resp.Body).Decode(flowResp)
 		assert.NilError(t, err)
 
 		assert.Equal(t, resp.Code, http.StatusCreated, (*responseDebug)(resp))
 		expected := &api.DeviceFlowResponse{
 			DeviceCode:          "<any-string>",
 			UserCode:            "<any-string>",
-			VerificationURI:     "https://api.example.com:2020/device",
+			VerificationURI:     "https://example.com/device",
 			ExpiresInSeconds:    600,
 			PollIntervalSeconds: 5,
 		}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`Request.URL.Host` may be empty. Instead use `Request.Host` which should the required string

From https://pkg.go.dev/net/http#Request:

	// For server requests, the URL is parsed from the URI
	// supplied on the Request-Line as stored in RequestURI.  For
	// most requests, fields other than Path and RawQuery will be
	// empty. (See [RFC 7230, Section 5.3](https://rfc-editor.org/rfc/rfc7230.html#section-5.3))
