### PR TITLE
Add SSH commands and integrate with login

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -248,6 +248,10 @@ func (c Client) GetUser(ctx context.Context, id uid.ID) (*User, error) {
 	return get[User](ctx, c, fmt.Sprintf("/api/users/%s", id), Query{})
 }
 
+func (c Client) GetUserSelf(ctx context.Context) (*User, error) {
+	return get[User](ctx, c, "/api/users/self", Query{})
+}
+
 func (c Client) CreateUser(ctx context.Context, req *CreateUserRequest) (*CreateUserResponse, error) {
 	return post[CreateUserResponse](ctx, c, "/api/users", req)
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -74,13 +74,12 @@ func printTable(data interface{}, out io.Writer) {
 }
 
 // Creates a new API Client from the current config
-// Deprecated: use readConfig and ClientConfig.APIClient
 func defaultAPIClient() (*api.Client, error) {
-	config, err := readConfig()
+	config, err := currentHostConfig()
 	if err != nil {
 		return nil, err
 	}
-	return config.APIClient()
+	return apiClientFromHostConfig(config)
 }
 
 func apiClientFromHostConfig(config *ClientHostConfig) (*api.Client, error) {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -74,12 +74,16 @@ func printTable(data interface{}, out io.Writer) {
 }
 
 // Creates a new API Client from the current config
+// Deprecated: use readConfig and ClientConfig.APIClient
 func defaultAPIClient() (*api.Client, error) {
-	config, err := currentHostConfig()
+	config, err := readConfig()
 	if err != nil {
 		return nil, err
 	}
+	return config.APIClient()
+}
 
+func apiClientFromHostConfig(config *ClientHostConfig) (*api.Client, error) {
 	server := config.Host
 	var accessKey string
 	if !config.isExpired() {
@@ -230,7 +234,8 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 		newTokensCmd(cli),
 		newServerCmd(),
 		newConnectorCmd(),
-		newAgentCmd())
+		newAgentCmd(),
+		newSSHCmd(cli))
 
 	rootCmd.PersistentFlags().String("log-level", "info", "Show logs when running the command [error, warn, info, debug]")
 	rootCmd.PersistentFlags().Bool("help", false, "Display help")

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/certs"
+	"github.com/infrahq/infra/internal/server"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -79,6 +80,29 @@ func newTestClientConfig(srv *httptest.Server, user api.User) ClientConfig {
 				Host:               srv.Listener.Addr().String(),
 				TrustedCertificate: string(certs.PEMEncodeCertificate(srv.Certificate().Raw)),
 				AccessKey:          "the-access-key",
+				Expires:            api.Time(time.Now().Add(time.Hour)),
+				Current:            true,
+			},
+		},
+	}
+}
+
+func newTestClientConfigForServer(srv *server.Server, user api.User, acKey string) ClientConfig {
+	if user.Name == "" {
+		user.Name = "testuser@example.com"
+	}
+	if user.ID == 0 {
+		user.ID = uid.New()
+	}
+	return ClientConfig{
+		ClientConfigVersion: clientConfigVersion,
+		Hosts: []ClientHostConfig{
+			{
+				UserID:             user.ID,
+				Name:               user.Name,
+				Host:               srv.Addrs.HTTPS.String(),
+				TrustedCertificate: string(srv.Options().TLS.Certificate),
+				AccessKey:          acKey,
 				Expires:            api.Time(time.Now().Add(time.Hour)),
 				Current:            true,
 			},

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -170,17 +170,33 @@ func saveHostConfig(hostConfig ClientHostConfig) error {
 	return nil
 }
 
+// Deprecated: use readConfig and ClientConfig.CurrentHostConfig
 func currentHostConfig() (*ClientHostConfig, error) {
 	cfg, err := readConfig()
 	if err != nil {
 		return nil, err
 	}
+	return cfg.CurrentHostConfig()
+}
 
-	for i, c := range cfg.Hosts {
-		if c.Current {
-			return &cfg.Hosts[i], nil
+func (c ClientConfig) CurrentHostConfig() (*ClientHostConfig, error) {
+	for i, host := range c.Hosts {
+		if host.Current {
+			return &c.Hosts[i], nil
 		}
 	}
 
 	return nil, ErrConfigNotFound
+}
+
+func (c ClientConfig) APIClient() (*api.Client, error) {
+	cfg, err := readConfig()
+	if err != nil {
+		return nil, err
+	}
+	hostConfig, err := cfg.CurrentHostConfig()
+	if err != nil {
+		return nil, err
+	}
+	return apiClientFromHostConfig(hostConfig)
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -170,33 +170,17 @@ func saveHostConfig(hostConfig ClientHostConfig) error {
 	return nil
 }
 
-// Deprecated: use readConfig and ClientConfig.CurrentHostConfig
 func currentHostConfig() (*ClientHostConfig, error) {
 	cfg, err := readConfig()
 	if err != nil {
 		return nil, err
 	}
-	return cfg.CurrentHostConfig()
-}
 
-func (c ClientConfig) CurrentHostConfig() (*ClientHostConfig, error) {
-	for i, host := range c.Hosts {
-		if host.Current {
-			return &c.Hosts[i], nil
+	for i, c := range cfg.Hosts {
+		if c.Current {
+			return &cfg.Hosts[i], nil
 		}
 	}
 
 	return nil, ErrConfigNotFound
-}
-
-func (c ClientConfig) APIClient() (*api.Client, error) {
-	cfg, err := readConfig()
-	if err != nil {
-		return nil, err
-	}
-	hostConfig, err := cfg.CurrentHostConfig()
-	if err != nil {
-		return nil, err
-	}
-	return apiClientFromHostConfig(hostConfig)
 }

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -177,7 +177,15 @@ func login(cli *CLI, options loginCmdOptions) error {
 		}
 	}
 
-	return loginToInfra(cli, lc, loginReq, options.NoAgent)
+	if err := loginToInfra(cli, lc, loginReq, options.NoAgent); err != nil {
+		return err
+	}
+	// TODO: return this from login response?
+	sshUsername, err := getSSHUsername(ctx)
+	if err != nil {
+		return err
+	}
+	return updateUserSSHConfig(cli, sshUsername)
 }
 
 func checkDeviceFlowCompatibility(ctx context.Context, api *api.Client) error {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -180,12 +180,7 @@ func login(cli *CLI, options loginCmdOptions) error {
 	if err := loginToInfra(cli, lc, loginReq, options.NoAgent); err != nil {
 		return err
 	}
-	// TODO: return this from login response?
-	sshUsername, err := getSSHUsername(ctx)
-	if err != nil {
-		return err
-	}
-	return updateUserSSHConfig(cli, sshUsername)
+	return updateUserSSHConfig(cli)
 }
 
 func checkDeviceFlowCompatibility(ctx context.Context, api *api.Client) error {

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -117,9 +117,20 @@ func writeInfraKnownHosts(infraSSHDir string, dests []api.Destination) error {
 		return err
 	}
 	for _, dest := range dests {
-		line := fmt.Sprintf("%v %v", dest.Connection.URL, dest.Connection.CA)
-		if _, err := fh.WriteString(line); err != nil {
-			return err
+		hostname := dest.Connection.URL
+		if host, _, err := net.SplitHostPort(hostname); err == nil {
+			hostname = host
+		}
+
+		for _, key := range strings.Split(string(dest.Connection.CA), "\n") {
+			if key == "" {
+				continue
+			}
+
+			line := fmt.Sprintf("%v %v\n", hostname, key)
+			if _, err := fh.WriteString(line); err != nil {
+				return err
+			}
 		}
 	}
 	if err := fh.Sync(); err != nil {

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -371,7 +371,7 @@ func writeDestinationSSHConfig(infraSSHDir string, destination *api.Destination,
 
 	host, port := splitHostPortSSH(destination.Connection.URL)
 	data := map[string]any{
-		"Username": user.SSHUsername,
+		"Username": user.SSHLoginName,
 		"Hostname": host,
 		"Port":     port,
 	}

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -155,11 +155,7 @@ func setupDestinationSSHConfig(ctx context.Context, cli *CLI, destination *api.D
 	infraSSHDir := filepath.Join(homeDir, ".ssh/infra")
 	_ = os.MkdirAll(infraSSHDir, 0700)
 
-	cfg, err := readConfig()
-	if err != nil {
-		return err
-	}
-	client, err := cfg.APIClient()
+	client, err := defaultAPIClient()
 	if err != nil {
 		return err
 	}
@@ -299,7 +295,6 @@ func updateUserSSHConfig(cli *CLI) error {
 	}
 	cli.Output(`
 Your SSH config at %v has been updated to connect to Infra SSH destinations.
-connecting to Infra SSH destinations.
 `,
 		filename)
 	return nil

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -111,7 +111,7 @@ func splitHostPortSSH(hostname string) (host, port string) {
 	var err error
 	host, port, err = net.SplitHostPort(hostname)
 	if err != nil {
-		return hostname, "22"
+		return hostname, "22" // default port for ssh client connections is 22
 	}
 	return host, port
 }
@@ -298,7 +298,7 @@ func updateUserSSHConfig(cli *CLI) error {
 		return err
 	}
 	cli.Output(`
-Your SSH config at %v has been created or updated to use 'infra ssh hosts' for
+Your SSH config at %v has been updated to connect to Infra SSH destinations.
 connecting to Infra SSH destinations.
 `,
 		filename)

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -1,0 +1,343 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/logging"
+)
+
+func newSSHCmd(cli *CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "ssh",
+		Short:  "Commands for integrating with ssh",
+		Hidden: true,
+	}
+
+	cmd.AddCommand(newSSHHostsCmd(cli))
+
+	return cmd
+}
+
+func newSSHHostsCmd(*CLI) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "hosts",
+		Short: "Check if the host is known to infra",
+		Args:  ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runSSHHosts(args[0]); err != nil {
+				// Prevent an error from being printed to stderr, because it
+				// is printed every time a user runs ssh for a non-infra host.
+				logging.L.Debug().Err(err).Msg("exit from infra ssh hosts")
+				return exitError{code: 1}
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// exitCode is used to exit with a non-zero code without printing any error
+// to stderr.
+type exitError struct {
+	code int
+}
+
+func (e exitError) ExitCode() int {
+	return e.code
+}
+
+func (e exitError) Error() string {
+	return fmt.Sprintf("exit code %v", e.code)
+}
+
+func runSSHHosts(hostname string) error {
+	ctx := context.Background()
+
+	client, err := defaultAPIClient()
+	if err != nil {
+		return err
+	}
+
+	// TODO: check a local file cache to avoid querying the server in all cases
+	dests, err := client.ListDestinations(ctx, api.ListDestinationsRequest{Kind: "ssh"})
+	if err != nil {
+		return err
+	}
+
+	// Exit if the hostname is not known to infra
+	destination := destinationForName(dests.Items, hostname)
+	if destination == nil {
+		return fmt.Errorf("no destination matching that hostname")
+	}
+
+	if err := setupSSHConfig(ctx, dests.Items); err != nil {
+		return err
+	}
+	return nil
+}
+
+func destinationForName(dests []api.Destination, hostname string) *api.Destination {
+	for _, dest := range dests {
+		if dest.Connection.URL == hostname {
+			return &dest
+		}
+
+		// Try the url without port
+		host, _, err := net.SplitHostPort(dest.Connection.URL)
+		if err == nil && hostname == host {
+			return &dest
+		}
+	}
+	return nil
+}
+
+// TODO: write this file path to the infra config as well?
+// TODO: only write one dest at a time, and leave the rest of the file.
+func writeInfraKnownHosts(infraSSHDir string, dests []api.Destination) error {
+	filename := filepath.Join(infraSSHDir, "known_hosts")
+	fh, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	for _, dest := range dests {
+		line := fmt.Sprintf("%v %v", dest.Connection.URL, dest.Connection.CA)
+		if _, err := fh.WriteString(line); err != nil {
+			return err
+		}
+	}
+	if err := fh.Sync(); err != nil {
+		return err
+	}
+	if err := fh.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setupSSHConfig(ctx context.Context, destinations []api.Destination) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("user home directory: %w", err)
+	}
+	infraSSHDir := filepath.Join(homeDir, ".ssh/infra")
+	_ = os.MkdirAll(infraSSHDir, 0700)
+
+	cfg, err := readConfig()
+	if err != nil {
+		return err
+	}
+	client, err := cfg.APIClient()
+	if err != nil {
+		return err
+	}
+
+	if err := provisionSSHKey(ctx, client, infraSSHDir); err != nil {
+		return err
+	}
+
+	if err := writeInfraKnownHosts(infraSSHDir, destinations); err != nil {
+		return fmt.Errorf("write known hosts: %w", err)
+	}
+	return nil
+}
+
+func provisionSSHKey(ctx context.Context, client *api.Client, infraSSHDir string) error {
+	keyFilename := filepath.Join(infraSSHDir, "key")
+
+	// TODO: check expiration
+	// TODO: check the key exists in the API
+	if fileExists(keyFilename) {
+		return nil
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate key pair: %w", err)
+	}
+
+	fh, err := os.OpenFile(keyFilename, os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+	block := &pem.Block{Type: "OPENSSH PRIVATE KEY", Bytes: priv}
+	if err := pem.Encode(fh, block); err != nil {
+		return err
+	}
+	if err := fh.Close(); err != nil {
+		return err
+	}
+
+	sshPubKey, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return err
+	}
+
+	pubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+	if err := os.WriteFile(keyFilename+".pub", pubKeyBytes, 0600); err != nil {
+		return err
+	}
+
+	hostname, _ := os.Hostname()
+	_, err = client.AddUserPublicKey(ctx, &api.AddUserPublicKeyRequest{
+		Name:      hostname,
+		PublicKey: string(pubKeyBytes),
+	})
+	return err
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+func getSSHUsername(ctx context.Context) (string, error) {
+	cfg, err := readConfig()
+	if err != nil {
+		return "", err
+	}
+	hostCfg, err := cfg.CurrentHostConfig()
+	if err != nil {
+		return "", err
+	}
+	client, err := cfg.APIClient()
+	if err != nil {
+		return "", err
+	}
+	user, err := client.GetUser(ctx, hostCfg.UserID)
+	if err != nil {
+		return "", err
+	}
+	return user.SSHUsername, nil
+}
+
+func updateUserSSHConfig(cli *CLI, sshUsername string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("user home directory: %w", err)
+	}
+
+	userSSHDir := filepath.Join(homeDir, ".ssh")
+	filename := filepath.Join(userSSHDir, "config")
+
+	var original []byte
+	fh, err := os.Open(filename)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// file is missing, we'll create it later
+		_ = os.MkdirAll(userSSHDir, 0700)
+	case err != nil:
+		return fmt.Errorf("open ssh config: %w", err)
+	default:
+		defer fh.Close() // closing the read only file
+
+		if hasInfraMatchLine(fh) {
+			return nil
+		}
+
+		_, err = fh.Seek(0, io.SeekStart)
+		if err != nil {
+			return fmt.Errorf("seek: %w", err)
+		}
+
+		original, err = io.ReadAll(fh)
+		if err != nil {
+			return fmt.Errorf("read file: %w", err)
+		}
+
+		_ = fh.Close() // closing the read only file
+	}
+
+	tmp, err := os.CreateTemp(userSSHDir, "config-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.Write(original); err != nil {
+		return err
+	}
+
+	data := map[string]string{"Username": sshUsername}
+	if err := infraSSHConfigTemplate.Execute(tmp, data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmp.Name(), filename); err != nil {
+		return err
+	}
+	cli.Output(`
+Your SSH config at %v has been created or updated to use 'infra ssh hosts' for
+connecting to Infra SSH destinations.
+`,
+		filename)
+	return nil
+}
+
+var infraSSHConfigTemplate = template.Must(template.New("ssh-config").Parse(infraSSHConfig))
+
+const infraSSHConfig = `
+
+Match exec "infra ssh hosts %h"
+    IdentityFile ~/.ssh/infra/key
+    IdentitiesOnly yes
+    User {{ .Username }}
+    UserKnownHostsFile ~/.ssh/infra/known_hosts
+
+`
+
+// hasInfraMatchLine does a minimal parse of the ssh client config file and
+// returns true if it finds the "Match" line required to use infra ssh,
+// otherwise returns false. Scanning errors are ignored.
+//
+// See https://man.openbsd.org/ssh_config.5 for details about the file format.
+func hasInfraMatchLine(sshConfig io.Reader) bool {
+	if sshConfig == nil {
+		return false
+	}
+
+	// TODO: test many match lines that don't match
+	lineScan := bufio.NewScanner(sshConfig)
+	for lineScan.Scan() {
+		fields := strings.Fields(lineScan.Text())
+		if len(fields) < 3 {
+			continue
+		}
+		if !strings.EqualFold(fields[0], "Match") {
+			continue
+		}
+		if !strings.EqualFold(fields[1], "exec") {
+			continue
+		}
+		cmd := strings.Join(fields[2:], " ")
+		if strings.Contains(cmd, "infra ssh hosts") {
+			return true
+		}
+	}
+	if err := lineScan.Err(); err != nil {
+		logging.Warnf("Failed to read ssh config: %v", err)
+	}
+	return false
+}

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -7,10 +7,133 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"golang.org/x/crypto/ssh"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/fs"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/server"
 )
+
+func TestSSHHostsCmd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("INFRA_LOG_LEVEL", "debug")
+
+	srvDir := t.TempDir()
+	opts := defaultServerOptions(srvDir)
+	opts.Config = server.Config{
+		Users: []server.User{
+			{Name: "admin@example.com", AccessKey: "0000000001.adminadminadminadmin1234"},
+			{Name: "anyuser@example.com", AccessKey: "0000000002.notadminsecretnotadmin02"},
+		},
+		Grants: []server.Grant{
+			{User: "admin@example.com", Resource: "infra", Role: "admin"},
+			{User: "anyuser@example.com", Resource: "prodhost", Role: "connect"},
+		},
+	}
+	setupServerOptions(t, &opts)
+	srv, err := server.New(opts)
+	assert.NilError(t, err)
+
+	ctx := context.Background()
+	runAndWait(ctx, t, srv.Run)
+
+	client, err := apiClientFromHostConfig(&ClientHostConfig{
+		AccessKey:          "0000000001.adminadminadminadmin1234",
+		Expires:            api.Time(time.Now().Add(time.Hour)),
+		Host:               srv.Addrs.HTTPS.String(),
+		TrustedCertificate: string(opts.TLS.Certificate),
+	})
+	assert.NilError(t, err)
+
+	hostKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDbFeHekEHKkH8R9UgQt586OjjYRAC2FnxxWA8+T68wm4XB5Rcvrth2hAZhN12NKOaR57MuscFkmn6fUc2Z+hjj8saX14/zyuJLqz2Svk9p2tFkVM+A1B1ZuluZLyGe86i5anb+H19L2MkcojMCxSgScwgRgRmcXpTEQAIILQL5HCfxtMpFmmL03Vl1sPWh9p7G8FPuqMTElSITumMokrMFeDEP8H06LhjM4jBgGxZds7FVFqKrQgE73GdGKl936HgY9JE8RLSOyJ2GSVcKUZKYirYCa6LHAO37NSA0ulZrlx0nl6Yt7nMIAhDDRY/UzeJ6wW1+UAzmqA1mbY16+AHY8ItIQCkfxXaoS59Z3k7qczfYTpZpNYeNo/7Xypt1yz0NRdKuDzGLhzYIg2toQ3jSXWWgUlJ8IGnrvbStvt+tnnbObpgkVBRHZCIUUXB/ZC5zDXvGy+5BTkTPSSyXes39ZwRgAeI0OHO1Fr8gvxscWWB2ygfPRmpLo5JWOLABxi8= root@006100a32148\n"
+	_, err = client.CreateDestination(ctx, &api.CreateDestinationRequest{
+		Name: "prodhost",
+		Kind: "ssh",
+		Connection: api.DestinationConnection{
+			URL: "127.12.12.1",
+			CA:  api.PEM(hostKey),
+		},
+	})
+	assert.NilError(t, err)
+
+	users, err := client.ListUsers(ctx, api.ListUsersRequest{Name: "anyuser@example.com"})
+	assert.NilError(t, err)
+	assert.Equal(t, len(users.Items), 1)
+	user := users.Items[0]
+	assert.Equal(t, user.SSHUsername, "anyuser")
+
+	cfg := newTestClientConfigForServer(srv, user, "0000000002.notadminsecretnotadmin02")
+	assert.NilError(t, writeConfig(&cfg))
+
+	err = Run(ctx, "ssh", "hosts", "127.12.12.1", "22")
+	assert.NilError(t, err)
+
+	expected := fs.Expected(t,
+		// the mode of the temp dir is not relevant to this test
+		fs.MatchAnyFileMode,
+		// the infra dir is not relevant to this test
+		fs.WithDir(".infra", fs.MatchExtraFiles),
+		fs.WithDir(".ssh",
+			fs.WithMode(0700),
+			fs.WithDir("infra",
+				fs.WithMode(0700),
+				fs.WithFile("config", `
+
+# This file is managed by Infra. Do not edit!
+
+Match 127.12.12.1
+    IdentityFile ~/.ssh/infra/key
+    IdentitiesOnly yes
+    UserKnownHostsFile ~/.ssh/infra/known_hosts
+    User anyuser
+    Port 22
+
+`,
+					fs.WithMode(0600)),
+				fs.WithFile("key", "",
+					fs.WithMode(0600),
+					fs.MatchAnyFileContent),
+				fs.WithFile("key.pub", "",
+					fs.WithMode(0600),
+					fs.MatchAnyFileContent),
+				fs.WithFile("known_hosts",
+					"127.12.12.1 "+hostKey,
+					fs.WithMode(0600)),
+			),
+		),
+	)
+	assert.Assert(t, fs.Equal(home, expected))
+
+	raw, err := os.ReadFile(filepath.Join(home, ".ssh/infra/key"))
+	assert.NilError(t, err)
+
+	_, err = ssh.ParseRawPrivateKey(raw)
+	assert.NilError(t, err)
+
+	raw, err = os.ReadFile(filepath.Join(home, ".ssh/infra/key.pub"))
+	assert.NilError(t, err)
+
+	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(raw)
+	assert.NilError(t, err)
+	assert.Equal(t, pubKey.Type(), "ssh-rsa")
+
+	// TODO: use GetUser when that API response includes public keys
+	users, err = client.ListUsers(ctx, api.ListUsersRequest{Name: "anyuser@example.com"})
+	assert.NilError(t, err)
+	assert.Equal(t, len(users.Items), 1)
+	user = users.Items[0]
+
+	assert.Equal(t, len(user.PublicKeys), 1)
+	assert.Equal(t, user.PublicKeys[0].KeyType, "ssh-rsa")
+	parts := strings.Fields(string(raw))
+	assert.Equal(t, user.PublicKeys[0].PublicKey, parts[1])
+}
 
 func TestUpdateUserSSHConfig(t *testing.T) {
 	type testCase struct {

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -33,7 +33,7 @@ func TestUpdateUserSSHConfig(t *testing.T) {
 
 		ctx := context.Background()
 		ctx, bufs := PatchCLI(ctx)
-		err := updateUserSSHConfig(newCLI(ctx), "theusername")
+		err := updateUserSSHConfig(newCLI(ctx))
 		assert.NilError(t, err)
 
 		expectedOutput := "has been created or updated to use 'infra ssh hosts'"
@@ -62,7 +62,7 @@ Match something
 
 
 Match exec "infra ssh hosts %h"
-    ProxyCommand "infra ssh connect %h"
+    Include somethingelse
 
 
 Host more below
@@ -75,11 +75,8 @@ Host bastion
 
 	var expectedInfraSSHConfig = `
 
-Match exec "infra ssh hosts %h"
-    IdentityFile ~/.ssh/infra/key
-    IdentitiesOnly yes
-    User theusername
-    UserKnownHostsFile ~/.ssh/infra/known_hosts
+Match exec "infra ssh hosts %h %p"
+    Include ~/.ssh/infra/config
 
 `
 

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestUpdateUserSSHConfig(t *testing.T) {
+	type testCase struct {
+		name            string
+		setup           func(t *testing.T, filename string)
+		expected        func(t *testing.T, fh *os.File)
+		expectCLIOutput bool
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+
+		sshConfigFilename := filepath.Join(home, ".ssh/config")
+
+		if tc.setup != nil {
+			tc.setup(t, sshConfigFilename)
+		}
+
+		ctx := context.Background()
+		ctx, bufs := PatchCLI(ctx)
+		err := updateUserSSHConfig(newCLI(ctx), "theusername")
+		assert.NilError(t, err)
+
+		expectedOutput := "has been created or updated to use 'infra ssh hosts'"
+		if tc.expectCLIOutput {
+			assert.Assert(t, cmp.Contains(bufs.Stdout.String(), expectedOutput))
+		} else {
+			assert.Equal(t, bufs.Stdout.String(), "")
+		}
+
+		fh, err := os.Open(sshConfigFilename)
+		assert.NilError(t, err)
+		defer fh.Close()
+
+		fi, err := fh.Stat()
+		assert.NilError(t, err)
+		assert.Equal(t, fi.Mode(), os.FileMode(0600))
+
+		tc.expected(t, fh)
+	}
+
+	var contentWithMatchLine = `
+
+Host somethingelse
+
+Match something
+
+
+Match exec "infra ssh hosts %h"
+    ProxyCommand "infra ssh connect %h"
+
+
+Host more below
+`
+
+	var contentNoMatchLine = `
+Host bastion
+	Username shared
+`
+
+	var expectedInfraSSHConfig = `
+
+Match exec "infra ssh hosts %h"
+    IdentityFile ~/.ssh/infra/key
+    IdentitiesOnly yes
+    User theusername
+    UserKnownHostsFile ~/.ssh/infra/known_hosts
+
+`
+
+	testCases := []testCase{
+		{
+			name:            "file does not exist",
+			expectCLIOutput: true,
+			expected: func(t *testing.T, fh *os.File) {
+				content, err := io.ReadAll(fh)
+				assert.NilError(t, err)
+				assert.Equal(t, string(content), expectedInfraSSHConfig)
+			},
+		},
+		{
+			name: "file exists with match line",
+			setup: func(t *testing.T, filename string) {
+				assert.NilError(t, os.MkdirAll(filepath.Dir(filename), 0700))
+				err := os.WriteFile(filename, []byte(contentWithMatchLine), 0600)
+				assert.NilError(t, err)
+			},
+			expected: func(t *testing.T, fh *os.File) {
+				content, err := io.ReadAll(fh)
+				assert.NilError(t, err)
+				assert.Equal(t, string(content), contentWithMatchLine)
+			},
+		},
+		{
+			name: "file exists with no match line",
+			setup: func(t *testing.T, filename string) {
+				assert.NilError(t, os.MkdirAll(filepath.Dir(filename), 0700))
+				err := os.WriteFile(filename, []byte(contentNoMatchLine), 0600)
+				assert.NilError(t, err)
+			},
+			expectCLIOutput: true,
+			expected: func(t *testing.T, fh *os.File) {
+				content, err := io.ReadAll(fh)
+				assert.NilError(t, err)
+				expected := contentNoMatchLine + expectedInfraSSHConfig
+				assert.Equal(t, string(content), expected)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestHasInfraMatchLine(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    io.Reader
+		expected bool
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		actual := hasInfraMatchLine(tc.input)
+		assert.Equal(t, actual, tc.expected)
+	}
+
+	testCases := []testCase{
+		{
+			name:     "nil",
+			expected: false,
+		},
+		{
+			name:     "empty file",
+			input:    strings.NewReader(""),
+			expected: false,
+		},
+		{
+			name: "only comments",
+			input: strings.NewReader(`
+
+# Match exec "infra ssh hosts %h"
+# Other comments
+
+`),
+		},
+		{
+			name: "different match lines",
+			input: strings.NewReader(`
+Match "infra ssh hosts"
+
+Match hostname.example.com
+
+`),
+		},
+		{
+			name: "Match line found",
+			input: strings.NewReader(`
+
+Match other lines before
+
+# Some comment
+MATCH exec "infra ssh hosts %h"
+	Anything here
+
+Match other lines after
+
+`),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -66,7 +66,7 @@ func TestSSHHostsCmd(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(users.Items), 1)
 	user := users.Items[0]
-	assert.Equal(t, user.SSHUsername, "anyuser")
+	assert.Equal(t, user.SSHLoginName, "anyuser")
 
 	cfg := newTestClientConfigForServer(srv, user, "0000000002.notadminsecretnotadmin02")
 	assert.NilError(t, writeConfig(&cfg))
@@ -123,16 +123,13 @@ Match 127.12.12.1
 	assert.NilError(t, err)
 	assert.Equal(t, pubKey.Type(), "ssh-rsa")
 
-	// TODO: use GetUser when that API response includes public keys
-	users, err = client.ListUsers(ctx, api.ListUsersRequest{Name: "anyuser@example.com"})
+	updated, err := client.GetUser(ctx, user.ID)
 	assert.NilError(t, err)
-	assert.Equal(t, len(users.Items), 1)
-	user = users.Items[0]
 
-	assert.Equal(t, len(user.PublicKeys), 1)
-	assert.Equal(t, user.PublicKeys[0].KeyType, "ssh-rsa")
+	assert.Equal(t, len(updated.PublicKeys), 1)
+	assert.Equal(t, updated.PublicKeys[0].KeyType, "ssh-rsa")
 	parts := strings.Fields(string(raw))
-	assert.Equal(t, user.PublicKeys[0].PublicKey, parts[1])
+	assert.Equal(t, updated.PublicKeys[0].PublicKey, parts[1])
 }
 
 func TestUpdateUserSSHConfig(t *testing.T) {

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -156,7 +156,7 @@ func TestUpdateUserSSHConfig(t *testing.T) {
 		err := updateUserSSHConfig(newCLI(ctx))
 		assert.NilError(t, err)
 
-		expectedOutput := "has been created or updated to use 'infra ssh hosts'"
+		expectedOutput := "has been updated to connect to Infra SSH destinations"
 		if tc.expectCLIOutput {
 			assert.Assert(t, cmp.Contains(bufs.Stdout.String(), expectedOutput))
 		} else {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -230,6 +230,10 @@ func (s *Server) DB() *data.DB {
 	return s.db
 }
 
+func (s *Server) Options() Options {
+	return s.options
+}
+
 func (s *Server) Run(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
 

--- a/main.go
+++ b/main.go
@@ -17,8 +17,13 @@ func main() {
 	if err := cmd.Run(context.Background(), os.Args[1:]...); err != nil {
 		var userErr cmd.Error
 		var unknownAuthErr x509.UnknownAuthorityError
+		var exitCodeErr exitCoder
 
 		switch {
+		case errors.As(err, &exitCodeErr):
+			// error message must be printed by caller
+			os.Exit(exitCodeErr.ExitCode())
+
 		case errors.Is(err, terminal.InterruptErr):
 			logging.Debugf("user interrupted the process")
 		case errors.As(err, &userErr):
@@ -33,4 +38,8 @@ func main() {
 
 		os.Exit(1)
 	}
+}
+
+type exitCoder interface {
+	ExitCode() int
 }


### PR DESCRIPTION
## Summary

Branched from #3620

This PR adds 2 things:

1. `infra login` now checks that `~/.ssh/config` exists and includes `Match exec "infra ssh hosts"`. If it doesn't, the file is created and these two lines are appended:

    ```
    Match exec "infra ssh hosts %h %p"
        Include ~/.ssh/infra/config
    ```

2. Adds the `infra ssh hosts` command does a few things:
   1. tries to match the hostname and port from the `ssh [-p port] <hostname>` command run by the user to the list of destinations the user has access to. If any of them match, proceeds with the following steps. If none match then it returns immediately (which indicates to `ssh` that it should not include the `~/.ssh/infra/config` file).
   2. checks if a key pair exists in `~/.ssh/infra/key`, and if it doesn't generates the key pair and uploads the public key to the infra API
   3. writes the host keys of the target destination to `~/.ssh/infra/known_hosts`
   4. writes a config file to `~/.ssh/infra/config` which tells ssh about the key pair, the known hosts file, the port, and the username to use in the SSH connection.

The `infra ssh hosts` command will be run first. This gives us a nice hook to generate all the files in the `~/.ssh/infra` directory each time the user tries to connect to a new server.

There are a few things to do as follow ups, but this PR has test coverage for the new command, so I think it's in a reasonable state to be reviewed and merged.

See https://github.com/infrahq/internal/issues/27 for more details
