### PR TITLE
Add parseDuration that supports years, weeks, and days

### DIFF
--- a/internal/cmd/types/duration.go
+++ b/internal/cmd/types/duration.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Duration time.Duration
+
+func (d *Duration) String() string {
+	if d == nil {
+		return "0s"
+	}
+	return time.Duration(*d).String()
+}
+
+func (d *Duration) Set(s string) error {
+	v, err := parseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = Duration(v)
+	return nil
+}
+
+func (d *Duration) Type() string {
+	return "duration"
+}
+
+func parseDuration(raw string) (time.Duration, error) {
+	if raw == "" {
+		return 0, fmt.Errorf(`invalid duration ""`)
+	}
+
+	var result time.Duration
+
+	years, rest, ok := strings.Cut(raw, "y")
+	if ok {
+		raw = rest
+		v, err := strconv.ParseInt(years, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid number of years: %v", years)
+		}
+		result += time.Duration(v) * 365 * 24 * time.Hour
+	}
+
+	weeks, rest, ok := strings.Cut(raw, "w")
+	if ok {
+		raw = rest
+		v, err := strconv.ParseInt(weeks, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid number of weeks: %v", weeks)
+		}
+		result += time.Duration(v) * 7 * 24 * time.Hour
+	}
+
+	days, rest, ok := strings.Cut(raw, "d")
+	if ok {
+		raw = rest
+		v, err := strconv.ParseInt(days, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid number of days: %v", days)
+		}
+		result += time.Duration(v) * 24 * time.Hour
+	}
+
+	if raw != "" {
+		v, err := time.ParseDuration(raw)
+		if err != nil {
+			return 0, err
+		}
+		result += v
+	}
+	return result, nil
+}

--- a/internal/cmd/types/duration_test.go
+++ b/internal/cmd/types/duration_test.go
@@ -1,0 +1,82 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestDuration_Set(t *testing.T) {
+	type testCase struct {
+		source      string
+		expected    time.Duration
+		expectedErr string
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		d := Duration(0)
+		err := d.Set(tc.source)
+		if tc.expectedErr != "" {
+			assert.ErrorContains(t, err, tc.expectedErr)
+			return
+		}
+
+		assert.NilError(t, err)
+		actual := time.Duration(d)
+		assert.Equal(t, actual, tc.expected)
+	}
+
+	testCases := []testCase{
+		{
+			source:      "",
+			expectedErr: `invalid duration ""`,
+		},
+		{
+			source:   "3h2m1s",
+			expected: 3*time.Hour + 121*time.Second,
+		},
+		{
+			source:   "3y",
+			expected: 26280 * time.Hour,
+		},
+		{
+			source:   "11d",
+			expected: 264 * time.Hour,
+		},
+		{
+			source:   "4w",
+			expected: 672 * time.Hour,
+		},
+		{
+			source:   "3y2h",
+			expected: 26282 * time.Hour,
+		},
+		{
+			source:   "3y2d",
+			expected: 26328 * time.Hour,
+		},
+		{
+			source:   "3y2w4d",
+			expected: 26712 * time.Hour,
+		},
+		{
+			source:   "3y2w4d5h8m7s",
+			expected: 26717*time.Hour + 487*time.Second,
+		},
+		{
+			source:      "3w2y",
+			expectedErr: "invalid number of years: 3w2",
+		},
+		{
+			source:   "-7y",
+			expected: -61320 * time.Hour,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.source, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Resolves #3750

This PR implements the parse portion of #3750. It ended up being pretty easy to support years, weeks, and days along with hours, minutes, seconds, and sub-seconds. This implementation happened to also support negative without any extra work.

The only thing not supported is putting smaller units before larger ones. That means that the input string must be sorted from years, weeks, days, hours, minutes, seconds, sub-seconds. 

Making this a draft for now. 

TODO:
* [ ] more test coverage (missing value for unit, fuzz test for unexpected input)
* [ ] use this new type in the CLI
* [ ] support printing these units in `format.ExactDuration`