### PR TITLE
maintain: api doc categories

### DIFF
--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1035,77 +1035,6 @@
           }
         }
       },
-      "SignupResponse": {
-        "properties": {
-          "organization": {
-            "properties": {
-              "created": {
-                "description": "formatted as an RFC3339 date-time",
-                "example": "2022-03-14T09:48:00Z",
-                "format": "date-time",
-                "type": "string"
-              },
-              "domain": {
-                "type": "string"
-              },
-              "id": {
-                "example": "4yJ3n3D8E2",
-                "format": "uid",
-                "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "updated": {
-                "description": "formatted as an RFC3339 date-time",
-                "example": "2022-03-14T09:48:00Z",
-                "format": "date-time",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "user": {
-            "properties": {
-              "created": {
-                "description": "formatted as an RFC3339 date-time",
-                "example": "2022-03-14T09:48:00Z",
-                "format": "date-time",
-                "type": "string"
-              },
-              "id": {
-                "example": "4yJ3n3D8E2",
-                "format": "uid",
-                "pattern": "[\\da-zA-HJ-NP-Z]{1,11}",
-                "type": "string"
-              },
-              "lastSeenAt": {
-                "description": "formatted as an RFC3339 date-time",
-                "example": "2022-03-14T09:48:00Z",
-                "format": "date-time",
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "providerNames": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              "updated": {
-                "description": "formatted as an RFC3339 date-time",
-                "example": "2022-03-14T09:48:00Z",
-                "format": "date-time",
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        }
-      },
       "User": {
         "properties": {
           "created": {
@@ -2389,7 +2318,7 @@
         },
         "summary": "StartDeviceFlow",
         "tags": [
-          "Misc"
+          "Authentication"
         ]
       }
     },
@@ -2503,7 +2432,7 @@
         },
         "summary": "ApproveDeviceAdd",
         "tags": [
-          "Misc"
+          "Authentication"
         ]
       }
     },
@@ -2605,7 +2534,7 @@
         },
         "summary": "GetDeviceFlowStatus",
         "tags": [
-          "Misc"
+          "Authentication"
         ]
       }
     },
@@ -2708,7 +2637,7 @@
         },
         "summary": "RequestForgotDomains",
         "tags": [
-          "Misc"
+          "Organizations"
         ]
       }
     },
@@ -4464,7 +4393,7 @@
         },
         "summary": "ListOrganizations",
         "tags": [
-          "Misc"
+          "Organizations"
         ]
       },
       "post": {
@@ -4582,7 +4511,7 @@
         },
         "summary": "CreateOrganization",
         "tags": [
-          "Misc"
+          "Organizations"
         ]
       }
     },
@@ -4689,7 +4618,7 @@
         },
         "summary": "DeleteOrganization",
         "tags": [
-          "Misc"
+          "Organizations"
         ]
       },
       "get": {
@@ -4795,7 +4724,7 @@
         },
         "summary": "GetOrganization",
         "tags": [
-          "Misc"
+          "Organizations"
         ]
       }
     },
@@ -4904,7 +4833,7 @@
         },
         "summary": "VerifiedPasswordReset",
         "tags": [
-          "Misc"
+          "Authentication"
         ]
       }
     },
@@ -5007,7 +4936,7 @@
         },
         "summary": "RequestPasswordReset",
         "tags": [
-          "Misc"
+          "Authentication"
         ]
       }
     },
@@ -5872,7 +5801,7 @@
         },
         "summary": "GetServerConfiguration",
         "tags": [
-          "Misc"
+          "Settings"
         ]
       }
     },
