### PR TITLE
fix(ui): trim leading and trailing whitespace in group names

### DIFF
--- a/ui/pages/groups/index.js
+++ b/ui/pages/groups/index.js
@@ -22,7 +22,7 @@ function AddGroupsDialog({ setOpen }) {
     try {
       const res = await fetch('/api/groups', {
         method: 'POST',
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name: name.trim() }),
       })
 
       const group = await jsonBody(res)
@@ -59,7 +59,9 @@ function AddGroupsDialog({ setOpen }) {
                   }
                 }}
                 value={name}
-                onChange={e => setName(e.target.value)}
+                // trim leading whitespace on input. trailing whitespace will be
+                // trimmed on submit
+                onChange={e => setName(e.target.value.trimLeft())}
                 className={`mt-1 block w-full rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm ${
                   error ? 'border-red-500' : 'border-gray-300'
                 }`}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

leading whitespaces are particularly problematic because it makes it possible to create group names that look empty, e.g. " ". a side effect is group names with " " (one whitespace) and "  " (multple consecutive whitespaces) will cause a 409 Conflict on creation since the server trims inputs.

non-leading or non-trailing whitespaces are left as is so it's possible to have repeats in t between other characters