### PR TITLE
Update tests that use gorm to use the stdlib interface

### DIFF
--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -307,21 +307,6 @@ func isOrgMember(model any) bool {
 	return ok
 }
 
-func add[T models.Modelable](tx GormTxn, model *T) error {
-	db := tx.GormDB()
-	setOrg(tx, model)
-
-	var err error
-	// failures on postgres need to be rolled back in order to
-	// continue using the same transaction
-	db.SavePoint("beforeCreate")
-	err = db.Create(model).Error
-	if err != nil {
-		db.RollbackTo("beforeCreate")
-	}
-	return handleError(err)
-}
-
 type UniqueConstraintError struct {
 	Table  string
 	Column string

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
-	"gorm.io/gorm"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal"
@@ -115,31 +114,6 @@ func TestPaginationSelector(t *testing.T) {
 		for i, user := range actual {
 			assert.Equal(t, user.Name, alphabeticalIdentities[i])
 		}
-	})
-}
-
-func TestCreateTransactionError(t *testing.T) {
-	// on creation error (such as conflict) the database transaction should still be usable
-	runDBTests(t, func(t *testing.T, db *DB) {
-		err := db.Transaction(func(txDB *gorm.DB) error {
-			tx := &Transaction{DB: txDB, orgID: 12345}
-
-			g := &models.Grant{}
-			err := add(tx, g)
-			if err != nil {
-				return err
-			}
-
-			// attempt to re-create, which results in a conflict
-			err = add(tx, g)
-			assert.ErrorContains(t, err, "already exists")
-
-			// the same transaction should still be usable
-			_, err = get[models.Grant](tx, ByID(g.ID))
-			return err
-		})
-
-		assert.NilError(t, err)
 	})
 }
 

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -51,19 +51,14 @@ func TestSnowflakeIDSerialization(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		id := uid.New()
 		g := &models.Group{Model: models.Model{ID: id}, Name: "Foo"}
-		err := db.Create(g).Error
+
+		err := CreateGroup(db, g)
 		assert.NilError(t, err)
 
-		var group models.Group
-		err = db.First(&group, &models.Group{Name: "Foo"}).Error
+		actual, err := GetGroup(db, GetGroupOptions{ByID: g.ID})
 		assert.NilError(t, err)
-		assert.Assert(t, 0 != group.ID)
-
-		var intID int64
-		err = db.Select("id").Table("groups").Scan(&intID).Error
-		assert.NilError(t, err)
-
-		assert.Equal(t, int64(id), intID)
+		assert.Assert(t, actual.ID != 0)
+		assert.Equal(t, actual.ID, g.ID)
 	})
 }
 

