### PR TITLE
feature: grants by name

### DIFF
--- a/api/grant.go
+++ b/api/grant.go
@@ -146,7 +146,8 @@ func (r ListGrantsRequest) SetPage(page int) Paginatable {
 type GrantRequest struct {
 	User      uid.ID `json:"user"`
 	Group     uid.ID `json:"group"`
-	Name      string `json:"name"`
+	UserName  string `json:"userName"`
+	GroupName string `json:"groupName"`
 	Privilege string `json:"privilege" example:"view" note:"a role or permission"`
 	Resource  string `json:"resource" example:"production" note:"a resource name in Infra's Universal Resource Notation"`
 }
@@ -155,8 +156,9 @@ func (r GrantRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.RequireOneOf(
 			validate.Field{Name: "user", Value: r.User},
-			validate.Field{Name: "name", Value: r.Name},
+			validate.Field{Name: "userName", Value: r.UserName},
 			validate.Field{Name: "group", Value: r.Group},
+			validate.Field{Name: "groupName", Value: r.GroupName},
 		),
 		validate.Required("privilege", r.Privilege),
 		validate.Required("resource", r.Resource),

--- a/api/grant.go
+++ b/api/grant.go
@@ -146,6 +146,7 @@ func (r ListGrantsRequest) SetPage(page int) Paginatable {
 type GrantRequest struct {
 	User      uid.ID `json:"user"`
 	Group     uid.ID `json:"group"`
+	Name      string `json:"name"`
 	Privilege string `json:"privilege" example:"view" note:"a role or permission"`
 	Resource  string `json:"resource" example:"production" note:"a resource name in Infra's Universal Resource Notation"`
 }
@@ -154,6 +155,7 @@ func (r GrantRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.RequireOneOf(
 			validate.Field{Name: "user", Value: r.User},
+			validate.Field{Name: "name", Value: r.Name},
 			validate.Field{Name: "group", Value: r.Group},
 		),
 		validate.Required("privilege", r.Privilege),

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -2925,7 +2925,17 @@
                         },
                         {
                           "required": [
+                            "userName"
+                          ]
+                        },
+                        {
+                          "required": [
                             "group"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "groupName"
                           ]
                         }
                       ],
@@ -2934,6 +2944,9 @@
                           "example": "4yJ3n3D8E2",
                           "format": "uid",
                           "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                          "type": "string"
+                        },
+                        "groupName": {
                           "type": "string"
                         },
                         "privilege": {
@@ -2950,6 +2963,9 @@
                           "example": "4yJ3n3D8E2",
                           "format": "uid",
                           "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                          "type": "string"
+                        },
+                        "userName": {
                           "type": "string"
                         }
                       },
@@ -2971,7 +2987,17 @@
                         },
                         {
                           "required": [
+                            "userName"
+                          ]
+                        },
+                        {
+                          "required": [
                             "group"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "groupName"
                           ]
                         }
                       ],
@@ -2980,6 +3006,9 @@
                           "example": "4yJ3n3D8E2",
                           "format": "uid",
                           "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                          "type": "string"
+                        },
+                        "groupName": {
                           "type": "string"
                         },
                         "privilege": {
@@ -2996,6 +3025,9 @@
                           "example": "4yJ3n3D8E2",
                           "format": "uid",
                           "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                          "type": "string"
+                        },
+                        "userName": {
                           "type": "string"
                         }
                       },
@@ -3119,7 +3151,17 @@
                   },
                   {
                     "required": [
+                      "userName"
+                    ]
+                  },
+                  {
+                    "required": [
                       "group"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "groupName"
                     ]
                   }
                 ],
@@ -3128,6 +3170,9 @@
                     "example": "4yJ3n3D8E2",
                     "format": "uid",
                     "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                    "type": "string"
+                  },
+                  "groupName": {
                     "type": "string"
                   },
                   "privilege": {
@@ -3144,6 +3189,9 @@
                     "example": "4yJ3n3D8E2",
                     "format": "uid",
                     "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                    "type": "string"
+                  },
+                  "userName": {
                     "type": "string"
                   }
                 },

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -53,7 +53,7 @@ func CreateCredential(c *gin.Context, user models.Identity) (string, error) {
 
 func UpdateCredential(c *gin.Context, user *models.Identity, oldPassword, newPassword string) error {
 	rCtx := GetRequestContext(c)
-	isSelf := isIdentitySelf(rCtx, user.ID)
+	isSelf := isIdentitySelf(rCtx, data.GetIdentityOptions{ByID: user.ID})
 
 	// anyone can update their own credentials, so check authorization when not self
 	if !isSelf {

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -964,7 +964,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 				assert.NilError(t, err)
 
 				expected := []api.FieldError{
-					{Errors: []string{"one of (user, name, group) is required"}},
+					{Errors: []string{"one of (user, userName, group, groupName) is required"}},
 					{FieldName: "privilege", Errors: []string{"is required"}},
 					{FieldName: "resource", Errors: []string{"is required"}},
 				}
@@ -1395,7 +1395,7 @@ func TestAPI_UpdateGrants(t *testing.T) {
 			body: api.UpdateGrantsRequest{
 				GrantsToRemove: []api.GrantRequest{
 					{
-						UserName:  user.Name,
+						GroupName: group.Name,
 						Privilege: models.InfraAdminRole,
 						Resource:  "another-cluster3",
 					},

--- a/internal/server/groups.go
+++ b/internal/server/groups.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
+	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -23,7 +24,7 @@ func (a *API) ListGroups(c *gin.Context, r *api.ListGroupsRequest) (*api.ListRes
 }
 
 func (a *API) GetGroup(c *gin.Context, r *api.Resource) (*api.Group, error) {
-	group, err := access.GetGroup(c, r.ID)
+	group, err := access.GetGroup(c, data.GetGroupOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -37,7 +37,7 @@ func (a *API) GetUser(c *gin.Context, r *api.GetUserRequest) (*api.User, error) 
 		}
 		r.ID.ID = iden.ID
 	}
-	identity, err := access.GetIdentity(c, r.ID.ID)
+	identity, err := access.GetIdentity(c, data.GetIdentityOptions{ByID: r.ID.ID, LoadProviders: true})
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (a *API) CreateUser(c *gin.Context, r *api.CreateUserRequest) (*api.CreateU
 
 func (a *API) UpdateUser(c *gin.Context, r *api.UpdateUserRequest) (*api.User, error) {
 	// right now this endpoint can only update a user's credentials, so get the user identity
-	identity, err := access.GetIdentity(c, r.ID)
+	identity, err := access.GetIdentity(c, data.GetIdentityOptions{ByID: r.ID, LoadProviders: true})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Allow `PATCH /api/grants` to use user names as well as user/group IDs

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged

