### PR TITLE
Change Access Keys API + CLI

### DIFF
--- a/api/access_key.go
+++ b/api/access_key.go
@@ -8,6 +8,7 @@ import (
 type AccessKey struct {
 	ID                uid.ID `json:"id"`
 	Created           Time   `json:"created"`
+	LastUsed          Time   `json:"lastUsed"`
 	Name              string `json:"name"`
 	IssuedForName     string `json:"issuedForName"`
 	IssuedFor         uid.ID `json:"issuedFor"`
@@ -48,6 +49,7 @@ func (r CreateAccessKeyRequest) ValidationRules() []validate.ValidationRule {
 type CreateAccessKeyResponse struct {
 	ID                uid.ID `json:"id"`
 	Created           Time   `json:"created"`
+	LastUsed          Time   `json:"lastUsed"`
 	Name              string `json:"name"`
 	IssuedFor         uid.ID `json:"issuedFor"`
 	ProviderID        uid.ID `json:"providerID"`

--- a/api/access_key.go
+++ b/api/access_key.go
@@ -49,7 +49,6 @@ func (r CreateAccessKeyRequest) ValidationRules() []validate.ValidationRule {
 type CreateAccessKeyResponse struct {
 	ID                uid.ID `json:"id"`
 	Created           Time   `json:"created"`
-	LastUsed          Time   `json:"lastUsed"`
 	Name              string `json:"name"`
 	IssuedFor         uid.ID `json:"issuedFor"`
 	ProviderID        uid.ID `json:"providerID"`

--- a/api/access_key.go
+++ b/api/access_key.go
@@ -83,3 +83,10 @@ func (req ListAccessKeysRequest) SetPage(page int) Paginatable {
 type DeleteAccessKeyRequest struct {
 	Name string `form:"name"`
 }
+
+func (r DeleteAccessKeyRequest) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		ValidateName(r.Name),
+		validate.Required("name", r.Name),
+	}
+}

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -37,12 +37,6 @@
             "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
             "type": "string"
           },
-          "lastUsed": {
-            "description": "formatted as an RFC3339 date-time",
-            "example": "2022-03-14T09:48:00Z",
-            "format": "date-time",
-            "type": "string"
-          },
           "name": {
             "type": "string"
           },

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -37,6 +37,12 @@
             "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
             "type": "string"
           },
+          "lastUsed": {
+            "description": "formatted as an RFC3339 date-time",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },
@@ -448,6 +454,12 @@
                   "type": "string"
                 },
                 "issuedForName": {
+                  "type": "string"
+                },
+                "lastUsed": {
+                  "description": "formatted as an RFC3339 date-time",
+                  "example": "2022-03-14T09:48:00Z",
+                  "format": "date-time",
                   "type": "string"
                 },
                 "name": {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1079,6 +1079,9 @@
             "in": "query",
             "name": "name",
             "schema": {
+              "format": "[a-zA-Z0-9\\-_.]",
+              "maxLength": 256,
+              "minLength": 2,
               "type": "string"
             }
           }

--- a/docs/manage/connectors/kubernetes.md
+++ b/docs/manage/connectors/kubernetes.md
@@ -25,7 +25,7 @@ Copy the commands shown. They will add the Helm repo and update it, and then ins
 First, generate an access key:
 
 ```shell
-infra keys add connector
+ACCESS_KEY=$(infra keys add --connector -q)
 ```
 
 Next, use this access key to connect your cluster:
@@ -33,7 +33,7 @@ Next, use this access key to connect your cluster:
 ```shell
 helm upgrade --install infra-connector infrahq/infra \
     --set connector.config.server=INFRA_SERVER_HOSTNAME \
-    --set connector.config.accessKey=ACCESS_KEY \
+    --set connector.config.accessKey=$ACCESS_KEY \
     --set connector.config.name=example-cluster-name
 ```
 
@@ -63,7 +63,7 @@ Here is a sample Helm values file you might want to start with, replacing the
 connector:
   config:
     ## Infra server access key. You can get this by running
-    ## infra keys add connector --name connectorname --ttl=87600h
+    ## infra keys add --connector --name connectorname --ttl=87600h
     accessKey: "XXXXXXXXXX.YYYYYYYYYYYYYYYYYYYYYYYY"
     ## Infra server address
     server: "api.infrahq.com"

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -590,7 +590,8 @@ infra keys remove KEY [flags]
 #### Options
 
 ```console
-      --force   Exit successfully even if access key does not exist
+      --force         Exit successfully even if access key does not exist
+      --user string   The name of the user who owns the key
 ```
 
 **Additional options**

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -524,6 +524,7 @@ infra keys list [flags]
 #### Options
 
 ```console
+      --all            Show keys for all users
       --show-expired   Show expired access keys
       --user string    The name of a user to list access keys for
 ```
@@ -543,7 +544,7 @@ Create an access key
 Create an access key for a user or a connector.
 
 ```bash
-infra keys add USER|connector [flags]
+infra keys add [flags]
 ```
 
 #### Examples
@@ -551,19 +552,25 @@ infra keys add USER|connector [flags]
 ```bash
 
 # Create an access key named 'example-key' for a user that expires in 12 hours
-$ infra keys add user@example.com --ttl=12h --name example-key
+$ infra keys add --ttl=12h --name example-key
 
 # Create an access key to add a Kubernetes connection to Infra
-$ infra keys add connector
+$ infra keys add --connector
+
+# Set an environment variable with the newly created access key
+$ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
 
 ```
 
 #### Options
 
 ```console
+      --connector                     Create the key for the connector
       --extension-deadline duration   A specified deadline that the access key must be used within to remain valid (default 720h0m0s)
       --name string                   The name of the access key
+  -q, --quiet                         Only display the access key
       --ttl duration                  The total time that the access key will be valid for (default 720h0m0s)
+      --user string                   The name of the user who will own the key
 ```
 
 **Additional options**

--- a/helm/charts/infra/templates/NOTES.txt
+++ b/helm/charts/infra/templates/NOTES.txt
@@ -81,7 +81,7 @@
   establish a connection to Infra. If you do not already have an access key,
   generate one using Infra CLI.
 
-  $ infra keys add connector
+  $ infra keys add --connector
 
   Set an access key with `connector.config.accessKey`.
 

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -82,7 +82,7 @@ func DeleteAccessKey(c *gin.Context, id uid.ID, name string) error {
 		if len(keys) > 0 {
 			key = &keys[0]
 		} else {
-			return fmt.Errorf("no key named '%s' found", name)
+			return fmt.Errorf("%w: no key named '%s' found", internal.ErrNotFound, name)
 		}
 	}
 

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -60,9 +60,30 @@ func CreateAccessKey(c *gin.Context, accessKey *models.AccessKey) (body string, 
 func DeleteAccessKey(c *gin.Context, id uid.ID, name string) error {
 	rCtx := GetRequestContext(c)
 
-	key, err := data.GetAccessKey(rCtx.DBTxn, data.GetAccessKeysOptions{ByID: id, ByName: name})
-	if err != nil {
-		return err
+	var key *models.AccessKey
+	var err error
+
+	if id != 0 {
+		key, err = data.GetAccessKey(rCtx.DBTxn, data.GetAccessKeysOptions{ByID: id})
+		if err != nil {
+			return err
+		}
+	} else {
+		// if the specific key isn't specified, look up the key by name for the current user
+		opts := data.ListAccessKeyOptions{
+			IncludeExpired: false,
+			ByIssuedForID:  rCtx.Authenticated.User.ID,
+			ByName:         name,
+		}
+		keys, err := data.ListAccessKeys(rCtx.DBTxn, opts)
+		if err != nil {
+			return err
+		}
+		if len(keys) > 0 {
+			key = &keys[0]
+		} else {
+			return fmt.Errorf("no key named '%s' found", name)
+		}
 	}
 
 	if key.IssuedFor == rCtx.Authenticated.User.ID {

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -40,17 +40,18 @@ type keyCreateOptions struct {
 	UserName          string
 	TTL               time.Duration
 	ExtensionDeadline time.Duration
+	Connector         bool
+	Quiet             bool
 }
 
 func newKeysAddCmd(cli *CLI) *cobra.Command {
 	var options keyCreateOptions
-	var connector bool
-	var quiet bool
 
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Create an access key",
 		Long:  `Create an access key for a user or a connector.`,
+		Args:  NoArgs,
 		Example: `
 # Create an access key named 'example-key' for a user that expires in 12 hours
 $ infra keys add --ttl=12h --name example-key
@@ -83,7 +84,7 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
 			userID := config.UserID
 
 			// override the user setting if the user wants to create a connector access key
-			if connector {
+			if options.Connector {
 				options.UserName = "connector"
 			}
 
@@ -118,43 +119,49 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
 				return err
 			}
 
-			if !quiet {
-				var expMsg strings.Builder
-				expMsg.WriteString("This key will expire in ")
-				expMsg.WriteString(format.ExactDuration(options.TTL))
-				if !resp.Expires.Equal(resp.ExtensionDeadline) {
-					expMsg.WriteString(", and must be used every ")
-					expMsg.WriteString(format.ExactDuration(options.ExtensionDeadline))
-					expMsg.WriteString(" to remain valid")
-				}
-				if options.UserName != "" {
-					cli.Output("Issued access key %q for %q", resp.Name, options.UserName)
-				} else {
-					cli.Output("Issued access key %q", resp.Name)
-				}
-				cli.Output(expMsg.String())
-				cli.Output("")
-
-				cli.Output("Key: %s", resp.AccessKey)
-			} else {
+			if options.Quiet {
 				cli.Output(resp.AccessKey)
+				return nil
 			}
+
+			var expMsg strings.Builder
+			expMsg.WriteString("This key will expire in ")
+			expMsg.WriteString(format.ExactDuration(options.TTL))
+			if !resp.Expires.Equal(resp.ExtensionDeadline) {
+				expMsg.WriteString(", and must be used every ")
+				expMsg.WriteString(format.ExactDuration(options.ExtensionDeadline))
+				expMsg.WriteString(" to remain valid")
+			}
+			if options.UserName != "" {
+				cli.Output("Issued access key %q for %q", resp.Name, options.UserName)
+			} else {
+				cli.Output("Issued access key %q", resp.Name)
+			}
+			cli.Output(expMsg.String())
+			cli.Output("")
+
+			cli.Output("Key: %s", resp.AccessKey)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&options.Name, "name", "", "The name of the access key")
 	cmd.Flags().StringVar(&options.UserName, "user", "", "The name of the user who will own the key")
-	cmd.Flags().BoolVar(&connector, "connector", false, "Create the key for the connector")
-	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only display the access key")
+	cmd.Flags().BoolVar(&options.Connector, "connector", false, "Create the key for the connector")
+	cmd.Flags().BoolVarP(&options.Quiet, "quiet", "q", false, "Only display the access key")
 	cmd.Flags().DurationVar(&options.TTL, "ttl", thirtyDays, "The total time that the access key will be valid for")
 	cmd.Flags().DurationVar(&options.ExtensionDeadline, "extension-deadline", thirtyDays, "A specified deadline that the access key must be used within to remain valid")
 
 	return cmd
 }
 
+type keyRemoveOptions struct {
+	Force    bool
+	UserName string
+}
+
 func newKeysRemoveCmd(cli *CLI) *cobra.Command {
-	var force bool
+	var options keyRemoveOptions
 
 	cmd := &cobra.Command{
 		Use:     "remove KEY",
@@ -174,8 +181,22 @@ func newKeysRemoveCmd(cli *CLI) *cobra.Command {
 			}
 
 			keyName := args[0]
-
 			userID := config.UserID
+
+			if options.UserName != "" {
+				user, err := getUserByNameOrID(client, options.UserName)
+				if err != nil {
+					if api.ErrorStatusCode(err) == 403 {
+						logging.Debugf("%s", err.Error())
+						return Error{
+							Message: "Cannot list keys: missing privileges for GetUser",
+						}
+					}
+					return err
+				}
+				userID = user.ID
+			}
+
 			keys, err := listAll(ctx, client.ListAccessKeys, api.ListAccessKeysRequest{Name: keyName, UserID: userID})
 			if err != nil {
 				return err
@@ -204,7 +225,8 @@ func newKeysRemoveCmd(cli *CLI) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&force, "force", false, "Exit successfully even if access key does not exist")
+	cmd.Flags().BoolVar(&options.Force, "force", false, "Exit successfully even if access key does not exist")
+	cmd.Flags().StringVar(&options.UserName, "user", "", "The name of the user who owns the key")
 
 	return cmd
 }

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -272,6 +272,7 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 				Name              string `header:"NAME"`
 				IssuedFor         string `header:"ISSUED FOR"`
 				Created           string `header:"CREATED"`
+				LastUsed          string `header:"LAST USED"`
 				Expires           string `header:"EXPIRES"`
 				ExtensionDeadline string `header:"EXTENSION DEADLINE"`
 			}
@@ -286,6 +287,7 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 					Name:              k.Name,
 					IssuedFor:         name,
 					Created:           format.HumanTime(k.Created.Time(), "never"),
+					LastUsed:          format.HumanTime(k.LastUsed.Time(), "never"),
 					Expires:           format.HumanTime(k.Expires.Time(), "never"),
 					ExtensionDeadline: format.HumanTime(k.ExtensionDeadline.Time(), "never"),
 				})

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -99,6 +99,12 @@ func TestKeysAddCmd(t *testing.T) {
 		assert.Equal(t, req.Name, "") // filled by server
 		assert.Equal(t, withNewline(bufs.Stdout.String()), expectedKeysAddOutput)
 	})
+
+	t.Run("with unexpected arguments", func(t *testing.T) {
+		err := Run(context.Background(), "keys", "add", "something")
+		assert.ErrorContains(t, err, `"infra keys add" accepts no arguments`)
+		assert.ErrorContains(t, err, `Usage:  infra keys add`)
+	})
 }
 
 // expectedKeysAddOutput can be updated automatically by running tests with -update

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -74,7 +74,7 @@ func TestKeysAddCmd(t *testing.T) {
 		ch := setup(t)
 
 		ctx, bufs := PatchCLI(context.Background())
-		err := Run(ctx, "keys", "add", "--ttl=400h", "--extension-deadline=5h", "--name=the-name", "my-user")
+		err := Run(ctx, "keys", "add", "--ttl=400h", "--extension-deadline=5h", "--name=the-name", "--user=my-user")
 		assert.NilError(t, err)
 
 		req := <-ch
@@ -92,18 +92,12 @@ func TestKeysAddCmd(t *testing.T) {
 		ch := setup(t)
 
 		ctx, bufs := PatchCLI(context.Background())
-		err := Run(ctx, "keys", "add", "--ttl=400h", "--extension-deadline=5h", "my-user")
+		err := Run(ctx, "keys", "add", "--ttl=400h", "--extension-deadline=5h", "--user=my-user")
 		assert.NilError(t, err)
 
 		req := <-ch
 		assert.Equal(t, req.Name, "") // filled by server
 		assert.Equal(t, withNewline(bufs.Stdout.String()), expectedKeysAddOutput)
-	})
-
-	t.Run("without required arguments", func(t *testing.T) {
-		err := Run(context.Background(), "keys", "add")
-		assert.ErrorContains(t, err, `"infra keys add" requires exactly 1 argument`)
-		assert.ErrorContains(t, err, `Usage:  infra keys add USER`)
 	})
 }
 

--- a/internal/cmd/testdata/TestKeysListCmd/filter_by_user_name
+++ b/internal/cmd/testdata/TestKeysListCmd/filter_by_user_name
@@ -1,2 +1,2 @@
-  NAME      ISSUED FOR  CREATED       EXPIRES           EXTENSION DEADLINE  
-  user-key  my-user     24 hours ago  6 hours from now  never               
+  NAME      ISSUED FOR  CREATED       LAST USED  EXPIRES           EXTENSION DEADLINE  
+  user-key  my-user     24 hours ago  never      6 hours from now  never               

--- a/internal/cmd/testdata/TestKeysListCmd/list_all
+++ b/internal/cmd/testdata/TestKeysListCmd/list_all
@@ -1,4 +1,4 @@
-  NAME        ISSUED FOR  CREATED       EXPIRES           EXTENSION DEADLINE  
-  front-door  admin       24 hours ago  never             never               
-  side-door   admin       24 hours ago  6 hours from now  26 hours from now   
-  storage     clerk       20 hours ago  6 hours from now  never               
+  NAME        ISSUED FOR  CREATED       LAST USED  EXPIRES           EXTENSION DEADLINE  
+  front-door  admin       24 hours ago  never      never             never               
+  side-door   admin       24 hours ago  never      6 hours from now  26 hours from now   
+  storage     clerk       20 hours ago  never      6 hours from now  never               

--- a/internal/server/access_keys.go
+++ b/internal/server/access_keys.go
@@ -53,7 +53,6 @@ func (a *API) CreateAccessKey(c *gin.Context, r *api.CreateAccessKeyRequest) (*a
 		Created:           api.Time(accessKey.CreatedAt),
 		Name:              accessKey.Name,
 		IssuedFor:         accessKey.IssuedFor,
-		LastUsed:          api.Time(accessKey.UpdatedAt),
 		Expires:           api.Time(accessKey.ExpiresAt),
 		ExtensionDeadline: api.Time(accessKey.ExtensionDeadline),
 		AccessKey:         raw,

--- a/internal/server/access_keys.go
+++ b/internal/server/access_keys.go
@@ -53,6 +53,7 @@ func (a *API) CreateAccessKey(c *gin.Context, r *api.CreateAccessKeyRequest) (*a
 		Created:           api.Time(accessKey.CreatedAt),
 		Name:              accessKey.Name,
 		IssuedFor:         accessKey.IssuedFor,
+		LastUsed:          api.Time(accessKey.UpdatedAt),
 		Expires:           api.Time(accessKey.ExpiresAt),
 		ExtensionDeadline: api.Time(accessKey.ExtensionDeadline),
 		AccessKey:         raw,

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -255,7 +255,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodDelete, "/api/access-keys?name=delete+me", nil)
-		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+		req.Header.Set("Authorization", "Bearer "+ak1.Token())
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
 		routes.ServeHTTP(resp, req)

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -245,7 +245,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 
 	t.Run("delete by name", func(t *testing.T) {
 		key := &models.AccessKey{
-			Name:       "delete me",
+			Name:       "deleteme",
 			IssuedFor:  user.ID,
 			ProviderID: provider.ID,
 			ExpiresAt:  time.Now().Add(5 * time.Minute),
@@ -254,7 +254,7 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 		assert.NilError(t, err)
 
 		resp := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodDelete, "/api/access-keys?name=delete+me", nil)
+		req := httptest.NewRequest(http.MethodDelete, "/api/access-keys?name=deleteme", nil)
 		req.Header.Set("Authorization", "Bearer "+ak1.Token())
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
@@ -267,17 +267,27 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 		err := data.CreateIdentity(db, user)
 		assert.NilError(t, err)
 
-		key := &models.AccessKey{Name: "delete me too", IssuedFor: user.ID, ProviderID: provider.ID, ExpiresAt: time.Now().Add(5 * time.Minute), OrganizationMember: models.OrganizationMember{OrganizationID: provider.OrganizationID}}
+		key := &models.AccessKey{Name: "deletemetoo", IssuedFor: user.ID, ProviderID: provider.ID, ExpiresAt: time.Now().Add(5 * time.Minute), OrganizationMember: models.OrganizationMember{OrganizationID: provider.OrganizationID}}
 		_, err = data.CreateAccessKey(srv.db, key)
 		assert.NilError(t, err)
 
 		resp := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodDelete, "/api/access-keys?name=delete+me+too", nil)
+		req := httptest.NewRequest(http.MethodDelete, "/api/access-keys?name=deletemetoo", nil)
 		req.Header.Set("Authorization", "Bearer "+key.Token())
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
 		routes.ServeHTTP(resp, req)
 		assert.Equal(t, resp.Code, http.StatusNoContent)
+	})
+
+	t.Run("delete by name missing", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodDelete, "/api/access-keys?name=deletesomething", nil)
+		req.Header.Set("Authorization", "Bearer "+ak1.Token())
+		req.Header.Set("Infra-Version", apiVersionLatest)
+
+		routes.ServeHTTP(resp, req)
+		assert.Equal(t, resp.Code, http.StatusNotFound)
 	})
 
 	t.Run("show expired", func(t *testing.T) {

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -961,9 +961,15 @@ func getTestDefaultOrgUserDetails(t *testing.T, server *Server, name string) (*m
 		assert.NilError(t, err, "credentials")
 	}
 
-	accessKey, err := data.GetAccessKey(tx, data.GetAccessKeysOptions{IssuedFor: user.ID})
+	keys, err := data.ListAccessKeys(tx, data.ListAccessKeyOptions{ByIssuedForID: user.ID})
 	if !errors.Is(err, internal.ErrNotFound) {
 		assert.NilError(t, err, "access_key")
+	}
+
+	// only return the first key
+	var accessKey *models.AccessKey
+	if len(keys) > 0 {
+		accessKey = &keys[0]
 	}
 
 	return user, credential, accessKey

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -46,7 +46,7 @@ func secretChecksum(secret string) []byte {
 func validateAccessKey(accessKey *models.AccessKey) error {
 	switch {
 	case accessKey.IssuedFor == 0:
-		return fmt.Errorf("issusedFor is required")
+		return fmt.Errorf("issuedFor is required")
 	case accessKey.ProviderID == 0:
 		return fmt.Errorf("providerID is required")
 	case len(accessKey.KeyID) != models.AccessKeyKeyLength:
@@ -226,7 +226,7 @@ func GetAccessKey(tx ReadTxn, opts GetAccessKeysOptions) (*models.AccessKey, err
 		query.B("AND access_keys.name = ?", opts.ByName)
 		query.B("AND access_keys.issued_for = ?", opts.IssuedFor)
 	default:
-		return nil, fmt.Errorf("either an ID, or name and issused_for are required")
+		return nil, fmt.Errorf("either an ID, or name and issued_for are required")
 	}
 
 	fields := append(accessKey.ScanFields(), &accessKey.IssuedForName)

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -210,10 +210,6 @@ type GetAccessKeysOptions struct {
 
 // GetAccessKey by any unique field. This must be scoped by organizationID as it's callable by users.
 func GetAccessKey(tx ReadTxn, opts GetAccessKeysOptions) (*models.AccessKey, error) {
-	if opts.ByID == 0 && opts.ByName == "" && opts.IssuedFor == 0 {
-		return nil, fmt.Errorf("GetAccessKey must supply id, issuedFor, or name")
-	}
-
 	accessKey := &accessKeyTable{}
 	query := querybuilder.New("SELECT")
 	query.B(columnsForSelect(accessKey))
@@ -222,14 +218,15 @@ func GetAccessKey(tx ReadTxn, opts GetAccessKeysOptions) (*models.AccessKey, err
 	query.B("ON access_keys.issued_for = identities.id")
 	query.B("WHERE access_keys.deleted_at is null")
 	query.B("AND access_keys.organization_id = ?", tx.OrganizationID())
-	if opts.ByID != 0 {
+
+	switch {
+	case opts.ByID != 0:
 		query.B("AND access_keys.id = ?", opts.ByID)
-	}
-	if opts.ByName != "" {
+	case opts.ByName != "" && opts.IssuedFor != 0:
 		query.B("AND access_keys.name = ?", opts.ByName)
-	}
-	if opts.IssuedFor != 0 {
-		query.B("AND issued_for = ?", opts.IssuedFor)
+		query.B("AND access_keys.issued_for = ?", opts.IssuedFor)
+	default:
+		return nil, fmt.Errorf("either an ID, or name and issused_for are required")
 	}
 
 	fields := append(accessKey.ScanFields(), &accessKey.IssuedForName)

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -605,8 +605,15 @@ func TestGetAccessKey(t *testing.T) {
 
 		createAccessKeys(t, db, ak, other)
 
+		t.Run("default options", func(t *testing.T) {
+			_, err := GetAccessKey(db, GetAccessKeysOptions{})
+			assert.ErrorContains(t, err, "either an ID, or name")
+		})
 		t.Run("found by name", func(t *testing.T) {
-			actual, err := GetAccessKey(db, GetAccessKeysOptions{ByName: "the-key"})
+			actual, err := GetAccessKey(db, GetAccessKeysOptions{
+				ByName:    "the-key",
+				IssuedFor: user.ID,
+			})
 			assert.NilError(t, err)
 			expected := *ak
 			expected.Secret = ""
@@ -633,7 +640,10 @@ func TestGetAccessKey(t *testing.T) {
 		})
 
 		t.Run("not found", func(t *testing.T) {
-			_, err := GetAccessKey(db, GetAccessKeysOptions{ByName: "not-this-key-name"})
+			_, err := GetAccessKey(db, GetAccessKeysOptions{
+				ByName:    "not-this-key-name",
+				IssuedFor: 600600,
+			})
 			assert.ErrorIs(t, err, internal.ErrNotFound)
 		})
 

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -858,6 +858,10 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 				_, err = tx.Exec(`INSERT INTO access_keys(id, issued_for, name) VALUES(10001, 12346, 'foo')`)
 				assert.NilError(t, err)
 			},
+			cleanup: func(t *testing.T, tx WriteTxn) {
+				_, err := tx.Exec(`DELETE FROM access_keys WHERE id IN (10000, 10001)`)
+				assert.NilError(t, err)
+			},
 		},
 	}
 

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -850,6 +850,15 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 				assert.NilError(t, err)
 			},
 		},
+		{
+			label: testCaseLine("2022-11-15T10:00"),
+			expected: func(t *testing.T, tx WriteTxn) {
+				_, err := tx.Exec(`INSERT INTO access_keys(id, issued_for, name) VALUES(10000, 12345, 'foo')`)
+				assert.NilError(t, err)
+				_, err = tx.Exec(`INSERT INTO access_keys(id, issued_for, name) VALUES(10001, 12346, 'foo')`)
+				assert.NilError(t, err)
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -316,9 +316,9 @@ ALTER TABLE ONLY settings
 
 CREATE INDEX idx_access_keys_expires_at ON access_keys USING btree (expires_at);
 
-CREATE UNIQUE INDEX idx_access_keys_key_id ON access_keys USING btree (key_id) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_access_keys_issued_for_name ON access_keys USING btree (organization_id, issued_for, name) WHERE (deleted_at IS NULL);
 
-CREATE UNIQUE INDEX idx_access_keys_name ON access_keys USING btree (organization_id, name) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_access_keys_key_id ON access_keys USING btree (key_id) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_credentials_identity_id ON credentials USING btree (organization_id, identity_id) WHERE (deleted_at IS NULL);
 

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -46,6 +46,7 @@ func (ak *AccessKey) ToAPI() *api.AccessKey {
 		ID:                ak.ID,
 		Name:              ak.Name,
 		Created:           api.Time(ak.CreatedAt),
+		LastUsed:          api.Time(ak.UpdatedAt),
 		IssuedFor:         ak.IssuedFor,
 		IssuedForName:     ak.IssuedForName,
 		ProviderID:        ak.ProviderID,

--- a/internal/server/models/access_key.go
+++ b/internal/server/models/access_key.go
@@ -46,7 +46,7 @@ func (ak *AccessKey) ToAPI() *api.AccessKey {
 		ID:                ak.ID,
 		Name:              ak.Name,
 		Created:           api.Time(ak.CreatedAt),
-		LastUsed:          api.Time(ak.UpdatedAt),
+		LastUsed:          api.Time(ak.UpdatedAt), // this tracks UpdatedAt which requires the ExtensionDeadline to be set, otherwise it won't be updated
 		IssuedFor:         ak.IssuedFor,
 		IssuedForName:     ak.IssuedForName,
 		ProviderID:        ak.ProviderID,


### PR DESCRIPTION
## Summary

This change makes a number of quality of life changes to both the access keys API and CLI.

* Change access keys to make their names unique to a specific user, instead of for an entire org
* Make `infra keys list` default to the current user
* Add an `--all` flag to `infra keys list` for admins which can list all access keys in the org
* Make `infra keys add` not require a user name
* Add a `--user=` argument to `infra keys add` to be consistent with `infra keys list`
* Add a `--connector` flag to `infra keys add` to create the key for a connector
* Make `infra keys remove` to be specific to the current user
* Add a `--user=` argument similar to `infra keys list` and `infra keys add`
* Changed the API to call `DELETE /api/access-keys/:id` instead of `DELETE /api/access-keys`
* Added `LastUsed` field to the API and updated `infra keys list` to show the last time a specific key was used

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

Note: This change should be backwards compatible, but there are a number of caveats. I didn't remove the `DELETE /api/access-keys` endpoint because older CLI clients will still need to use it, and it's not 100% clear how to accomplish this with the current API migrator. Also, if a client upgrades and hits an older version of the server, it will have issues displaying the `LAST USED` column because the API won't populate it.

