### PR TITLE
maintain: display login error

### DIFF
--- a/ui/pages/login/callback.js
+++ b/ui/pages/login/callback.js
@@ -67,7 +67,7 @@ export default function Callback() {
   return (
     <>
       {error ? (
-        <p className='my-1 text-xs text-red-500'>{error}</p>
+        <p className='my-1 text-xs text-red-500'>An error occurred while logging in: {error}</p>
       ) : (
         <Loader className='h-20 w-20' />
       )}

--- a/ui/pages/login/callback.js
+++ b/ui/pages/login/callback.js
@@ -67,7 +67,9 @@ export default function Callback() {
   return (
     <>
       {error ? (
-        <p className='my-1 text-xs text-red-500'>An error occurred while logging in: {error}</p>
+        <p className='my-1 text-xs text-red-500'>
+          An error occurred while logging in: {error}
+        </p>
       ) : (
         <Loader className='h-20 w-20' />
       )}

--- a/ui/pages/login/callback.js
+++ b/ui/pages/login/callback.js
@@ -21,17 +21,17 @@ export default function Callback() {
     async function finish({ providerID, code, redirectURL, next }) {
       try {
         const user = await login({
-        oidc: {
-          providerID,
-          code,
-          redirectURL,
-        },
-      })
+          oidc: {
+            providerID,
+            code,
+            redirectURL,
+          },
+        })
 
-      router.replace(next ? decodeURIComponent(next) : '/')
+        router.replace(next ? decodeURIComponent(next) : '/')
 
-      window.localStorage.removeItem('next')
-      saveToVisitedOrgs(window.location.host, user?.organizationName)
+        window.localStorage.removeItem('next')
+        saveToVisitedOrgs(window.location.host, user?.organizationName)
       } catch (e) {
         setError(e.message)
       }

--- a/ui/pages/login/callback.js
+++ b/ui/pages/login/callback.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { useSWRConfig } from 'swr'
 
@@ -15,10 +15,12 @@ export default function Callback() {
   const router = useRouter()
   const { isReady } = router
   const { code, state } = router.query
+  const [error, setError] = useState('')
 
   useEffect(() => {
     async function finish({ providerID, code, redirectURL, next }) {
-      const user = await login({
+      try {
+        const user = await login({
         oidc: {
           providerID,
           code,
@@ -30,6 +32,9 @@ export default function Callback() {
 
       window.localStorage.removeItem('next')
       saveToVisitedOrgs(window.location.host, user?.organizationName)
+      } catch (e) {
+        setError(e.message)
+      }
     }
 
     const providerID = window.localStorage.getItem('providerID')
@@ -59,7 +64,15 @@ export default function Callback() {
     return null
   }
 
-  return <Loader className='h-20 w-20' />
+  return (
+    <>
+      {error ? (
+        <p className='my-1 text-xs text-red-500'>{error}</p>
+      ) : (
+        <Loader className='h-20 w-20' />
+      )}
+    </>
+  )
 }
 
 Callback.layout = page => <LoginLayout>{page}</LoginLayout>


### PR DESCRIPTION
## Summary
If OIDC login failed for some reason, this spinner would just run forever. Update the UI to display an error if the login fails.

📸 
![Screen Shot 2022-11-24 at 4 05 48 PM](https://user-images.githubusercontent.com/5853428/203865817-8cf6ac61-d835-45fc-84e1-2b6ba57f467c.png)


## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
