### PR TITLE
Convert count queries to SQL

### DIFF
--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -488,21 +488,6 @@ func delete[T models.Modelable](tx GormTxn, id uid.ID) error {
 	return db.Delete(new(T), id).Error
 }
 
-// GlobalCount gives the count of all records, not scoped by org.
-func GlobalCount[T models.Modelable](tx GormTxn, selectors ...SelectorFunc) (int64, error) {
-	db := tx.GormDB()
-	for _, selector := range selectors {
-		db = selector(db)
-	}
-
-	var count int64
-	if err := db.Model((*T)(nil)).Count(&count).Error; err != nil {
-		return -1, err
-	}
-
-	return count, nil
-}
-
 // InfraProvider returns the infra provider for the organization set in the tx.
 func InfraProvider(tx ReadTxn) *models.Provider {
 	infra, err := GetProvider(tx, GetProviderOptions{KindInfra: true})

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -179,3 +179,7 @@ func CountDestinationsByConnectedVersion(tx ReadTxn) ([]DestinationsCount, error
 		return []any{&item.Version, &item.Connected, &item.Count}
 	})
 }
+
+func CountAllDestinations(tx ReadTxn) (int64, error) {
+	return countRows(tx, destinationsTable{})
+}

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -302,3 +302,19 @@ func createDestinations(t *testing.T, tx GormTxn, destinations ...*models.Destin
 		assert.NilError(t, err, destinations[i].Name)
 	}
 }
+
+func TestCountAllDestinations(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		createDestinations(t, db,
+			&models.Destination{Name: "1", UniqueID: "1"},
+			&models.Destination{Name: "2", UniqueID: "2"},
+			&models.Destination{Name: "3", UniqueID: "3"},
+			&models.Destination{Name: "4", UniqueID: "4"},
+			&models.Destination{Name: "5", UniqueID: "5"},
+		)
+		actual, err := CountAllDestinations(db)
+		assert.NilError(t, err)
+
+		assert.Equal(t, actual, int64(5))
+	})
+}

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -497,3 +497,7 @@ func deleteGrantsBulk(tx WriteTxn, grants []*models.Grant) error {
 	_, err := tx.Exec(query.String(), query.Args...)
 	return err
 }
+
+func CountAllGrants(tx ReadTxn) (int64, error) {
+	return countRows(tx, grantsTable{})
+}

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -849,3 +849,16 @@ func isNotBlocked[T any](t *testing.T, ch chan T) (result T) {
 		return result
 	}
 }
+
+func TestCountAllGrants(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		createGrants(t, db,
+			&models.Grant{Subject: "sub", Privilege: "priv", Resource: "res1"},
+			&models.Grant{Subject: "sub", Privilege: "priv", Resource: "res2"},
+			&models.Grant{Subject: "sub", Privilege: "priv", Resource: "res3"})
+
+		actual, err := CountAllGrants(db)
+		assert.NilError(t, err)
+		assert.Equal(t, actual, int64(4)) // 3 + connector grant
+	})
+}

--- a/internal/server/data/group.go
+++ b/internal/server/data/group.go
@@ -202,3 +202,7 @@ func countUsersInGroup(tx ReadTxn, groupID uid.ID) (int64, error) {
 	err := tx.QueryRow(stmt, groupID).Scan(&count)
 	return count, handleError(err)
 }
+
+func CountAllGroups(tx ReadTxn) (int64, error) {
+	return countRows(tx, groupsTable{})
+}

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -394,3 +394,16 @@ func TestRemoveUsersFromGroup(t *testing.T) {
 		assert.DeepEqual(t, actual, expected, cmpModelsIdentityShallow)
 	})
 }
+
+func TestCountAllGroups(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		createGroups(t, db,
+			&models.Group{Name: "Everyone"},
+			&models.Group{Name: "Engineering"},
+			&models.Group{Name: "Product"})
+
+		actual, err := CountAllGroups(db)
+		assert.NilError(t, err)
+		assert.Equal(t, actual, int64(3))
+	})
+}

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -515,3 +515,7 @@ func deleteReferencesToIdentities(tx GormTxn, providerID uid.ID, toDelete []mode
 	}
 	return unreferencedIdentityIDs, nil
 }
+
+func CountAllIdentities(tx ReadTxn) (int64, error) {
+	return countRows(tx, identitiesTable{})
+}

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -722,3 +722,18 @@ func TestAssignIdentityToGroups(t *testing.T) {
 		}
 	})
 }
