### PR TITLE
Demonstrate authorization in routes

### DIFF
--- a/internal/server/authorization.go
+++ b/internal/server/authorization.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"github.com/infrahq/infra/internal/access"
+)
+
+type authorization struct {
+	OneOfRoles []string
+	Resource   string
+	Operation  string
+	// AuthorizedByID is a custom function that can be set by a route to
+	// authorize the request. Generally the function should compare the
+	// requested ID to the rCtx.Authenticated.User.ID to see if the request is
+	// for the authorized user.
+	// The request will be authorized if AuthorizedByID returns nil. Any error
+	// instructs IsAuthorized to proceed to authorizing by role.
+	AuthorizeByID func(rCtx access.RequestContext, req any) error
+}
+
+func (a authorization) IsAuthorized(rCtx access.RequestContext, req any) error {
+	if a.AuthorizeByID != nil {
+		if err := a.AuthorizeByID(rCtx, req); err == nil {
+			return nil
+		}
+	}
+
+	err := access.IsAuthorized(rCtx, a.OneOfRoles...)
+	return access.HandleAuthErr(err, a.Resource, a.Operation, a.OneOfRoles...)
+}
+
+func requireRole(resource, operation string, oneOfRole ...string) *authorization {
+	return &authorization{
+		OneOfRoles: oneOfRole,
+		Resource:   resource,
+		Operation:  operation,
+	}
+}
+
+type noAuthorization struct{}
+
+func (n noAuthorization) IsAuthorized(access.RequestContext, any) error {
+	return nil
+}

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -37,9 +37,16 @@ func (a *API) ListProviders(c *gin.Context, r *api.ListProvidersRequest) (*api.L
 	return result, nil
 }
 
+var getProviderRoute = route[api.Resource, *api.Provider]{
+	handler:       GetProvider,
+	authorization: noAuthorization{},
+	routeSettings: routeSettingsGetMethodDefaults,
+}
+
 // caution: this endpoint is unauthenticated, do not return sensitive info
-func (a *API) GetProvider(c *gin.Context, r *api.Resource) (*api.Provider, error) {
-	provider, err := access.GetProvider(c, r.ID)
+func GetProvider(c *gin.Context, r *api.Resource) (*api.Provider, error) {
+	rCtx := getRequestContext(c)
+	provider, err := data.GetProvider(rCtx.DBTxn, data.GetProviderOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -103,6 +103,15 @@ func TestAPI_GetUser(t *testing.T) {
 				assert.Equal(t, resp.Code, http.StatusForbidden)
 			},
 		},
+		"authorized by role": {
+			urlPath: "/api/users/" + idHal.String(),
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusOK, (*responseDebug)(resp))
+			},
+		},
 		"identity not found": {
 			urlPath: "/api/users/2341",
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -678,7 +687,7 @@ func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 			var tmpUserID uid.ID
 
 			t.Run("I can create a user", func(t *testing.T) {
-				resp, err := a.CreateUser(ctx, &api.CreateUserRequest{
+				resp, err := CreateUser(ctx, &api.CreateUserRequest{
 					Name: "joe+" + generate.MathRandom(10, generate.CharsetAlphaNumeric),
 				})
 				tmpUserID = resp.ID


### PR DESCRIPTION
## Summary

This draft PR is an example of how we might move authorization from the `access` package to the routes.

There are 3 examples here, which I think cover all the common authorization cases:

1. `GetProvider` - uses `noAuthorization` to explicitly indicate that the endpoint does not require authorization.
2. `CreateUser` - uses the `requireRole` helper to specify the resource, operation and required roles
3. `GetUser` - uses a custom function along with roles, this case is more rare, we only have about 5 or 6 endpoints that require a custom function

The goal of this approach is to solve a few problems we have today, while still getting the benefit of handling authorization in `access`  (requiring every endpoint to be explicit about what authorization is required).

1. Include the required role (or permission) in the OpenAPI doc for each endpoint - today we don't have any way to automatically document which role is required for a route.
2. Return the correct authorization error - today an API endpoint may return an error message that indicates the wrong operation, or the wrong set of required roles. This happens because the authorization is done for an arbitrary `access` function, not for an API endpoint.
3. Remove the mirrored API in `access` - today the `access` package provides a wrapper function for every `data` function, and the contributor is expected to know that they have to call the access one. With this approach we'll no longer need to create an extra mirror function in `access`, which makes it easier to write new routes, and read and modify existing routes.
