### PR TITLE
fix: postgres data mountpoint

### DIFF
--- a/helm/charts/infra/Chart.yaml
+++ b/helm/charts/infra/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: infra
 description: A Helm chart for Infra
 type: application
-version: 0.20.4
-appVersion: 0.15.2
+version: 0.20.5
+appVersion: 0.16.1

--- a/helm/charts/infra/templates/postgres/_helpers.tpl
+++ b/helm/charts/infra/templates/postgres/_helpers.tpl
@@ -106,6 +106,7 @@ postgres 'env' values. Merges global and local values.
 {{- else }}
 {{- $env = append $env (dict "name" "POSTGRES_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" (include "postgres.fullname" .) "key" "password"))) }}
 {{- end }}
+{{- $env = append $env (dict "name" "PGDATA" "value" "/var/lib/postgresql/data/pgdata") }}
 {{- $env | uniq | toYaml }}
 {{- end }}
 

--- a/helm/charts/infra/templates/postgres/statefulset.yaml
+++ b/helm/charts/infra/templates/postgres/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
               protocol: TCP
           livenessProbe:
             exec:
-              command: [pg_isready]
+              command: [pg_isready, -d, {{ .Values.postgres.dbName }}, -U, {{ .Values.postgres.dbUsername }}]
             successThreshold: {{ .Values.postgres.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.postgres.livenessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.postgres.livenessProbe.initialDelaySeconds }}
@@ -56,7 +56,7 @@ spec:
             timeoutSeconds: {{ .Values.postgres.livenessProbe.timeoutSeconds }}
           readinessProbe:
             exec:
-              command: [pg_isready]
+              command: [pg_isready, -d, {{ .Values.postgres.dbName }}, -U, {{ .Values.postgres.dbUsername }}]
             successThreshold: {{ .Values.postgres.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.postgres.readinessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.postgres.readinessProbe.initialDelaySeconds }}
@@ -64,8 +64,8 @@ spec:
             timeoutSeconds: {{ .Values.postgres.readinessProbe.timeoutSeconds }}
           resources:
 {{- toYaml .Values.postgres.resources | nindent 12 }}
-{{- if .Values.server.persistence.enabled }}
       initContainers:
+{{- if .Values.server.persistence.enabled }}
         - name: migration
           image: alpine:latest
           command: [sh, -c]
@@ -91,6 +91,22 @@ spec:
               mountPath: /mnt/initdb
             - name: old-data
               mountPath: /var/lib/infrahq/server
+{{- end }}
+{{- if .Values.postgres.persistence.enabled }}
+        - name: pgdata
+          image: busybox:latest
+          command: [sh, -c]
+          args:
+            - |
+              MOUNTPOINT=/var/lib/postgresql/data
+              if [ ! -d "$MOUNTPOINT/pgdata" ]; then
+                mkdir -p $MOUNTPOINT/pgdata
+                # migrate data previously stored in /var/lib/postgresql/data, exclude `pgdata` and `lost+found`
+                find $MOUNTPOINT -not -name 'pgdata' -not -name 'lost+found' -maxdepth 1 -mindepth 1 -exec mv -v {} $MOUNTPOINT/pgdata/ \;
+              fi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
 {{- end }}
       volumes:
         - name: initdb


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Using the data mountpoint directly causes problems for postgres in certain scenario where the directly may not initialize empty. Instead, use a subdirectory under the mountpoint to store the actual data.

* Add migration to move data previously stored in the mountpoint to the subdirectory (`/var/lib/postgresql/data -> /var/lib/postgresql/data/pgdata`)
* Fix postgres health checks to use the right user and database name
* Bump appVersion to 0.16.1, chart version to 0.20.5

### Testing Migration
- Install Infra locally with chart 0.20.4
- Load some data (users, groups)
- Upgrade chart
- Verify data still exists

### Testing AWS
- Install Infra with chart 0.20.4.
- Postgres pod goes into crash loop
- Install updated chart
- No crash loop

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3124
Resolves #3555 
