### PR TITLE
Fix update destination

### DIFF
--- a/internal/access/destination.go
+++ b/internal/access/destination.go
@@ -18,7 +18,7 @@ func CreateDestination(c *gin.Context, destination *models.Destination) error {
 	return data.CreateDestination(db, destination)
 }
 
-func SaveDestination(rCtx RequestContext, destination *models.Destination) error {
+func UpdateDestination(rCtx RequestContext, destination *models.Destination) error {
 	roles := []string{models.InfraAdminRole, models.InfraConnectorRole}
 	if err := IsAuthorized(rCtx, roles...); err != nil {
 		return HandleAuthErr(err, "destination", "update", roles...)

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -27,23 +27,6 @@ func (d *destinationsTable) ScanFields() []any {
 	return []any{&d.ConnectionCA, &d.ConnectionURL, &d.CreatedAt, &d.DeletedAt, &d.ID, &d.Kind, &d.LastSeenAt, &d.Name, &d.OrganizationID, &d.Resources, &d.Roles, &d.UniqueID, &d.UpdatedAt, &d.Version}
 }
 
-// destinationsUpdateTable is used to update the destination. It excludes
-// the CreatedAt field, because that field is not part of the input to
-// UpdateDestination.
-type destinationsUpdateTable models.Destination
-
-func (d destinationsUpdateTable) Table() string {
-	return "destinations"
-}
-
-func (d destinationsUpdateTable) Columns() []string {
-	return []string{"connection_ca", "connection_url", "deleted_at", "id", "last_seen_at", "name", "organization_id", "resources", "roles", "unique_id", "updated_at", "version"}
-}
-
-func (d destinationsUpdateTable) Values() []any {
-	return []any{d.ConnectionCA, d.ConnectionURL, d.DeletedAt, d.ID, d.LastSeenAt, d.Name, d.OrganizationID, d.Resources, d.Roles, d.UniqueID, d.UpdatedAt, d.Version}
-}
-
 func validateDestination(dest *models.Destination) error {
 	if dest.Name == "" {
 		return fmt.Errorf("Destination.Name is required")
@@ -68,7 +51,7 @@ func UpdateDestination(tx WriteTxn, destination *models.Destination) error {
 	if err := validateDestination(destination); err != nil {
 		return err
 	}
-	return update(tx, (*destinationsUpdateTable)(destination))
+	return update(tx, (*destinationsTable)(destination))
 }
 
 type GetDestinationOptions struct {

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -93,11 +93,8 @@ func TestUpdateDestination(t *testing.T) {
 			}
 			createDestinations(t, tx, orig)
 
-			// Unlike other update operations, the passed in destination
-			// may be constructed entirely by the caller and may not have the
-			// created, or updated time set.
 			destination := &models.Destination{
-				Model:         models.Model{ID: orig.ID},
+				Model:         orig.Model,
 				Name:          "example-cluster-2",
 				UniqueID:      "22222",
 				Kind:          "kubernetes",

--- a/internal/server/destinations.go
+++ b/internal/server/destinations.go
@@ -74,20 +74,22 @@ func (a *API) CreateDestination(c *gin.Context, r *api.CreateDestinationRequest)
 
 func (a *API) UpdateDestination(c *gin.Context, r *api.UpdateDestinationRequest) (*api.Destination, error) {
 	rCtx := getRequestContext(c)
-	destination := &models.Destination{
-		Model: models.Model{
-			ID: r.ID,
-		},
-		Name:          r.Name,
-		UniqueID:      r.UniqueID,
-		ConnectionURL: r.Connection.URL,
-		ConnectionCA:  string(r.Connection.CA),
-		Resources:     r.Resources,
-		Roles:         r.Roles,
-		Version:       r.Version,
+
+	// Start with the existing value, so that non-update fields are not set to zero.
+	destination, err := access.GetDestination(c, r.ID)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := access.SaveDestination(rCtx, destination); err != nil {
+	destination.Name = r.Name
+	destination.UniqueID = r.UniqueID
+	destination.ConnectionURL = r.Connection.URL
+	destination.ConnectionCA = string(r.Connection.CA)
+	destination.Resources = r.Resources
+	destination.Roles = r.Roles
+	destination.Version = r.Version
+
+	if err := access.UpdateDestination(rCtx, destination); err != nil {
 		return nil, fmt.Errorf("update destination: %w", err)
 	}
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -34,7 +34,7 @@ func handleInfraDestinationHeader(rCtx access.RequestContext, uniqueID string) e
 	// only save if there's significant difference between LastSeenAt and Now
 	if time.Since(destination.LastSeenAt) > lastSeenUpdateThreshold {
 		destination.LastSeenAt = time.Now()
-		if err := access.SaveDestination(rCtx, destination); err != nil {
+		if err := access.UpdateDestination(rCtx, destination); err != nil {
 			return fmt.Errorf("failed to update destination lastSeenAt: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary

Start with the existing data so that we don't lose values for fields that
are not updated. We have 3 non-update fields now: CreatedAt,
LastSeenAt, and Kind.

Also remove the extra logic in the data layer, we no longer need this
now that we're handling it properly in the API.  This allows the
update operation for destination to look like all the other update
operations.

Also adds test cases for the `UpdateDestination` API endpoint.


## Related Issues

Resolves #3594
