### PR TITLE
maintain: make userid field for access keys consistent

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -17,7 +17,7 @@ type AccessKey struct {
 }
 
 type ListAccessKeysRequest struct {
-	UserID      uid.ID `form:"user_id"`
+	UserID      uid.ID `form:"userID"`
 	Name        string `form:"name"`
 	ShowExpired bool   `form:"show_expired"`
 	PaginationRequest

--- a/api/access_key.go
+++ b/api/access_key.go
@@ -19,7 +19,7 @@ type AccessKey struct {
 type ListAccessKeysRequest struct {
 	UserID      uid.ID `form:"userID"`
 	Name        string `form:"name"`
-	ShowExpired bool   `form:"show_expired"`
+	ShowExpired bool   `form:"showExpired"`
 	PaginationRequest
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -378,7 +378,7 @@ func (c Client) DeleteDestination(ctx context.Context, id uid.ID) error {
 
 func (c Client) ListAccessKeys(ctx context.Context, req ListAccessKeysRequest) (*ListResponse[AccessKey], error) {
 	return get[ListResponse[AccessKey]](ctx, c, "/api/access-keys", Query{
-		"user_id":      {req.UserID.String()},
+		"userID":       {req.UserID.String()},
 		"name":         {req.Name},
 		"show_expired": {fmt.Sprint(req.ShowExpired)},
 		"page":         {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1303,7 +1303,7 @@
           },
           {
             "in": "query",
-            "name": "show_expired",
+            "name": "showExpired",
             "schema": {
               "type": "boolean"
             }

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1286,7 +1286,7 @@
           },
           {
             "in": "query",
-            "name": "user_id",
+            "name": "userID",
             "schema": {
               "example": "4yJ3n3D8E2",
               "format": "uid",

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -159,7 +159,7 @@ func TestKeysListCmd(t *testing.T) {
 			}
 
 			resp.WriteHeader(http.StatusOK)
-			if query.Get("user_id") == uid.ID(12345678).String() {
+			if query.Get("userID") == uid.ID(12345678).String() {
 				err := json.NewEncoder(resp).Encode(api.ListResponse[api.AccessKey]{
 					Count: 1,
 					Items: []api.AccessKey{

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -239,7 +239,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 
 	t.Run("show expired", func(t *testing.T) {
 		resp := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/api/access-keys?show_expired=1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/access-keys?showExpired=1", nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Set("Infra-Version", apiVersionLatest)
 

--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -7,10 +7,26 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/uid"
 )
 
 func (a *API) addRequestRewrites() {
 	// all request migrations go here
+	type oldListAccessKeysRequest struct {
+		UserID      uid.ID `form:"user_id"`
+		Name        string `form:"name"`
+		ShowExpired bool   `form:"show_expired"`
+		api.PaginationRequest
+	}
+	type newListAccessKeysRequest struct {
+		UserID      uid.ID `form:"userID"`
+		Name        string `form:"name"`
+		ShowExpired bool   `form:"showExpired"`
+		api.PaginationRequest
+	}
+	addRequestRewrite(a, http.MethodGet, "/api/access-keys", "0.16.1", func(o oldListAccessKeysRequest) newListAccessKeysRequest {
+		return newListAccessKeysRequest(o)
+	})
 }
 
 func (a *API) addResponseRewrites() {

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -162,7 +162,7 @@ func TestTrimWhitespace(t *testing.T) {
 	assert.Equal(t, resp.Code, http.StatusCreated, resp.Body.String())
 
 	// nolint:noctx
-	req = httptest.NewRequest(http.MethodGet, "/api/grants?privilege=%20admin%20&user_id="+userID.String(), nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/grants?privilege=%20admin%20&userID="+userID.String(), nil)
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 	req.Header.Add("Infra-Version", "0.13.1")
 


### PR DESCRIPTION
## Summary

Change `user_id` to `userID` in `GET /api/access-keys?userID=` to make it consistent with the rest of the API.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades

Note that this will break the old API if something is using it, however, it's unlikely that a lot of callers (or any, really) are actually using it right now.