+
+func TestCountAllIdentities(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		createIdentities(t, db,
+			&models.Identity{Name: "one"},
+			&models.Identity{Name: "two"},
+			&models.Identity{Name: "three"},
+			&models.Identity{Name: "four"},
+			&models.Identity{Name: "five"})
+
+		actual, err := CountAllIdentities(db)
+		assert.NilError(t, err)
+		assert.Equal(t, actual, int64(6)) // 5 + connector
+	})
+}

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -154,3 +154,7 @@ func DeleteOrganization(tx WriteTxn, id uid.ID) error {
 func UpdateOrganization(tx WriteTxn, org *models.Organization) error {
 	return update(tx, (*organizationsTable)(org))
 }
+
+func CountOrganizations(tx ReadTxn) (int64, error) {
+	return countRows(tx, organizationsTable{})
+}

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -259,3 +259,20 @@ func TestDeleteOrganization(t *testing.T) {
 		})
 	})
 }
+
+func TestCountOrganizations(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		assert.NilError(t, CreateOrganization(db, &models.Organization{
+			Name:   "first",
+			Domain: "first.example.com",
+		}))
+		assert.NilError(t, CreateOrganization(db, &models.Organization{
+			Name:   "second",
+			Domain: "second.example.com",
+		}))
+
+		actual, err := CountOrganizations(db)
+		assert.NilError(t, err)
+		assert.Equal(t, actual, int64(3)) // 2 + default org
+	})
+}

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -259,3 +259,7 @@ func CountProvidersByKind(tx ReadTxn) ([]providersCount, error) {
 		return []any{&item.Kind, &item.Count}
 	})
 }
+
+func CountAllProviders(tx ReadTxn) (int64, error) {
+	return countRows(tx, providersTable{})
+}

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -457,3 +457,17 @@ func TestCountProvidersByKind(t *testing.T) {
 		assert.DeepEqual(t, actual, expected)
 	})
 }
+
+func TestCountAllProviders(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		createProviders(t, db,
+			&models.Provider{Name: "oidc", Kind: "oidc"},
+			&models.Provider{Name: "azure", Kind: "azure"},
+			&models.Provider{Name: "google", Kind: "google"},
+		)
+
+		actual, err := CountAllProviders(db)
+		assert.NilError(t, err)
+		assert.Equal(t, actual, int64(4)) // 3 + infra provider
+	})
+}

--- a/internal/server/data/query.go
+++ b/internal/server/data/query.go
@@ -190,3 +190,19 @@ func scanRows[T any](rows *sql.Rows, fields func(*T) []any) ([]T, error) {
 	}
 	return result, rows.Err()
 }
+
+// countRows performs a query that returns the number of rows in the table where
+// deleted_at is null. The count includes all organizations.
+//
+// To get counts for tables that do not have a deleted_at column, or to scope
+// the count, copy the implementation of this function and add the necessary
+// parameters to the query.
+func countRows(tx ReadTxn, table Table) (int64, error) {
+	query := querybuilder.New("SELECT count(*) FROM")
+	query.B(table.Table())
+	query.B("WHERE deleted_at is null")
+
+	var count int64
+	err := tx.QueryRow(query.String(), query.Args...).Scan(&count)
+	return count, handleError(err)
+}

--- a/internal/server/data/selectors.go
+++ b/internal/server/data/selectors.go
@@ -23,12 +23,6 @@ func ByOrgID(orgID uid.ID) SelectorFunc {
 	}
 }
 
-func ByName(name string) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("name = ?", name)
-	}
-}
-
 func ByPagination(p Pagination) SelectorFunc {
 	return func(db *gorm.DB) *gorm.DB {
 		if p.Page == 0 && p.Limit == 0 {
@@ -36,23 +30,5 @@ func ByPagination(p Pagination) SelectorFunc {
 		}
 		resultsForPage := p.Limit * (p.Page - 1)
 		return db.Offset(resultsForPage).Limit(p.Limit)
-	}
-}
-
-func Limit(limit int) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Limit(limit)
-	}
-}
-
-func NotName(name string) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Not("name = ?", name)
-	}
-}
-
-func NotPrivilege(privilege string) SelectorFunc {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Not("privilege = ?", privilege)
 	}
 }

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
-	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/metrics"
 )
 
