### PR TITLE
fix: go test ci

### DIFF
--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -36,7 +36,7 @@ jobs:
         # disable auto-fix, and enable verbose
         run: LINT_ARGS=-v  make lint
 
-  test:
+  go-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -78,6 +78,15 @@ jobs:
           git diff --exit-code
           # show and check for uncommitted files
           git status --short; [[ "$(git status --short)" == "" ]]
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [go-test]
+    if: ${{ always() }}
+    steps:
+      - run: |
+          RESULT="${{ needs.go-test.result }}"
+          [ "$RESULT" = 'success' ] || [ "$RESULT" = 'skipped' ] || exit 1
 
   check-generated:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

GitHub's required status check need exact job name matches. In case of `strategy.matrix`, the job name gets modified by the matrix such that it no longer matches the configured required status check. Instead, rename the job to `test-matrix` and create a new job matching the required status check name dependent on `text-matrix` results.