### PR TITLE
feat: add last used column

### DIFF
--- a/ui/pages/settings/access-key/add.js
+++ b/ui/pages/settings/access-key/add.js
@@ -212,8 +212,6 @@ function CalendarInput({ setSelectedTTL, selectedTTL }) {
             selectedDate={selectedCustom}
             extensionHour={720} // the default extension deadline is 30 days (720h)
             onChange={e => {
-              console.log(e)
-
               const duration = moment
                 .duration(
                   moment(e, 'YYYY/MM/DD')

--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -269,7 +269,6 @@ export default function Settings() {
                 columns={[
                   {
                     cell: function Cell(info) {
-                      console.log(info)
                       return (
                         <div className='flex flex-col py-0.5'>
                           <div className='truncate text-sm font-medium text-gray-700'>

--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -269,11 +269,28 @@ export default function Settings() {
                 columns={[
                   {
                     cell: function Cell(info) {
+                      console.log(info)
                       return (
                         <div className='flex flex-col py-0.5'>
                           <div className='truncate text-sm font-medium text-gray-700'>
                             {info.getValue()}
                           </div>
+                          {info.row.original.created && (
+                            <div className='space-y-1 pt-2 text-3xs text-gray-500 sm:hidden'>
+                              created -{' '}
+                              <span className='font-semibold text-gray-700'>
+                                {moment(info.row.original.created).from()}
+                              </span>
+                            </div>
+                          )}
+                          {info.row.original.lastUsed && (
+                            <div className='space-y-1 pt-2 text-3xs text-gray-500 sm:hidden'>
+                              last used -{' '}
+                              <span className='font-semibold text-gray-700'>
+                                {moment(info.row.original.lastUsed).from()}
+                              </span>
+                            </div>
+                          )}
                           <div className='space-y-1 pt-2 text-3xs text-gray-500 sm:hidden'>
                             the key will expire on{' '}
                             <span className='font-semibold text-gray-700'>
@@ -298,6 +315,17 @@ export default function Settings() {
                       <span className='hidden sm:table-cell'>Created</span>
                     ),
                     accessorKey: 'created',
+                  },
+                  {
+                    cell: info => (
+                      <div className='hidden sm:table-cell'>
+                        {info.getValue() ? moment(info.getValue()).from() : '-'}
+                      </div>
+                    ),
+                    header: () => (
+                      <span className='hidden sm:table-cell'>Last used</span>
+                    ),
+                    accessorKey: 'lastUsed',
                   },
                   {
                     cell: info => (


### PR DESCRIPTION
## Summary
API added the new field `last used` for the access keys and it is also available on CLI. So we updated the access keys table on UI as well to expose the value of last used of access key

## 📷 
<img width="1222" alt="Screen Shot 2022-11-17 at 11 17 26 PM" src="https://user-images.githubusercontent.com/63033505/202615844-a0685c87-0cc2-42a2-958f-a26aff96e57c.png">
<img width="495" alt="Screen Shot 2022-11-17 at 11 17 10 PM" src="https://user-images.githubusercontent.com/63033505/202615846-33fe9783-49fe-45ac-a7bf-8f232e43af1a.png">
