### PR TITLE
Revert "Merge pull request #3543 from infrahq/mxyng/http-connector"

### DIFF
--- a/helm/charts/infra/templates/connector/deployment.yaml
+++ b/helm/charts/infra/templates/connector/deployment.yaml
@@ -61,9 +61,6 @@ spec:
 {{- toYaml .Values.connector.volumeMounts | nindent 12 }}
 {{- end }}
           ports:
-            - name: http
-              containerPort: {{ .Values.connector.config.addr.http }}
-              protocol: TCP
             - name: https
               containerPort: {{ .Values.connector.config.addr.https }}
               protocol: TCP
@@ -73,7 +70,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: https
+              scheme: HTTPS
             successThreshold: {{ .Values.connector.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.connector.livenessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.connector.livenessProbe.initialDelaySeconds }}
@@ -82,7 +80,8 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: https
+              scheme: HTTPS
             successThreshold: {{ .Values.connector.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.connector.readinessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.connector.readinessProbe.initialDelaySeconds }}

--- a/helm/charts/infra/templates/connector/service.yaml
+++ b/helm/charts/infra/templates/connector/service.yaml
@@ -26,13 +26,6 @@ spec:
   sessionAffinity: {{ .Values.connector.service.sessionAffinity }}
 {{- end }}
   ports:
-    - port: {{ .Values.connector.service.port }}
-      name: {{ .Values.connector.service.portName }}
-      targetPort: http
-      protocol: TCP
-{{- if eq .Values.connector.service.type "NodePort" }}
-      nodePort: {{ .Values.connector.service.nodePort }}
-{{- end }}
     - port: {{ .Values.connector.service.securePort }}
       name: {{ .Values.connector.service.securePortName }}
       targetPort: https

--- a/helm/charts/infra/values.yaml
+++ b/helm/charts/infra/values.yaml
@@ -1061,7 +1061,6 @@ connector:
 
     ## Connector container service ports
     addr:
-      http: 9080
       https: 9443
       metrics: 9091
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -340,7 +340,6 @@ var runConnector = connector.Run
 func defaultConnectorOptions() connector.Options {
 	return connector.Options{
 		Addr: connector.ListenerOptions{
-			HTTP:    ":80",
 			HTTPS:   ":443",
 			Metrics: ":9090",
 		},

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -403,7 +403,6 @@ name: the-name
 caCert: /path/to/cert
 caKey: /path/to/key
 addr:
-  http: localhost:84
   https: localhost:414
   metrics: 127.0.0.1:8000
 `,
@@ -411,7 +410,6 @@ addr:
 				return connector.Options{
 					Name: "the-name",
 					Addr: connector.ListenerOptions{
-						HTTP:    "localhost:84",
 						HTTPS:   "localhost:414",
 						Metrics: "127.0.0.1:8000",
 					},

--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -79,7 +79,6 @@ func TestConnector_Run(t *testing.T) {
 			CA:        types.StringOrFile(certs.PEMEncodeCertificate(kubeSrv.Certificate().Raw)),
 		},
 		Addr: connector.ListenerOptions{
-			HTTP:    "127.0.0.1:0",
 			HTTPS:   "127.0.0.1:0",
 			Metrics: "127.0.0.1:0",
 		},

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -58,7 +58,6 @@ type ServerOptions struct {
 }
 
 type ListenerOptions struct {
-	HTTP    string
 	HTTPS   string
 	Metrics string
 }
@@ -262,12 +261,11 @@ func Run(ctx context.Context, options Options) error {
 		MinVersion: tls.VersionTLS12,
 	}
 
-	httpErrorLog := log.New(logging.NewFilteredHTTPLogger(), "", 0)
-
 	proxy := httputil.NewSingleHostReverseProxy(kubeAPIAddr)
 	proxy.Transport = proxyTransport
-	proxy.ErrorLog = httpErrorLog
+	proxy.ErrorLog = log.New(logging.NewFilteredHTTPLogger(), "", 0)
 
+	httpErrorLog := log.New(logging.NewFilteredHTTPLogger(), "", 0)
 	metricsServer := &http.Server{
 		ReadHeaderTimeout: 30 * time.Second,
 		ReadTimeout:       60 * time.Second,
@@ -278,27 +276,6 @@ func Run(ctx context.Context, options Options) error {
 
 	group.Go(func() error {
 		err := metricsServer.ListenAndServe()
-		if errors.Is(err, http.ErrServerClosed) {
-			return nil
-		}
-		return err
-	})
-
-	healthOnlyRouter := gin.New()
-	healthOnlyRouter.GET("/healthz", func(c *gin.Context) {
-		c.Status(http.StatusOK)
-	})
-
-	plaintextServer := &http.Server{
-		ReadHeaderTimeout: 30 * time.Second,
-		ReadTimeout:       60 * time.Second,
-		Addr:              options.Addr.HTTP,
-		Handler:           healthOnlyRouter,
-		ErrorLog:          httpErrorLog,
-	}
-
-	group.Go(func() error {
-		err := plaintextServer.ListenAndServe()
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil
 		}
@@ -319,7 +296,7 @@ func Run(ctx context.Context, options Options) error {
 		ErrorLog:          httpErrorLog,
 	}
 
-	logging.Infof("starting infra connector (%s) - http:%s https:%s metrics:%s", internal.FullVersion(), plaintextServer.Addr, tlsServer.Addr, metricsServer.Addr)
+	logging.Infof("starting infra connector (%s) - https:%s metrics:%s", internal.FullVersion(), tlsServer.Addr, metricsServer.Addr)
 
 	group.Go(func() error {
 		err = tlsServer.ListenAndServeTLS("", "")
@@ -336,9 +313,6 @@ func Run(ctx context.Context, options Options) error {
 	defer shutdownCancel()
 	if err := tlsServer.Shutdown(shutdownCtx); err != nil {
 		logging.L.Warn().Err(err).Msgf("shutdown proxy server")
-	}
-	if err := plaintextServer.Close(); err != nil {
-		logging.L.Warn().Err(err).Msgf("shutdown plaintext server")
 	}
 	if err := metricsServer.Close(); err != nil {
 		logging.L.Warn().Err(err).Msgf("shutdown metrics server")


### PR DESCRIPTION
This reverts commit f55e99bfc817ada7ad27c56bd8cc6de5d571c6e1, reversing changes made to 50a9ffc68024d4426b04b444289bdd66044b41d5.

The HTTP service is interfering with the connector's endpoint discovery among other things. Reverting for now