### PR TITLE
feat: fail when client is ahead of server version

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -479,7 +479,7 @@ func ServerCompatible(ctx context.Context, client *Client) error {
 		return nil // result inconclusive
 	}
 	if ahead {
-		return fmt.Errorf("client version (%s) is ahead of server version (%s), please upgrade your server", apiVersion, srv.Version)
+		return fmt.Errorf("client version (%s) is ahead of server version (%s)", apiVersion, srv.Version)
 	}
 	return nil
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -224,3 +224,38 @@ func TestListGrants(t *testing.T) {
 		assert.DeepEqual(t, apiError, expected)
 	})
 }
+
+func TestVersionAhead(t *testing.T) {
+	t.Run("patch version", func(t *testing.T) {
+		res, err := versionAhead("1.0.1", "1.0.0")
+		assert.NilError(t, err)
+		assert.Assert(t, res)
+
+		res, err = versionAhead("1.0.0", "1.0.1")
+		assert.NilError(t, err)
+		assert.Assert(t, !res)
+	})
+	t.Run("minor version", func(t *testing.T) {
+		res, err := versionAhead("1.1.0", "1.0.0")
+		assert.NilError(t, err)
+		assert.Assert(t, res)
+
+		res, err = versionAhead("1.0.0", "1.1.0")
+		assert.NilError(t, err)
+		assert.Assert(t, !res)
+	})
+	t.Run("major version", func(t *testing.T) {
+		res, err := versionAhead("2.0.0", "1.0.0")
+		assert.NilError(t, err)
+		assert.Assert(t, res)
+
+		res, err = versionAhead("1.0.0", "2.0.0")
+		assert.NilError(t, err)
+		assert.Assert(t, !res)
+	})
+	t.Run("equal", func(t *testing.T) {
+		res, err := versionAhead("1.0.0", "1.0.0")
+		assert.NilError(t, err)
+		assert.Assert(t, !res)
+	})
+}

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -161,9 +161,13 @@ func writeAgentConfig(pid int) error {
 
 // syncKubeConfig updates the local kubernetes configuration from Infra grants
 func syncKubeConfig(_ context.Context) error {
-	client, err := defaultAPIClient()
+	opts, err := defaultClientOpts()
 	if err != nil {
-		return fmt.Errorf("get api client: %w", err)
+		return err
+	}
+	client, err := NewAPIClient(opts)
+	if err != nil {
+		return err
 	}
 	client.Name = "agent"
 

--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -66,7 +66,7 @@ func (c *CLI) apiClient() (*api.Client, error) {
 func (c *CLI) serverCompatible(client *api.Client) error {
 	if !c.RootOptions.SkipAPIVersionCheck && !strings.HasSuffix(client.URL, ".infrahq.com") {
 		if err := api.ServerCompatible(context.Background(), client); err != nil {
-			return fmt.Errorf("%w, download the CLI version that matches your server, reference https://infrahq.com/docs/reference/self-hosting#cli-versions", err)
+			return fmt.Errorf("%w, download the CLI version that matches your server, reference https://infrahq.com/docs/messages/cli-versions", err)
 		}
 	}
 

--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -64,7 +64,9 @@ func (c *CLI) apiClient() (*api.Client, error) {
 
 func (c *CLI) serverCompatible(client *api.Client) error {
 	if !c.RootOptions.SkipAPIVersionCheck && !strings.HasSuffix(client.URL, ".infrahq.com") {
-		return api.ServerCompatible(context.Background(), client)
+		if err := api.ServerCompatible(context.Background(), client); err != nil {
+			return fmt.Errorf("%w, download the CLI version that matches your server, reference https://infrahq.com/docs/reference/self-hosting#cli-versions", err)
+		}
 	}
 
 	return nil

--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
+
 	"github.com/infrahq/infra/api"
 )
 

--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/infrahq/infra/api"
 )
 
 // CLI exposes common dependencies to commands.
@@ -15,6 +17,13 @@ type CLI struct {
 	Stdin  terminal.FileReader
 	Stdout terminal.FileWriter
 	Stderr io.Writer
+
+	RootOptions RootOptions
+}
+
+type RootOptions struct {
+	LogLevel            string
+	SkipAPIVersionCheck bool
 }
 
 // Output a string to CLI.Stdout. Output is like fmt.Printf except that it always
@@ -36,6 +45,30 @@ type key struct{}
 
 // ctxKey used to store CLI in the context.
 var ctxKey = key{}
+
+func (c *CLI) apiClient() (*api.Client, error) {
+	opts, err := defaultClientOpts()
+	if err != nil {
+		return nil, err
+	}
+	client, err := NewAPIClient(opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.serverCompatible(client); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func (c *CLI) serverCompatible(client *api.Client) error {
+	if !c.RootOptions.SkipAPIVersionCheck && !strings.HasSuffix(client.URL, ".infrahq.com") {
+		return api.ServerCompatible(context.Background(), client)
+	}
+
+	return nil
+}
 
 // newCli looks for a CLI stores in context. If one exists, the CLI from
 // context is returned, otherwise a new CLI is created with streams set to the

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -146,7 +146,7 @@ func TestInvalidSessions(t *testing.T) {
 		assert.NilError(t, err)
 
 		err = Run(context.Background(), "destinations", "list")
-		assert.ErrorContains(t, err, "Session expired")
+		assert.ErrorContains(t, err, "Access key is expired, please `infra login` again")
 	})
 
 	t.Run("Logged out session", func(t *testing.T) {
@@ -158,7 +158,7 @@ func TestInvalidSessions(t *testing.T) {
 		assert.NilError(t, err)
 
 		err = Run(context.Background(), "destinations", "list")
-		assert.ErrorContains(t, err, "Not logged in")
+		assert.ErrorContains(t, err, "Missing access key, must `infra login` or set INFRA_ACCESS_KEY in your environment")
 	})
 }
 

--- a/internal/cmd/destinations.go
+++ b/internal/cmd/destinations.go
@@ -25,12 +25,6 @@ func newDestinationsCmd(cli *CLI) *cobra.Command {
 		Aliases: []string{"dst", "dest", "destination"},
 		Short:   "Manage destinations",
 		GroupID: groupManagement,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootPreRun(cmd.Flags()); err != nil {
-				return err
-			}
-			return mustBeLoggedIn()
-		},
 	}
 
 	cmd.AddCommand(newDestinationsListCmd(cli))
@@ -47,7 +41,7 @@ func newDestinationsListCmd(cli *CLI) *cobra.Command {
 		Short:   "List connected destinations",
 		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -127,7 +121,7 @@ func newDestinationsRemoveCmd(cli *CLI) *cobra.Command {
 		Args:    ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -31,12 +31,6 @@ func newGrantsCmd(cli *CLI) *cobra.Command {
 		Short:   "Manage access to resources",
 		Aliases: []string{"grant"},
 		GroupID: groupManagement,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootPreRun(cmd.Flags()); err != nil {
-				return err
-			}
-			return mustBeLoggedIn()
-		},
 	}
 
 	cmd.AddCommand(newGrantsListCmd(cli))
@@ -55,7 +49,7 @@ func newGrantsListCmd(cli *CLI) *cobra.Command {
 		Short:   "List grants",
 		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -249,7 +243,7 @@ $ infra grants remove janedoe@example.com infra --role admin
 }
 
 func removeGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
-	client, err := defaultAPIClient()
+	client, err := cli.apiClient()
 	if err != nil {
 		return err
 	}
@@ -357,7 +351,7 @@ $ infra grants add johndoe@example.com infra --role admin
 }
 
 func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
-	client, err := defaultAPIClient()
+	client, err := cli.apiClient()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -45,12 +45,6 @@ func newGroupsCmd(cli *CLI) *cobra.Command {
 		Short:   "Manage groups of identities",
 		Aliases: []string{"group"},
 		GroupID: groupManagement,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootPreRun(cmd.Flags()); err != nil {
-				return err
-			}
-			return mustBeLoggedIn()
-		},
 	}
 
 	cmd.AddCommand(newGroupsAddCmd(cli))
@@ -71,7 +65,7 @@ func newGroupsListCmd(cli *CLI) *cobra.Command {
 		Short:   "List groups",
 		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -147,7 +141,7 @@ func newGroupsAddCmd(cli *CLI) *cobra.Command {
 $ infra groups add Engineering`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -176,7 +170,7 @@ $ infra groups remove Engineering`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -222,7 +216,7 @@ $ infra groups adduser johndoe@example.com Engineering
 
 			ctx := context.Background()
 
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -275,7 +269,7 @@ $ infra groups removeuser johndoe@example.com Engineering
 
 			ctx := context.Background()
 
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -18,9 +18,6 @@ func newInfoCmd(cli *CLI) *cobra.Command {
 		Args:    NoArgs,
 		GroupID: groupOther,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := mustBeLoggedIn(); err != nil {
-				return err
-			}
 			return info(cli)
 		},
 	}
@@ -32,7 +29,7 @@ func info(cli *CLI) error {
 		return err
 	}
 
-	client, err := defaultAPIClient()
+	client, err := cli.apiClient()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -23,12 +23,6 @@ func newKeysCmd(cli *CLI) *cobra.Command {
 		Short:   "Manage access keys",
 		Aliases: []string{"key"},
 		GroupID: groupManagement,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootPreRun(cmd.Flags()); err != nil {
-				return err
-			}
-			return mustBeLoggedIn()
-		},
 	}
 
 	cmd.AddCommand(newKeysListCmd(cli))
@@ -74,7 +68,7 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
 				}
 			}
 
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -181,7 +175,7 @@ func newKeysRemoveCmd(cli *CLI) *cobra.Command {
 		Args:    ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -257,7 +251,7 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 		Short:   "List access keys",
 		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -18,12 +18,6 @@ func newListCmd(cli *CLI) *cobra.Command {
 		Short:   "List accessible destinations",
 		Args:    NoArgs,
 		GroupID: groupCore,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootPreRun(cmd.Flags()); err != nil {
-				return err
-			}
-			return mustBeLoggedIn()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return list(cli)
 		},
@@ -31,7 +25,7 @@ func newListCmd(cli *CLI) *cobra.Command {
 }
 
 func list(cli *CLI) error {
-	client, err := defaultAPIClient()
+	client, err := cli.apiClient()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -43,8 +43,13 @@ func TestListCmd(t *testing.T) {
 	ctx := context.Background()
 	runAndWait(ctx, t, srv.Run)
 
-	httpTransport := httpTransportForHostConfig(&ClientHostConfig{SkipTLSVerify: true})
-	c := apiClient(srv.Addrs.HTTPS.String(), "0000000001.adminadminadminadmin1234", httpTransport)
+	clientOpts := &APIClientOpts{
+		Host:      srv.Addrs.HTTPS.String(),
+		AccessKey: "0000000001.adminadminadminadmin1234",
+		Transport: httpTransportForHostConfig(&ClientHostConfig{SkipTLSVerify: true}),
+	}
+	c, err := NewAPIClient(clientOpts)
+	assert.NilError(t, err)
 
 	_, err = c.CreateDestination(ctx, &api.CreateDestinationRequest{
 		UniqueID: "space",

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -328,8 +328,19 @@ func newLoginClient(cli *CLI, options loginCmdOptions) (loginClient, error) {
 		TrustedCertificate: options.TrustedCertificate,
 		SkipTLSVerify:      options.SkipTLSVerify,
 	}
+	client, err := NewAPIClient(&APIClientOpts{
+		Host:      options.Server,
+		Transport: httpTransportForHostConfig(cfg),
+	},
+	)
+	if err != nil {
+		return loginClient{}, err
+	}
+	if err := cli.serverCompatible(client); err != nil {
+		return loginClient{}, err
+	}
 	c := loginClient{
-		APIClient:          apiClient(options.Server, "", httpTransportForHostConfig(cfg)),
+		APIClient:          client,
 		TrustedCertificate: options.TrustedCertificate,
 	}
 	if options.SkipTLSVerify {
@@ -372,7 +383,14 @@ func newLoginClient(cli *CLI, options loginCmdOptions) (loginClient, error) {
 				RootCAs:    pool,
 			},
 		}
-		c.APIClient = apiClient(options.Server, "", transport)
+		client, err := NewAPIClient(&APIClientOpts{
+			Host:      options.Server,
+			Transport: transport,
+		})
+		if err != nil {
+			return c, err
+		}
+		c.APIClient = client
 		c.TrustedCertificate = string(certs.PEMEncodeCertificate(uaErr.Cert.Raw))
 	}
 	return c, nil

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -65,7 +65,16 @@ $ infra logout --all --clear`,
 
 func logoutOfServer(hostConfig *ClientHostConfig) (success bool) {
 	ctx := context.TODO()
-	client := apiClient(hostConfig.Host, hostConfig.AccessKey, httpTransportForHostConfig(hostConfig))
+	opts := &APIClientOpts{
+		Host:      hostConfig.Host,
+		AccessKey: hostConfig.AccessKey,
+		Transport: httpTransportForHostConfig(hostConfig),
+	}
+	client, err := NewAPIClient(opts)
+	if err != nil {
+		logging.Debugf("err: %s", err)
+		return false
+	}
 
 	defer func() {
 		hostConfig.AccessKey = ""

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -22,12 +22,6 @@ func newProvidersCmd(cli *CLI) *cobra.Command {
 		Short:   "Manage identity providers",
 		Aliases: []string{"provider"},
 		GroupID: groupManagement,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootPreRun(cmd.Flags()); err != nil {
-				return err
-			}
-			return mustBeLoggedIn()
-		},
 	}
 
 	cmd.AddCommand(newProvidersListCmd(cli))
@@ -127,7 +121,7 @@ func newProvidersListCmd(cli *CLI) *cobra.Command {
 		Short:   "List connected identity providers",
 		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -229,7 +223,7 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 				return err
 			}
 
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -293,7 +287,7 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 }
 
 func updateProvider(cli *CLI, name string, opts providerEditOptions) error {
-	client, err := defaultAPIClient()
+	client, err := cli.apiClient()
 	if err != nil {
 		return err
 	}
@@ -393,7 +387,7 @@ func newProvidersRemoveCmd(cli *CLI) *cobra.Command {
 		Example: "$ infra providers remove okta",
 		Args:    ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/testdata/expected-usage
+++ b/internal/cmd/testdata/expected-usage
@@ -23,7 +23,8 @@ Other commands:
   completion   Generate shell auto-completion for the CLI
 
 Flags:
-      --help               Display help
-      --log-level string   Show logs when running the command [error, warn, info, debug] (default "info")
+      --help                 Display help
+      --log-level string     Show logs when running the command [error, warn, info, debug] (default "info")
+      --skip-version-check   Skip checking if the CLI is ahead of the server version
 
 Use "infra [command] --help" for more information about a command.

--- a/internal/cmd/tokens.go
+++ b/internal/cmd/tokens.go
@@ -15,12 +15,6 @@ func newTokensCmd(cli *CLI) *cobra.Command {
 		Use:    "tokens",
 		Short:  "Create & manage tokens",
 		Hidden: true,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootPreRun(cmd.Flags()); err != nil {
-				return err
-			}
-			return mustBeLoggedIn()
-		},
 	}
 
 	cmd.AddCommand(newTokensAddCmd(cli))
@@ -41,7 +35,7 @@ func newTokensAddCmd(cli *CLI) *cobra.Command {
 
 func tokensCreate(cli *CLI) error {
 	ctx := context.Background()
-	client, err := defaultAPIClient()
+	client, err := cli.apiClient()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -19,16 +19,10 @@ $ infra use development.kube-system`,
 		Args:              ExactArgs(1),
 		GroupID:           groupCore,
 		ValidArgsFunction: getUseCompletion,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootPreRun(cmd.Flags()); err != nil {
-				return err
-			}
-			return mustBeLoggedIn()
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			destination := args[0]
 
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -55,7 +49,11 @@ $ infra use development.kube-system`,
 }
 
 func getUseCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	client, err := defaultAPIClient()
+	opts, err := defaultClientOpts()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	client, err := NewAPIClient(opts)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -88,5 +86,4 @@ func getUseCompletion(cmd *cobra.Command, args []string, toComplete string) ([]s
 	}
 
 	return validArgs, cobra.ShellCompDirectiveNoSpace
-
 }

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -25,12 +25,6 @@ func newUsersCmd(cli *CLI) *cobra.Command {
 		Short:   "Manage user identities",
 		Aliases: []string{"user"},
 		GroupID: groupManagement,
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := rootPreRun(cmd.Flags()); err != nil {
-				return err
-			}
-			return mustBeLoggedIn()
-		},
 	}
 
 	cmd.AddCommand(newUsersAddCmd(cli))
@@ -61,7 +55,7 @@ $ infra users add johndoe@example.com`,
 
 			ctx := context.Background()
 
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -141,7 +135,7 @@ func newUsersListCmd(cli *CLI) *cobra.Command {
 		Short:   "List users",
 		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -212,7 +206,7 @@ $ infra users remove janedoe@example.com`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
-			client, err := defaultAPIClient()
+			client, err := cli.apiClient()
 			if err != nil {
 				return err
 			}
@@ -263,7 +257,7 @@ $ infra users remove janedoe@example.com`,
 func updateUser(cli *CLI, name string) error {
 	ctx := context.Background()
 
-	client, err := defaultAPIClient()
+	client, err := cli.apiClient()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -34,7 +34,7 @@ func version(cli *CLI) error {
 	fmt.Fprintln(w, "Client:\t", strings.TrimPrefix(internal.FullVersion(), "v"))
 
 	// Note that we use the client to get this version, but it is in fact the server version
-	client, err := defaultAPIClient()
+	client, err := cli.apiClient()
 	if err != nil {
 		fmt.Fprintln(w, "Server:\t", "disconnected")
 		logging.Debugf("%s", err.Error())


### PR DESCRIPTION
## Summary
When the CLI version is ahead of the server version fail fast.

```
$ infra groups list
Error: client version (0.18.1) is ahead of server version (0.18.0), download the CLI version that matches your server, reference https://infrahq.com/docs/reference/self-hosting#cli-versions
```

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged