### PR TITLE
fix: use httptest.NewRequest where appropriate

### DIFF
--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,8 +34,7 @@ func TestAPI_CreateAccessKey(t *testing.T) {
 		body := tc.setup(t)
 
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPost, "/api/access-keys", jsonBody(t, body))
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/access-keys", jsonBody(t, body))
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -188,8 +186,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		resp := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "/api/access-keys", nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, "/api/access-keys", nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -214,9 +211,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 		assert.NilError(t, err)
 
 		resp := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/access-keys?name=delete+me", nil)
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodDelete, "/api/access-keys?name=delete+me", nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -234,9 +229,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 		assert.NilError(t, err)
 
 		resp := httptest.NewRecorder()
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/access-keys?name=delete+me+too", nil)
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodDelete, "/api/access-keys?name=delete+me+too", nil)
 		req.Header.Set("Authorization", "Bearer "+key.Token())
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -246,8 +239,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 
 	t.Run("show expired", func(t *testing.T) {
 		resp := httptest.NewRecorder()
-		req, err := http.NewRequest(http.MethodGet, "/api/access-keys?show_expired=1", nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, "/api/access-keys?show_expired=1", nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -255,7 +247,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 		assert.Equal(t, resp.Code, http.StatusOK)
 
 		keys := api.ListResponse[api.AccessKey]{}
-		err = json.Unmarshal(resp.Body.Bytes(), &keys)
+		err := json.Unmarshal(resp.Body.Bytes(), &keys)
 		assert.NilError(t, err)
 
 		// TODO: replace this with a more strict assertion using DeepEqual
@@ -269,8 +261,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 	t.Run("latest", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodGet, "/api/access-keys", nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, "/api/access-keys", nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", "0.12.3")
 
@@ -278,7 +269,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 		assert.Equal(t, resp.Code, http.StatusOK)
 
 		resp1 := &api.ListResponse[api.AccessKey]{}
-		err = json.Unmarshal(resp.Body.Bytes(), resp1)
+		err := json.Unmarshal(resp.Body.Bytes(), resp1)
 		assert.NilError(t, err)
 
 		assert.Assert(t, len(resp1.Items) > 0)
@@ -287,15 +278,14 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 	t.Run("no version header", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodGet, "/api/access-keys", nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, "/api/access-keys", nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 
 		routes.ServeHTTP(resp, req)
 		assert.Equal(t, resp.Code, http.StatusBadRequest)
 
 		errMsg := api.Error{}
-		err = json.Unmarshal(resp.Body.Bytes(), &errMsg)
+		err := json.Unmarshal(resp.Body.Bytes(), &errMsg)
 		assert.NilError(t, err)
 
 		assert.Assert(t, strings.Contains(errMsg.Message, "Infra-Version header is required"))

--- a/internal/server/authn_test.go
+++ b/internal/server/authn_test.go
@@ -28,9 +28,7 @@ func TestServerLimitsAccessWithTemporaryPassword(t *testing.T) {
 	// user can't access other urls.
 	tryOtherURL := func() *httptest.ResponseRecorder {
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodGet, "/api/users/"+loginResp.UserID.String(), nil)
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodGet, "/api/users/"+loginResp.UserID.String(), nil)
 		req.Header.Add("Authorization", "Bearer "+key)
 		req.Header.Add("Infra-Version", "0.14")
 
@@ -60,9 +58,7 @@ func changePassword(t *testing.T, routes Routes, accessKey string, id uid.ID, ol
 	assert.NilError(t, err)
 
 	// nolint:noctx
-	req, err := http.NewRequest(http.MethodPut, "/api/users/"+id.String(), bytes.NewReader(body))
-	assert.NilError(t, err)
-
+	req := httptest.NewRequest(http.MethodPut, "/api/users/"+id.String(), bytes.NewReader(body))
 	req.Header.Add("Authorization", "Bearer "+accessKey)
 	req.Header.Add("Infra-Version", "0.14")
 

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -28,9 +28,8 @@ func TestAPI_PProfHandler(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodGet, "/api/debug/pprof/heap?debug=1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/debug/pprof/heap?debug=1", nil)
 		req.Header.Add("Infra-Version", "0.12.3")
-		assert.NilError(t, err)
 
 		if tc.setupRequest != nil {
 			tc.setupRequest(t, req)

--- a/internal/server/deviceflow_test.go
+++ b/internal/server/deviceflow_test.go
@@ -102,7 +102,7 @@ func TestAPI_StartDeviceFlow(t *testing.T) {
 		srv := setupServer(t, withAdminUser)
 		routes := srv.GenerateRoutes()
 
-		req := httptest.NewRequest(http.MethodPost, "/api/device", nil)
+		req := httptest.NewRequest(http.MethodPost, "https://api.example.com:2020/api/device", nil)
 		req.Header.Set("Infra-Version", apiVersionLatest)
 		resp := httptest.NewRecorder()
 		routes.ServeHTTP(resp, req)
@@ -115,7 +115,7 @@ func TestAPI_StartDeviceFlow(t *testing.T) {
 		expected := &api.DeviceFlowResponse{
 			DeviceCode:          "<any-string>",
 			UserCode:            "<any-string>",
-			VerificationURI:     "https://example.com/device",
+			VerificationURI:     "https://api.example.com:2020/device",
 			ExpiresInSeconds:    600,
 			PollIntervalSeconds: 5,
 		}

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -33,8 +33,7 @@ func TestAPI_ListGrants(t *testing.T) {
 		err := json.NewEncoder(&buf).Encode(body)
 		assert.NilError(t, err)
 
-		req, err := http.NewRequest(http.MethodPost, "/api/users", &buf)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/users", &buf)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", "0.12.3")
 
@@ -59,8 +58,7 @@ func TestAPI_ListGrants(t *testing.T) {
 		assert.NilError(t, err)
 
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPost, "/api/grants", &buf)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/grants", &buf)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", "0.12.3")
 
@@ -113,8 +111,7 @@ func TestAPI_ListGrants(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		req, err := http.NewRequest(http.MethodGet, tc.urlPath, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
 		req.Header.Add("Infra-Version", "0.12.3")
 
@@ -525,8 +522,7 @@ func TestAPI_ListGrants_InheritedGrants(t *testing.T) {
 		err := json.NewEncoder(&buf).Encode(body)
 		assert.NilError(t, err)
 
-		req, err := http.NewRequest(http.MethodPost, "/api/users", &buf)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/users", &buf)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", "0.12.3")
 
@@ -593,9 +589,7 @@ func TestAPI_ListGrants_InheritedGrants(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		req, err := http.NewRequest(http.MethodGet, tc.urlPath, nil)
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
 		req.Header.Add("Infra-Version", "0.12.3")
 
 		if tc.setup != nil {
@@ -717,8 +711,7 @@ func TestAPI_ListGrants_ExtendedRequestTimeout(t *testing.T) {
 	routes := srv.GenerateRoutes()
 
 	urlPath := "/api/grants?destination=infra&lastUpdateIndex=10001"
-	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
-	assert.NilError(t, err)
+	req := httptest.NewRequest(http.MethodGet, urlPath, nil)
 	req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 	req.Header.Add("Infra-Version", apiVersionLatest)
 
@@ -746,8 +739,7 @@ func TestAPI_ListGrants_ExtendedRequestTimeout_CancelledByClient(t *testing.T) {
 	routes := srv.GenerateRoutes()
 
 	urlPath := "/api/grants?destination=infra&lastUpdateIndex=10001"
-	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
-	assert.NilError(t, err)
+	req := httptest.NewRequest(http.MethodGet, urlPath, nil)
 	req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 	req.Header.Add("Infra-Version", apiVersionLatest)
 
@@ -791,8 +783,7 @@ func TestAPI_ListGrants_BlockingRequest_BlocksUntilUpdate(t *testing.T) {
 	respCh := make(chan *httptest.ResponseRecorder)
 	g.Go(func() error {
 		urlPath := "/api/grants?destination=infra&lastUpdateIndex=10001"
-		req, err := http.NewRequest(http.MethodGet, urlPath, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", apiVersionLatest)
 
@@ -864,8 +855,7 @@ func TestAPI_ListGrants_BlockingRequest_NotFoundBlocksUntilUpdate(t *testing.T) 
 	respCh := make(chan *httptest.ResponseRecorder)
 	g.Go(func() error {
 		urlPath := "/api/grants?destination=deferred&lastUpdateIndex=1"
-		req, err := http.NewRequest(http.MethodGet, urlPath, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", apiVersionLatest)
 
@@ -947,8 +937,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		body := jsonBody(t, tc.body)
-		req, err := http.NewRequest(http.MethodPost, "/api/grants", body)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/grants", body)
 		req.Header.Add("Infra-Version", "0.12.3")
 
 		if tc.setup != nil {
@@ -1207,8 +1196,7 @@ func TestAPI_UpdateGrants(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		body := jsonBody(t, tc.body)
-		req, err := http.NewRequest(http.MethodPatch, "/api/grants", body)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPatch, "/api/grants", body)
 		req.Header.Add("Infra-Version", "0.15.2")
 
 		if tc.setup != nil {

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -59,8 +59,7 @@ func TestAPI_ListGroups(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		req, err := http.NewRequest(http.MethodGet, tc.urlPath, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
 		req.Header.Add("Infra-Version", "0.13.0")
 
@@ -199,8 +198,7 @@ func TestAPI_CreateGroup(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		body := jsonBody(t, tc.body)
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPost, "/api/groups", body)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/groups", body)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
 		req.Header.Add("Infra-Version", "0.13.0")
 
@@ -288,8 +286,7 @@ func TestAPI_DeleteGroup(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodDelete, tc.urlPath, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodDelete, tc.urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
 		req.Header.Add("Infra-Version", "0.13.0")
 
@@ -365,8 +362,7 @@ func TestAPI_UpdateUsersInGroup(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		body := jsonBody(t, tc.body)
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPatch, tc.urlPath, body)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPatch, tc.urlPath, body)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
 		req.Header.Add("Infra-Version", "0.13.0")
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -64,8 +64,7 @@ func TestWellKnownJWKs(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil)
 
 		if tc.setup != nil {
 			tc.setup(t, req)

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -157,9 +157,7 @@ func createUser(t *testing.T, srv *Server, routes Routes, email string) *api.Cre
 	assert.NilError(t, err)
 
 	// nolint:noctx
-	req, err := http.NewRequest(http.MethodPost, "/api/users", bytes.NewReader(body))
-	assert.NilError(t, err)
-
+	req := httptest.NewRequest(http.MethodPost, "/api/users", bytes.NewReader(body))
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 	req.Header.Add("Infra-Version", "0.14")
 

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -44,8 +44,7 @@ func TestAPI_GetOrganization(t *testing.T) {
 		assert.NilError(t, err)
 
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPost, "/api/users", &buf)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/users", &buf)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -75,8 +74,7 @@ func TestAPI_GetOrganization(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		req, err := http.NewRequest(http.MethodGet, tc.urlPath, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
 		req.Header.Add("Infra-Version", "0.15.2")
 
 		if tc.setup != nil {
@@ -202,8 +200,7 @@ func TestAPI_ListOrganizations(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		req, err := http.NewRequest(http.MethodGet, tc.urlPath, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
 		req.Header.Add("Infra-Version", "0.14.1")
 
 		if tc.setup != nil {
@@ -276,8 +273,7 @@ func TestAPI_CreateOrganization(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		body := jsonBody(t, tc.body)
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPost, "/api/organizations", body)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/organizations", body)
 		req.Header.Add("Infra-Version", "0.14.1")
 
 		if tc.setup != nil {
@@ -353,8 +349,7 @@ func TestAPI_DeleteOrganization(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodDelete, tc.urlPath, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodDelete, tc.urlPath, nil)
 		req.Header.Add("Infra-Version", "0.14.1")
 
 		if tc.setup != nil {

--- a/internal/server/passwordreset_test.go
+++ b/internal/server/passwordreset_test.go
@@ -43,9 +43,7 @@ func TestPasswordResetFlow(t *testing.T) {
 	assert.NilError(t, err)
 
 	// nolint:noctx
-	req, err := http.NewRequest(http.MethodPost, "/api/password-reset-request", bytes.NewBuffer(body))
-	assert.NilError(t, err)
-
+	req := httptest.NewRequest(http.MethodPost, "/api/password-reset-request", bytes.NewBuffer(body))
 	req.Header.Add("Infra-Version", "0.13.6")
 
 	resp := httptest.NewRecorder()
@@ -80,9 +78,7 @@ func TestPasswordResetFlow(t *testing.T) {
 	assert.NilError(t, err)
 
 	// nolint:noctx
-	req, err = http.NewRequest(http.MethodPost, "/api/password-reset", bytes.NewBuffer(body))
-	assert.NilError(t, err)
-
+	req = httptest.NewRequest(http.MethodPost, "/api/password-reset", bytes.NewBuffer(body))
 	req.Header.Add("Infra-Version", "0.13.6")
 
 	resp = httptest.NewRecorder()

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -38,9 +38,7 @@ func TestAPI_ListProviders(t *testing.T) {
 	assert.Equal(t, len(dbProviders), 2)
 
 	// nolint:noctx
-	req, err := http.NewRequest(http.MethodGet, "/api/providers", nil)
-	assert.NilError(t, err)
-
+	req := httptest.NewRequest(http.MethodGet, "/api/providers", nil)
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(s))
 	req.Header.Add("Infra-Version", "0.12.3")
 
@@ -80,8 +78,7 @@ func TestAPI_DeleteProvider(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		req, err := http.NewRequest(http.MethodDelete, tc.urlPath, nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodDelete, tc.urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -149,8 +146,7 @@ func TestAPI_CreateProvider(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		body := jsonBody(t, tc.body)
 
-		req, err := http.NewRequest(http.MethodPost, "/api/providers", body)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/providers", body)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -414,8 +410,7 @@ func TestAPI_UpdateProvider(t *testing.T) {
 		body := jsonBody(t, tc.body)
 
 		id := provider.ID.String()
-		req, err := http.NewRequest(http.MethodPut, "/api/providers/"+id, body)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPut, "/api/providers/"+id, body)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -571,8 +566,7 @@ func TestAPI_PatchProvider(t *testing.T) {
 		body := jsonBody(t, tc.body)
 
 		id := provider.ID.String()
-		req, err := http.NewRequest(http.MethodPatch, "/api/providers/"+id, body)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPatch, "/api/providers/"+id, body)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 

--- a/internal/server/redirect_test.go
+++ b/internal/server/redirect_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,9 +26,7 @@ func TestVerifyAndRedirect_Works(t *testing.T) {
 	redirectURL := "https://example.com/hello"
 	url := wrapLinkWithVerification(redirectURL, "example.com", user.VerificationToken)
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
-	assert.NilError(t, err)
-
+	req := httptest.NewRequest(http.MethodGet, url, nil)
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
 

--- a/internal/server/scim_test.go
+++ b/internal/server/scim_test.go
@@ -100,9 +100,7 @@ func TestAPI_GetProviderUser(t *testing.T) {
 	for _, tc := range testCases {
 		bearer, routes, user := tc.setup(t)
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/scim/v2/Users/%s", user.ID), nil)
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/scim/v2/Users/%s", user.ID), nil)
 		req.Header.Add("Authorization", "Bearer "+bearer)
 		req.Header.Add("Infra-Version", apiVersionLatest)
 
@@ -236,9 +234,7 @@ func TestAPI_ListProviderUsers(t *testing.T) {
 	for _, tc := range testCases {
 		bearer, params, routes, exp := tc.setup(t)
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/scim/v2/Users%s", params), nil)
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/scim/v2/Users%s", params), nil)
 		req.Header.Add("Authorization", "Bearer "+bearer)
 		req.Header.Add("Infra-Version", apiVersionLatest)
 
@@ -469,9 +465,7 @@ func TestAPI_CreateProviderUser(t *testing.T) {
 	for _, tc := range testCases {
 		bearer, routes, reqBody := tc.setup(t)
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPost, "/api/scim/v2/Users", jsonBody(t, reqBody))
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodPost, "/api/scim/v2/Users", jsonBody(t, reqBody))
 		req.Header.Add("Authorization", "Bearer "+bearer)
 		req.Header.Add("Infra-Version", apiVersionLatest)
 
@@ -674,9 +668,7 @@ func TestAPI_UpdateProviderUser(t *testing.T) {
 	for _, tc := range testCases {
 		bearer, routes, id, reqBody := tc.setup(t)
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPut, "/api/scim/v2/Users/"+id.String(), jsonBody(t, reqBody))
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodPut, "/api/scim/v2/Users/"+id.String(), jsonBody(t, reqBody))
 		req.Header.Add("Authorization", "Bearer "+bearer)
 		req.Header.Add("Infra-Version", apiVersionLatest)
 
@@ -782,9 +774,7 @@ func TestAPI_PatchProviderUser(t *testing.T) {
 	for _, tc := range testCases {
 		bearer, routes, id, reqBody := tc.setup(t)
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPatch, "/api/scim/v2/Users/"+id.String(), jsonBody(t, reqBody))
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodPatch, "/api/scim/v2/Users/"+id.String(), jsonBody(t, reqBody))
 		req.Header.Add("Authorization", "Bearer "+bearer)
 		req.Header.Add("Infra-Version", apiVersionLatest)
 
@@ -843,9 +833,7 @@ func TestAPI_DeleteProviderUser(t *testing.T) {
 	for _, tc := range testCases {
 		bearer, routes, id := tc.setup(t)
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodDelete, "/api/scim/v2/Users/"+id.String(), nil)
-		assert.NilError(t, err)
-
+		req := httptest.NewRequest(http.MethodDelete, "/api/scim/v2/Users/"+id.String(), nil)
 		req.Header.Add("Authorization", "Bearer "+bearer)
 		req.Header.Add("Infra-Version", apiVersionLatest)
 

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -33,8 +33,7 @@ func TestAPI_Signup(t *testing.T) {
 		body := tc.setup(t)
 
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPost, "/api/signup", jsonBody(t, body))
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/signup", jsonBody(t, body))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
 		resp := httptest.NewRecorder()
@@ -217,8 +216,7 @@ func TestAPI_Signup(t *testing.T) {
 
 				key := cookies[0].Value
 				// nolint:noctx
-				req, err := http.NewRequest(http.MethodGet, "/api/users/self", nil)
-				assert.NilError(t, err)
+				req := httptest.NewRequest(http.MethodGet, "/api/users/self", nil)
 				req.Header.Set("Infra-Version", apiVersionLatest)
 				req.Header.Set("Authorization", "Bearer "+key)
 

--- a/internal/server/tokens_test.go
+++ b/internal/server/tokens_test.go
@@ -26,8 +26,7 @@ func TestAPI_CreateToken(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		// nolint:noctx
-		req, err := http.NewRequest(http.MethodPost, "/api/tokens", nil)
-		assert.NilError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
 		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`httptest.NewRequest` is more appropriate use with `ServeHTTP` as its intended to simulate an incoming request rather than a client request (`http.NewRequest`). This is critical as one of the differences between server and client requests has caused problems on [two](https://github.com/infrahq/infra/pull/2945) [separate](https://github.com/infrahq/infra/pull/3548) occasions.

Instances where the request is used with a `http.Client` are left unchanged.