### PR TITLE
Add API and data support for user public keys

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -234,9 +234,13 @@ func (c Client) ListUsers(ctx context.Context, req ListUsersRequest) (*ListRespo
 		return id.String()
 	})
 	return get[ListResponse[User]](ctx, c, "/api/users", Query{
-		"name": {req.Name}, "group": {req.Group.String()}, "ids": ids,
-		"page": {strconv.Itoa(req.Page)}, "limit": {strconv.Itoa(req.Limit)},
-		"showSystem": {strconv.FormatBool(req.ShowSystem)},
+		"name":                 {req.Name},
+		"group":                {req.Group.String()},
+		"ids":                  ids,
+		"page":                 {strconv.Itoa(req.Page)},
+		"limit":                {strconv.Itoa(req.Limit)},
+		"showSystem":           {strconv.FormatBool(req.ShowSystem)},
+		"publicKeyFingerprint": {req.PublicKeyFingerprint},
 	})
 }
 
@@ -254,6 +258,10 @@ func (c Client) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*User, 
 
 func (c Client) DeleteUser(ctx context.Context, id uid.ID) error {
 	return delete(ctx, c, fmt.Sprintf("/api/users/%s", id), Query{})
+}
+
+func (c Client) AddUserPublicKey(ctx context.Context, req *AddUserPublicKeyRequest) (*UserPublicKey, error) {
+	return put[UserPublicKey](ctx, c, "/api/users/public-key", req)
 }
 
 func (c Client) StartDeviceFlow(ctx context.Context) (*DeviceFlowResponse, error) {

--- a/api/user.go
+++ b/api/user.go
@@ -78,7 +78,7 @@ func (req ListUsersRequest) SetPage(page int) Paginatable {
 }
 
 type AddUserPublicKeyRequest struct {
-	Name string `json:"name"`
+	Name string `json:"name" note:"Name of the public key, often the name of the device used to create it"`
 	// PublicKey is the key type and base64 encoded public key as it would appear
 	// in an authorized keys file.
 	PublicKey string `json:"publicKey"`

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -6840,6 +6840,7 @@
               "schema": {
                 "properties": {
                   "name": {
+                    "description": "Name of the public key, often the name of the device used to create it",
                     "format": "[a-zA-Z0-9\\-_.]",
                     "maxLength": 256,
                     "minLength": 2,

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1020,7 +1020,9 @@
                   "type": "array"
                 },
                 "publicKeys": {
+                  "description": "List of the users public keys",
                   "items": {
+                    "description": "List of the users public keys",
                     "properties": {
                       "created": {
                         "description": "formatted as an RFC3339 date-time",
@@ -1035,7 +1037,7 @@
                       "id": {
                         "example": "4yJ3n3D8E2",
                         "format": "uid",
-                        "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                        "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
                         "type": "string"
                       },
                       "keyType": {
@@ -1292,7 +1294,9 @@
             "type": "array"
           },
           "publicKeys": {
+            "description": "List of the users public keys",
             "items": {
+              "description": "List of the users public keys",
               "properties": {
                 "created": {
                   "description": "formatted as an RFC3339 date-time",
@@ -1307,7 +1311,7 @@
                 "id": {
                   "example": "4yJ3n3D8E2",
                   "format": "uid",
-                  "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                  "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
                   "type": "string"
                 },
                 "keyType": {
@@ -1347,7 +1351,7 @@
           "id": {
             "example": "4yJ3n3D8E2",
             "format": "uid",
-            "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+            "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
             "type": "string"
           },
           "keyType": {
@@ -6586,15 +6590,17 @@
             }
           },
           {
-            "description": "Page number to retrieve",
-            "example": "1",
+            "description": "Find the user with a public key that matches this SHA256 fingerprint.",
             "in": "query",
             "name": "publicKeyFingerprint",
             "schema": {
+              "description": "Find the user with a public key that matches this SHA256 fingerprint.",
               "type": "string"
             }
           },
           {
+            "description": "Page number to retrieve",
+            "example": "1",
             "in": "query",
             "name": "page",
             "schema": {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1019,6 +1019,39 @@
                   },
                   "type": "array"
                 },
+                "publicKeys": {
+                  "items": {
+                    "properties": {
+                      "created": {
+                        "description": "formatted as an RFC3339 date-time",
+                        "example": "2022-03-14T09:48:00Z",
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "fingerprint": {
+                        "description": "SHA256 fingerprint of the key",
+                        "type": "string"
+                      },
+                      "id": {
+                        "example": "4yJ3n3D8E2",
+                        "format": "uid",
+                        "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                        "type": "string"
+                      },
+                      "keyType": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "publicKey": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
                 "updated": {
                   "description": "formatted as an RFC3339 date-time",
                   "example": "2022-03-14T09:48:00Z",
@@ -1258,10 +1291,72 @@
             },
             "type": "array"
           },
+          "publicKeys": {
+            "items": {
+              "properties": {
+                "created": {
+                  "description": "formatted as an RFC3339 date-time",
+                  "example": "2022-03-14T09:48:00Z",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "fingerprint": {
+                  "description": "SHA256 fingerprint of the key",
+                  "type": "string"
+                },
+                "id": {
+                  "example": "4yJ3n3D8E2",
+                  "format": "uid",
+                  "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+                  "type": "string"
+                },
+                "keyType": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
           "updated": {
             "description": "formatted as an RFC3339 date-time",
             "example": "2022-03-14T09:48:00Z",
             "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
+      "UserPublicKey": {
+        "properties": {
+          "created": {
+            "description": "formatted as an RFC3339 date-time",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "fingerprint": {
+            "description": "SHA256 fingerprint of the key",
+            "type": "string"
+          },
+          "id": {
+            "example": "4yJ3n3D8E2",
+            "format": "uid",
+            "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
+            "type": "string"
+          },
+          "keyType": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "publicKey": {
             "type": "string"
           }
         }
@@ -6494,6 +6589,13 @@
             "description": "Page number to retrieve",
             "example": "1",
             "in": "query",
+            "name": "publicKeyFingerprint",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "page",
             "schema": {
               "description": "Page number to retrieve",
@@ -6693,6 +6795,125 @@
           }
         },
         "summary": "CreateUser",
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/api/users/public-key": {
+      "put": {
+        "description": "AddUserPublicKey",
+        "operationId": "AddUserPublicKey",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.0.0",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "description": "Bearer followed by your access key",
+              "example": "Bearer ACCESSKEY",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "format": "[a-zA-Z0-9\\-_.]",
+                    "maxLength": 256,
+                    "minLength": 2,
+                    "type": "string"
+                  },
+                  "publicKey": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "publicKey"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserPublicKey"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "AddUserPublicKey",
         "tags": [
           "Users"
         ]

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -77,25 +77,12 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 	return data.DeleteIdentities(db, opts)
 }
 
-func ListIdentities(c *gin.Context, name string, groupID uid.ID, ids []uid.ID, showSystem bool, p *data.Pagination) ([]models.Identity, error) {
+func ListIdentities(c *gin.Context, opts data.ListIdentityOptions) ([]models.Identity, error) {
 	roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
 	db, err := RequireInfraRole(c, roles...)
 	if err != nil {
 		return nil, HandleAuthErr(err, "users", "list", roles...)
 	}
-
-	opts := data.ListIdentityOptions{
-		Pagination:    p,
-		ByName:        name,
-		ByIDs:         ids,
-		ByGroupID:     groupID,
-		LoadProviders: true,
-	}
-
-	if !showSystem {
-		opts.ByNotName = models.InternalInfraConnectorIdentityName
-	}
-
 	return data.ListIdentities(db, opts)
 }
 

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -30,7 +30,7 @@ func TestListIdentities(t *testing.T) {
 	assert.NilError(t, err)
 
 	// test fetch all identities
-	ids, err := ListIdentities(c, "", 0, nil, true, nil)
+	ids, err := ListIdentities(c, data.ListIdentityOptions{})
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(ids), 4) // the two identities created, the admin one used to call these access functions, and the internal connector identity

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -148,10 +148,11 @@ func CreateIdentity(tx WriteTxn, identity *models.Identity) error {
 }
 
 type GetIdentityOptions struct {
-	ByID          uid.ID
-	ByName        string
-	LoadGroups    bool
-	LoadProviders bool
+	ByID           uid.ID
+	ByName         string
+	LoadGroups     bool
+	LoadProviders  bool
+	LoadPublicKeys bool
 }
 
 func GetIdentity(tx ReadTxn, opts GetIdentityOptions) (*models.Identity, error) {
@@ -166,9 +167,9 @@ func GetIdentity(tx ReadTxn, opts GetIdentityOptions) (*models.Identity, error) 
 	query.B("WHERE deleted_at IS NULL AND organization_id = ?", tx.OrganizationID())
 	switch {
 	case opts.ByID != 0:
-		query.B("AND id = ?", opts.ByID)
+		query.B("AND identities.id = ?", opts.ByID)
 	case opts.ByName != "":
-		query.B("AND name = ?", opts.ByName)
+		query.B("AND identities.name = ?", opts.ByName)
 	default:
 		return nil, fmt.Errorf("GetIdentity must specify id or name")
 	}
@@ -210,6 +211,14 @@ func GetIdentity(tx ReadTxn, opts GetIdentityOptions) (*models.Identity, error) 
 		}
 	}
 
+	// TODO: use a join?
+	if opts.LoadPublicKeys {
+		identity.PublicKeys, err = userPublicKeys(tx, identity.ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return (*models.Identity)(identity), nil
 }
 
@@ -222,16 +231,18 @@ func SetIdentityVerified(tx WriteTxn, token string) error {
 }
 
 type ListIdentityOptions struct {
-	ByID          uid.ID
-	ByIDs         []uid.ID
-	ByNotIDs      []uid.ID
-	ByName        string
-	ByNotName     string
-	ByGroupID     uid.ID
-	CreatedBy     uid.ID
-	Pagination    *Pagination
-	LoadGroups    bool
-	LoadProviders bool
+	ByID                   uid.ID
+	ByIDs                  []uid.ID
+	ByNotIDs               []uid.ID
+	ByName                 string
+	ByPublicKeyFingerprint string
+	ByNotName              string
+	ByGroupID              uid.ID
+	CreatedBy              uid.ID
+	Pagination             *Pagination
+	LoadGroups             bool
+	LoadProviders          bool
+	LoadPublicKeys         bool
 }
 
 func ListIdentities(tx ReadTxn, opts ListIdentityOptions) ([]models.Identity, error) {
@@ -249,7 +260,11 @@ func ListIdentities(tx ReadTxn, opts ListIdentityOptions) ([]models.Identity, er
 	if opts.ByGroupID != 0 {
 		query.B("JOIN identities_groups ON identities_groups.identity_id = id")
 	}
-	query.B("WHERE deleted_at IS NULL AND organization_id = ?", tx.OrganizationID())
+	if opts.ByPublicKeyFingerprint != "" {
+		query.B("INNER JOIN user_public_keys ON identities.id = user_public_keys.user_id")
+		query.B("AND user_public_keys.fingerprint = ?", opts.ByPublicKeyFingerprint)
+	}
+	query.B("WHERE identities.deleted_at IS NULL AND organization_id = ?", tx.OrganizationID())
 	if opts.ByID != 0 {
 		query.B("AND id = ?", opts.ByID)
 	}
@@ -307,6 +322,16 @@ func ListIdentities(tx ReadTxn, opts ListIdentityOptions) ([]models.Identity, er
 	if opts.LoadProviders {
 		if err := loadIdentitiesProviders(tx, result); err != nil {
 			return nil, err
+		}
+	}
+
+	// TODO: use a join?
+	if opts.LoadPublicKeys {
+		for i, identity := range result {
+			result[i].PublicKeys, err = userPublicKeys(tx, identity.ID)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -264,31 +264,32 @@ func ListIdentities(tx ReadTxn, opts ListIdentityOptions) ([]models.Identity, er
 		query.B("INNER JOIN user_public_keys ON identities.id = user_public_keys.user_id")
 		query.B("AND user_public_keys.fingerprint = ?", opts.ByPublicKeyFingerprint)
 	}
-	query.B("WHERE identities.deleted_at IS NULL AND organization_id = ?", tx.OrganizationID())
+	query.B("WHERE identities.deleted_at IS NULL")
+	query.B("AND identities.organization_id = ?", tx.OrganizationID())
 	if opts.ByID != 0 {
-		query.B("AND id = ?", opts.ByID)
+		query.B("AND identities.id = ?", opts.ByID)
 	}
 	if len(opts.ByIDs) > 0 {
-		query.B("AND id IN")
+		query.B("AND identities.id IN")
 		queryInClause(query, opts.ByIDs)
 	}
 	if opts.ByName != "" {
-		query.B("AND name = ?", opts.ByName)
+		query.B("AND identities.name = ?", opts.ByName)
 	}
 	if opts.ByNotName != "" {
-		query.B("AND name != ?", opts.ByNotName)
+		query.B("AND identities.name != ?", opts.ByNotName)
 	}
 	if opts.ByGroupID != 0 {
 		query.B("AND identities_groups.group_id = ?", opts.ByGroupID)
 	}
 	if opts.CreatedBy != 0 {
-		query.B("AND created_by = ?", opts.CreatedBy)
+		query.B("AND identities.created_by = ?", opts.CreatedBy)
 		if len(opts.ByNotIDs) > 0 {
-			query.B("AND id NOT IN ")
+			query.B("AND identities.id NOT IN ")
 			queryInClause(query, opts.ByNotIDs)
 		}
 	}
-	query.B("ORDER BY name ASC")
+	query.B("ORDER BY identities.name ASC")
 	if opts.Pagination != nil {
 		opts.Pagination.PaginateQuery(query)
 	}

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -879,7 +879,7 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 		{
 			label: testCaseLine("2022-10-26T18:00"),
 			expected: func(t *testing.T, tx WriteTxn) {
-				// TODO:
+				// schema changes are tested with schema comparison
 			},
 		},
 	}

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -876,6 +876,12 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 				// schema changes are tested with schema comparison
 			},
 		},
+		{
+			label: testCaseLine("2022-10-26T18:00"),
+			expected: func(t *testing.T, tx WriteTxn) {
+				// TODO:
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -275,6 +275,19 @@ CREATE TABLE settings (
     organization_id bigint
 );
 
+CREATE TABLE user_public_keys (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    fingerprint text NOT NULL,
+    key_type text NOT NULL,
+    public_key text NOT NULL,
+    name text,
+    expires_at timestamp with time zone,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone,
+    deleted_at timestamp with time zone
+);
+
 ALTER TABLE ONLY access_keys
     ADD CONSTRAINT access_keys_pkey PRIMARY KEY (id);
 
@@ -314,6 +327,9 @@ ALTER TABLE ONLY providers
 ALTER TABLE ONLY settings
     ADD CONSTRAINT settings_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY user_public_keys
+    ADD CONSTRAINT user_public_keys_pkey PRIMARY KEY (id);
+
 CREATE INDEX idx_access_keys_expires_at ON access_keys USING btree (expires_at);
 
 CREATE UNIQUE INDEX idx_access_keys_issued_for_name ON access_keys USING btree (organization_id, issued_for, name) WHERE (deleted_at IS NULL);
@@ -351,6 +367,8 @@ CREATE INDEX idx_password_reset_tokens_expires_at ON password_reset_tokens USING
 CREATE UNIQUE INDEX idx_password_reset_tokens_token ON password_reset_tokens USING btree (token);
 
 CREATE UNIQUE INDEX idx_providers_name ON providers USING btree (organization_id, name) WHERE (deleted_at IS NULL);
+
+CREATE UNIQUE INDEX idx_user_public_keys_user_fingerprint ON user_public_keys USING btree (fingerprint) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX settings_org_id ON settings USING btree (organization_id) WHERE (deleted_at IS NULL);
 

--- a/internal/server/data/tables_test.go
+++ b/internal/server/data/tables_test.go
@@ -26,6 +26,7 @@ var tables = []tabler{
 	providersTable{},
 	providerUserTable{},
 	settingsTable{},
+	userPublicKeysTable{},
 }
 
 type tabler interface {

--- a/internal/server/data/user_public_keys.go
+++ b/internal/server/data/user_public_keys.go
@@ -1,0 +1,56 @@
+package data
+
+import (
+	"fmt"
+
+	"github.com/infrahq/infra/internal/server/data/querybuilder"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+type userPublicKeysTable models.UserPublicKey
+
+func (t userPublicKeysTable) Table() string {
+	return "user_public_keys"
+}
+
+func (t userPublicKeysTable) Columns() []string {
+	return []string{"created_at", "deleted_at", "expires_at", "fingerprint", "id", "key_type", "name", "public_key", "updated_at", "user_id"}
+}
+
+func (t userPublicKeysTable) Values() []any {
+	return []any{t.CreatedAt, t.DeletedAt, t.ExpiresAt, t.Fingerprint, t.ID, t.KeyType, t.Name, t.PublicKey, t.UpdatedAt, t.UserID}
+}
+
+func (t *userPublicKeysTable) ScanFields() []any {
+	return []any{&t.CreatedAt, &t.DeletedAt, &t.ExpiresAt, &t.Fingerprint, &t.ID, &t.KeyType, &t.Name, &t.PublicKey, &t.UpdatedAt, &t.UserID}
+}
+
+func userPublicKeys(tx ReadTxn, userID uid.ID) ([]models.UserPublicKey, error) {
+	table := userPublicKeysTable{}
+	query := querybuilder.New("SELECT")
+	query.B(columnsForSelect(table))
+	query.B("FROM user_public_keys")
+	query.B("WHERE deleted_at is null")
+	query.B("AND user_id = ?", userID)
+
+	rows, err := tx.Query(query.String(), query.Args...)
+	if err != nil {
+		return nil, err
+	}
+	return scanRows(rows, func(k *models.UserPublicKey) []any {
+		return (*userPublicKeysTable)(k).ScanFields()
+	})
+}
+
+func AddUserPublicKey(tx WriteTxn, key *models.UserPublicKey) error {
+	switch {
+	case key.UserID == 0:
+		return fmt.Errorf("a userID is required")
+	case key.Fingerprint == "":
+		return fmt.Errorf("fingerprint is required")
+	case key.KeyType == "":
+		return fmt.Errorf("key type is required")
+	}
+	return insert(tx, (*userPublicKeysTable)(key))
+}

--- a/internal/server/data/user_public_keys_test.go
+++ b/internal/server/data/user_public_keys_test.go
@@ -1,0 +1,76 @@
+package data
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/server/models"
+)
+
+func TestUserPublicKeys(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+		user := &models.Identity{Name: "main@example.com"}
+		other := &models.Identity{Name: "other@example.com"}
+		createIdentities(t, tx, user, other)
+
+		publicKey := &models.UserPublicKey{
+			UserID:      user.ID,
+			PublicKey:   "the-public-key",
+			KeyType:     "ssh-rsa",
+			Fingerprint: "the-fingerprint",
+		}
+		err := AddUserPublicKey(tx, publicKey)
+		assert.NilError(t, err)
+
+		second := &models.UserPublicKey{
+			UserID:      user.ID,
+			PublicKey:   "the-public-key-2",
+			KeyType:     "ssh-rsa",
+			Fingerprint: "the-fingerprint-2",
+		}
+		err = AddUserPublicKey(tx, second)
+		assert.NilError(t, err)
+
+		actual, err := userPublicKeys(tx, user.ID)
+		assert.NilError(t, err)
+		expected := []models.UserPublicKey{*publicKey, *second}
+		assert.DeepEqual(t, actual, expected, cmpTimeWithDBPrecision)
+	})
+}
+
+func TestAddUserPublicKey(t *testing.T) {
+	runDBTests(t, func(t *testing.T, db *DB) {
+		tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+		user := &models.Identity{Name: "main@example.com"}
+		createIdentities(t, tx, user)
+
+		publicKey := &models.UserPublicKey{
+			UserID:      user.ID,
+			Name:        "the-name",
+			PublicKey:   "the-public-key",
+			KeyType:     "ssh-rsa",
+			Fingerprint: "the-fingerprint",
+		}
+		err := AddUserPublicKey(tx, publicKey)
+		assert.NilError(t, err)
+
+		expected := &models.UserPublicKey{
+			Model: models.Model{
+				ID:        999,
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			UserID:      user.ID,
+			Name:        "the-name",
+			PublicKey:   "the-public-key",
+			KeyType:     "ssh-rsa",
+			Fingerprint: "the-fingerprint",
+		}
+		assert.DeepEqual(t, publicKey, expected, cmpModel)
+	})
+}

--- a/internal/server/models/identity.go
+++ b/internal/server/models/identity.go
@@ -30,10 +30,12 @@ type Identity struct {
 	// Providers may be populated by some queries to contain the list of
 	// providers that provide this user.
 	Providers []Provider `db:"-"`
+
+	PublicKeys []UserPublicKey `db:"-"`
 }
 
 func (i *Identity) ToAPI() *api.User {
-	return &api.User{
+	u := &api.User{
 		ID:         i.ID,
 		Created:    api.Time(i.CreatedAt),
 		Updated:    api.Time(i.UpdatedAt),
@@ -43,9 +45,35 @@ func (i *Identity) ToAPI() *api.User {
 			return p.Name
 		}),
 	}
+	for _, k := range i.PublicKeys {
+		u.PublicKeys = append(u.PublicKeys, k.ToAPI())
+	}
+	return u
 }
 
 // PolyID is a polymorphic name that points to both a model type and an ID
 func (i *Identity) PolyID() uid.PolymorphicID {
 	return uid.NewIdentityPolymorphicID(i.ID)
+}
+
+type UserPublicKey struct {
+	Model
+	UserID    uid.ID
+	Name      string
+	PublicKey string
+	KeyType   string
+	ExpiresAt time.Time
+	// Fingerprint is the sha256 fingerprint of PublicKey
+	Fingerprint string
+}
+
+func (u UserPublicKey) ToAPI() api.UserPublicKey {
+	return api.UserPublicKey{
+		ID:          u.ID,
+		Name:        u.Name,
+		Created:     api.Time(u.CreatedAt),
+		PublicKey:   u.PublicKey,
+		KeyType:     u.KeyType,
+		Fingerprint: u.Fingerprint,
+	}
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -59,6 +59,7 @@ func (s *Server) GenerateRoutes() Routes {
 	get(a, authn, "/api/users/:id", a.GetUser)
 	put(a, authn, "/api/users/:id", a.UpdateUser)
 	del(a, authn, "/api/users/:id", a.DeleteUser)
+	put(a, authn, "/api/users/public-key", AddUserPublicKey)
 
 	get(a, authn, "/api/access-keys", a.ListAccessKeys)
 	post(a, authn, "/api/access-keys", a.CreateAccessKey)

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -29,7 +29,7 @@ func (a *API) ListUsers(c *gin.Context, r *api.ListUsersRequest) (*api.ListRespo
 		ByGroupID:              r.Group,
 		ByPublicKeyFingerprint: r.PublicKeyFingerprint,
 		LoadProviders:          true,
-		LoadPublicKeys:         true,
+		LoadPublicKeys:         r.PublicKeyFingerprint != "",
 	}
 	if !r.ShowSystem {
 		opts.ByNotName = models.InternalInfraConnectorIdentityName
@@ -55,7 +55,11 @@ func (a *API) GetUser(c *gin.Context, r *api.GetUserRequest) (*api.User, error) 
 		}
 		r.ID.ID = iden.ID
 	}
-	identity, err := access.GetIdentity(c, data.GetIdentityOptions{ByID: r.ID.ID, LoadProviders: true})
+	identity, err := access.GetIdentity(c, data.GetIdentityOptions{
+		ByID:           r.ID.ID,
+		LoadProviders:  true,
+		LoadPublicKeys: true,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -160,6 +164,7 @@ func AddUserPublicKey(c *gin.Context, r *api.AddUserPublicKeyRequest) (*api.User
 	}
 
 	userPublicKey := &models.UserPublicKey{
+		Name:        r.Name,
 		UserID:      rCtx.Authenticated.User.ID,
 		PublicKey:   base64.StdEncoding.EncodeToString(key.Marshal()),
 		KeyType:     key.Type(),

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -158,7 +158,7 @@ func AddUserPublicKey(c *gin.Context, r *api.AddUserPublicKeyRequest) (*api.User
 	case err != nil:
 		// the error text is always the same "ssh: no key found", so we return
 		// a better error message.
-		return nil, validate.Error{"publicKey": {"must be in authorized keys format"}}
+		return nil, validate.Error{"publicKey": {"must be in authorized_keys format"}}
 	case len(bytes.TrimSpace(rest)) > 0:
 		return nil, validate.Error{"publicKey": {"must be only a single key"}}
 	}


### PR DESCRIPTION
## Summary

Adds a new `user_public_keys` table, support for listing users by public key fingerprint, and returning a users public keys from `GetUser` and `ListUsers`.

I think the main thing to review here are the API changes. The API changes are:

1. A new `PUT /api/users/public-key` endpoint for uploading public keys. Should we make this `/api/users/:id/public-key` and initially only accept `self` for the `:id`? I'm not sure there is ever going to be a use case for an admin uploading a public key for a different user. The admin could always create an access key for that user, and use that access key to upload the public key. This endpoint accepts two fields: a `Name` for the key (the CLI populates this with `os.Hostname()`, and the `PublicKey` which is in the form `ssh-rsa <public key>` (this is the format that `ssh-keygen` produces).
2. `ListUsers` has a new `?publicKeyFingerprint=<fingerprint>` query parameter for finding the user associated with a public key.
4. `api.User` (the response struct for `ListUsers`, and `GetUser`) has a new `PublicKeys` field that is a list of the users public keys. Currently only the `ListUsers` endpoint populates this list, which seems strange. Should both `ListUser` and `GetUser` populate this list? It's potentially a lot of data that will not be used by most callers. Or should we only include the public keys in the `GetUser` response. Or should we have a different endpoint for `GET /api/users/:userID/public-keys` to query for the keys separately (not idea as it would require more API calls). Or we could add a query parameter `includePublicKeys` to populate it on either `GetUser` or `ListUser`. I like the query parameter approach.


TODO:
* [ ] test coverage for the new api endpoint, and new parameters to existing endpoints
* [x] add UserPublicKeys to `GetUser` response

See https://github.com/infrahq/internal/issues/27 for more details
See #3722 for an overview diagram