### PR TITLE
maintain: exit tests if the postgres_connection string isn't specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-test:
+test: check-psql-env
 	go test -short ./...
 
-test-all:
+test-all: check-psql-env
 	go test ./...
 
 # update the expected command output file
@@ -57,3 +57,8 @@ docs: docs/api/openapi3.json
 .PHONY: docs/api/openapi3.json
 docs/api/openapi3.json:
 	go run ./internal/openapigen $@
+
+check-psql-env:
+ifndef POSTGRESQL_CONNECTION
+	$(error POSTGRESQL_CONNECTION is not defined. Use `make postgres` if you need to start postgres)
+endif


### PR DESCRIPTION
## Summary

Don't run unit tests w/ `make test` and `make test-all` if the POSTGRES_CONNECTION env variable is not set.

If the string is not set, `go test ./...` gets run, and it will silently skip a number of unit tests which rely on the postgres db. These tests _will_ be run in our CI system, but will leave you scratching your head why they're not running locally.

