### PR TITLE
maintain: default access key lifetime 1 year

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -569,7 +569,7 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
       --extension-deadline duration   A specified deadline that the access key must be used within to remain valid (default 720h0m0s)
       --name string                   The name of the access key
   -q, --quiet                         Only display the access key
-      --ttl duration                  The total time that the access key will be valid for (default 720h0m0s)
+      --ttl duration                  The total time that the access key will be valid for (default 8784h0m0s)
       --user string                   The name of the user who will own the key
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -569,7 +569,7 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
       --extension-deadline duration   A specified deadline that the access key must be used within to remain valid (default 720h0m0s)
       --name string                   The name of the access key
   -q, --quiet                         Only display the access key
-      --ttl duration                  The total time that the access key will be valid for (default 8784h0m0s)
+      --ttl duration                  The total time that the access key will be valid for (default 8760h0m0s)
       --user string                   The name of the user who will own the key
 ```
 

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -12,7 +12,10 @@ import (
 	"github.com/infrahq/infra/internal/logging"
 )
 
-const thirtyDays = 30 * (24 * time.Hour)
+const (
+	thirtyDays = 30 * (24 * time.Hour)
+	oneYear    = 366 * (24 * time.Hour) // leap year
+)
 
 func newKeysCmd(cli *CLI) *cobra.Command {
 	cmd := &cobra.Command{
@@ -126,10 +129,18 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
 
 			var expMsg strings.Builder
 			expMsg.WriteString("This key will expire in ")
-			expMsg.WriteString(format.ExactDuration(options.TTL))
+			if options.TTL == oneYear {
+				expMsg.WriteString("1 year")
+			} else {
+				expMsg.WriteString(format.ExactDuration(options.TTL))
+			}
 			if !resp.Expires.Equal(resp.ExtensionDeadline) {
 				expMsg.WriteString(", and must be used every ")
-				expMsg.WriteString(format.ExactDuration(options.ExtensionDeadline))
+				if options.ExtensionDeadline == thirtyDays {
+					expMsg.WriteString("30 days")
+				} else {
+					expMsg.WriteString(format.ExactDuration(options.ExtensionDeadline))
+				}
 				expMsg.WriteString(" to remain valid")
 			}
 			if options.UserName != "" {
@@ -149,7 +160,7 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
 	cmd.Flags().StringVar(&options.UserName, "user", "", "The name of the user who will own the key")
 	cmd.Flags().BoolVar(&options.Connector, "connector", false, "Create the key for the connector")
 	cmd.Flags().BoolVarP(&options.Quiet, "quiet", "q", false, "Only display the access key")
-	cmd.Flags().DurationVar(&options.TTL, "ttl", thirtyDays, "The total time that the access key will be valid for")
+	cmd.Flags().DurationVar(&options.TTL, "ttl", oneYear, "The total time that the access key will be valid for")
 	cmd.Flags().DurationVar(&options.ExtensionDeadline, "extension-deadline", thirtyDays, "A specified deadline that the access key must be used within to remain valid")
 
 	return cmd

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	thirtyDays = 30 * (24 * time.Hour)
-	oneYear    = 366 * (24 * time.Hour) // leap year
+	oneYear    = 365 * (24 * time.Hour)
 )
 
 func newKeysCmd(cli *CLI) *cobra.Command {

--- a/ui/pages/settings/access-key/add.js
+++ b/ui/pages/settings/access-key/add.js
@@ -22,10 +22,10 @@ import Calendar from '../../../components/calendar'
 const CUSTOM_TITLE = 'custom...'
 
 const EXPIRATION_RATE = [
-  { name: '30 days', value: '720h' },
-  { name: '60 days', value: '1440h' },
-  { name: '90 days', value: '2160h' },
   { name: '1 year', value: '8766h' },
+  { name: '90 days', value: '2160h' },
+  { name: '60 days', value: '1440h' },
+  { name: '30 days', value: '720h' },
   { name: CUSTOM_TITLE, value: '720h', custom: true },
 ]
 

--- a/ui/pages/settings/access-key/add.js
+++ b/ui/pages/settings/access-key/add.js
@@ -22,10 +22,10 @@ import Calendar from '../../../components/calendar'
 const CUSTOM_TITLE = 'custom...'
 
 const EXPIRATION_RATE = [
-  { name: '1 year', value: '8766h' },
-  { name: '90 days', value: '2160h' },
-  { name: '60 days', value: '1440h' },
   { name: '30 days', value: '720h' },
+  { name: '60 days', value: '1440h' },
+  { name: '90 days', value: '2160h' },
+  { name: '1 year', value: '8766h' },
   { name: CUSTOM_TITLE, value: '720h', custom: true },
 ]
 


### PR DESCRIPTION
## Summary
Change the default access key lifetime to be 1 year, with an inactivity timeout of 30 days. This means tokens that are actively in use will not unexpectedly fail in a short window.

![Screen Shot 2022-11-23 at 9 51 37 AM](https://user-images.githubusercontent.com/5853428/203577719-0c9d59a6-a599-47d5-ab4a-da2309ecf44f.png)

```
infra keys add
Issued access key "test@example.com-gWf2fJwD39"
This key will expire in 1 year, and must be used every 30 days to remain valid

Key: aaa.bbb
```

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
