### PR TITLE
maintain: update make docs to output correct version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docs: docs/api/openapi3.json
 
 .PHONY: docs/api/openapi3.json
 docs/api/openapi3.json:
-	go test ./internal/server -run TestWriteOpenAPIDocToFile -update
+	go run -ldflags '-s -X github.com/infrahq/infra/internal.Version=0.0.0' ./internal/openapigen $@
 
 check-psql-env:
 ifndef POSTGRESQL_CONNECTION

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docs: docs/api/openapi3.json
 
 .PHONY: docs/api/openapi3.json
 docs/api/openapi3.json:
-	go run ./internal/openapigen $@
+	go test ./internal/server -run TestWriteOpenAPIDocToFile -update
 
 check-psql-env:
 ifndef POSTGRESQL_CONNECTION


### PR DESCRIPTION
## Summary
The `make docs` command was setting the version to the `99...` placeholder value from the code. Updating the command to use the correctly generated output.
