### PR TITLE
improve: add GetGrant api

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -348,6 +348,10 @@ func (c Client) ListGrants(ctx context.Context, req ListGrantsRequest) (*ListRes
 	})
 }
 
+func (c Client) GetGrant(ctx context.Context, id uid.ID) (*Grant, error) {
+	return get[Grant](ctx, c, fmt.Sprintf("/api/grants/%s", id), Query{})
+}
+
 func (c Client) CreateGrant(ctx context.Context, req *GrantRequest) (*CreateGrantResponse, error) {
 	return post[CreateGrantResponse](ctx, c, "/api/grants", req)
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`api.GetGrant` is missing which makes retrieving a single grant by ID unnecessarily difficult