### PR TITLE
fix: access key api migration

### DIFF
--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -315,26 +315,8 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 		})
 	})
 
-	t.Run("latest", func(t *testing.T) {
-		resp := httptest.NewRecorder()
-		// nolint:noctx
-		req := httptest.NewRequest(http.MethodGet, "/api/access-keys", nil)
-		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
-		req.Header.Set("Infra-Version", "0.12.3")
-
-		routes.ServeHTTP(resp, req)
-		assert.Equal(t, resp.Code, http.StatusOK)
-
-		resp1 := &api.ListResponse[api.AccessKey]{}
-		err := json.Unmarshal(resp.Body.Bytes(), resp1)
-		assert.NilError(t, err)
-
-		assert.Assert(t, len(resp1.Items) > 0)
-	})
-
 	t.Run("no version header", func(t *testing.T) {
 		resp := httptest.NewRecorder()
-		// nolint:noctx
 		req := httptest.NewRequest(http.MethodGet, "/api/access-keys", nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 
@@ -347,6 +329,50 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 
 		assert.Assert(t, strings.Contains(errMsg.Message, "Infra-Version header is required"))
 		assert.Equal(t, errMsg.Code, int32(400))
+	})
+
+	t.Run("version 0.18.0", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/access-keys?name=foo", nil)
+		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+		req.Header.Set("Infra-Version", "0.18.0")
+
+		routes.ServeHTTP(resp, req)
+		assert.Equal(t, resp.Code, http.StatusOK)
+
+		var cmpResponse = gocmp.Options{
+			gocmp.FilterPath(pathMapKey(`created`, `lastUsed`, `expires`), cmpApproximateTime),
+		}
+
+		actual := jsonUnmarshal(t, resp.Body.String())
+		expected := jsonUnmarshal(t, fmt.Sprintf(`
+			{
+				"limit": 100,
+				"page": 1,
+				"totalCount": 1,
+				"totalPages": 1,
+				"count": 1,
+				"items": [
+					{
+						"id": "%[2]v",
+						"created": "%[1]v",
+						"lastUsed": "%[1]v",
+						"name": "foo",
+						"extensionDeadline": null,
+						"issuedForName": "foo@example.com",
+						"issuedFor": "%[3]v",
+						"expires": "%[4]v",
+						"providerID": "%[5]v"
+					}
+				]
+			}
+			`,
+			time.Now().Format(time.RFC3339),
+			ak1.ID,
+			user.ID,
+			ak1.ExpiresAt.Format(time.RFC3339),
+			provider.ID))
+		assert.DeepEqual(t, actual, expected, cmpResponse)
 	})
 }
 

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -42,7 +42,6 @@ func TestAPI_CreateAccessKey(t *testing.T) {
 		req.Header.Set("Infra-Version", apiVersionLatest)
 
 		for k := range tc.headers {
-			req.Header.Del(k)
 			for _, v := range tc.headers[k] {
 				req.Header.Set(k, v)
 			}

--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -53,19 +53,43 @@ func (a *API) addResponseRewrites() {
 		IssuedFor         uid.ID   `json:"issuedFor"`
 		ProviderID        uid.ID   `json:"providerID"`
 		Expires           api.Time `json:"expires"`
-		ExtensionDeadline api.Time `json:"inactivityTimeout"`
+		ExtensionDeadline api.Time `json:"extensionDeadline"`
 	}
-	addResponseRewrite(a, http.MethodPost, "/api/access-keys", "0.18.0", func(newResponse *api.AccessKey) *accessKeyV0_18_0 {
-		return &accessKeyV0_18_0{
+	addResponseRewrite(a, http.MethodGet, "/api/access-keys", "0.18.0", func(newResponse *api.ListResponse[api.AccessKey]) *api.ListResponse[accessKeyV0_18_0] {
+		return api.NewListResponse(newResponse.Items, newResponse.PaginationResponse, func(newResponseItem api.AccessKey) accessKeyV0_18_0 {
+			return accessKeyV0_18_0{
+				ID:                newResponseItem.ID,
+				Created:           newResponseItem.Created,
+				LastUsed:          newResponseItem.LastUsed,
+				Name:              newResponseItem.Name,
+				IssuedForName:     newResponseItem.IssuedForName,
+				IssuedFor:         newResponseItem.IssuedFor,
+				ProviderID:        newResponseItem.ProviderID,
+				Expires:           newResponseItem.Expires,
+				ExtensionDeadline: newResponseItem.InactivityTimeout,
+			}
+		})
+	})
+	type createAccessKeyV0_18_0 struct {
+		ID                uid.ID   `json:"id"`
+		Created           api.Time `json:"created"`
+		Name              string   `json:"name"`
+		IssuedFor         uid.ID   `json:"issuedFor"`
+		ProviderID        uid.ID   `json:"providerID"`
+		Expires           api.Time `json:"expires"`
+		ExtensionDeadline api.Time `json:"extensionDeadline"`
+		AccessKey         string   `json:"accessKey"`
+	}
+	addResponseRewrite(a, http.MethodPost, "/api/access-keys", "0.18.0", func(newResponse *api.CreateAccessKeyResponse) *createAccessKeyV0_18_0 {
+		return &createAccessKeyV0_18_0{
 			ID:                newResponse.ID,
 			Created:           newResponse.Created,
-			LastUsed:          newResponse.LastUsed,
 			Name:              newResponse.Name,
-			IssuedForName:     newResponse.IssuedForName,
 			IssuedFor:         newResponse.IssuedFor,
 			ProviderID:        newResponse.ProviderID,
 			Expires:           newResponse.Expires,
 			ExtensionDeadline: newResponse.InactivityTimeout,
+			AccessKey:         newResponse.AccessKey,
 		}
 	})
 	// all response migrations go here


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Fixing a few bugs related to the access key migration.

* The JSON tag for `ExtensionDeadline` is `inactivityTimeout` so the migration isn't actually doing anything
* The response for `MethodPost` should be `CreateAccessKeyResponse` and not `AccessKey`
* The response for `MethodGet` is missing which should return a list of `AccessKey`s

This bug highlights a limitation of the API migrator: the type of the new response (the input into the migrator) cannot be statically checked. It's possible the data being migrated is completely off