--- a/internal/server/data/migrator/helpers.go
+++ b/internal/server/data/migrator/helpers.go
@@ -15,7 +15,7 @@ func HasTable(tx DB, name string) bool {
 		SELECT count(*)
 		FROM information_schema.tables
 		WHERE table_schema = CURRENT_SCHEMA()
-		AND table_name = ? AND table_type = 'BASE TABLE'
+		AND table_name = $1 AND table_type = 'BASE TABLE'
 	`
 	if err := tx.QueryRow(stmt, name).Scan(&count); err != nil {
 		logging.L.Warn().Err(err).Msg("failed to check if table exists")
@@ -34,7 +34,7 @@ func HasColumn(tx DB, table string, column string) bool {
 		SELECT count(*)
 		FROM information_schema.columns
 		WHERE table_schema = CURRENT_SCHEMA()
-		AND table_name = ? AND column_name = ?
+		AND table_name = $1 AND column_name = $2
 	`
 	if err := tx.QueryRow(stmt, table, column).Scan(&count); err != nil {
 		logging.L.Warn().Err(err).Msg("failed to check if column exists")
@@ -52,7 +52,7 @@ func HasConstraint(tx DB, table string, constraint string) bool {
 		SELECT count(*)
 		FROM information_schema.table_constraints
 		WHERE table_schema = CURRENT_SCHEMA()
-		AND table_name = ? AND constraint_name = ?
+		AND table_name = $1 AND constraint_name = $2
 	`
 	if err := tx.QueryRow(stmt, table, constraint).Scan(&count); err != nil {
 		logging.L.Warn().Err(err).Msg("failed to check if constraint exists")
@@ -69,7 +69,7 @@ func HasFunction(tx DB, funcName string) bool {
 		SELECT count(*)
 		FROM pg_proc
 		INNER JOIN pg_namespace ON pg_proc.pronamespace = pg_namespace.oid
-		WHERE proname = ? AND nspname = CURRENT_SCHEMA()`
+		WHERE proname = $1 AND nspname = CURRENT_SCHEMA()`
 
 	var count int
 	// function names are stored in lowercase, so convert to lowercase

--- a/internal/server/data/migrator/migrator.go
+++ b/internal/server/data/migrator/migrator.go
@@ -167,7 +167,7 @@ func (g *Migrator) rollbackMigration(m *Migration) error {
 	if err := m.Rollback(g.tx); err != nil {
 		return err
 	}
-	_, err := g.tx.Exec("DELETE FROM migrations WHERE id = ?", m.ID)
+	_, err := g.tx.Exec("DELETE FROM migrations WHERE id = $1", m.ID)
 	return err
 }
 
@@ -215,7 +215,7 @@ func (g *Migrator) createMigrationTableIfNotExists() error {
 // individually
 func (g *Migrator) migrationRan(m *Migration) (bool, error) {
 	var count int64
-	err := g.tx.QueryRow(`SELECT count(id) FROM migrations WHERE id = ?`, m.ID).Scan(&count)
+	err := g.tx.QueryRow(`SELECT count(id) FROM migrations WHERE id = $1`, m.ID).Scan(&count)
 	return count > 0, err
 }
 
@@ -235,6 +235,6 @@ func (g *Migrator) mustInitializeSchema() (bool, error) {
 }
 
 func (g *Migrator) insertMigration(id string) error {
-	_, err := g.tx.Exec("INSERT INTO migrations (id) VALUES (?)", id)
+	_, err := g.tx.Exec("INSERT INTO migrations (id) VALUES ($1)", id)
 	return err
 }

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal"
@@ -16,13 +17,12 @@ func TestCreateProvider(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		providerDevelop := models.Provider{Name: "okta-development", URL: "example.com", Kind: models.ProviderKindOkta}
 
-		err := db.Create(&providerDevelop).Error
+		err := CreateProvider(db, &providerDevelop)
 		assert.NilError(t, err)
 
-		var provider models.Provider
-		err = db.Not("name = ?", models.InternalInfraProviderName).First(&provider).Error
+		actual, err := GetProvider(db, GetProviderOptions{ByID: providerDevelop.ID})
 		assert.NilError(t, err)
-		assert.Equal(t, "example.com", provider.URL)
+		assert.DeepEqual(t, &providerDevelop, actual, cmpTimeWithDBPrecision, cmpopts.EquateEmpty())
 	})
 }
 

--- a/internal/server/data/sqlfunc_test.go
+++ b/internal/server/data/sqlfunc_test.go
@@ -17,7 +17,7 @@ func TestSQLUidStrToIntRoundTrip(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		var i int64
-		err := db.Raw("select uidStrToInt(?);", tc.base58).Scan(&i).Error
+		err := db.QueryRow("select uidStrToInt(?);", tc.base58).Scan(&i)
 		if err != nil {
 			if tc.err != "" {
 				assert.ErrorContains(t, err, tc.err)
@@ -34,7 +34,7 @@ func TestSQLUidStrToIntRoundTrip(t *testing.T) {
 			return
 		}
 		var s string
-		err = db.Raw("select uidIntToStr(?);", tc.intval).Scan(&s).Error
+		err = db.QueryRow("select uidIntToStr(?);", tc.intval).Scan(&s)
 		if err != nil {
 			if tc.err != "" {
 				assert.ErrorContains(t, err, tc.err)

--- a/internal/server/passwordreset_test.go
+++ b/internal/server/passwordreset_test.go
@@ -54,9 +54,15 @@ func TestPasswordResetFlow(t *testing.T) {
 	assert.Assert(t, len(email.TestDataSent) > 0)
 
 	// cheat and grab the token from the db.
-	tokens := []string{}
-	err = s.db.Raw("select token from password_reset_tokens").Pluck("token", &tokens).Error
+	rows, err := s.db.Query("select token from password_reset_tokens")
 	assert.NilError(t, err)
+	tokens := []string{}
+	for rows.Next() {
+		var v string
+		assert.NilError(t, rows.Scan(&v))
+		tokens = append(tokens, v)
+	}
+	assert.NilError(t, rows.Close())
 
 	assert.Assert(t, len(tokens) > 0)
 	token := tokens[len(tokens)-1]


### PR DESCRIPTION
## Summary

This PR updates a bunch of tests that were using the gorm interface for queries to use the stdlib interface for queries.

Best viewed by individual commit.