### PR TITLE
Probably fix some test flakes

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -24,6 +24,11 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("HOME", "/this test forgot to t.SetEnv(HOME, ...)")
 	_ = os.Setenv("USERPROFILE", "/this test forgot to t.SetEnv(USERPROFILE, ...)")
 	_ = os.Setenv("KUBECONFIG", "/this test forgot to t.SetEnv(KUBECONFIG, ...)")
+
+	// Default to not running the agent in tests, because background processes
+	// are difficult to manage.
+	_ = os.Setenv("INFRA_NO_AGENT", "true")
+
 	os.Exit(m.Run())
 }
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/certs"
+	"github.com/infrahq/infra/internal/cmd/cliopts"
 	"github.com/infrahq/infra/internal/cmd/types"
 	"github.com/infrahq/infra/internal/format"
 	"github.com/infrahq/infra/internal/generate"
@@ -76,6 +77,10 @@ $ infra login`,
 		Args:    MaxArgs(1),
 		GroupID: groupCore,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cliopts.DefaultsFromEnv("INFRA", cmd.Flags()); err != nil {
+				return err
+			}
+			// There is no flag for server, so we check it separately
 			if server, ok := os.LookupEnv("INFRA_SERVER"); ok {
 				options.Server = server
 			}

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -215,9 +215,7 @@ func setupServerOptions(t *testing.T, opts *server.Options) {
 	assert.NilError(t, err)
 	opts.TLS.Certificate = types.StringOrFile(cert)
 
-	// TODO: why do tests fail when the same schemaSuffix is used?
-	suffix := "_cmd_" + t.Name()
-	pgDriver := database.PostgresDriver(t, suffix)
+	pgDriver := database.PostgresDriver(t, "_cmd")
 	opts.DBConnectionString = pgDriver.DSN
 }
 

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -348,7 +348,7 @@ api:
 }
 
 func TestServerCmd_WithSecretsConfig(t *testing.T) {
-	pgDriver := database.PostgresDriver(t, "cmd_server")
+	pgDriver := database.PostgresDriver(t, "_cmd")
 	patchRunServer(t, noServerRun)
 
 	content := `

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -11,6 +11,7 @@ import (
 const (
 	CharsetAlphaNumeric         = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	CharsetAlphaNumericNoVowels = "0123456789BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz" // For user-facing areas, to avoid profanity
+	CharsetNumbers              = "0123456789"
 	CharsetPassword             = CharsetAlphaNumeric + `!@#$%^&*()_+-=[]|;:,./<>?`
 	CharsetDeviceFlowUserCode   = "BCDFGHJKLMNPQRSTVWXZ" // no vowels to avoid spelling words
 )

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -30,8 +30,7 @@ func setupDB(t *testing.T) *data.DB {
 	t.Helper()
 	tpatch.ModelsSymmetricKey(t)
 
-	schema := "_server_" + generate.MathRandom(4, "0123456789")
-	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, schema).DSN})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_server").DSN})
 	assert.NilError(t, err)
 	t.Cleanup(func() {
 		assert.NilError(t, db.Close())

--- a/internal/server/models/encryption.go
+++ b/internal/server/models/encryption.go
@@ -18,7 +18,7 @@ var SymmetricKey *secrets.SymmetricKey
 var SkipSymmetricKey bool
 
 func (s EncryptedAtRest) Encrypt() (string, error) {
-	if SkipSymmetricKey {
+	if SkipSymmetricKey || s == "" {
 		return string(s), nil
 	}
 
@@ -38,9 +38,9 @@ func (s EncryptedAtRest) Value() (driver.Value, error) {
 	return s.Encrypt()
 }
 
-func (s EncryptedAtRest) Decrypt() (string, error) {
-	if SkipSymmetricKey {
-		return string(s), nil
+func decrypt(s string) (string, error) {
+	if SkipSymmetricKey || s == "" {
+		return s, nil
 	}
 
 	if SymmetricKey == nil {
@@ -66,12 +66,7 @@ func (s *EncryptedAtRest) Scan(v interface{}) error {
 		return fmt.Errorf("unsupported type: %T", v)
 	}
 
-	if SkipSymmetricKey {
-		*s = EncryptedAtRest(vStr)
-		return nil
-	}
-
-	str, err := EncryptedAtRest(vStr).Decrypt()
+	str, err := decrypt(vStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

This PR includes 3 small changes that I made while debugging [this flaky test](https://github.com/infrahq/infra/actions/runs/3501714088/jobs/5865598897). Full details in the commit messages.

1. Use a random schema name in most tests. This is possibly the main fix for the flake (at least the ones I was seeing locally), but I don't think I can explain how this would fix CI because there should not have been duplicate schema names in any CI run.
2. Disable the `infra agent` in tests. It would have been started by login tests. This should prevent the background process from running, and prevent request goroutines from outliving the test and keeping the old schema around, with old data in it. Now that we're using random schemas this should be less of a problem, but could still cause strange behaviour.
3. A small optimization to avoid encrypting an empty payload. This prevented the test flake because the field that was causing the "wrong key" error was an empty value, but I don't think that's the root cause of the problem. 