### PR TITLE
Use standard kubernetes loading instead of custom options in the connector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
-	github.com/aws/aws-sdk-go v1.44.146
+	github.com/aws/aws-sdk-go v1.44.146 // indirect
 	github.com/cli/browser v1.1.0
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-playground/validator/v10 v10.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hashicorp/vault/api v1.7.2 // indirect
 	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
-	github.com/jessevdk/go-flags v1.5.0
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7
 	github.com/muesli/termenv v0.13.0
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,6 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
-github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/internal/cmd/connector.go
+++ b/internal/cmd/connector.go
@@ -68,11 +68,6 @@ func newConnectorCmd() *cobra.Command {
 	cmd.Flags().String("ca-cert", "", "Path to CA certificate file")
 	cmd.Flags().String("ca-key", "", "Path to CA key file")
 	cmd.Flags().Bool("server-skip-tls-verify", false, "Skip verifying server TLS certificates")
-	cmd.Flags().String("endpoint-addr-host", "", "Connector proxy host")
-	cmd.Flags().String("endpoint-addr-port", "", "Connector proxy port")
-	cmd.Flags().String("addr-http", "", "HTTP address to bind to")
-	cmd.Flags().String("addr-https", "", "HTTPS address to bind to")
-	cmd.Flags().String("addr-metrics", "", "HTTP address to bind to for metrics")
 
 	return cmd
 }

--- a/internal/cmd/connector.go
+++ b/internal/cmd/connector.go
@@ -68,6 +68,11 @@ func newConnectorCmd() *cobra.Command {
 	cmd.Flags().String("ca-cert", "", "Path to CA certificate file")
 	cmd.Flags().String("ca-key", "", "Path to CA key file")
 	cmd.Flags().Bool("server-skip-tls-verify", false, "Skip verifying server TLS certificates")
+	cmd.Flags().String("endpoint-addr-host", "", "Connector proxy host")
+	cmd.Flags().String("endpoint-addr-port", "", "Connector proxy port")
+	cmd.Flags().String("addr-http", "", "HTTP address to bind to")
+	cmd.Flags().String("addr-https", "", "HTTPS address to bind to")
+	cmd.Flags().String("addr-metrics", "", "HTTP address to bind to for metrics")
 
 	return cmd
 }

--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"reflect"
 	"sort"
 	"strings"
