### PR TITLE
Revert "maintain: remove unused get grant endpoint (#3650)"

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -348,6 +348,10 @@ func (c Client) ListGrants(ctx context.Context, req ListGrantsRequest) (*ListRes
 	})
 }
 
+func (c Client) GetGrant(ctx context.Context, id uid.ID) (*Grant, error) {
+	return get[Grant](ctx, c, fmt.Sprintf("/api/grants/%s", id), Query{})
+}
+
 func (c Client) CreateGrant(ctx context.Context, req *GrantRequest) (*CreateGrantResponse, error) {
 	return post[CreateGrantResponse](ctx, c, "/api/grants", req)
 }

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -302,6 +302,55 @@
           }
         }
       },
+      "Grant": {
+        "properties": {
+          "created": {
+            "description": "formatted as an RFC3339 date-time",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "created_by": {
+            "description": "id of the user that created the grant",
+            "example": "4yJ3n3D8E2",
+            "format": "uid",
+            "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+            "type": "string"
+          },
+          "group": {
+            "example": "4yJ3n3D8E2",
+            "format": "uid",
+            "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+            "type": "string"
+          },
+          "id": {
+            "example": "4yJ3n3D8E2",
+            "format": "uid",
+            "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+            "type": "string"
+          },
+          "privilege": {
+            "description": "a role or permission",
+            "type": "string"
+          },
+          "resource": {
+            "description": "a resource name in Infra's Universal Resource Notation",
+            "type": "string"
+          },
+          "updated": {
+            "description": "formatted as an RFC3339 date-time",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "user": {
+            "example": "4yJ3n3D8E2",
+            "format": "uid",
+            "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+            "type": "string"
+          }
+        }
+      },
       "Group": {
         "properties": {
           "created": {
@@ -3282,6 +3331,111 @@
           }
         },
         "summary": "DeleteGrant",
+        "tags": [
+          "Grants"
+        ]
+      },
+      "get": {
+        "description": "GetGrant",
+        "operationId": "GetGrant",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Infra-Version",
+            "required": true,
+            "schema": {
+              "description": "Version of the API being requested",
+              "example": "0.0.0",
+              "format": "\\d+\\.\\d+\\(.\\d+)?(-.\\w(+\\w)?)?",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "schema": {
+              "description": "Bearer followed by your access key",
+              "example": "Bearer ACCESSKEY",
+              "format": "Bearer [\\da-zA-Z]{10}\\.[\\da-zA-Z]{24}",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "4yJ3n3D8E2",
+              "format": "uid",
+              "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Unauthorized: Requestor is not authenticated"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Forbidden: Requestor does not have the right permissions"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Duplicate Record"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Grant"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "GetGrant",
         "tags": [
           "Grants"
         ]

--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -73,6 +73,15 @@ func (a *API) ListGrants(c *gin.Context, r *api.ListGrantsRequest) (*ListGrantsR
 	return (*ListGrantsResponse)(result), nil
 }
 
+func (a *API) GetGrant(c *gin.Context, r *api.Resource) (*api.Grant, error) {
+	grant, err := access.GetGrant(c, r.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return grant.ToAPI(), nil
+}
+
 func (a *API) CreateGrant(c *gin.Context, r *api.GrantRequest) (*api.CreateGrantResponse, error) {
 	var subject uid.PolymorphicID
 
@@ -99,6 +108,7 @@ func (a *API) CreateGrant(c *gin.Context, r *api.GrantRequest) (*api.CreateGrant
 			ByPrivileges: []string{grant.Privilege},
 		}
 		grants, err := access.ListGrants(c, opts, 0)
+
 		if err != nil {
 			return nil, err
 		}
@@ -115,6 +125,7 @@ func (a *API) CreateGrant(c *gin.Context, r *api.GrantRequest) (*api.CreateGrant
 	}
 
 	return &api.CreateGrantResponse{Grant: grant.ToAPI(), WasCreated: true}, nil
+
 }
 
 func (a *API) DeleteGrant(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -77,6 +77,7 @@ func (s *Server) GenerateRoutes() Routes {
 	del(a, authn, "/api/organizations/:id", a.DeleteOrganization)
 
 	get(a, authn, "/api/grants", a.ListGrants)
+	get(a, authn, "/api/grants/:id", a.GetGrant)
 	post(a, authn, "/api/grants", a.CreateGrant)
 	del(a, authn, "/api/grants/:id", a.DeleteGrant)
 	patch(a, authn, "/api/grants", a.UpdateGrants)


### PR DESCRIPTION
This reverts commit d4259e4e7657337d11c817516c2948809d7672a4.

## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

While `GetGrant` and `GET /api/grants/:id` is not used by code in this repo, it'll be used by the Terraform provider. Removing it break that use case.