### PR TITLE
maintain: remove references to local redirect

### DIFF
--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -721,7 +721,7 @@ func (s Server) loadProvider(db data.WriteTxn, input Provider) (*models.Provider
 		if provider.Kind != models.ProviderKindInfra {
 			// only call the provider to resolve info if it is not known
 			if input.AuthURL == "" && len(input.Scopes) == 0 {
-				providerClient := providers.NewOIDCClient(*provider, clientSecret, "http://localhost:8301")
+				providerClient := providers.NewOIDCClient(*provider, clientSecret, "")
 				authServerInfo, err := providerClient.AuthServerInfo(context.Background())
 				if err != nil {
 					if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -162,7 +162,7 @@ func addAuthURLAndScopeToProviders() *migrator.Migration {
 
 					logging.Debugf("migrating %s provider", provider.Name)
 
-					providerClient := providers.NewOIDCClient(provider, "not-used", "http://localhost:8301")
+					providerClient := providers.NewOIDCClient(provider, "not-used", "")
 					authServerInfo, err := providerClient.AuthServerInfo(context.Background())
 					if err != nil {
 						if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -174,7 +174,7 @@ func (a *API) DeleteProvider(c *gin.Context, r *api.Resource) (*api.EmptyRespons
 // setProviderInfoFromServer checks information provided by an OIDC server
 func (a *API) setProviderInfoFromServer(c *gin.Context, provider *models.Provider) error {
 	// create a provider client to validate the server and get its info
-	oidc, err := a.providerClient(c, provider, "http://localhost:8301")
+	oidc, err := a.providerClient(c, provider, "")
 	if err != nil {
 		return fmt.Errorf("%w: %s", internal.ErrBadRequest, err)
 	}

--- a/internal/server/providers/azure_test.go
+++ b/internal/server/providers/azure_test.go
@@ -155,7 +155,7 @@ func TestAzure_GetUserInfo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			server, ctx := setupOIDCTest(t, test.infoResponse)
 			serverURL := server.run(t, azureHandlers)
-			provider := NewOIDCClient(models.Provider{Kind: models.ProviderKindAzure, URL: serverURL, ClientID: "invalid"}, "invalid", "http://localhost:8301")
+			provider := NewOIDCClient(models.Provider{Kind: models.ProviderKindAzure, URL: serverURL, ClientID: "invalid"}, "invalid", "https://example.com/callback")
 			patchGraphGroupMemberEndpoint(t, "https://"+serverURL+"/v1.0/me/memberOf")
 			info, err := provider.GetUserInfo(ctx, &models.ProviderUser{AccessToken: "aaa", RefreshToken: "bbb", ExpiresAt: time.Now().UTC().Add(5 * time.Minute)})
 			test.verifyFunc(t, info, err)

--- a/internal/server/providers/google_test.go
+++ b/internal/server/providers/google_test.go
@@ -113,7 +113,7 @@ func TestGoogle_GetUserInfo(t *testing.T) {
 				ClientEmail:      "something",
 				DomainAdminEmail: "admin",
 			}
-			oidcClient := NewOIDCClient(provider, "invalid", "http://localhost:8301")
+			oidcClient := NewOIDCClient(provider, "invalid", "https://example.com/callback")
 			info, err := oidcClient.GetUserInfo(context.WithValue(ctx, testGroupsKey{}, test.groupsResponse), &models.ProviderUser{AccessToken: "aaa", RefreshToken: "bbb", ExpiresAt: time.Now().UTC().Add(5 * time.Minute)})
 			test.verifyFunc(t, info, err)
 		})

--- a/internal/server/providers/oidc_test.go
+++ b/internal/server/providers/oidc_test.go
@@ -198,7 +198,7 @@ func TestValidate(t *testing.T) {
 	}{
 		{
 			name:     "invalid URL",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: "example.com"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: "example.com"}, "some_client_secret", "https://example.com/callback"),
 			verifyFunc: func(t *testing.T, err error) {
 				var vErr validate.Error
 				assert.Assert(t, errors.As(err, &vErr), "expected validation error")
@@ -208,7 +208,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name:     "invalid client ID",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "invalid-client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "invalid-client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: tokenResponse{
 				code: 500,
 				body: oktaInvalidClientIDResp,
@@ -222,7 +222,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name:     "invalid client secret",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: tokenResponse{
 				code: 500,
 				body: oktaInvalidClientSecretResp,
@@ -237,7 +237,7 @@ func TestValidate(t *testing.T) {
 
 		{
 			name:     "valid provider client",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: tokenResponse{
 				code: 500,
 				body: oktaInvalidAuthCodeResp,
@@ -269,7 +269,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 	}{
 		{
 			name:     "invalid provider client fails",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "invalid"}, "invalid", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "invalid"}, "invalid", "https://example.com/callback"),
 			tokenResponse: func(t *testing.T) tokenResponse {
 				return tokenResponse{
 					code: 500,
@@ -286,7 +286,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 		},
 		{
 			name:     "invalid auth code fails",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: func(t *testing.T) tokenResponse {
 				return tokenResponse{
 					code: 500,
@@ -303,7 +303,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 		},
 		{
 			name:     "empty access token response fails",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: func(t *testing.T) tokenResponse {
 				return tokenResponse{
 					code: 200,
@@ -320,7 +320,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 		},
 		{
 			name:     "id token issued by a different provider fails",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: func(t *testing.T) tokenResponse {
 				claims := jwt.Claims{
 					Issuer: "unknown-issuer",
@@ -345,7 +345,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 		},
 		{
 			name:     "id token issued for wrong audience fails",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: func(t *testing.T) tokenResponse {
 				claims := jwt.Claims{
 					Issuer:   "https://" + serverURL,
@@ -371,7 +371,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 		},
 		{
 			name:     "expired id token fails",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: func(t *testing.T) tokenResponse {
 				now := time.Now().UTC()
 
@@ -402,7 +402,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 		},
 		{
 			name:     "id token without email claim fails",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: func(t *testing.T) tokenResponse {
 				now := time.Now().UTC()
 
@@ -433,7 +433,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 		},
 		{
 			name:     "empty email claim fails",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: func(t *testing.T) tokenResponse {
 				now := time.Now().UTC()
 
@@ -464,7 +464,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 		},
 		{
 			name:     "valid id token is successful",
-			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "http://localhost:8301"),
+			provider: NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "client-id"}, "some_client_secret", "https://example.com/callback"),
 			tokenResponse: func(t *testing.T) tokenResponse {
 				now := time.Now().UTC()
 
@@ -507,7 +507,7 @@ func TestExchangeAuthCodeForProviderToken(t *testing.T) {
 func TestRefreshAccessToken(t *testing.T) {
 	server, ctx := setupOIDCTest(t, "")
 	serverURL := server.run(t, nil)
-	provider := NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "whatever"}, "secret", "http://localhost:8301")
+	provider := NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "whatever"}, "secret", "https://example.com/callback")
 
 	now := time.Now().UTC()
 
@@ -661,7 +661,7 @@ func TestOIDC_GetUserInfo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			server, ctx := setupOIDCTest(t, test.infoResponse)
 			serverURL := server.run(t, nil)
-			provider := NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "invalid"}, "invalid", "http://localhost:8301")
+			provider := NewOIDCClient(models.Provider{Kind: models.ProviderKindOIDC, URL: serverURL, ClientID: "invalid"}, "invalid", "https://example.com/callback")
 			info, err := provider.GetUserInfo(ctx, &models.ProviderUser{AccessToken: "aaa", RefreshToken: "bbb", ExpiresAt: time.Now().UTC().Add(5 * time.Minute)})
 			test.verifyFunc(t, info, err)
 		})


### PR DESCRIPTION
- localhost redirect not needed in provider validation
- remove example localhost redirections from tests

## Summary
Clean up these references to the localhost redirect where it isn't needed on our OIDC client anymore.

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
