### PR TITLE
feat: social login

### DIFF
--- a/api/provider.go
+++ b/api/provider.go
@@ -29,16 +29,30 @@ type Provider struct {
 	Kind     string   `json:"kind" example:"oidc"`
 	AuthURL  string   `json:"authURL" example:"https://example.com/oauth2/v1/authorize"`
 	Scopes   []string `json:"scopes" example:"['openid', 'email']"`
+	Managed  bool     `json:"managed"`
 }
 
-type CreateProviderRequest struct {
-	Name           string                  `json:"name" example:"okta"`
+type OIDCClient struct {
 	URL            string                  `json:"url" example:"infrahq.okta.com"`
 	ClientID       string                  `json:"clientID" example:"0oapn0qwiQPiMIyR35d6"`
 	ClientSecret   string                  `json:"clientSecret" example:"jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU"`
 	AllowedDomains []string                `json:"allowedDomains" example:"['example.com', 'infrahq.com']"`
-	Kind           string                  `json:"kind" example:"oidc"`
 	API            *ProviderAPICredentials `json:"api"`
+}
+
+func (r OIDCClient) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.Required("url", r.URL),
+		validate.Required("clientID", r.ClientID),
+		validate.Required("clientSecret", r.ClientSecret),
+	}
+}
+
+type CreateProviderRequest struct {
+	Name           string      `json:"name" example:"okta"`
+	Kind           string      `json:"kind" example:"okta"`
+	AllowedDomains []string    `json:"allowedDomains" example:"['example.com', 'infrahq.com']"`
+	Client         *OIDCClient `json:"client"`
 }
 
 var kinds = []string{"oidc", "okta", "azure", "google"}
@@ -66,12 +80,9 @@ func ValidateAllowedDomains(value []string) validate.StringSliceRule {
 
 func (r CreateProviderRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		ValidateName(r.Name),
-		validate.Required("url", r.URL),
-		validate.Required("clientID", r.ClientID),
-		validate.Required("clientSecret", r.ClientSecret),
 		validate.Enum("kind", r.Kind, kinds),
 		ValidateAllowedDomains(r.AllowedDomains),
+		ValidateName(r.Name),
 	}
 }
 
@@ -82,26 +93,20 @@ type PatchProviderRequest struct {
 }
 
 type UpdateProviderRequest struct {
-	ID             uid.ID                  `uri:"id" json:"-"`
-	Name           string                  `json:"name" example:"okta"`
-	URL            string                  `json:"url" example:"infrahq.okta.com"`
-	ClientID       string                  `json:"clientID" example:"0oapn0qwiQPiMIyR35d6"`
-	ClientSecret   string                  `json:"clientSecret" example:"jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU"`
-	AllowedDomains []string                `json:"allowedDomains" example:"['example.com', 'infrahq.com']"`
-	Kind           string                  `json:"kind" example:"oidc"`
-	API            *ProviderAPICredentials `json:"api"`
+	ID             uid.ID      `uri:"id" json:"-"`
+	Name           string      `json:"name" example:"okta"`
+	Kind           string      `json:"kind" example:"okta"`
+	AllowedDomains []string    `json:"allowedDomains" example:"['example.com', 'infrahq.com']"`
+	Client         *OIDCClient `json:"client"`
 }
 
 func (r UpdateProviderRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		ValidateName(r.Name),
 		validate.Required("id", r.ID),
-		validate.Required("name", r.Name),
-		validate.Required("url", r.URL),
-		validate.Required("clientID", r.ClientID),
-		validate.Required("clientSecret", r.ClientSecret),
 		validate.Enum("kind", r.Kind, kinds),
 		ValidateAllowedDomains(r.AllowedDomains),
+		validate.Required("name", r.Name),
+		ValidateName(r.Name),
 	}
 }
 

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -777,6 +777,9 @@
                   "example": "oidc",
                   "type": "string"
                 },
