### PR TITLE
load google client secret from secrets

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -199,11 +199,15 @@ func New(options Options) (*Server, error) {
 	}
 
 	if options.GoogleClientID != "" {
+		clientSecret, err := secrets.GetSecret(options.GoogleClientSecret, server.secrets)
+		if err != nil {
+			return nil, fmt.Errorf("could not load google client secret: %w", err)
+		}
 		server.Google = &models.Provider{
 			Name:         "Google",
 			URL:          "accounts.google.com",
 			ClientID:     options.GoogleClientID,
-			ClientSecret: models.EncryptedAtRest(options.GoogleClientSecret),
+			ClientSecret: models.EncryptedAtRest(clientSecret),
 			CreatedBy:    models.CreatedBySystem,
 			Kind:         models.ProviderKindGoogle,
 			AuthURL:      "https://accounts.google.com/o/oauth2/v2/auth",


### PR DESCRIPTION
## Summary
In order to be able to load our client secret from a kubernetes secret in our infrastructure configuration we need the ability to load the Google client secret with the `secrets` library.

## Checklist

- [x] Considered security implications of the change
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged