### PR TITLE
Update cobra to official version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/muesli/termenv v0.13.0
 	github.com/prometheus/client_golang v1.13.1
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
-	github.com/spf13/cobra v1.4.0
+	github.com/spf13/cobra v1.6.1
 	golang.org/x/crypto v0.2.0
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	golang.org/x/term v0.2.0
@@ -134,7 +134,7 @@ require (
 	github.com/hashicorp/vault/sdk v0.5.3 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -192,9 +192,6 @@ require (
 
 // switch back to main repo when https://github.com/gin-gonic/gin/pull/3045 is merged
 replace github.com/gin-gonic/gin => github.com/infrahq/gin v1.7.2-0.20220120203023-0eaa562f3a8a
-
-// switch back to main repo when https://github.com/spf13/cobra/pull/1003 is merged
-replace github.com/spf13/cobra => github.com/infrahq/cobra v1.4.0-groups
 
 // switch back to main repo when https://github.com/go-gorm/gorm/pull/5288 is merged
 replace gorm.io/gorm => github.com/infrahq/gorm v1.23.5-0.20220422194753-04115485c083

--- a/go.sum
+++ b/go.sum
@@ -136,7 +136,7 @@ github.com/coreos/go-oidc/v3 v3.4.0/go.mod h1:eHUXhZtXPQLgEaDrOVTgwbgmz1xGOkJNye
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -387,10 +387,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
-github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/infrahq/cobra v1.4.0-groups h1:SkTVqbQBLDx/cIYUP88Tg5Ooi2f2n6fh2FKM2SeXA84=
-github.com/infrahq/cobra v1.4.0-groups/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/infrahq/gin v1.7.2-0.20220120203023-0eaa562f3a8a h1:0IuR5ELjJz636UzenPRDT5NY1qNOOtQnuiFxRAt+v7Q=
 github.com/infrahq/gin v1.7.2-0.20220120203023-0eaa562f3a8a/go.mod h1:DBqzoPGrzHYPk0x6KcX6JiOjgFMOztPfWkVwlUDYV88=
 github.com/infrahq/gorm v1.23.5-0.20220422194753-04115485c083 h1:v/LVwioJIx6tGeyt9sk1tjLzoiejuFZRHCpn22swip4=
@@ -657,6 +655,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/ssoroka/slice v0.0.0-20220402005549-78f0cea3df8b h1:nDFJ1KYD1CSRP3nHtkvCH+ztuoz+QW++OvCLgpS6kQE=

--- a/internal/cmd/about.go
+++ b/internal/cmd/about.go
@@ -18,11 +18,11 @@ type triangle struct {
 
 func newAboutCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:    "about",
-		Short:  "Display information about Infra",
-		Args:   NoArgs,
-		Group:  "Other commands:",
-		Hidden: false,
+		Use:     "about",
+		Short:   "Display information about Infra",
+		Args:    NoArgs,
+		GroupID: groupOther,
+		Hidden:  false,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return about()
 		},

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -383,29 +383,30 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 			Title: "Other commands:",
 		})
 
