### PR TITLE
fix: unique roles in access pop up

### DIFF
--- a/ui/pages/destinations/[id]/index.js
+++ b/ui/pages/destinations/[id]/index.js
@@ -604,7 +604,9 @@ function AccessCluster({ roles, resource }) {
       </div>
       <p className='mx-6 my-4 text-xs text-gray-300'>
         You have{' '}
-        <span className='font-semibold text-white'>{roles.join(', ')}</span>{' '}
+        <span className='font-semibold text-white'>
+          {[...new Set(roles)].join(', ')}
+        </span>{' '}
         access.
       </p>
       <div className='group relative mt-4 flex flex-1 flex-col'>


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Deduplicate role labels in access cluster drop down.

![image](https://user-images.githubusercontent.com/2372640/203396516-a186d4cc-50ea-476c-9a47-5e93f2f45ccd.png)

Resolves #3703 