@@ -26,6 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/certs"
@@ -72,6 +75,15 @@ func TestConnector_Run(t *testing.T) {
 	ctx := context.Background()
 	runAndWait(ctx, t, srv.Run)
 
+	kubeconfig := path.Join(dir, "kubeconfig")
+	os.Setenv("KUBECONFIG", kubeconfig)
+	err = clientcmd.WriteToFile(api.Config{
+		Clusters:       map[string]*api.Cluster{"test": {Server: kubeSrv.URL, CertificateAuthorityData: certs.PEMEncodeCertificate(kubeSrv.Certificate().Raw)}},
+		Contexts:       map[string]*api.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+		AuthInfos:      map[string]*api.AuthInfo{"test": {Token: "auth-token"}},
+		CurrentContext: "test",
+	}, kubeconfig)
+
 	opts := connector.Options{
 		Server: connector.ServerOptions{
 			URL:                srv.Addrs.HTTPS.String(),
@@ -82,11 +94,6 @@ func TestConnector_Run(t *testing.T) {
 		CACert:       types.StringOrFile(readFile(t, "testdata/pki/connector.crt")),
 		CAKey:        types.StringOrFile(readFile(t, "testdata/pki/connector.key")),
 		EndpointAddr: types.HostPort{Host: "127.0.0.1", Port: 55555},
-		Kubernetes: connector.KubernetesOptions{
-			AuthToken: "auth-token",
-			Addr:      kubeSrv.URL,
-			CA:        types.StringOrFile(certs.PEMEncodeCertificate(kubeSrv.Certificate().Raw)),
-		},
 		Addr: connector.ListenerOptions{
 			HTTP:    "127.0.0.1:0",
 			HTTPS:   "127.0.0.1:0",

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -46,8 +46,6 @@ type Options struct {
 	// This value is sent to the infra API server to update the
 	// Destination.Connection.URL.
 	EndpointAddr types.HostPort
-
-	Kubernetes KubernetesOptions
 }
 
 type ServerOptions struct {
@@ -112,10 +110,7 @@ type kubeClient interface {
 }
 
 func Run(ctx context.Context, options Options) error {
-	k8s, err := kubernetes.NewKubernetes(
-		options.Kubernetes.AuthToken.String(),
-		options.Kubernetes.Addr,
-		options.Kubernetes.CA.String())
+	k8s, err := kubernetes.NewKubernetes()
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
@@ -124,12 +119,7 @@ func Run(ctx context.Context, options Options) error {
 	logging.L.Debug().Str("uniqueID", checkSum).Msg("Cluster uniqueID")
 
 	if options.Name == "" {
-		autoname, err := k8s.Name(checkSum)
-		if err != nil {
-			logging.Errorf("k8s name error: %s", err)
-			return err
-		}
-		options.Name = autoname
+		options.Name = checkSum
 	}
 
 	certCache := NewCertCache([]byte(options.CACert), []byte(options.CAKey))

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -61,22 +61,6 @@ type ListenerOptions struct {
 	Metrics string
 }
 
-type KubernetesOptions struct {
-	// AuthToken may be used to override the token used to authenticate with the
-	// kubernetes API server. When the connector is run in-cluster, the
-	// service account associated with the pod will be used by default.
-	// When run outside of cluster there is no default, and this value must
-	// be set to a token that has permission to impersonate users in the cluster.
-	AuthToken types.StringOrFile
-
-	// Addr is the host:port used to connect to the kubernetes API server. The
-	// default value is looked up from the in-cluster config.
-	Addr string
-	// CA is the CA certificate used by the kubernetes API server. The default
-	// value is looked up from the in-cluster config.
-	CA types.StringOrFile
-}
-
 // connector stores all the dependencies for the connector operations.
 type connector struct {
 	k8s         kubeClient

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -4,25 +4,17 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
-	"net/http"
 	"strings"
-	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/jessevdk/go-flags"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/infrahq/infra/internal/logging"
 )
@@ -32,32 +24,18 @@ type Kubernetes struct {
 	Config *rest.Config
 }
 
-func NewKubernetes(authToken, addr, ca string) (*Kubernetes, error) {
-	if authToken != "" && addr != "" && ca != "" {
-		k := &Kubernetes{Config: &rest.Config{}}
-		k.Config.Host = addr
-		k.Config.TLSClientConfig.CAData = []byte(ca)
-		k.Config.BearerToken = authToken
-		return k, nil
-	}
+func NewKubernetes() (*Kubernetes, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.WarnIfAllMissing = false
 
-	config, err := rest.InClusterConfig()
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+	config, err := kubeConfig.ClientConfig()
 	if err != nil {
 		return nil, err
 	}
 
 	if err := rest.LoadTLSFiles(config); err != nil {
 		return nil, fmt.Errorf("load TLS files: %w", err)
-	}
-
-	if authToken != "" {
-		config.BearerToken = authToken
-	}
-	if addr != "" {
-		config.Host = addr
-	}
-	if ca != "" {
-		config.CAData = []byte(ca)
 	}
 
 	k := &Kubernetes{Config: config}
@@ -273,198 +251,6 @@ func (k *Kubernetes) Namespaces() ([]string, error) {
 	return results, nil
 }
 
-func (k *Kubernetes) ec2ClusterName() (string, error) {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://169.254.169.254/latest/dynamic/instance-identity/document", nil)
-	if err != nil {
-		return "", err
-	}
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return "", errors.New("received non-OK code from metadata service")
-	}
-
-	body, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return "", err
-	}
-
-	var identity struct {
-		Region     string
-		InstanceID string
-	}
-
-	err = json.Unmarshal(body, &identity)
-	if err != nil {
-		return "", err
-	}
-
-	awsSess, err := session.NewSession(&aws.Config{Region: aws.String(identity.Region)})
-	if err != nil {
-		return "", err
-	}
-
-	connection := ec2.New(awsSess)
-	name := "instance-id"
-	value := identity.InstanceID
-
-	describeInstancesOutput, err := connection.DescribeInstances(&ec2.DescribeInstancesInput{Filters: []*ec2.Filter{{Name: &name, Values: []*string{&value}}}})
-	if err != nil {
-		return "", err
-	}
-
-	reservations := describeInstancesOutput.Reservations
-	if len(reservations) == 0 {
-		return "", errors.New("could not fetch ec2 instance reservations")
-	}
-
-	ec2Instances := reservations[0].Instances
-	if len(ec2Instances) == 0 {
-		return "", errors.New("could not fetch ec2 instances")
-	}
-
-	instance := ec2Instances[0]
-
-	tags := []string{}
-	for _, tag := range instance.Tags {
-		tags = append(tags, fmt.Sprintf("%s:%s", *tag.Key, *tag.Value))
-	}
-
-	var clusterName string
-
-	for _, tag := range tags {
-		if strings.HasPrefix(tag, "kubernetes.io/cluster/") { // tag key format: kubernetes.io/cluster/clustername"
-			key := strings.Split(tag, ":")[0]
-			clusterName = strings.Split(key, "/")[2] // rely on ec2 tag format to extract clustername
-
-			break
-		}
-	}
-
-	if clusterName == "" {
-		return "", errors.New("unable to parse cluster name from EC2 tags")
-	}
-
-	return clusterName, nil
-}
-
-func (k *Kubernetes) gkeClusterName() (string, error) {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://169.254.169.254/computeMetadata/v1/instance/attributes/cluster-name", nil)
-	if err != nil {
-		return "", err
-	}
-
-	req.Header.Add("Metadata-Flavor", "Google")
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return "", errors.New("received non-OK code from metadata service")
-	}
-
-	name, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return "", err
-	}
-
-	return string(name), nil
-}
-
-func (k *Kubernetes) aksClusterName() (string, error) {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://169.254.169.254/metadata/instance/compute/resourceGroupName?api-version=2017-08-01&format=text", nil)
-	if err != nil {
-		return "", err
-	}
-
-	req.Header.Add("Metadata", "true")
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return "", errors.New("received non-OK code from metadata service")
-	}
-
-	all, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return "", fmt.Errorf("error while reading response from azure metadata endpoint: %w", err)
-	}
-
-	splitAll := strings.Split(string(all), "_")
-	if len(splitAll) < 4 || strings.ToLower(splitAll[0]) != "mc" {
-		return "", fmt.Errorf("cannot parse the clustername from resource group name: %s", all)
-	}
-
-	return splitAll[len(splitAll)-2], nil
-}
-
-func (k *Kubernetes) kubeControllerManagerClusterName() (string, error) {
-	clientset, err := kubernetes.NewForConfig(k.Config)
-	if err != nil {
-		return "", err
-	}
-
-	k8sAppPods, err := clientset.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{
-		LabelSelector: "k8s-app=kube-controller-manager",
-	})
-	if err != nil {
-		return "", err
-	}
-
-	componentPods, err := clientset.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{
-		LabelSelector: "component=kube-controller-manager",
-	})
-	if err != nil {
-		return "", err
-	}
-
-	pods := k8sAppPods.Items
-	pods = append(pods, componentPods.Items...)
-
-	if len(pods) == 0 {
-		return "", errors.New("no kube-controller-manager pods to inspect")
-	}
-
-	pod := pods[0]
-
-	specContainers := pod.Spec.Containers
-
-	if len(specContainers) == 0 {
-		return "", errors.New("no containers in kube-controller-manager podspec")
-	}
-
-	container := specContainers[0]
-
-	var opts struct {
-		ClusterName string `long:"cluster-name"`
-	}
-
-	p := flags.NewParser(&opts, flags.IgnoreUnknown)
-
-	_, err = p.ParseArgs(container.Args)
-	if err != nil {
-		return "", err
-	}
-
-	if opts.ClusterName == "" {
-		return "", errors.New("empty cluster-name argument in kube-controller-manager pod spec")
-	}
-
-	return opts.ClusterName, nil
-}
-
 // Checksum returns a sha256 hash of the PEM encoded CA certificate used for
 // TLS by this kubernetes cluster.
 func (k *Kubernetes) Checksum() string {
@@ -472,34 +258,6 @@ func (k *Kubernetes) Checksum() string {
 	h.Write(k.Config.CAData)
 	hash := h.Sum(nil)
 	return hex.EncodeToString(hash)
-}
-
-func (k *Kubernetes) Name(chksm string) (string, error) {
-	name := chksm[:12]
-
-	// 169.254.169.254 is an address used by cloud platforms for instance metadata
-	if _, err := net.DialTimeout("tcp", "169.254.169.254:80", 1*time.Second); err == nil {
-		if name, err := k.ec2ClusterName(); err == nil {
-			return name, nil
-		}
-
-		if name, err := k.gkeClusterName(); err == nil {
-			return name, nil
-		}
-
-		if name, err := k.aksClusterName(); err == nil {
-			return name, nil
-		}
-	}
-
-	if name, err := k.kubeControllerManagerClusterName(); err == nil {
-		return name, nil
-	}
-
-	// truncated checksum will be used as default name if one could not be found
-	logging.Debugf("could not fetch cluster name, resorting to hashed cluster CA")
-
-	return name, nil
 }
 
 const podLabelsFilePath = "/etc/podinfo/labels"


### PR DESCRIPTION
This PR changes the connector to load Kubernetes cluster info via standard Kubernetes loading.

The benefits of this are:
1. Less options for `infra connector`
2. Familiar: it's how most tools that connect to a Kubernetes cluster load config info and credentials
3. Support for running the connector out-of-cluster using a local kubeconfig (e.g. via `infra connector ...`)
4. Support for non-token authentication to Kubernetes clusters (probably rare, but good for local development against tools such as Docker Desktop which uses a keypair)

This PR also cleans up some unused code for now that directly require the aws sdk (a big dependency), and adds a few missing CLI arguments to make running the connector (locally and elsewhere) without needing to write out a config file.