### PR TITLE
Add kind field to destinations

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -364,6 +364,7 @@ func (c Client) ListDestinations(ctx context.Context, req ListDestinationsReques
 	return get[ListResponse[Destination]](ctx, c, "/api/destinations", Query{
 		"name":      {req.Name},
 		"unique_id": {req.UniqueID},
+		"kind":      {req.Kind},
 		"page":      {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
 	})
 }

--- a/api/destination.go
+++ b/api/destination.go
@@ -9,6 +9,7 @@ type Destination struct {
 	ID         uid.ID                `json:"id"`
 	UniqueID   string                `json:"uniqueID" form:"uniqueID" example:"94c2c570a20311180ec325fd56"`
 	Name       string                `json:"name" form:"name"`
+	Kind       string                `json:"kind"`
 	Created    Time                  `json:"created"`
 	Updated    Time                  `json:"updated"`
 	Connection DestinationConnection `json:"connection"`
@@ -36,6 +37,7 @@ func (r DestinationConnection) ValidationRules() []validate.ValidationRule {
 
 type ListDestinationsRequest struct {
 	Name     string `form:"name"`
+	Kind     string `form:"kind"`
 	UniqueID string `form:"unique_id"`
 	PaginationRequest
 }
@@ -49,6 +51,7 @@ func (r ListDestinationsRequest) ValidationRules() []validate.ValidationRule {
 type CreateDestinationRequest struct {
 	UniqueID   string                `json:"uniqueID"`
 	Name       string                `json:"name"`
+	Kind       string                `json:"kind"`
 	Version    string                `json:"version"`
 	Connection DestinationConnection `json:"connection"`
 
@@ -61,6 +64,9 @@ func (r CreateDestinationRequest) ValidationRules() []validate.ValidationRule {
 		validate.Required("uniqueID", r.UniqueID),
 		validateDestinationName(r.Name),
 		validate.Required("name", r.Name),
+		// Allow "" for versions 0.16.1 and prior
+		// TODO: make this required in the future
+		validate.Enum("kind", r.Kind, []string{"kubernetes", "ssh", ""}),
 	}
 }
 

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -162,6 +162,9 @@
             "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
             "type": "string"
           },
+          "kind": {
+            "type": "string"
+          },
           "lastSeen": {
             "description": "formatted as an RFC3339 date-time",
             "example": "2022-03-14T09:48:00Z",
@@ -566,6 +569,9 @@
                   "example": "4yJ3n3D8E2",
                   "format": "uid",
                   "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                  "type": "string"
+                },
+                "kind": {
                   "type": "string"
                 },
                 "lastSeen": {
@@ -1673,6 +1679,13 @@
           },
           {
             "in": "query",
+            "name": "kind",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "unique_id",
             "schema": {
               "type": "string"
@@ -1812,6 +1825,14 @@
                       "ca"
                     ],
                     "type": "object"
+                  },
+                  "kind": {
+                    "enum": [
+                      "kubernetes",
+                      "ssh",
+                      ""
+                    ],
+                    "type": "string"
                   },
                   "name": {
                     "format": "[a-zA-Z0-9\\-_]",

--- a/internal/access/destination.go
+++ b/internal/access/destination.go
@@ -32,13 +32,8 @@ func GetDestination(c *gin.Context, id uid.ID) (*models.Destination, error) {
 	return data.GetDestination(rCtx.DBTxn, data.GetDestinationOptions{ByID: id})
 }
 
-func ListDestinations(c *gin.Context, uniqueID, name string, p *data.Pagination) ([]models.Destination, error) {
+func ListDestinations(c *gin.Context, opts data.ListDestinationsOptions) ([]models.Destination, error) {
 	rCtx := GetRequestContext(c)
-	opts := data.ListDestinationsOptions{
-		ByName:     name,
-		ByUniqueID: uniqueID,
-		Pagination: p,
-	}
 	return data.ListDestinations(rCtx.DBTxn, opts)
 }
 

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -167,7 +167,7 @@ func syncKubeConfig(_ context.Context) error {
 	}
 	client.Name = "agent"
 
-	user, destinations, grants, err := getUserDestinationGrants(client)
+	user, destinations, grants, err := getUserDestinationGrants(client, "kubernetes")
 	if err != nil {
 		return fmt.Errorf("list grants: %w", err)
 	}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -228,7 +228,7 @@ func getUseCompletion(cmd *cobra.Command, args []string, toComplete string) ([]s
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
-	_, destinations, grants, err := getUserDestinationGrants(client)
+	_, destinations, grants, err := getUserDestinationGrants(client, "")
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -121,6 +121,7 @@ func TestConnector_Run(t *testing.T) {
 		},
 		OrganizationMember: models.OrganizationMember{OrganizationID: srv.DB().OrganizationID()},
 		Name:               "testing",
+		Kind:               "kubernetes",
 		UniqueID:           "4ebfd7dabeec5b37eafd20e3775f70ab86c7422036367d77d9bebfa03864e08b",
 		ConnectionURL:      "127.0.0.1:55555",
 		ConnectionCA:       opts.CACert.String(),

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -76,6 +76,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 			default:
 				type row struct {
 					Name     string `header:"NAME"`
+					Kind     string `header:"KIND"`
 					URL      string `header:"URL"`
 					Status   string `header:"STATUS"`
 					LastSeen string `header:"LAST SEEN"`
@@ -95,6 +96,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 
 					rows = append(rows, row{
 						Name:     d.Name,
+						Kind:     d.Kind,
 						URL:      d.Connection.URL,
 						Status:   status,
 						LastSeen: humanfmt.HumanTime(d.LastSeen.Time(), "never"),

--- a/internal/cmd/destinations_test.go
+++ b/internal/cmd/destinations_test.go
@@ -31,7 +31,11 @@ func TestDestinationsListCmd(t *testing.T) {
 			var apiDestinations []api.Destination
 			apiDestinations = append(apiDestinations, api.Destination{
 				Name: "destinationName",
+				Kind: "kubernetes",
 				ID:   123,
+				Connection: api.DestinationConnection{
+					URL: "10.0.0.1",
+				},
 			})
 
 			b, err := json.Marshal(api.ListResponse[api.Destination]{
@@ -67,5 +71,15 @@ func TestDestinationsListCmd(t *testing.T) {
 		err := Run(ctx, "destinations", "list", "--format=yaml")
 		assert.NilError(t, err)
 		golden.Assert(t, bufs.Stdout.String(), t.Name())
+	})
+
+	t.Run("list default table format", func(t *testing.T) {
+		setup(t)
+		ctx, bufs := PatchCLI(context.Background())
+
+		err := Run(ctx, "destinations", "list")
+		assert.NilError(t, err)
+		golden.Assert(t, bufs.Stdout.String(), t.Name())
+
 	})
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -36,7 +36,7 @@ func list(cli *CLI) error {
 		return err
 	}
 
-	user, destinations, grants, err := getUserDestinationGrants(client)
+	user, destinations, grants, err := getUserDestinationGrants(client, "kubernetes")
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func isResourceForDestination(resource string, destination string) bool {
 	return resource == destination || strings.HasPrefix(resource, destination+".")
 }
 
-func getUserDestinationGrants(client *api.Client) (*api.User, []api.Destination, []api.Grant, error) {
+func getUserDestinationGrants(client *api.Client, kind string) (*api.User, []api.Destination, []api.Grant, error) {
 	ctx := context.TODO()
 
 	config, err := currentHostConfig()
@@ -136,7 +136,7 @@ func getUserDestinationGrants(client *api.Client) (*api.User, []api.Destination,
 		return nil, nil, nil, err
 	}
 
-	destinations, err := listAll(ctx, client.ListDestinations, api.ListDestinationsRequest{})
+	destinations, err := listAll(ctx, client.ListDestinations, api.ListDestinationsRequest{Kind: kind})
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/cmd/testdata/TestDestinationsListCmd/list_default_table_format
+++ b/internal/cmd/testdata/TestDestinationsListCmd/list_default_table_format
@@ -1,0 +1,2 @@
+  NAME             KIND        URL       STATUS        LAST SEEN  
+  destinationName  kubernetes  10.0.0.1  Disconnected  never      

--- a/internal/cmd/testdata/TestDestinationsListCmd/list_with_json
+++ b/internal/cmd/testdata/TestDestinationsListCmd/list_with_json
@@ -1,1 +1,1 @@
-[{"id":"38","uniqueID":"","name":"destinationName","created":null,"updated":null,"connection":{"url":"","ca":""},"resources":null,"roles":null,"lastSeen":null,"connected":false,"version":""}]
+[{"id":"38","uniqueID":"","name":"destinationName","kind":"kubernetes","created":null,"updated":null,"connection":{"url":"10.0.0.1","ca":""},"resources":null,"roles":null,"lastSeen":null,"connected":false,"version":""}]

--- a/internal/cmd/testdata/TestDestinationsListCmd/list_with_yaml
+++ b/internal/cmd/testdata/TestDestinationsListCmd/list_with_yaml
@@ -1,9 +1,10 @@
 - connected: false
   connection:
     ca: ""
-    url: ""
+    url: 10.0.0.1
   created: null
   id: "38"
+  kind: kubernetes
   lastSeen: null
   name: destinationName
   resources: null

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -603,6 +603,7 @@ func createOrUpdateDestination(ctx context.Context, client apiClient, local *api
 
 	request := &api.CreateDestinationRequest{
 		Name:       local.Name,
+		Kind:       "kubernetes",
 		UniqueID:   local.UniqueID,
 		Version:    internal.FullVersion(),
 		Connection: local.Connection,

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -16,15 +16,15 @@ func (d destinationsTable) Table() string {
 }
 
 func (d destinationsTable) Columns() []string {
-	return []string{"connection_ca", "connection_url", "created_at", "deleted_at", "id", "last_seen_at", "name", "organization_id", "resources", "roles", "unique_id", "updated_at", "version"}
+	return []string{"connection_ca", "connection_url", "created_at", "deleted_at", "id", "kind", "last_seen_at", "name", "organization_id", "resources", "roles", "unique_id", "updated_at", "version"}
 }
 
 func (d destinationsTable) Values() []any {
-	return []any{d.ConnectionCA, d.ConnectionURL, d.CreatedAt, d.DeletedAt, d.ID, d.LastSeenAt, d.Name, d.OrganizationID, d.Resources, d.Roles, d.UniqueID, d.UpdatedAt, d.Version}
+	return []any{d.ConnectionCA, d.ConnectionURL, d.CreatedAt, d.DeletedAt, d.ID, d.Kind, d.LastSeenAt, d.Name, d.OrganizationID, d.Resources, d.Roles, d.UniqueID, d.UpdatedAt, d.Version}
 }
 
 func (d *destinationsTable) ScanFields() []any {
-	return []any{&d.ConnectionCA, &d.ConnectionURL, &d.CreatedAt, &d.DeletedAt, &d.ID, &d.LastSeenAt, &d.Name, &d.OrganizationID, &d.Resources, &d.Roles, &d.UniqueID, &d.UpdatedAt, &d.Version}
+	return []any{&d.ConnectionCA, &d.ConnectionURL, &d.CreatedAt, &d.DeletedAt, &d.ID, &d.Kind, &d.LastSeenAt, &d.Name, &d.OrganizationID, &d.Resources, &d.Roles, &d.UniqueID, &d.UpdatedAt, &d.Version}
 }
 
 // destinationsUpdateTable is used to update the destination. It excludes
@@ -50,6 +50,9 @@ func validateDestination(dest *models.Destination) error {
 	}
 	if dest.UniqueID == "" {
 		return fmt.Errorf("Destination.UniqueID is required")
+	}
+	if dest.Kind == "" {
+		return fmt.Errorf("Destination.Kind is required")
 	}
 	return nil
 }
@@ -107,6 +110,7 @@ func GetDestination(tx ReadTxn, opts GetDestinationOptions) (*models.Destination
 type ListDestinationsOptions struct {
 	ByUniqueID string
 	ByName     string
+	ByKind     string
 
 	Pagination *Pagination
 }
@@ -127,6 +131,9 @@ func ListDestinations(tx ReadTxn, opts ListDestinationsOptions) ([]models.Destin
 	}
 	if opts.ByName != "" {
 		query.B("AND name = ?", opts.ByName)
+	}
+	if opts.ByKind != "" {
+		query.B("AND kind = ?", opts.ByKind)
 	}
 
 	query.B("ORDER BY name")

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -71,6 +71,7 @@ func migrations() []*migrator.Migration {
 		addDeviceFlowAuthRequestTable(),
 		modifyDeviceFlowAuthRequestDropApproved(),
 		addExpiresAtIndices(),
+		addDestinationKind(),
 		// next one here
 	}
 }
@@ -863,6 +864,19 @@ func addExpiresAtIndices() *migrator.Migration {
 				CREATE INDEX IF NOT EXISTS idx_device_flow_auth_requests_expires_at on device_flow_auth_requests (expires_at);
 				CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expires_at on password_reset_tokens (expires_at);
 			`)
+			return err
+		},
+	}
+}
+
+func addDestinationKind() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-11-07T14:00",
+		Migrate: func(tx migrator.DB) error {
+			stmt := `
+				ALTER TABLE destinations
+				ADD COLUMN IF NOT EXISTS kind text NOT NULL DEFAULT 'kubernetes'`
+			_, err := tx.Exec(stmt)
 			return err
 		},
 	}

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -825,6 +825,29 @@ DELETE FROM settings WHERE id=24567;
 				// schema changes are tested with schema comparison
 			},
 		},
+		{
+			label: testCaseLine("2022-11-07T14:00"),
+			setup: func(t *testing.T, tx WriteTxn) {
+				stmt := `INSERT INTO destinations(id, name) VALUES(12345, 'some')`
+				_, err := tx.Exec(stmt)
+				assert.NilError(t, err)
+			},
+			cleanup: func(t *testing.T, tx WriteTxn) {
+				_, err := tx.Exec(`DELETE FROM destinations`)
+				assert.NilError(t, err)
+			},
+			expected: func(t *testing.T, tx WriteTxn) {
+				var dest destinationsTable
+
+				err := tx.QueryRow(`SELECT id, kind FROM destinations`).Scan(&dest.ID, &dest.Kind)
+				assert.NilError(t, err)
+				expected := destinationsTable{
+					Model: models.Model{ID: 12345},
+					Kind:  models.DestinationKind("kubernetes"),
+				}
+				assert.DeepEqual(t, expected, dest)
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -130,7 +130,8 @@ CREATE TABLE destinations (
     version text,
     resources text,
     roles text,
-    organization_id bigint
+    organization_id bigint,
+    kind text DEFAULT 'kubernetes'::text NOT NULL
 );
 
 CREATE TABLE device_flow_auth_requests (

--- a/internal/server/destination_test.go
+++ b/internal/server/destination_test.go
@@ -59,6 +59,7 @@ func TestAPI_CreateDestination(t *testing.T) {
 {
 	"id": "<any-valid-uid>",
 	"name": "final",
+	"kind": "kubernetes",
 	"uniqueID": "unique-id",
 	"version": "",
 	"connection": {

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -85,11 +85,11 @@ func TestMetrics(t *testing.T) {
 	t.Run("infra destinations", func(t *testing.T) {
 		db := setupDB(t)
 
-		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "1", UniqueID: "1", LastSeenAt: time.Now()}))
-		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "2", UniqueID: "2", Version: "", LastSeenAt: time.Now().Add(-10 * time.Minute)}))
-		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "3", UniqueID: "3", Version: "0.1.0", LastSeenAt: time.Now()}))
-		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "4", UniqueID: "4", Version: "0.1.0"}))
-		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "5", UniqueID: "5", Version: "0.1.0"}))
+		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "1", UniqueID: "1", Kind: models.DestinationKindKubernetes, LastSeenAt: time.Now()}))
+		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "2", UniqueID: "2", Kind: models.DestinationKindSSH, Version: "", LastSeenAt: time.Now().Add(-10 * time.Minute)}))
+		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "3", UniqueID: "3", Kind: models.DestinationKindKubernetes, Version: "0.1.0", LastSeenAt: time.Now()}))
+		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "4", UniqueID: "4", Kind: models.DestinationKindSSH, Version: "0.1.0"}))
+		assert.NilError(t, data.CreateDestination(db, &models.Destination{Name: "5", UniqueID: "5", Kind: models.DestinationKindSSH, Version: "0.1.0"}))
 
 		actual := run(db, `infra_destinations({.*})? \d+`)
 		golden.Assert(t, string(actual), t.Name())

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -359,7 +359,11 @@ func TestHandleInfraDestinationHeader(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("good", func(t *testing.T) {
-		destination := &models.Destination{Name: t.Name(), UniqueID: t.Name()}
+		destination := &models.Destination{
+			Name:     t.Name(),
+			UniqueID: t.Name(),
+			Kind:     models.DestinationKindKubernetes,
+		}
 		err := data.CreateDestination(db, destination)
 		assert.NilError(t, err)
 
@@ -387,7 +391,11 @@ func TestHandleInfraDestinationHeader(t *testing.T) {
 	})
 
 	t.Run("good no destination header", func(t *testing.T) {
-		destination := &models.Destination{Name: t.Name(), UniqueID: t.Name()}
+		destination := &models.Destination{
+			Name:     t.Name(),
+			UniqueID: t.Name(),
+			Kind:     models.DestinationKindKubernetes,
+		}
 		err := data.CreateDestination(db, destination)
 		assert.NilError(t, err)
 

--- a/internal/server/models/destination.go
+++ b/internal/server/models/destination.go
@@ -6,6 +6,13 @@ import (
 	"github.com/infrahq/infra/api"
 )
 
+type DestinationKind string
+
+const (
+	DestinationKindKubernetes DestinationKind = "kubernetes"
+	DestinationKindSSH        DestinationKind = "ssh"
+)
+
 type Destination struct {
 	Model
 	OrganizationMember
@@ -20,6 +27,7 @@ type Destination struct {
 
 	Resources CommaSeparatedStrings
 	Roles     CommaSeparatedStrings
+	Kind      DestinationKind
 }
 
 func (d *Destination) ToAPI() *api.Destination {
@@ -33,6 +41,7 @@ func (d *Destination) ToAPI() *api.Destination {
 		Created:  api.Time(d.CreatedAt),
 		Updated:  api.Time(d.UpdatedAt),
 		Name:     d.Name,
+		Kind:     string(d.Kind),
 		UniqueID: d.UniqueID,
 		Connection: api.DestinationConnection{
 			URL: d.ConnectionURL,


### PR DESCRIPTION
## Summary

So that we can support more than one kind of destination.

This PR adds api, data, and CLI support for `destination.kind`. I'm not sure what (if anything) needs to change for the UI.

I made this a non-breaking change by making the API field optional and defaulting to kubernetes (since that's the only destination that exists right now). In the future we can make it required in the API as well. 