### PR TITLE
Enable debug log to track down test flakes in TestConnector_Run

### DIFF
--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/infrahq/infra/internal/certs"
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/connector"
+	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -37,6 +38,11 @@ func TestConnector_Run(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for short run")
 	}
+
+	assert.NilError(t, logging.SetLevel("debug"))
+	t.Cleanup(func() {
+		assert.NilError(t, logging.SetLevel("info"))
+	})
 
 	dir := t.TempDir()
 	serverOpts := defaultServerOptions(dir)
@@ -84,7 +90,7 @@ func TestConnector_Run(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	t.Cleanup(cancel)
 
 	runAndWait(ctx, t, func(ctx context.Context) error {
@@ -103,7 +109,7 @@ func TestConnector_Run(t *testing.T) {
 			return poll.Error(err)
 		}
 		return poll.Success()
-	})
+	}, poll.WithTimeout(30*time.Second))
 
 	// check the destination was updated
 	expected := &models.Destination{


### PR DESCRIPTION
## Summary

`TestConnector_Run` can flake occasionally in CI ([example](https://github.com/infrahq/infra/actions/runs/3396067574/jobs/5646711979)), but I've never been able to reproduce it locally.

From what I can tell, the connector is attempting to list destinations, but that API request never completes. The test ends up failing because the destination is not registered before the timeout.

I'm hoping it's just that CI can be very slow sometimes. The `poll.WaitOn` defaults to 10 second timeout, so I've created both the context deadline and this timeout to 30 seconds.

Also enable debug logging so that when it flakes maybe it gives us a bit more information about what is happening.

More links to flakes:
* https://github.com/infrahq/infra/actions/runs/3397238044/jobs/5649186761