+                "managed": {
+                  "type": "boolean"
+                },
                 "name": {
                   "example": "okta",
                   "type": "string"
@@ -968,6 +971,9 @@
           "kind": {
             "example": "oidc",
             "type": "string"
+          },
+          "managed": {
+            "type": "boolean"
           },
           "name": {
             "example": "okta",
@@ -5164,30 +5170,52 @@
                     "maxItems": 20,
                     "type": "array"
                   },
-                  "api": {
+                  "client": {
                     "properties": {
-                      "clientEmail": {
-                        "format": "email",
+                      "allowedDomains": {
+                        "example": "['example.com', 'infrahq.com']",
+                        "items": {
+                          "example": "['example.com', 'infrahq.com']",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "api": {
+                        "properties": {
+                          "clientEmail": {
+                            "format": "email",
+                            "type": "string"
+                          },
+                          "domainAdminEmail": {
+                            "format": "email",
+                            "type": "string"
+                          },
+                          "privateKey": {
+                            "example": "-----BEGIN PRIVATE KEY-----\nMIIDNTCCAh2gAwIBAgIRALRetnpcTo9O3V2fAK3ix+c\n-----END PRIVATE KEY-----\n",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "clientID": {
+                        "example": "0oapn0qwiQPiMIyR35d6",
                         "type": "string"
                       },
-                      "domainAdminEmail": {
-                        "format": "email",
+                      "clientSecret": {
+                        "example": "jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU",
                         "type": "string"
                       },
-                      "privateKey": {
-                        "example": "-----BEGIN PRIVATE KEY-----\nMIIDNTCCAh2gAwIBAgIRALRetnpcTo9O3V2fAK3ix+c\n-----END PRIVATE KEY-----\n",
+                      "url": {
+                        "example": "infrahq.okta.com",
                         "type": "string"
                       }
                     },
+                    "required": [
+                      "url",
+                      "clientID",
+                      "clientSecret"
+                    ],
                     "type": "object"
-                  },
-                  "clientID": {
-                    "example": "0oapn0qwiQPiMIyR35d6",
-                    "type": "string"
-                  },
-                  "clientSecret": {
-                    "example": "jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU",
-                    "type": "string"
                   },
                   "kind": {
                     "enum": [
@@ -5196,7 +5224,7 @@
                       "azure",
                       "google"
                     ],
-                    "example": "oidc",
+                    "example": "okta",
                     "type": "string"
                   },
                   "name": {
@@ -5205,17 +5233,8 @@
                     "maxLength": 256,
                     "minLength": 2,
                     "type": "string"
-                  },
-                  "url": {
-                    "example": "infrahq.okta.com",
-                    "type": "string"
                   }
                 },
-                "required": [
-                  "url",
-                  "clientID",
-                  "clientSecret"
-                ],
                 "type": "object"
               }
             }
@@ -5665,30 +5684,52 @@
                     "maxItems": 20,
                     "type": "array"
                   },
-                  "api": {
+                  "client": {
                     "properties": {
-                      "clientEmail": {
-                        "format": "email",
+                      "allowedDomains": {
+                        "example": "['example.com', 'infrahq.com']",
+                        "items": {
+                          "example": "['example.com', 'infrahq.com']",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "api": {
+                        "properties": {
+                          "clientEmail": {
+                            "format": "email",
+                            "type": "string"
+                          },
+                          "domainAdminEmail": {
+                            "format": "email",
+                            "type": "string"
+                          },
+                          "privateKey": {
+                            "example": "-----BEGIN PRIVATE KEY-----\nMIIDNTCCAh2gAwIBAgIRALRetnpcTo9O3V2fAK3ix+c\n-----END PRIVATE KEY-----\n",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "clientID": {
+                        "example": "0oapn0qwiQPiMIyR35d6",
                         "type": "string"
                       },
-                      "domainAdminEmail": {
-                        "format": "email",
+                      "clientSecret": {
+                        "example": "jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU",
                         "type": "string"
                       },
-                      "privateKey": {
-                        "example": "-----BEGIN PRIVATE KEY-----\nMIIDNTCCAh2gAwIBAgIRALRetnpcTo9O3V2fAK3ix+c\n-----END PRIVATE KEY-----\n",
+                      "url": {
+                        "example": "infrahq.okta.com",
                         "type": "string"
                       }
                     },
+                    "required": [
+                      "url",
+                      "clientID",
+                      "clientSecret"
+                    ],
                     "type": "object"
-                  },
-                  "clientID": {
-                    "example": "0oapn0qwiQPiMIyR35d6",
-                    "type": "string"
-                  },
-                  "clientSecret": {
-                    "example": "jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU",
-                    "type": "string"
                   },
                   "kind": {
                     "enum": [
@@ -5697,7 +5738,7 @@
                       "azure",
                       "google"
                     ],
-                    "example": "oidc",
+                    "example": "okta",
                     "type": "string"
                   },
                   "name": {
@@ -5706,17 +5747,10 @@
                     "maxLength": 256,
                     "minLength": 2,
                     "type": "string"
-                  },
-                  "url": {
-                    "example": "infrahq.okta.com",
-                    "type": "string"
                   }
                 },
                 "required": [
-                  "name",
-                  "url",
-                  "clientID",
-                  "clientSecret"
+                  "name"
                 ],
                 "type": "object"
               }

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -241,15 +241,17 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 
 			logging.Debugf("call server: create provider named %q", args[0])
 			provider, err := client.CreateProvider(ctx, &api.CreateProviderRequest{
-				Name:         args[0],
-				URL:          opts.URL,
-				ClientID:     opts.ClientID,
-				ClientSecret: opts.ClientSecret,
-				Kind:         opts.Kind,
-				API: &api.ProviderAPICredentials{
-					PrivateKey:       api.PEM(opts.ProviderAPIOptions.PrivateKey),
-					ClientEmail:      opts.ProviderAPIOptions.ClientEmail,
-					DomainAdminEmail: opts.ProviderAPIOptions.WorkspaceDomainAdminEmail,
+				Name: args[0],
+				Kind: opts.Kind,
+				Client: &api.OIDCClient{
+					URL:          opts.URL,
+					ClientID:     opts.ClientID,
+					ClientSecret: opts.ClientSecret,
+					API: &api.ProviderAPICredentials{
+						PrivateKey:       api.PEM(opts.ProviderAPIOptions.PrivateKey),
+						ClientEmail:      opts.ProviderAPIOptions.ClientEmail,
+						DomainAdminEmail: opts.ProviderAPIOptions.WorkspaceDomainAdminEmail,
+					},
 				},
 			})
 			if err != nil {
@@ -356,16 +358,18 @@ func updateProvider(cli *CLI, name string, opts providerEditOptions) error {
 
 		logging.Debugf("call server: update provider named %q", name)
 		_, err = client.UpdateProvider(ctx, api.UpdateProviderRequest{
-			ID:           provider.ID,
-			Name:         name,
-			URL:          provider.URL,
-			ClientID:     provider.ClientID,
-			ClientSecret: opts.ClientSecret,
-			Kind:         provider.Kind,
-			API: &api.ProviderAPICredentials{
-				PrivateKey:       api.PEM(opts.ProviderAPIOptions.PrivateKey),
-				ClientEmail:      opts.ProviderAPIOptions.ClientEmail,
-				DomainAdminEmail: opts.ProviderAPIOptions.WorkspaceDomainAdminEmail,
+			ID:   provider.ID,
+			Name: name,
+			Kind: provider.Kind,
+			Client: &api.OIDCClient{
+				URL:          provider.URL,
+				ClientID:     provider.ClientID,
+				ClientSecret: opts.ClientSecret,
+				API: &api.ProviderAPICredentials{
+					PrivateKey:       api.PEM(opts.ProviderAPIOptions.PrivateKey),
+					ClientEmail:      opts.ProviderAPIOptions.ClientEmail,
+					DomainAdminEmail: opts.ProviderAPIOptions.WorkspaceDomainAdminEmail,
+				},
 			},
 		})
 

--- a/internal/cmd/providers_test.go
+++ b/internal/cmd/providers_test.go
@@ -91,12 +91,14 @@ func TestProvidersAddCmd(t *testing.T) {
 		createProviderRequest := <-ch
 
 		expected := api.CreateProviderRequest{
-			Name:         "okta",
-			URL:          "https://okta.com/path",
-			ClientID:     "okta-client-id",
-			ClientSecret: "okta-client-secret",
-			Kind:         "oidc",
-			API:          &api.ProviderAPICredentials{},
+			Name: "okta",
+			Kind: "oidc",
+			Client: &api.OIDCClient{
+				URL:          "https://okta.com/path",
+				ClientID:     "okta-client-id",
+				ClientSecret: "okta-client-secret",
+				API:          &api.ProviderAPICredentials{},
+			},
 		}
 		assert.DeepEqual(t, createProviderRequest, expected)
 	})
@@ -117,12 +119,14 @@ func TestProvidersAddCmd(t *testing.T) {
 		createProviderRequest := <-provCh
 
 		expectedProvider := api.CreateProviderRequest{
-			Name:         "okta",
-			URL:          "https://okta.com/path",
-			ClientID:     "okta-client-id",
-			ClientSecret: "okta-client-secret",
-			Kind:         "oidc",
-			API:          &api.ProviderAPICredentials{},
+			Name: "okta",
+			Kind: "oidc",
+			Client: &api.OIDCClient{
+				URL:          "https://okta.com/path",
+				ClientID:     "okta-client-id",
+				ClientSecret: "okta-client-secret",
+				API:          &api.ProviderAPICredentials{},
+			},
 		}
 		assert.DeepEqual(t, createProviderRequest, expectedProvider)
 
@@ -150,12 +154,14 @@ func TestProvidersAddCmd(t *testing.T) {
 		createProviderRequest := <-ch
 
 		expected := api.CreateProviderRequest{
-			Name:         "okta",
-			URL:          "https://okta.com/path",
-			ClientID:     "okta-client-id",
-			ClientSecret: "okta-client-secret",
-			Kind:         "oidc",
-			API:          &api.ProviderAPICredentials{},
+			Name: "okta",
+			Kind: "oidc",
+			Client: &api.OIDCClient{
+				URL:          "https://okta.com/path",
+				ClientID:     "okta-client-id",
+				ClientSecret: "okta-client-secret",
+				API:          &api.ProviderAPICredentials{},
+			},
 		}
 		assert.DeepEqual(t, createProviderRequest, expected)
 	})
@@ -175,12 +181,14 @@ func TestProvidersAddCmd(t *testing.T) {
 		createProviderRequest := <-ch
 
 		expected := api.CreateProviderRequest{
-			Name:         "google",
-			URL:          "accounts.google.com",
-			ClientID:     "aaa.apps.googleusercontent.com",
-			ClientSecret: "GOCSPX-bbb",
-			Kind:         "google",
-			API:          &api.ProviderAPICredentials{},
+			Name: "google",
+			Kind: "google",
+			Client: &api.OIDCClient{
+				URL:          "accounts.google.com",
+				ClientID:     "aaa.apps.googleusercontent.com",
+				ClientSecret: "GOCSPX-bbb",
+				API:          &api.ProviderAPICredentials{},
+			},
 		}
 		assert.DeepEqual(t, createProviderRequest, expected)
 	})
@@ -203,15 +211,17 @@ func TestProvidersAddCmd(t *testing.T) {
 		createProviderRequest := <-ch
 
 		expected := api.CreateProviderRequest{
-			Name:         "google",
-			URL:          "accounts.google.com",
-			ClientID:     "aaa.apps.googleusercontent.com",
-			ClientSecret: "GOCSPX-bbb",
-			Kind:         "google",
-			API: &api.ProviderAPICredentials{
-				PrivateKey:       api.PEM("-----BEGIN PRIVATE KEY-----\naaa=\n-----END PRIVATE KEY-----\n"),
-				ClientEmail:      "example@tenant.iam.gserviceaccount.com",
-				DomainAdminEmail: "admin@example.com",
+			Name: "google",
+			Kind: "google",
+			Client: &api.OIDCClient{
+				URL:          "accounts.google.com",
+				ClientID:     "aaa.apps.googleusercontent.com",
+				ClientSecret: "GOCSPX-bbb",
+				API: &api.ProviderAPICredentials{
+					PrivateKey:       api.PEM("-----BEGIN PRIVATE KEY-----\naaa=\n-----END PRIVATE KEY-----\n"),
+					ClientEmail:      "example@tenant.iam.gserviceaccount.com",
+					DomainAdminEmail: "admin@example.com",
+				},
 			},
 		}
 		assert.DeepEqual(t, createProviderRequest, expected)
@@ -386,12 +396,14 @@ func TestProvidersEditCmd(t *testing.T) {
 		updateProviderRequest := <-ch
 
 		expected := api.UpdateProviderRequest{
-			Name:         "okta",
-			URL:          "https://okta.com/path",
-			ClientID:     "okta-client-id",
-			ClientSecret: "okta-client-secret",
-			Kind:         "oidc",
-			API:          &api.ProviderAPICredentials{},
+			Name: "okta",
+			Kind: "oidc",
+			Client: &api.OIDCClient{
+				URL:          "https://okta.com/path",
+				ClientID:     "okta-client-id",
+				ClientSecret: "okta-client-secret",
+				API:          &api.ProviderAPICredentials{},
+			},
 		}
 		assert.DeepEqual(t, updateProviderRequest, expected)
 	})
@@ -411,15 +423,17 @@ func TestProvidersEditCmd(t *testing.T) {
 		updateProviderRequest := <-ch
 
 		expected := api.UpdateProviderRequest{
-			Name:         "google",
-			URL:          "https://example.com/google",
-			ClientID:     "google-client-id",
-			ClientSecret: "google-client-secret-2",
-			Kind:         "google",
-			API: &api.ProviderAPICredentials{
-				PrivateKey:       "-----BEGIN PRIVATE KEY-----\naaa=\n-----END PRIVATE KEY-----\n",
-				ClientEmail:      "example@tenant.iam.gserviceaccount.com",
-				DomainAdminEmail: "admin@example.com",
+			Name: "google",
+			Kind: "google",
+			Client: &api.OIDCClient{
+				URL:          "https://example.com/google",
+				ClientID:     "google-client-id",
+				ClientSecret: "google-client-secret-2",
+				API: &api.ProviderAPICredentials{
+					PrivateKey:       "-----BEGIN PRIVATE KEY-----\naaa=\n-----END PRIVATE KEY-----\n",
+					ClientEmail:      "example@tenant.iam.gserviceaccount.com",
+					DomainAdminEmail: "admin@example.com",
+				},
 			},
 		}
 		assert.DeepEqual(t, updateProviderRequest, expected)
@@ -437,12 +451,14 @@ func TestProvidersEditCmd(t *testing.T) {
 		updateProviderRequest := <-ch
 
 		expected := api.UpdateProviderRequest{
-			Name:         "google",
-			URL:          "https://example.com/google",
-			ClientID:     "google-client-id",
-			ClientSecret: "google-client-secret-3",
-			Kind:         "google",
-			API:          &api.ProviderAPICredentials{},
+			Name: "google",
+			Kind: "google",
+			Client: &api.OIDCClient{
+				URL:          "https://example.com/google",
+				ClientID:     "google-client-id",
+				ClientSecret: "google-client-secret-3",
+				API:          &api.ProviderAPICredentials{},
+			},
 		}
 		assert.DeepEqual(t, updateProviderRequest, expected)
 	})

--- a/internal/cmd/testdata/TestProvidersAddCmd/list_with_json
+++ b/internal/cmd/testdata/TestProvidersAddCmd/list_with_json
@@ -1,1 +1,1 @@
-[{"id":"","name":"okta","created":null,"updated":null,"url":"https://okta.com/path","clientID":"okta-client-id","kind":"","authURL":"","scopes":null}]
+[{"id":"","name":"okta","created":null,"updated":null,"url":"https://okta.com/path","clientID":"okta-client-id","kind":"","authURL":"","scopes":null,"managed":false}]

--- a/internal/cmd/testdata/TestProvidersAddCmd/list_with_yaml
+++ b/internal/cmd/testdata/TestProvidersAddCmd/list_with_yaml
@@ -3,6 +3,7 @@
   created: null
   id: ""
   kind: ""
+  managed: false
   name: okta
   scopes: null
   updated: null

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -44,6 +44,7 @@ func (p Provider) ValidationRules() []validate.ValidationRule {
 		validate.Required("url", p.URL),
 		validate.Required("clientID", p.ClientID),
 		validate.Required("clientSecret", p.ClientSecret),
+		validate.Required("kind", p.Kind),
 	}
 }
 
@@ -80,9 +81,10 @@ func (u User) ValidationRules() []validate.ValidationRule {
 
 type Config struct {
 	DefaultOrganizationDomain string
-	Providers                 []Provider
+	Providers                 []Provider // identity providers that the default org can use to log in
 	Grants                    []Grant
 	Users                     []User
+	SocialProviders           []Provider // social login options not configured by admin, but pre-configured by infra
 }
 
 func (c Config) ValidationRules() []validate.ValidationRule {
@@ -659,6 +661,10 @@ func (s Server) loadConfig(config Config) error {
 		return fmt.Errorf("load grants: %w", err)
 	}
 
+	if err := s.loadSocialProviders(tx, config.SocialProviders); err != nil {
+		return fmt.Errorf("load social provider config: %w", err)
+	}
+
 	return tx.Commit()
 }
 
@@ -685,6 +691,7 @@ func (s Server) loadProviders(db data.WriteTxn, providers []Provider) error {
 	return nil
 }
 
+// loadProvider from config for the default org
 func (s Server) loadProvider(db data.WriteTxn, input Provider) (*models.Provider, error) {
 	// provider kind is an optional field
 	kind, err := models.ParseProviderKind(input.Kind)
@@ -703,45 +710,9 @@ func (s Server) loadProvider(db data.WriteTxn, input Provider) (*models.Provider
 			return nil, err
 		}
 
-		provider := &models.Provider{
-			Name:         input.Name,
-			URL:          input.URL,
-			ClientID:     input.ClientID,
-			ClientSecret: models.EncryptedAtRest(clientSecret),
-			AuthURL:      input.AuthURL,
-			Scopes:       input.Scopes,
-			Kind:         kind,
-			CreatedBy:    models.CreatedBySystem,
-
-			PrivateKey:       models.EncryptedAtRest(input.PrivateKey),
-			ClientEmail:      input.ClientEmail,
-			DomainAdminEmail: input.DomainAdminEmail,
-		}
-
-		if provider.Kind != models.ProviderKindInfra {
-			// only call the provider to resolve info if it is not known
-			if input.AuthURL == "" && len(input.Scopes) == 0 {
-				providerClient := providers.NewOIDCClient(*provider, clientSecret, "http://localhost:8301")
-				authServerInfo, err := providerClient.AuthServerInfo(context.Background())
-				if err != nil {
-					if errors.Is(err, context.DeadlineExceeded) {
-						return nil, fmt.Errorf("%w: %s", internal.ErrBadGateway, err)
-					}
-					return nil, err
-				}
-
-				provider.AuthURL = authServerInfo.AuthURL
-				provider.Scopes = authServerInfo.ScopesSupported
-			}
-
-			// check that the scopes we need are set
-			supportedScopes := make(map[string]bool)
-			for _, s := range provider.Scopes {
-				supportedScopes[s] = true
-			}
-			if !supportedScopes["openid"] || !supportedScopes["email"] {
-				return nil, fmt.Errorf("required scopes 'openid' and 'email' not found on provider %q", input.Name)
-			}
+		provider, err := getConfigProviderDetails(input, kind, clientSecret)
+		if err != nil {
+			return nil, err
 		}
 
 		if err := data.CreateProvider(db, provider); err != nil {
@@ -759,6 +730,51 @@ func (s Server) loadProvider(db data.WriteTxn, input Provider) (*models.Provider
 
 	if err := data.UpdateProvider(db, provider); err != nil {
 		return nil, err
+	}
+
+	return provider, nil
+}
+
+func getConfigProviderDetails(input Provider, kind models.ProviderKind, clientSecret string) (*models.Provider, error) {
+	provider := &models.Provider{
+		Name:         input.Name,
+		URL:          input.URL,
+		ClientID:     input.ClientID,
+		ClientSecret: models.EncryptedAtRest(clientSecret),
+		AuthURL:      input.AuthURL,
+		Scopes:       input.Scopes,
+		Kind:         kind,
+		CreatedBy:    models.CreatedBySystem,
+
+		PrivateKey:       models.EncryptedAtRest(input.PrivateKey),
+		ClientEmail:      input.ClientEmail,
+		DomainAdminEmail: input.DomainAdminEmail,
+	}
+
+	if provider.Kind != models.ProviderKindInfra {
+		// only call the provider to resolve info if it is not known
+		if input.AuthURL == "" && len(input.Scopes) == 0 {
+			providerClient := providers.NewOIDCClient(*provider, clientSecret, "http://localhost:8301")
+			authServerInfo, err := providerClient.AuthServerInfo(context.Background())
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					return nil, fmt.Errorf("%w: %s", internal.ErrBadGateway, err)
+				}
+				return nil, err
+			}
+
+			provider.AuthURL = authServerInfo.AuthURL
+			provider.Scopes = authServerInfo.ScopesSupported
+		}
+
+		// check that the scopes we need are set
+		supportedScopes := make(map[string]bool)
+		for _, s := range provider.Scopes {
+			supportedScopes[s] = true
+		}
+		if !supportedScopes["openid"] || !supportedScopes["email"] {
+			return nil, fmt.Errorf("required scopes 'openid' and 'email' not found on provider %q", input.Name)
+		}
 	}
 
 	return provider, nil
@@ -927,6 +943,71 @@ func (s Server) loadUser(db data.WriteTxn, input User) (*models.Identity, error)
 	}
 
 	return identity, nil
+}
+
+func (s Server) loadSocialProviders(db data.WriteTxn, providers []Provider) error {
+	keep := []uid.ID{}
+
+	for _, p := range providers {
+		provider, err := s.loadSocialProvider(db, p)
+		if err != nil {
+			return err
+		}
+
+		keep = append(keep, provider.ID)
+	}
+
+	// remove any social login providers previously defined by config
+	if err := data.DeleteSocialLoginProviders(db, data.DeleteSocialLoginProvidersOpts{ByNotIDs: keep}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// loadSocialProvider loads a social login provider that is shared between all orgs
+func (s Server) loadSocialProvider(db data.WriteTxn, input Provider) (*models.Provider, error) {
+	kind, err := models.ParseProviderKind(input.Kind)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse provider in config load: %w", err)
+	}
+
+	clientSecret, err := secrets.GetSecret(input.ClientSecret, s.secrets)
+	if err != nil {
+		return nil, fmt.Errorf("could not load provider client secret: %w", err)
+	}
+
+	provider, err := data.GetSocialLoginProvider(db, kind)
+	if err != nil {
+		if !errors.Is(err, internal.ErrNotFound) {
+			return nil, err
+		}
+
+		provider, err = getConfigProviderDetails(input, kind, clientSecret)
+		if err != nil {
+			return nil, fmt.Errorf("get social provider details: %w", err)
+		}
+
+		provider.SocialLogin = true
+
+		if err := data.CreateSocialLoginProvider(db, provider); err != nil {
+			return nil, err
+		}
+
+		return provider, nil
+	}
+
+	// social provider already exists, update it
+	provider.URL = input.URL
+	provider.ClientID = input.ClientID
+	provider.ClientSecret = models.EncryptedAtRest(clientSecret)
+	provider.Kind = kind
+
+	if err := data.UpdateSocialLoginProvider(db, provider); err != nil {
+		return nil, err
+	}
+
+	return provider, nil
 }
 
 func (s Server) loadCredential(db data.WriteTxn, identity *models.Identity, password string) error {

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -403,6 +403,7 @@ func TestLoadConfigWithProviders(t *testing.T) {
 				ClientSecret: "client-secret",
 				AuthURL:      "example.com/oauth2/default/v1/token",
 				Scopes:       []string{"openid", "email"},
+				Kind:         models.ProviderKindOkta.String(),
 			},
 			{
 				Name:         "azure",
@@ -448,7 +449,7 @@ func TestLoadConfigWithProviders(t *testing.T) {
 		URL:                "example.com",
 		ClientID:           "client-id",
 		ClientSecret:       "client-secret",
-		Kind:               models.ProviderKindOIDC, // the kind gets the default value
+		Kind:               models.ProviderKindOkta,
 		AuthURL:            "example.com/oauth2/default/v1/token",
 		Scopes:             []string{"openid", "email"},
 		OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrg.ID},
@@ -659,6 +660,7 @@ func TestLoadConfigPruneConfig(t *testing.T) {
 				ClientSecret: "client-secret",
 				AuthURL:      "example.com/auth",
 				Scopes:       []string{"openid", "email"},
+				Kind:         models.ProviderKindOkta.String(),
 			},
 		},
 		Grants: []Grant{
@@ -713,6 +715,7 @@ func TestLoadConfigPruneConfig(t *testing.T) {
 				ClientSecret: "new-client-secret",
 				AuthURL:      "new.example.com/auth",
 				Scopes:       []string{"openid", "email"},
+				Kind:         models.ProviderKindOkta.String(),
 			},
 		},
 	}
@@ -749,6 +752,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 				ClientSecret: "client-secret",
 				AuthURL:      "example.com/auth",
 				Scopes:       []string{"openid", "email"},
+				Kind:         models.ProviderKindOkta.String(),
 			},
 		},
 		Users: []User{
@@ -833,6 +837,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 				ClientSecret: "client-secret-2",
 				AuthURL:      "new.example.com/v1/auth",
 				Scopes:       []string{"openid", "email", "groups"},
+				Kind:         models.ProviderKindOkta.String(),
 			},
 		},
 		Grants: []Grant{
@@ -866,7 +871,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 		URL:                "new.example.com",
 		ClientID:           "client-id-2",
 		ClientSecret:       "client-secret-2",
-		Kind:               models.ProviderKindOIDC, // the kind gets the default value
+		Kind:               models.ProviderKindOkta,
 		AuthURL:            "new.example.com/v1/auth",
 		Scopes:             []string{"openid", "email", "groups"},
 		OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrg.ID},
@@ -967,4 +972,41 @@ func getTestDefaultOrgUserDetails(t *testing.T, server *Server, name string) (*m
 	}
 
 	return user, credential, accessKey
+}
+
+func TestSocialLoginProvider(t *testing.T) {
+	config := Config{
+		SocialProviders: []Provider{
+			{
+				Name:         "moogle",
+				URL:          "new.example.com",
+				ClientID:     "client-id-2",
+				ClientSecret: "client-secret-2",
+				AuthURL:      "new.example.com/v1/auth",
+				Scopes:       []string{"openid", "email", "groups"},
+				Kind:         models.ProviderKindGoogle.String(),
+			},
+		},
+	}
+
+	s := setupServer(t)
+	assert.NilError(t, s.loadConfig(config))
+
+	result, err := data.GetSocialLoginProvider(s.DB(), models.ProviderKindGoogle)
+	assert.NilError(t, err)
+
+	expected := &models.Provider{
+		Model:          result.Model,     // does not matter
+		CreatedBy:      result.CreatedBy, // does not matter
+		Name:           "moogle",
+		URL:            "new.example.com",
+		ClientID:       "client-id-2",
+		ClientSecret:   "client-secret-2",
+		AuthURL:        "new.example.com/v1/auth",
+		Scopes:         []string{"openid", "email", "groups"},
+		AllowedDomains: []string{},
+		SocialLogin:    true,
+		Kind:           models.ProviderKindGoogle,
+	}
+	assert.DeepEqual(t, expected, result)
 }

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -74,6 +74,7 @@ func migrations() []*migrator.Migration {
 		addDestinationKind(),
 		addAllowedDomainsToProvidersTable(),
 		fixDefaultOrgCreatedByMigration(),
+		addSocialLoginsToProvidersTable(),
 		// next one here
 	}
 }
@@ -904,6 +905,21 @@ func fixDefaultOrgCreatedByMigration() *migrator.Migration {
 			stmt := `
 				UPDATE organizations SET created_by=1 WHERE created_by is null;
 				UPDATE organizations SET domain='' WHERE domain is null`
+			_, err := tx.Exec(stmt)
+			return err
+		},
+	}
+}
+
+func addSocialLoginsToProvidersTable() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-11-05T13:00",
+		Migrate: func(tx migrator.DB) error {
+			stmt := `
+				ALTER TABLE providers
+					ADD COLUMN IF NOT EXISTS social_login boolean DEFAULT false,
+					ADD COLUMN IF NOT EXISTS managed boolean DEFAULT false;
+			`
 			_, err := tx.Exec(stmt)
 			return err
 		},

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -850,6 +850,12 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 				assert.NilError(t, err)
 			},
 		},
+		{
+			label: testCaseLine("2022-11-05T13:00"),
+			expected: func(t *testing.T, db WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -18,15 +18,35 @@ func (p providersTable) Table() string {
 }
 
 func (p providersTable) Columns() []string {
-	return []string{"auth_url", "client_email", "client_id", "client_secret", "created_at", "created_by", "deleted_at", "domain_admin_email", "id", "kind", "name", "organization_id", "private_key", "scopes", "updated_at", "url", "allowed_domains"}
+	return []string{"auth_url", "client_email", "client_id", "client_secret", "created_at", "created_by", "deleted_at", "domain_admin_email", "id", "kind", "name", "organization_id", "private_key", "scopes", "updated_at", "url", "allowed_domains", "social_login", "managed"}
 }
 
 func (p providersTable) Values() []any {
-	return []any{p.AuthURL, p.ClientEmail, p.ClientID, p.ClientSecret, p.CreatedAt, p.CreatedBy, p.DeletedAt, p.DomainAdminEmail, p.ID, p.Kind, p.Name, p.OrganizationID, p.PrivateKey, p.Scopes, p.UpdatedAt, p.URL, p.AllowedDomains}
+	return []any{p.AuthURL, p.ClientEmail, p.ClientID, p.ClientSecret, p.CreatedAt, p.CreatedBy, p.DeletedAt, p.DomainAdminEmail, p.ID, p.Kind, p.Name, p.OrganizationID, p.PrivateKey, p.Scopes, p.UpdatedAt, p.URL, p.AllowedDomains, p.SocialLogin, p.Managed}
 }
 
 func (p *providersTable) ScanFields() []any {
-	return []any{&p.AuthURL, &p.ClientEmail, &p.ClientID, &p.ClientSecret, &p.CreatedAt, &p.CreatedBy, &p.DeletedAt, &p.DomainAdminEmail, &p.ID, &p.Kind, &p.Name, &p.OrganizationID, &p.PrivateKey, &p.Scopes, &p.UpdatedAt, &p.URL, &p.AllowedDomains}
+	return []any{&p.AuthURL, &p.ClientEmail, &p.ClientID, &p.ClientSecret, &p.CreatedAt, &p.CreatedBy, &p.DeletedAt, &p.DomainAdminEmail, &p.ID, &p.Kind, &p.Name, &p.OrganizationID, &p.PrivateKey, &p.Scopes, &p.UpdatedAt, &p.URL, &p.AllowedDomains, &p.SocialLogin, &p.Managed}
+}
+
+// loadProviderFromManagedSocialClient populates a an org-scoped provider with fields from an infra-managed social provider
+func loadProviderFromManagedSocialClient(tx WriteTxn, provider *models.Provider) error {
+	template, err := GetSocialLoginProvider(tx, provider.Kind)
+	if err != nil {
+		if !errors.Is(err, internal.ErrNotFound) {
+			return ErrSocialLoginNotAvailable
+		}
+		return err
+	}
+	provider.AuthURL = template.AuthURL
+	provider.ClientEmail = template.ClientEmail
+	provider.ClientID = template.ClientID
+	provider.ClientSecret = template.ClientSecret
+	provider.DomainAdminEmail = template.DomainAdminEmail
+	provider.PrivateKey = template.PrivateKey
+	provider.Scopes = template.Scopes
+	provider.URL = template.URL
+	return nil
 }
 
 func validateProvider(p *models.Provider) error {
@@ -40,7 +60,15 @@ func validateProvider(p *models.Provider) error {
 	}
 }
 
+var ErrSocialLoginNotAvailable = fmt.Errorf("this provider does not have a managed option, custom client must be specified")
+
 func CreateProvider(tx WriteTxn, provider *models.Provider) error {
+	if provider.Managed {
+		err := loadProviderFromManagedSocialClient(tx, provider)
+		if err != nil {
+			return err
+		}
+	}
 	if err := validateProvider(provider); err != nil {
 		return err
 	}
@@ -145,6 +173,12 @@ func ListProviders(tx ReadTxn, opts ListProvidersOptions) ([]models.Provider, er
 }
 
 func UpdateProvider(tx WriteTxn, provider *models.Provider) error {
+	if provider.Managed {
+		err := loadProviderFromManagedSocialClient(tx, provider)
+		if err != nil {
+			return err
+		}
+	}
 	if err := validateProvider(provider); err != nil {
 		return err
 	}
@@ -262,4 +296,88 @@ func CountProvidersByKind(tx ReadTxn) ([]providersCount, error) {
 
 func CountAllProviders(tx ReadTxn) (int64, error) {
 	return countRows(tx, providersTable{})
+}
+
+// GetSocialLoginProvider gets social identity provider clients that exist outside of the org context
+func GetSocialLoginProvider(tx ReadTxn, kind models.ProviderKind) (*models.Provider, error) {
+	provider := &providersTable{}
+	query := querybuilder.New("SELECT")
+	query.B(columnsForSelect(provider))
+	query.B("FROM providers")
+	query.B("WHERE deleted_at is null AND social_login = true")
+	query.B("AND kind = ?", kind)
+
+	err := tx.QueryRow(query.String(), query.Args...).Scan(provider.ScanFields()...)
+	if err != nil {
+		return nil, handleError(err)
+	}
+	return (*models.Provider)(provider), nil
+}
+
+func validateSocialLoginProvider(p *models.Provider) error {
+	if !p.SocialLogin {
+		return fmt.Errorf("cannot create social login provider without the 'social_login' flag set")
+	}
+	if p.Managed {
+		return fmt.Errorf("cannot create managed social provider")
+	}
+	return validateProvider(p)
+}
+
+// CreateSocialLoginProvider creates a shared social login provider that all orgs can configure for log in
+func CreateSocialLoginProvider(tx WriteTxn, provider *models.Provider) error {
+	if err := validateSocialLoginProvider(provider); err != nil {
+		return err
+	}
+
+	if err := provider.OnInsert(); err != nil {
+		return err
+	}
+
+	table := (*providersTable)(provider)
+
+	query := querybuilder.New("INSERT INTO")
+	query.B(table.Table())
+	query.B("(")
+	query.B(columnsForInsert(table))
+	query.B(") VALUES (")
+	query.B(placeholderForColumns(table), table.Values()...)
+	query.B(");")
+	_, err := tx.Exec(query.String(), query.Args...)
+	return handleError(err)
+}
+
+// UpdateSocialLoginProvider updates the shared social login provider that all orgs can configure for log in
+func UpdateSocialLoginProvider(tx WriteTxn, provider *models.Provider) error {
+	if err := validateSocialLoginProvider(provider); err != nil {
+		return err
+	}
+
+	if err := provider.OnUpdate(); err != nil {
+		return err
+	}
+
+	table := (*providersTable)(provider)
+
+	query := querybuilder.New("UPDATE")
+	query.B(table.Table())
+	query.B("SET")
+	query.B(columnsForUpdate(table), table.Values()...)
+	query.B("WHERE deleted_at is null")
+	query.B("AND id = ?", table.Primary())
+	_, err := tx.Exec(query.String(), query.Args...)
+	return handleError(err)
+}
+
+type DeleteSocialLoginProvidersOpts struct {
+	ByNotIDs []uid.ID // the IDs of social login providers to not delete
+}
+
+func DeleteSocialLoginProviders(tx WriteTxn, opts DeleteSocialLoginProvidersOpts) error {
+	stmt := `
+		UPDATE providers
+		SET deleted_at = ?
+		WHERE deleted_at is null AND social_login = true AND id NOT IN (?)`
+	_, err := tx.Exec(stmt, time.Now(), opts.ByNotIDs)
+	return err
 }

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -250,7 +250,9 @@ CREATE TABLE providers (
     client_email text,
     domain_admin_email text,
     organization_id bigint,
-    allowed_domains text DEFAULT ''::text
+    allowed_domains text DEFAULT ''::text,
+    social_login boolean DEFAULT false,
+    managed boolean DEFAULT false
 );
 
 CREATE SEQUENCE seq_update_index

--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -27,6 +27,52 @@ func (a *API) addRequestRewrites() {
 	addRequestRewrite(a, http.MethodGet, "/api/access-keys", "0.16.1", func(o oldListAccessKeysRequest) newListAccessKeysRequest {
 		return newListAccessKeysRequest(o)
 	})
+	type createProviderRequestV0_16_1 struct {
+		Name           string                      `json:"name" example:"okta"`
+		Kind           string                      `json:"kind" example:"okta"`
+		URL            string                      `json:"url" example:"infrahq.okta.com"`
+		ClientID       string                      `json:"clientID" example:"0oapn0qwiQPiMIyR35d6"`
+		ClientSecret   string                      `json:"clientSecret" example:"jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU"`
+		AllowedDomains []string                    `json:"allowedDomains" example:"['example.com', 'infrahq.com']"`
+		API            *api.ProviderAPICredentials `json:"api"`
+	}
+	addRequestRewrite(a, http.MethodPost, "/api/providers", "0.16.1", func(oldRequest createProviderRequestV0_16_1) api.CreateProviderRequest {
+		return api.CreateProviderRequest{
+			Name: oldRequest.Name,
+			Kind: oldRequest.Kind,
+			Client: &api.OIDCClient{
+				URL:            oldRequest.URL,
+				ClientID:       oldRequest.ClientID,
+				ClientSecret:   oldRequest.ClientSecret,
+				AllowedDomains: oldRequest.AllowedDomains,
+				API:            oldRequest.API,
+			},
+		}
+	})
+	type updateProviderRequestV0_16_1 struct {
+		ID             uid.ID                      `uri:"id" json:"-"`
+		Name           string                      `json:"name" example:"okta"`
+		URL            string                      `json:"url" example:"infrahq.okta.com"`
+		ClientID       string                      `json:"clientID" example:"0oapn0qwiQPiMIyR35d6"`
+		ClientSecret   string                      `json:"clientSecret" example:"jmda5eG93ax3jMDxTGrbHd_TBGT6kgNZtrCugLbU"`
+		AllowedDomains []string                    `json:"allowedDomains" example:"['example.com', 'infrahq.com']"`
+		Kind           string                      `json:"kind" example:"oidc"`
+		API            *api.ProviderAPICredentials `json:"api"`
+	}
+	addRequestRewrite(a, http.MethodPut, "/api/providers", "0.16.1", func(oldRequest updateProviderRequestV0_16_1) api.UpdateProviderRequest {
+		return api.UpdateProviderRequest{
+			ID:   oldRequest.ID,
+			Name: oldRequest.Name,
+			Kind: oldRequest.Kind,
+			Client: &api.OIDCClient{
+				URL:            oldRequest.URL,
+				ClientID:       oldRequest.ClientID,
+				ClientSecret:   oldRequest.ClientSecret,
+				AllowedDomains: oldRequest.AllowedDomains,
+				API:            oldRequest.API,
+			},
+		}
+	})
 }
 
 func (a *API) addResponseRewrites() {

--- a/internal/server/models/provider.go
+++ b/internal/server/models/provider.go
@@ -60,6 +60,9 @@ type Provider struct {
 	PrivateKey       EncryptedAtRest
 	ClientEmail      string
 	DomainAdminEmail string
+
+	SocialLogin bool // this is a social login client that is owned by Infra not the orgs themselves
+	Managed     bool // this is a client that the organization admin cannot edit, it is owned by Infra as as social login
 }
 
 func (p *Provider) ToAPI() *api.Provider {
@@ -74,6 +77,7 @@ func (p *Provider) ToAPI() *api.Provider {
 		Kind:     p.Kind.String(),
 		AuthURL:  p.AuthURL,
 		Scopes:   p.Scopes,
+		Managed:  p.Managed,
 		// TODO: specify allowed domains here once login providers are a separate endpoint (#3599)
 	}
 }


### PR DESCRIPTION
## Summary
This change enables organizations to use our shared social login. Specifically this change allows the CLI to login using the shared social login. My next follow-up change will complete the social login feature by updating the UI to allow for social login also.

Configuring the server config file looks like this:
```
server:
  config:
    socialProviders:
      - name: google
        url: accounts.google.com
        clientID:  abc
        clientSecret: 123
        kind: google
```

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Part of #3261