@@ -19,7 +18,7 @@ func setupMetrics(db *data.DB) *prometheus.Registry {
 		Name:      "users",
 		Help:      "The total number of users",
 	}, []string{}, func() []metrics.Metric {
-		count, err := data.GlobalCount[models.Identity](db, data.NotName("connector"))
+		count, err := data.CountAllIdentities(db)
 		if err != nil {
 			logging.L.Warn().Err(err).Msg("users")
 			return []metrics.Metric{}
@@ -35,7 +34,7 @@ func setupMetrics(db *data.DB) *prometheus.Registry {
 		Name:      "groups",
 		Help:      "The total number of groups",
 	}, []string{}, func() []metrics.Metric {
-		count, err := data.GlobalCount[models.Group](db)
+		count, err := data.CountAllGroups(db)
 		if err != nil {
 			logging.L.Warn().Err(err).Msg("groups")
 			return []metrics.Metric{}
@@ -51,7 +50,7 @@ func setupMetrics(db *data.DB) *prometheus.Registry {
 		Name:      "grants",
 		Help:      "The total number of grants",
 	}, []string{}, func() []metrics.Metric {
-		count, err := data.GlobalCount[models.Grant](db, data.NotPrivilege("connector"))
+		count, err := data.CountAllGrants(db)
 		if err != nil {
 			logging.L.Warn().Err(err).Msg("grants")
 			return []metrics.Metric{}
@@ -113,7 +112,7 @@ func setupMetrics(db *data.DB) *prometheus.Registry {
 		Name:      "organizations",
 		Help:      "The total number of organizations",
 	}, []string{}, func() []metrics.Metric {
-		count, err := data.GlobalCount[models.Organization](db)
+		count, err := data.CountOrganizations(db)
 		if err != nil {
 			logging.L.Warn().Err(err).Msg("organizations")
 			return []metrics.Metric{}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -190,7 +190,7 @@ func New(options Options) (*Server, error) {
 	server.redis = redis
 
 	if options.EnableTelemetry {
-		server.tel = NewTelemetry(server.DB(), db.DefaultOrgSettings.ID)
+		server.tel = NewTelemetry(server.db, db.DefaultOrgSettings.ID)
 	}
 
 	if err := server.loadConfig(server.options.Config); err != nil {

--- a/internal/server/telemetry.go
+++ b/internal/server/telemetry.go
@@ -10,7 +10,6 @@ import (
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
-	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -18,12 +17,12 @@ type Properties = analytics.Properties
 
 type Telemetry struct {
 	client  analytics.Client
-	db      data.GormTxn
+	db      *data.DB
 	infraID uid.ID
 }
 
 // todo: store global settings like email/signup configured
-func NewTelemetry(db data.GormTxn, infraID uid.ID) *Telemetry {
+func NewTelemetry(db *data.DB, infraID uid.ID) *Telemetry {
 	return &Telemetry{
 		client:  analytics.New(internal.TelemetryWriteKey),
 		db:      db,
@@ -65,27 +64,27 @@ func (t *Telemetry) Close() {
 }
 
 func (t *Telemetry) EnqueueHeartbeat() {
-	users, err := data.GlobalCount[models.Identity](t.db)
+	users, err := data.CountAllIdentities(t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}
 
-	groups, err := data.GlobalCount[models.Group](t.db)
+	groups, err := data.CountAllGroups(t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}
 
-	grants, err := data.GlobalCount[models.Grant](t.db)
+	grants, err := data.CountAllGrants(t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}
 
-	providers, err := data.GlobalCount[models.Provider](t.db)
+	providers, err := data.CountAllProviders(t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}
 
-	destinations, err := data.GlobalCount[models.Destination](t.db)
+	destinations, err := data.CountAllDestinations(t.db)
 	if err != nil {
 		logging.Debugf("%s", err.Error())
 	}

--- a/internal/server/testdata/TestMetrics/infra_grants
+++ b/internal/server/testdata/TestMetrics/infra_grants
@@ -1,1 +1,1 @@
-infra_grants 0
+infra_grants 1

--- a/internal/server/testdata/TestMetrics/infra_users
+++ b/internal/server/testdata/TestMetrics/infra_users
@@ -1,1 +1,1 @@
-infra_users 3
+infra_users 4


### PR DESCRIPTION
This PR converts queries that used `GlobalCount` to use SQL. Instead of a single shared function for everything I created a `countRows` that works for the common case (tables with a `deleted_at` row), and called `countRows` from a type-specific function. In the future if we customize the counts for a type we can add an options struct to these functions.

Also adds test coverage of the count functions.

This PR makes one small changes to the counts. Previously we would exclude the connector user and connector grant from the metrics counts (but not from the telemetry counts, and we didn't exclude the infra provider from the list of providers in either case). 

I can add these excludes back if we think they are important, but I think we should consider omitting them because they make the query more expensive. We don't have an index on privilege (it's the third field in the composite uniqueness index, which can't be used here), and adding one for this one query would be relatively expensive for something where the count doesn't need to be precise.  

Counts of all these entities across all orgs isn't really relevant for anything except a very high level view of growth. For any meaningful questions we are going to need to know the percentile of users/groups/grants per-org. So I think we should keep these as low-cost approximations, and not add the excludes back into the queries.