### PR TITLE
maintain: return idpauth as struct

### DIFF
--- a/internal/server/authn/oidc_test.go
+++ b/internal/server/authn/oidc_test.go
@@ -30,8 +30,13 @@ func (m *mockOIDCImplementation) AuthServerInfo(_ context.Context) (*providers.A
 	return &providers.AuthServerInfo{AuthURL: "example.com/v1/auth", ScopesSupported: []string{"openid", "email"}}, nil
 }
 
-func (m *mockOIDCImplementation) ExchangeAuthCodeForProviderTokens(_ context.Context, _ string) (acc, ref string, exp time.Time, email string, err error) {
-	return "acc", "ref", exp, m.UserEmailResp, nil
+func (m *mockOIDCImplementation) ExchangeAuthCodeForProviderTokens(_ context.Context, _ string) (*providers.IdentityProviderAuth, error) {
+	return &providers.IdentityProviderAuth{
+		AccessToken:       "acc",
+		RefreshToken:      "ref",
+		AccessTokenExpiry: time.Now().Add(1 * time.Minute),
+		Email:             m.UserEmailResp,
+	}, nil
 }
 
 func (m *mockOIDCImplementation) RefreshAccessToken(_ context.Context, providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error) {

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -31,8 +31,13 @@ func (m *mockOIDCImplementation) AuthServerInfo(_ context.Context) (*providers.A
 	return &providers.AuthServerInfo{AuthURL: "example.com/v1/auth", ScopesSupported: []string{"openid", "email"}}, nil
 }
 
-func (m *mockOIDCImplementation) ExchangeAuthCodeForProviderTokens(_ context.Context, _ string) (acc, ref string, exp time.Time, email string, err error) {
-	return "acc", "ref", exp, m.UserEmailResp, nil
+func (m *mockOIDCImplementation) ExchangeAuthCodeForProviderTokens(_ context.Context, _ string) (*providers.IdentityProviderAuth, error) {
+	return &providers.IdentityProviderAuth{
+		AccessToken:       "acc",
+		RefreshToken:      "ref",
+		AccessTokenExpiry: time.Now().Add(1 * time.Minute),
+		Email:             m.UserEmailResp,
+	}, nil
 }
 
 func (m *mockOIDCImplementation) RefreshAccessToken(_ context.Context, providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error) {

--- a/internal/server/providers/azure.go
+++ b/internal/server/providers/azure.go
@@ -43,7 +43,7 @@ func (a *azure) AuthServerInfo(ctx context.Context) (*AuthServerInfo, error) {
 	return a.OIDCClient.AuthServerInfo(ctx)
 }
 
-func (a *azure) ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (rawAccessToken, rawRefreshToken string, accessTokenExpiry time.Time, email string, err error) {
+func (a *azure) ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (*IdentityProviderAuth, error) {
 	return a.OIDCClient.ExchangeAuthCodeForProviderTokens(ctx, code)
 }
 

--- a/internal/server/providers/google.go
+++ b/internal/server/providers/google.go
@@ -41,7 +41,7 @@ func (g *google) AuthServerInfo(ctx context.Context) (*AuthServerInfo, error) {
 	return g.OIDCClient.AuthServerInfo(ctx)
 }
 
-func (g *google) ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (rawAccessToken, rawRefreshToken string, accessTokenExpiry time.Time, email string, err error) {
+func (g *google) ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (*IdentityProviderAuth, error) {
 	return g.OIDCClient.ExchangeAuthCodeForProviderTokens(ctx, code)
 }
 

--- a/internal/server/providers/oidc.go
+++ b/internal/server/providers/oidc.go
@@ -30,10 +30,17 @@ type AuthServerInfo struct {
 	ScopesSupported []string `json:"scopes_supported"`
 }
 
+type IdentityProviderAuth struct {
+	AccessToken       string
+	RefreshToken      string
+	AccessTokenExpiry time.Time
+	Email             string
+}
+
 type OIDCClient interface {
 	Validate(context.Context) error
 	AuthServerInfo(context.Context) (*AuthServerInfo, error)
-	ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (accessToken, refreshToken string, accessTokenExpiry time.Time, email string, err error)
+	ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (*IdentityProviderAuth, error)
 	RefreshAccessToken(ctx context.Context, providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error)
 	GetUserInfo(ctx context.Context, providerUser *models.ProviderUser) (*UserInfoClaims, error)
 }
@@ -191,26 +198,26 @@ func (o *oidcClientImplementation) tokenSource(ctx context.Context, conf *oauth2
 }
 
 // ExchangeAuthCodeForProviderTokens exchanges the authorization code a user received on login for valid identity provider tokens
-func (o *oidcClientImplementation) ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (rawAccessToken, rawRefreshToken string, accessTokenExpiry time.Time, email string, err error) {
+func (o *oidcClientImplementation) ExchangeAuthCodeForProviderTokens(ctx context.Context, code string) (*IdentityProviderAuth, error) {
 	ctx, cancel := context.WithTimeout(ctx, oidcProviderRequestTimeout)
 	defer cancel()
 
 	conf, provider, err := o.clientConfig(ctx)
 	if err != nil {
-		return "", "", time.Time{}, "", fmt.Errorf("client exchange code: %w", err)
+		return nil, fmt.Errorf("client exchange code: %w", err)
 	}
 
 	exchanged, err := conf.Exchange(ctx, code)
 	if err != nil {
-		return "", "", time.Time{}, "", fmt.Errorf("code exchange: %w", err)
+		return nil, fmt.Errorf("code exchange: %w", err)
 	}
 
 	rawAccessToken, ok := exchanged.Extra("access_token").(string)
 	if !ok {
-		return "", "", time.Time{}, "", errors.New("could not extract access token from oauth2")
+		return nil, errors.New("could not extract access token from oauth2")
 	}
 
-	rawRefreshToken, ok = exchanged.Extra("refresh_token").(string)
+	rawRefreshToken, ok := exchanged.Extra("refresh_token").(string)
 	if !ok {
 		// this probably means that the client does not have refresh tokens enabled
 		logging.Warnf("no refresh token returned from oidc client for %q, session lifetime will be reduced", o.Domain)
@@ -218,7 +225,7 @@ func (o *oidcClientImplementation) ExchangeAuthCodeForProviderTokens(ctx context
 
 	rawIDToken, ok := exchanged.Extra("id_token").(string)
 	if !ok {
-		return "", "", time.Time{}, "", errors.New("could not extract id_token from oauth2 token")
+		return nil, errors.New("could not extract id_token from oauth2 token")
 	}
 
 	// we get sensitive claims from the ID token, must validate them
@@ -226,7 +233,7 @@ func (o *oidcClientImplementation) ExchangeAuthCodeForProviderTokens(ctx context
 
 	idToken, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		return "", "", time.Time{}, "", fmt.Errorf("validate id token: %w", err)
+		return nil, fmt.Errorf("validate id token: %w", err)
 	}
 
 	var claims struct {
@@ -234,20 +241,25 @@ func (o *oidcClientImplementation) ExchangeAuthCodeForProviderTokens(ctx context
 	}
 
 	if err := idToken.Claims(&claims); err != nil {
-		return "", "", time.Time{}, "", fmt.Errorf("id token claims: %w", err)
+		return nil, fmt.Errorf("id token claims: %w", err)
 	}
 
 	if claims.Email == "" {
 		err := fmt.Errorf("ID token claim is missing an email address")
-		return "", "", time.Time{}, "", err
+		return nil, err
 	}
 
 	if strings.ContainsAny(claims.Email, ` '`) {
 		err := fmt.Errorf("ID token claim has invalid email address")
-		return "", "", time.Time{}, "", err
+		return nil, err
 	}
 
-	return rawAccessToken, rawRefreshToken, exchanged.Expiry, claims.Email, nil
+	return &IdentityProviderAuth{
+		AccessToken:       rawAccessToken,
+		RefreshToken:      rawRefreshToken,
+		AccessTokenExpiry: exchanged.Expiry,
+		Email:             claims.Email,
+	}, nil
 }
 
 // RefreshAccessToken uses the refresh token to get a new access token if it is expired

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -772,8 +772,13 @@ func (m *fakeOIDCImplementation) AuthServerInfo(_ context.Context) (*providers.A
 	return &providers.AuthServerInfo{AuthURL: "example.com/v1/auth", ScopesSupported: []string{"openid", "email"}}, nil
 }
 
-func (m *fakeOIDCImplementation) ExchangeAuthCodeForProviderTokens(_ context.Context, _ string) (acc, ref string, exp time.Time, email string, err error) {
-	return "acc", "ref", exp, "", nil
+func (m *fakeOIDCImplementation) ExchangeAuthCodeForProviderTokens(_ context.Context, _ string) (*providers.IdentityProviderAuth, error) {
+	return &providers.IdentityProviderAuth{
+		AccessToken:       "acc",
+		RefreshToken:      "ref",
+		AccessTokenExpiry: time.Now().Add(1 * time.Minute),
+		Email:             "hello@example.com",
+	}, nil
 }
 
 func (m *fakeOIDCImplementation) RefreshAccessToken(_ context.Context, providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error) {


### PR DESCRIPTION
## Summary
This is just a clean-up, no logical changes. While working on the social login I noticed that the amount of values returned from OIDC login was unwieldy, refactoring them into their own struct instead. 

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
