### PR TITLE
Fix login with a temporary password

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -237,7 +237,11 @@ func loginToInfra(cli *CLI, lc loginClient, loginReq *api.LoginRequest, noAgent 
 		}
 
 		logging.Debugf("call server: update user %s", loginRes.UserID)
-		if _, err := lc.APIClient.UpdateUser(ctx, &api.UpdateUserRequest{ID: loginRes.UserID, Password: password}); err != nil {
+		if _, err := lc.APIClient.UpdateUser(ctx, &api.UpdateUserRequest{
+			ID:          loginRes.UserID,
+			Password:    password,
+			OldPassword: loginReq.PasswordCredentials.Password,
+		}); err != nil {
 			if passwordError(cli, err) {
 				goto PROMPTLOGIN
 			}


### PR DESCRIPTION
## Summary

Without this there is an error:

> Error: validation failed: oldPassword: is required

I tested this manually. An automated test would be nice, but kind of a pain since it requires interactive prompts.