@@ -5957,7 +5886,7 @@
         },
         "summary": "GetSettings",
         "tags": [
-          "Misc"
+          "Settings"
         ]
       },
       "put": {
@@ -6087,134 +6016,7 @@
         },
         "summary": "UpdateSettings",
         "tags": [
-          "Misc"
-        ]
-      }
-    },
-    "/api/signup": {
-      "post": {
-        "description": "Signup",
-        "operationId": "Signup",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "Infra-Version",
-            "required": true,
-            "schema": {
-              "description": "Version of the API being requested",
-              "example": "0.0.0",
-              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "name": {
-                    "format": "email",
-                    "type": "string"
-                  },
-                  "org": {
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "subDomain": {
-                        "format": "[a-zA-Z0-9\\-]",
-                        "maxLength": 63,
-                        "minLength": 4,
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "subDomain"
-                    ],
-                    "type": "object"
-                  },
-                  "password": {
-                    "maxLength": 253,
-                    "minLength": 8,
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name",
-                  "password"
-                ],
-                "type": "object"
-              }
-            }
-          }
-        },
-        "responses": {
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Unauthorized: Requestor is not authenticated"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Forbidden: Requestor does not have the right permissions"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Duplicate Record"
-          },
-          "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SignupResponse"
-                }
-              }
-            },
-            "description": "Success"
-          }
-        },
-        "summary": "Signup",
-        "tags": [
-          "Misc"
+          "Settings"
         ]
       }
     },
@@ -6999,7 +6801,7 @@
         },
         "summary": "Version",
         "tags": [
-          "Misc"
+          "Settings"
         ]
       }
     }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -76,6 +76,15 @@ type WellKnownJWKResponse struct {
 	Keys []jose.JSONWebKey `json:"keys"`
 }
 
+func (a *API) SignupRoute() route[api.SignupRequest, *api.SignupResponse] {
+	return route[api.SignupRequest, *api.SignupResponse]{
+		handler: a.Signup,
+		routeSettings: routeSettings{
+			omitFromDocs: true,
+		},
+	}
+}
+
 func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.SignupResponse, error) {
 	if !a.server.options.EnableSignup {
 		return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -78,14 +78,14 @@ type WellKnownJWKResponse struct {
 
 func (a *API) SignupRoute() route[api.SignupRequest, *api.SignupResponse] {
 	return route[api.SignupRequest, *api.SignupResponse]{
-		handler: a.Signup,
+		handler: a.signup,
 		routeSettings: routeSettings{
 			omitFromDocs: true,
 		},
 	}
 }
 
-func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.SignupResponse, error) {
+func (a *API) signup(c *gin.Context, r *api.SignupRequest) (*api.SignupResponse, error) {
 	if !a.server.options.EnableSignup {
 		return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)
 	}

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -37,12 +37,19 @@ var funcPartialNameToTagNames = []struct {
 	{partial: "AccessKey", tag: "Authentication"},
 	{partial: "Login", tag: "Authentication"},
 	{partial: "Logout", tag: "Authentication"},
+	{partial: "Device", tag: "Authentication"},
+	{partial: "Password", tag: "Authentication"},
 	{partial: "Destination", tag: "Destinations"},
 	{partial: "Token", tag: "Destinations"},
 	{partial: "Grant", tag: "Grants"},
 	{partial: "Group", tag: "Groups"},
 	{partial: "Provider", tag: "Providers"},
 	{partial: "User", tag: "Users"},
+	{partial: "Settings", tag: "Settings"},
+	{partial: "Configuration", tag: "Settings"},
+	{partial: "Version", tag: "Settings"},
+	{partial: "Organization", tag: "Organizations"},
+	{partial: "Domain", tag: "Organizations"},
 }
 
 // openAPIRouteDefinition converts the route into a format that can be used

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -110,7 +110,7 @@ func (s *Server) GenerateRoutes() Routes {
 
 	// no auth required, org not required
 	noAuthnNoOrg := &routeGroup{RouterGroup: apiGroup.Group("/"), noAuthentication: true, noOrgRequired: true}
-	post(a, noAuthnNoOrg, "/api/signup", a.Signup)
+	add(a, noAuthnNoOrg, http.MethodPost, "/api/signup", a.SignupRoute())
 	get(a, noAuthnNoOrg, "/api/version", a.Version)
 	get(a, noAuthnNoOrg, "/api/server-configuration", a.GetServerConfiguration)
 	post(a, noAuthnNoOrg, "/api/forgot-domain-request", a.RequestForgotDomains)


### PR DESCRIPTION
- move all api endpoints into specific categories
- hide the sign-up endpoint from the api docs

## Summary
A lot of new functionality was getting grouped under the `Misc` category in our API docs. This is my attempt at cleaning things up.


## Related Issues

Resolves #3597
