### PR TITLE
Do not require uniqueID for a destination

### DIFF
--- a/api/destination.go
+++ b/api/destination.go
@@ -61,7 +61,6 @@ type CreateDestinationRequest struct {
 
 func (r CreateDestinationRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		validate.Required("uniqueID", r.UniqueID),
 		validateDestinationName(r.Name),
 		validate.Required("name", r.Name),
 		// Allow "" for versions 0.16.1 and prior
@@ -83,7 +82,6 @@ type UpdateDestinationRequest struct {
 
 func (r UpdateDestinationRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		validate.Required("uniqueID", r.UniqueID),
 		validate.Required("id", r.ID),
 		validate.Required("name", r.Name),
 		validateDestinationName(r.Name),

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1740,7 +1740,6 @@
                   }
                 },
                 "required": [
-                  "uniqueID",
                   "name"
                 ],
                 "type": "object"
@@ -2112,7 +2111,6 @@
                   }
                 },
                 "required": [
-                  "uniqueID",
                   "name"
                 ],
                 "type": "object"

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -31,9 +31,6 @@ func validateDestination(dest *models.Destination) error {
 	if dest.Name == "" {
 		return fmt.Errorf("Destination.Name is required")
 	}
-	if dest.UniqueID == "" {
-		return fmt.Errorf("Destination.UniqueID is required")
-	}
 	if dest.Kind == "" {
 		return fmt.Errorf("Destination.Kind is required")
 	}

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -20,7 +20,6 @@ func TestCreateDestination(t *testing.T) {
 
 			destination := &models.Destination{
 				Name:          "thehost",
-				UniqueID:      "unique-id",
 				Kind:          "ssh",
 				ConnectionURL: "10.0.0.1:1001",
 				ConnectionCA:  "the-pem-encoded-cert",
@@ -42,7 +41,6 @@ func TestCreateDestination(t *testing.T) {
 				},
 				OrganizationMember: models.OrganizationMember{OrganizationID: defaultOrganizationID},
 				Name:               "thehost",
-				UniqueID:           "unique-id",
 				Kind:               "ssh",
 				ConnectionURL:      "10.0.0.1:1001",
 				ConnectionCA:       "the-pem-encoded-cert",

--- a/internal/server/destination_test.go
+++ b/internal/server/destination_test.go
@@ -98,7 +98,6 @@ func TestAPI_CreateDestination(t *testing.T) {
 				expected := []api.FieldError{
 					{FieldName: "connection.ca", Errors: []string{"is required"}},
 					{FieldName: "name", Errors: []string{"is required"}},
-					{FieldName: "uniqueID", Errors: []string{"is required"}},
 				}
 				assert.DeepEqual(t, respBody.FieldErrors, expected)
 			},
@@ -200,7 +199,6 @@ func TestAPI_UpdateDestination(t *testing.T) {
 				expected := []api.FieldError{
 					{FieldName: "connection.ca", Errors: []string{"is required"}},
 					{FieldName: "name", Errors: []string{"is required"}},
-					{FieldName: "uniqueID", Errors: []string{"is required"}},
 				}
 				assert.DeepEqual(t, respBody.FieldErrors, expected)
 			},
@@ -220,7 +218,7 @@ func TestAPI_UpdateDestination(t *testing.T) {
 			},
 			setup: func(t *testing.T, req *http.Request) {
 				// Set the header that connectors use
-				req.Header.Set(headerInfraDestination, "unique-id")
+				req.Header.Set(headerInfraDestinationName, "the-dest")
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK, (*responseDebug)(resp))

--- a/internal/server/destinations.go
+++ b/internal/server/destinations.go
@@ -60,7 +60,10 @@ func (a *API) CreateDestination(c *gin.Context, r *api.CreateDestinationRequest)
 
 	// set LastSeenAt if this request came from a connector. The middleware
 	// can't do this update in the case where the destination did not exist yet
-	if c.Request.Header.Get(headerInfraDestination) == r.UniqueID {
+	switch {
+	case c.Request.Header.Get(headerInfraDestinationName) == r.Name:
+		destination.LastSeenAt = time.Now()
+	case c.Request.Header.Get(headerInfraDestinationUniqueID) == r.UniqueID:
 		destination.LastSeenAt = time.Now()
 	}
 


### PR DESCRIPTION
## Summary

Related to #3595, #3620

This PR makes `destination.UniqueID` an optional field. We need to keep it for existing connectors, but after some time we can look to remove it.  

This PR also allows connectors to send either the uniqueID or name for updating the LastSeenAt status of the destination. A new `Infra-Destination-Name` header is added for accepting the name instead of uniqueID.

See https://github.com/infrahq/internal/issues/27 for more details