### PR TITLE
fix: allow for local example to override global

### DIFF
--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -189,8 +189,8 @@ func buildProperty(f reflect.StructField, t, parent reflect.Type, parentSchema *
 	}
 
 	s := &openapi3.Schema{}
-	updateSchemaFromStructTags(f, s)
 	setTypeInfo(t, s)
+	updateSchemaFromStructTags(f, s)
 
 	if s.Type == "array" {
 		s.Items = buildProperty(f, t.Elem(), parent, parentSchema)


### PR DESCRIPTION



Signed-off-by: Matt Williams <m@technovangelist.com>

## Summary

If you set an example in a struct but an example has already been set for that type more globally, the local example won't ever be seen. this just swaps the order of setting those so that the docs can be more descriptive.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

related to #3664 


