### PR TITLE
Use 499 status code for context cancelled.

### DIFF
--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -106,6 +106,11 @@ func sendAPIError(c *gin.Context, err error) {
 		resp.Code = http.StatusGatewayTimeout // not ideal, but StatusRequestTimeout isn't intended for this.
 		resp.Message = "request timed out"
 
+	case errors.Is(err, context.Canceled):
+		// Nginx uses this non-standard error code for the same purpose
+		resp.Code = 499
+		resp.Message = fmt.Sprintf("client closed the request: %v", err)
+
 	default:
 		log = logging.L.Error()
 	}

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -111,6 +112,20 @@ func TestSendAPIError(t *testing.T) {
 			err:               internal.ErrNotModified,
 			result:            api.Error{Code: http.StatusNotModified},
 			emptyResponseBody: true,
+		},
+		{
+			err: fmt.Errorf("wrapped: %w", context.DeadlineExceeded),
+			result: api.Error{
+				Code:    http.StatusGatewayTimeout,
+				Message: "request timed out",
+			},
+		},
+		{
+			err: fmt.Errorf("wrapped: %w", context.Canceled),
+			result: api.Error{
+				Code:    499,
+				Message: "client closed the request: wrapped: context canceled",
+			},
 		},
 	}
 


### PR DESCRIPTION
## Summary

So that these errors don't show up as 500 errors in our metrics and logs.

There's no standard response code for this, but Nginx uses 499 so let's do the same.