### PR TITLE
fix(ui): undefined reference in providers

### DIFF
--- a/ui/pages/providers/[id].js
+++ b/ui/pages/providers/[id].js
@@ -120,10 +120,6 @@ export default function ProvidersEditDetails() {
   ]
 
   useEffect(() => {
-    setName(provider?.name)
-  }, [provider])
-
-  useEffect(() => {
     return clearTimer()
   }, [])
 
@@ -298,6 +294,7 @@ export default function ProvidersEditDetails() {
               <label className='text-2xs font-medium text-gray-700'>Name</label>
               <input
                 type='search'
+                placeholder={provider?.name}
                 value={name}
                 onKeyDown={e => {
                   if (e.key === 'Escape' || e.key === 'Esc') {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

under specific conditions, the provider details page will throw an uncaught exception caused by `useEffect` setting `name` to undefined when provider is undefined.

use a placeholder instead of setting the field value directly. this also fixes the issue where an empty value is seens as a change, enabling save.

![image](https://user-images.githubusercontent.com/2372640/201248772-1197067c-b5b9-4280-9b7f-441e820536bc.png)
