### PR TITLE
Revert "improve: generate and publish openapi spec in release"

### DIFF
--- a/.github/workflows/cd-binaries.yaml
+++ b/.github/workflows/cd-binaries.yaml
@@ -48,9 +48,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: binaries
-          path: |
-            dist/
-            openapi-*.json
+          path: dist/
 
   publish:
     runs-on: ubuntu-latest
@@ -64,7 +62,7 @@ jobs:
       - run: |
           # fail fast if the release does not exist
           gh release view v${{ needs.prepare.outputs.release-name }} || exit 1
-          gh release upload v${{ needs.prepare.outputs.release-name }} *-checksums.txt *.zip *.deb *.rpm openapi-*.json
+          gh release upload v${{ needs.prepare.outputs.release-name }} *.txt *.zip *.deb *.rpm
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,3 @@ checksum:
   name_template: "{{ .ProjectName }}-checksums.txt"
 snapshot:
   name_template: "{{ .Env.RELEASE_NAME }}"
-before:
-  hooks:
-    - go run -ldflags '-s -X github.com/infrahq/infra/internal.Version={{ .Version }}' ./internal/openapigen ./openapi-{{ .Version }}.json


### PR DESCRIPTION
Reverts infrahq/infra#3674 as it is blocking v0.18.0