### PR TITLE
fix: save name of org to visited orgs cookie on signup

### DIFF
--- a/ui/pages/signup/index.js
+++ b/ui/pages/signup/index.js
@@ -39,7 +39,7 @@ export default function Signup() {
       let created = await jsonBody(res)
 
       window.location = `${window.location.protocol}//${created?.organization?.domain}`
-      saveToVisitedOrgs(`${created?.organization?.domain}`, baseDomain, orgName)
+      saveToVisitedOrgs(`${created?.organization?.domain}`, orgName)
     } catch (e) {
       setSubmitted(false)
       if (e.fieldErrors) {


### PR DESCRIPTION
## Summary
After sign-up `saveToVisitedOrgs` was being called with too many parameters, which resulted in the base domain getting saved as the org name. This change fixes that problem by calling the function with the correct number of parameters.


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3702