-	// Core commands:
-	rootCmd.AddCommand(newLoginCmd(cli))
-	rootCmd.AddCommand(newLogoutCmd(cli))
-	rootCmd.AddCommand(newListCmd(cli))
-	rootCmd.AddCommand(newUseCmd(cli))
+	rootCmd.AddCommand(
+		// Core commands
+		newLoginCmd(cli),
+		newLogoutCmd(cli),
+		newListCmd(cli),
+		newUseCmd(cli),
 
-	// Management commands:
-	rootCmd.AddCommand(newDestinationsCmd(cli))
-	rootCmd.AddCommand(newGrantsCmd(cli))
-	rootCmd.AddCommand(newUsersCmd(cli))
-	rootCmd.AddCommand(newGroupsCmd(cli))
-	rootCmd.AddCommand(newKeysCmd(cli))
-	rootCmd.AddCommand(newProvidersCmd(cli))
+		// Management commands
+		newDestinationsCmd(cli),
+		newGrantsCmd(cli),
+		newUsersCmd(cli),
+		newGroupsCmd(cli),
+		newKeysCmd(cli),
+		newProvidersCmd(cli),
 
-	// Other commands:
-	rootCmd.AddCommand(newInfoCmd(cli))
-	rootCmd.AddCommand(newVersionCmd(cli))
+		// Other commands
+		newInfoCmd(cli),
+		newVersionCmd(cli),
 
-	// Hidden
-	rootCmd.AddCommand(newTokensCmd(cli))
-	rootCmd.AddCommand(newServerCmd())
-	rootCmd.AddCommand(newConnectorCmd())
-	rootCmd.AddCommand(newAgentCmd())
+		// Hidden commands
+		newTokensCmd(cli),
+		newServerCmd(),
+		newConnectorCmd(),
+		newAgentCmd())
 
 	rootCmd.PersistentFlags().String("log-level", "info", "Show logs when running the command [error, warn, info, debug]")
 	rootCmd.PersistentFlags().Bool("help", false, "Display help")

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -186,7 +186,7 @@ $ infra use development
 # Use a Kubernetes namespace context
 $ infra use development.kube-system`,
 		Args:              ExactArgs(1),
-		Group:             "Core commands:",
+		GroupID:           groupCore,
 		ValidArgsFunction: getUseCompletion,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {
@@ -347,6 +347,12 @@ func defaultConnectorOptions() connector.Options {
 	}
 }
 
+const (
+	groupCore       = "group-core"
+	groupManagement = "group-management"
+	groupOther      = "group-other"
+)
+
 func NewRootCmd(cli *CLI) *cobra.Command {
 	cobra.EnableCommandSorting = false
 
@@ -362,6 +368,20 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 			return cmd.Help()
 		},
 	}
+
+	rootCmd.AddGroup(
+		&cobra.Group{
+			ID:    groupCore,
+			Title: "Core commands:",
+		},
+		&cobra.Group{
+			ID:    groupManagement,
+			Title: "Management commands:",
+		},
+		&cobra.Group{
+			ID:    groupOther,
+			Title: "Other commands:",
+		})
 
 	// Core commands:
 	rootCmd.AddCommand(newLoginCmd(cli))
@@ -390,7 +410,7 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 	rootCmd.PersistentFlags().String("log-level", "info", "Show logs when running the command [error, warn, info, debug]")
 	rootCmd.PersistentFlags().Bool("help", false, "Display help")
 
-	rootCmd.SetHelpCommandGroup("Other commands:")
+	rootCmd.SetHelpCommandGroupID(groupOther)
 	rootCmd.AddCommand(newAboutCmd())
 	rootCmd.AddCommand(newCompletionsCmd())
 	rootCmd.SetUsageTemplate(usageTemplate())
@@ -431,10 +451,10 @@ Aliases:
 Examples:
 {{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
 
-Available Commands:{{end}}{{range $cmds}}{{if (and (eq .Group "") (or .IsAvailableCommand (eq .Name "help")))}}
+Available Commands:{{end}}{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{range $group := .Groups}}
 
-{{.Title}}{{range $cmds}}{{if (and (eq .Group $group.Group) (or .IsAvailableCommand (eq .Name "help")))}}
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/env"
 	"gotest.tools/v3/fs"
+	"gotest.tools/v3/golden"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/certs"
@@ -557,4 +559,15 @@ func TestConnectorCmd_NoFlagDefaults(t *testing.T) {
 			t.Fatalf("Flag --%v uses non-zero value %v. %v", flag.Name, flag.Value, msg)
 		}
 	})
+}
+
+func TestRootCmd_UsageTemplate(t *testing.T) {
+	ctx := context.Background()
+	cmd := NewRootCmd(newCLI(ctx))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	assert.NilError(t, cmd.Usage())
+
+	golden.Assert(t, buf.String(), "expected-usage")
 }

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -50,7 +50,7 @@ To load completions for every new session, run:
 and source this file from your PowerShell profile.
 `, `infra`),
 		DisableFlagsInUseLine: true,
