### PR TITLE
fix: add http connector service

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -340,6 +340,7 @@ var runConnector = connector.Run
 func defaultConnectorOptions() connector.Options {
 	return connector.Options{
 		Addr: connector.ListenerOptions{
+			HTTP:    ":80",
 			HTTPS:   ":443",
 			Metrics: ":9090",
 		},

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -403,6 +403,7 @@ name: the-name
 caCert: /path/to/cert
 caKey: /path/to/key
 addr:
+  http: localhost:84
   https: localhost:414
   metrics: 127.0.0.1:8000
 `,
@@ -410,6 +411,7 @@ addr:
 				return connector.Options{
 					Name: "the-name",
 					Addr: connector.ListenerOptions{
+						HTTP:    "localhost:84",
 						HTTPS:   "localhost:414",
 						Metrics: "127.0.0.1:8000",
 					},

--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -79,6 +79,7 @@ func TestConnector_Run(t *testing.T) {
 			CA:        types.StringOrFile(certs.PEMEncodeCertificate(kubeSrv.Certificate().Raw)),
 		},
 		Addr: connector.ListenerOptions{
+			HTTP:    "127.0.0.1:0",
 			HTTPS:   "127.0.0.1:0",
 			Metrics: "127.0.0.1:0",
 		},

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -58,6 +58,7 @@ type ServerOptions struct {
 }
 
 type ListenerOptions struct {
+	HTTP    string
 	HTTPS   string
 	Metrics string
 }
@@ -261,11 +262,12 @@ func Run(ctx context.Context, options Options) error {
 		MinVersion: tls.VersionTLS12,
 	}
 
+	httpErrorLog := log.New(logging.NewFilteredHTTPLogger(), "", 0)
+
 	proxy := httputil.NewSingleHostReverseProxy(kubeAPIAddr)
 	proxy.Transport = proxyTransport
-	proxy.ErrorLog = log.New(logging.NewFilteredHTTPLogger(), "", 0)
+	proxy.ErrorLog = httpErrorLog
 
-	httpErrorLog := log.New(logging.NewFilteredHTTPLogger(), "", 0)
 	metricsServer := &http.Server{
 		ReadHeaderTimeout: 30 * time.Second,
 		ReadTimeout:       60 * time.Second,
@@ -276,6 +278,27 @@ func Run(ctx context.Context, options Options) error {
 
 	group.Go(func() error {
 		err := metricsServer.ListenAndServe()
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	})
+
+	healthOnlyRouter := gin.New()
+	healthOnlyRouter.GET("/healthz", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	plaintextServer := &http.Server{
+		ReadHeaderTimeout: 30 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		Addr:              options.Addr.HTTP,
+		Handler:           healthOnlyRouter,
+		ErrorLog:          httpErrorLog,
+	}
+
+	group.Go(func() error {
+		err := plaintextServer.ListenAndServe()
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil
 		}
@@ -296,7 +319,7 @@ func Run(ctx context.Context, options Options) error {
 		ErrorLog:          httpErrorLog,
 	}
 
-	logging.Infof("starting infra connector (%s) - https:%s metrics:%s", internal.FullVersion(), tlsServer.Addr, metricsServer.Addr)
+	logging.Infof("starting infra connector (%s) - http:%s https:%s metrics:%s", internal.FullVersion(), plaintextServer.Addr, tlsServer.Addr, metricsServer.Addr)
 
 	group.Go(func() error {
 		err = tlsServer.ListenAndServeTLS("", "")
@@ -313,6 +336,9 @@ func Run(ctx context.Context, options Options) error {
 	defer shutdownCancel()
 	if err := tlsServer.Shutdown(shutdownCtx); err != nil {
 		logging.L.Warn().Err(err).Msgf("shutdown proxy server")
+	}
+	if err := plaintextServer.Close(); err != nil {
+		logging.L.Warn().Err(err).Msgf("shutdown plaintext server")
 	}
 	if err := metricsServer.Close(); err != nil {
 		logging.L.Warn().Err(err).Msgf("shutdown metrics server")

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -657,11 +657,18 @@ func (k *Kubernetes) Endpoint() (string, int, error) {
 		return "", -1, fmt.Errorf("unsupported service type")
 	}
 
-	if len(service.Spec.Ports) == 0 {
-		return "", -1, fmt.Errorf("service has no ports")
+	var httpsPort int
+	for _, port := range service.Spec.Ports {
+		if port.Name == "https" {
+			httpsPort = int(port.Port)
+		}
 	}
 
-	return host, int(service.Spec.Ports[0].Port), nil
+	if httpsPort == 0 {
+		return "", -1, fmt.Errorf("service does not have an https port")
+	}
+
+	return host, httpsPort, nil
 }
 
 func (k *Kubernetes) IsServiceTypeClusterIP() (bool, error) {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Iteration on https://github.com/infrahq/infra/pull/3543. Separate out the Helm changes as it will cause problems if image and chart are deploy out of sync. Filter service port to pick out the `https` service port instead of using the first, which will be `http`. `http` will not work as the destination port since it does not serve the proxy