### PR TITLE
Refuse to delete the access key being used by the API request

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -26,17 +26,6 @@ func setupDB(t *testing.T) *data.DB {
 	return db
 }
 
-func loginAs(db *data.Transaction, user *models.Identity, org *models.Organization) (*gin.Context, *data.Transaction) {
-	ctx, _ := gin.CreateTestContext(nil)
-	tx := db.WithOrgID(org.ID)
-	ctx.Set(RequestContextKey, RequestContext{
-		DBTxn:         tx,
-		Authenticated: Authenticated{User: user, Organization: org},
-	})
-
-	return ctx, tx
-}
-
 func setupAccessTestContext(t *testing.T) (*gin.Context, *data.Transaction, *models.Provider) {
 	// setup db and context
 	db := setupDB(t)

--- a/internal/server/access_keys.go
+++ b/internal/server/access_keys.go
@@ -26,12 +26,12 @@ func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api
 
 // DeleteAccessKey deletes an access key by id
 func (a *API) DeleteAccessKey(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
-	return nil, access.DeleteAccessKey(c, r.ID, "")
+	return nil, access.DeleteAccessKey(getRequestContext(c), r.ID, "")
 }
 
 // DeleteAccessKeys deletes 0 or more access keys by any attribute
 func (a *API) DeleteAccessKeys(c *gin.Context, r *api.DeleteAccessKeyRequest) (*api.EmptyResponse, error) {
-	return nil, access.DeleteAccessKey(c, 0, r.Name)
+	return nil, access.DeleteAccessKey(getRequestContext(c), 0, r.Name)
 }
 
 func (a *API) CreateAccessKey(c *gin.Context, r *api.CreateAccessKeyRequest) (*api.CreateAccessKeyResponse, error) {


### PR DESCRIPTION
## Summary

Related to part of #3661

This PR changes the `DELETE /api/access-keys/:id` API to refuse to delete the key, if it's the key that was used to authenticate the current request. We do something similar for users (we don't allow users to delete themselves).We ran into this problem earlier in the week, and I suspect we don't want to allow this operation generally.

I did a bit of cleanup in the tests to split the `ListAccessKeys` tests from the `DeleteAccessKey` tests. That's done in a second commit, so you can look at just the first commit to see the new test case that was added.

I'll comment on some of the other cleanup inline.