-		Group:                 "Other commands:",
+		GroupID:               groupOther,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Run: func(cmd *cobra.Command, args []string) {
 			shell := filepath.Base(os.Getenv("SHELL"))

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -24,7 +24,7 @@ func newDestinationsCmd(cli *CLI) *cobra.Command {
 		Use:     "destinations",
 		Aliases: []string{"dst", "dest", "destination"},
 		Short:   "Manage destinations",
-		Group:   "Management commands:",
+		GroupID: groupManagement,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {
 				return err

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -30,7 +30,7 @@ func newGrantsCmd(cli *CLI) *cobra.Command {
 		Use:     "grants",
 		Short:   "Manage access to resources",
 		Aliases: []string{"grant"},
-		Group:   "Management commands:",
+		GroupID: groupManagement,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {
 				return err

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -44,7 +44,7 @@ func newGroupsCmd(cli *CLI) *cobra.Command {
 		Use:     "groups",
 		Short:   "Manage groups of identities",
 		Aliases: []string{"group"},
-		Group:   "Management commands:",
+		GroupID: groupManagement,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {
 				return err

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -13,10 +13,10 @@ import (
 
 func newInfoCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
-		Use:   "info",
-		Short: "Display the info about the current session",
-		Args:  NoArgs,
-		Group: "Other commands:",
+		Use:     "info",
+		Short:   "Display the info about the current session",
+		Args:    NoArgs,
+		GroupID: groupOther,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := mustBeLoggedIn(); err != nil {
 				return err

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -20,7 +20,7 @@ func newKeysCmd(cli *CLI) *cobra.Command {
 		Use:     "keys",
 		Short:   "Manage access keys",
 		Aliases: []string{"key"},
-		Group:   "Management commands:",
+		GroupID: groupManagement,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {
 				return err

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -17,7 +17,7 @@ func newListCmd(cli *CLI) *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List accessible destinations",
 		Args:    NoArgs,
-		Group:   "Core commands:",
+		GroupID: groupCore,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {
 				return err

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -73,8 +73,8 @@ $ infra login
 $ export INFRA_SERVER=example.infrahq.com
 $ export INFRA_PROVIDER=google
 $ infra login`,
-		Args:  MaxArgs(1),
-		Group: "Core commands:",
+		Args:    MaxArgs(1),
+		GroupID: groupCore,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if server, ok := os.LookupEnv("INFRA_SERVER"); ok {
 				options.Server = server

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -44,8 +44,8 @@ $ infra logout infraexampleserver.com --clear
 		
 # Logout and clear list of all servers 
 $ infra logout --all --clear`,
-		Args:  MaxArgs(1),
-		Group: "Core commands:",
+		Args:    MaxArgs(1),
+		GroupID: groupCore,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 1 {
 				if options.all {

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -21,7 +21,7 @@ func newProvidersCmd(cli *CLI) *cobra.Command {
 		Use:     "providers",
 		Short:   "Manage identity providers",
 		Aliases: []string{"provider"},
-		Group:   "Management commands:",
+		GroupID: groupManagement,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {
 				return err

--- a/internal/cmd/testdata/expected-usage
+++ b/internal/cmd/testdata/expected-usage
@@ -1,0 +1,29 @@
+Usage:
+  infra [flags]
+  infra [command]
+
+Core commands:
+  login        Login to Infra
+  logout       Log out of Infra
+  list         List accessible destinations
+  use          Access a destination
+
+Management commands:
+  destinations Manage destinations
+  grants       Manage access to resources
+  users        Manage user identities
+  groups       Manage groups of identities
+  keys         Manage access keys
+  providers    Manage identity providers
+
+Other commands:
+  info         Display the info about the current session
+  version      Display the Infra version
+  about        Display information about Infra
+  completion   Generate shell auto-completion for the CLI
+
+Flags:
+      --help               Display help
+      --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
+
+Use "infra [command] --help" for more information about a command.

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -24,7 +24,7 @@ func newUsersCmd(cli *CLI) *cobra.Command {
 		Use:     "users",
 		Short:   "Manage user identities",
 		Aliases: []string{"user"},
-		Group:   "Management commands:",
+		GroupID: groupManagement,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := rootPreRun(cmd.Flags()); err != nil {
 				return err

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -14,10 +14,10 @@ import (
 
 func newVersionCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
-		Use:   "version",
-		Short: "Display the Infra version",
-		Group: "Other commands:",
-		Args:  NoArgs,
+		Use:     "version",
+		Short:   "Display the Infra version",
+		GroupID: groupOther,
+		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return version(cli)
 		},


### PR DESCRIPTION
We were using a fork for group support. That feature is now in an official release so we can stop using our fork. This will allow dependabot to notify us of updates.

Once this is merged we can archive https://github.com/infrahq/cobra

I tested this with the following

```
$ go build .
$ ./infra --help > before
# update cobra
$ go build .
$ ./infra help > after
$ go diff -u before after
```

Added a test using `golden` to show that it still looks the same.