### PR TITLE
connector: improve ssh connector install

### DIFF
--- a/internal/cmd/connector.go
+++ b/internal/cmd/connector.go
@@ -83,12 +83,12 @@ func defaultConnectorOptions() connector.Options {
 			Metrics: ":9090",
 		},
 		Kind: "kubernetes",
-		Server: connector.ServerOptions{
-			URL: types.URL{Scheme: "https", Host: "api.infrahq.com"},
-		},
 		SSH: connector.SSHOptions{
 			Group:          "infra-users",
 			SSHDConfigPath: "/etc/ssh/sshd_config",
+		},
+		Server: connector.ServerOptions{
+			URL: types.URL{Scheme: "https", Host: "api.infrahq.com"},
 		},
 	}
 }

--- a/internal/cmd/connector.go
+++ b/internal/cmd/connector.go
@@ -83,11 +83,12 @@ func defaultConnectorOptions() connector.Options {
 			Metrics: ":9090",
 		},
 		Kind: "kubernetes",
-		SSH: connector.SSHOptions{
-			Group: "infra-users",
-		},
 		Server: connector.ServerOptions{
 			URL: types.URL{Scheme: "https", Host: "api.infrahq.com"},
+		},
+		SSH: connector.SSHOptions{
+			Group:          "infra-users",
+			SSHDConfigPath: "/etc/ssh/sshd_config",
 		},
 	}
 }

--- a/internal/cmd/connector.go
+++ b/internal/cmd/connector.go
@@ -83,5 +83,11 @@ func defaultConnectorOptions() connector.Options {
 			Metrics: ":9090",
 		},
 		Kind: "kubernetes",
+		SSH: connector.SSHOptions{
+			Group: "infra-users",
+		},
+		Server: connector.ServerOptions{
+			URL: types.URL{Scheme: "https", Host: "api.infrahq.com"},
+		},
 	}
 }

--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -397,7 +397,7 @@ addr:
 
 ssh:
   group: the-group
-  sshd_config_path: /opt/sshd
+  sshdConfigPath: /opt/sshd
 `,
 			expected: func() connector.Options {
 				return connector.Options{

--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -394,6 +394,10 @@ addr:
   http: localhost:84
   https: localhost:414
   metrics: 127.0.0.1:8000
+
+ssh:
+  group: the-group
+  sshd_config_path: /opt/sshd
 `,
 			expected: func() connector.Options {
 				return connector.Options{
@@ -412,6 +416,10 @@ addr:
 					},
 					CACert: "/path/to/cert",
 					CAKey:  "/path/to/key",
+					SSH: connector.SSHOptions{
+						Group:          "the-group",
+						SSHDConfigPath: "/opt/sshd",
+					},
 				}
 			},
 		},

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -346,7 +346,6 @@ func hasInfraMatchLine(sshConfig io.Reader) bool {
 		return false
 	}
 
-	// TODO: test many match lines that don't match
 	lineScan := bufio.NewScanner(sshConfig)
 	for lineScan.Scan() {
 		fields := strings.Fields(lineScan.Text())

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -59,6 +59,8 @@ type Options struct {
 	// Destination.Connection.URL.
 	EndpointAddr types.HostPort
 
+	SSH SSHOptions
+
 	// Kubernetes specific options below here
 
 	CACert     types.StringOrFile

--- a/internal/connector/ssh_test.go
+++ b/internal/connector/ssh_test.go
@@ -2,11 +2,13 @@ package connector
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
 
 	"github.com/infrahq/infra/api"
 	data "github.com/infrahq/infra/internal/linux"
@@ -51,16 +53,59 @@ useradd '--comment' 'Ej,managed by infra' '-m' '-p' '-g' 'infra-users' '*' 'two2
 	assert.Equal(t, expected, string(actual))
 }
 
-func TestReadHostKeysFromDir(t *testing.T) {
-	hostKeys, err := readHostKeysFromDir("./testdata/etcssh")
+func TestReadSSHHostKeys(t *testing.T) {
+	type testCase struct {
+		name      string
+		filenames []string
+		dir       string
+		expected  string
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		hostKeys, err := readSSHHostKeys(tc.filenames, tc.dir)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, hostKeys, tc.expected)
+	}
+
+	cwd, err := os.Getwd()
 	assert.NilError(t, err)
 
-	var expected = `ssh-dss AAAAB3NzaC1kc3MAAACBAIw6DfiYR9DDi/iojqjhM0mlhZ6K+QMukZv2S/Su/M4QmpPhLMgvz16QCS2Wo6y4No6XdTKqp8/RCRobQA6rELoNZHc4IDylwuu7/xn1tdLF5vxUgiz9YMFQDm8rbltA0Gpc6CaKmu0OIJmHKCUZNWoteXa+d9CaYNsc8DL7T3ChAAAAFQDpnbY6PEDh6plGF9hK1eiGPh1WuwAAAIAiAH3Ig+BfgQxk6fLzuTmZDxCAAfWy3dT28eH1Bhef+W5/kVU4zPg4MUnhruQM+ViGrjRyoMQyJJeVBnOkvVvBg5QZi5rMP5OkW5VZ3hTA7tMbouPiOFVUBUlNW4wl/tDr8BpGUlHU0MuO1o4hTV2lDPwjfNV1nX+um+Zdek0DggAAAIByYDA/oVFig/zPFcYGL3NgJ5Dttr3O0uJ6pcopZVzarYIBvWmqDdrHnK12H5SEnCgC4a3g9xtmD0F+A4va/M6jLD/aWbqmgy7g9zAflTH2NroA0UlmcbZqwMM8ITdPWpxOHQPmGuBwhQ4fZ4CTjtTzzUsWvcxlGOgU0KXHtCZi0g==
+	testCases := []testCase{
+		{
+			name: "read default keys",
+			dir:  "./testdata/etcssh",
+			expected: `ssh-dss AAAAB3NzaC1kc3MAAACBAIw6DfiYR9DDi/iojqjhM0mlhZ6K+QMukZv2S/Su/M4QmpPhLMgvz16QCS2Wo6y4No6XdTKqp8/RCRobQA6rELoNZHc4IDylwuu7/xn1tdLF5vxUgiz9YMFQDm8rbltA0Gpc6CaKmu0OIJmHKCUZNWoteXa+d9CaYNsc8DL7T3ChAAAAFQDpnbY6PEDh6plGF9hK1eiGPh1WuwAAAIAiAH3Ig+BfgQxk6fLzuTmZDxCAAfWy3dT28eH1Bhef+W5/kVU4zPg4MUnhruQM+ViGrjRyoMQyJJeVBnOkvVvBg5QZi5rMP5OkW5VZ3hTA7tMbouPiOFVUBUlNW4wl/tDr8BpGUlHU0MuO1o4hTV2lDPwjfNV1nX+um+Zdek0DggAAAIByYDA/oVFig/zPFcYGL3NgJ5Dttr3O0uJ6pcopZVzarYIBvWmqDdrHnK12H5SEnCgC4a3g9xtmD0F+A4va/M6jLD/aWbqmgy7g9zAflTH2NroA0UlmcbZqwMM8ITdPWpxOHQPmGuBwhQ4fZ4CTjtTzzUsWvcxlGOgU0KXHtCZi0g==
 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI928HrNO4w5wneti+mBYBC1ZGr0oVxUJTr5AwXoN2YEYZj/T+LSFEPrLRzyWBycpyPwld0AVhr1hm3mG9U6N/w=
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJluZNrFxN0dfBrJW4rebQnTjwFxP+WLoN1QnbjRoVvZ
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDNpxkQM9F1eTnfcxjLSqJ1W5v+e8x2jKpHPZdpB9Ug4OMD/F4lQi1Q7Ut+8L6Mnu1AlsahQGMSNCibITlTM+6Zk0UHpFZdaGz7v6lrMwcLP2bfcrvpbONZI1D0CG16VFTW3Gd7v5AdaqnaM4mog1+4C6K1SEwytX0YT1BBdBknIoM8thgZCYkZgJgnNoXasr0mN86LTCOfM2w6vIp3f2Zvlc8zmv4IFZ742mZXCLH1H0A1/0mRsj5iGJeRUPzQVHz6rxlz8kiaCDIhXRCSirR/TRiahxwgOHbrgv7kgugsdBapkmBBX5OsWakYFz+UCn9Fwf9uq/enVhKNn56Nq94p0WXTOl2nMKzVJb0gpBaWn14uH14/VOPxhzUh3GprW2FXJp5DXI2q8GrMK4EaHCkzm1gU5WVWbVPBQmfdpW6kCMlftsyDNACB5mZEmnQcT6mxH+xgQn+irLp34SpnUODkyhm9bV5hSDrhrzgRd3D8NVXf/YiZFWHRaa49kddrm+8=
-`
-	assert.DeepEqual(t, hostKeys, expected)
+`,
+		},
+		{
+			name:      "read keys from file list, relative paths",
+			dir:       "./testdata/etcssh",
+			filenames: []string{"ssh_host_rsa_key", "ssh_host_ed25519_key"},
+			expected: `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDNpxkQM9F1eTnfcxjLSqJ1W5v+e8x2jKpHPZdpB9Ug4OMD/F4lQi1Q7Ut+8L6Mnu1AlsahQGMSNCibITlTM+6Zk0UHpFZdaGz7v6lrMwcLP2bfcrvpbONZI1D0CG16VFTW3Gd7v5AdaqnaM4mog1+4C6K1SEwytX0YT1BBdBknIoM8thgZCYkZgJgnNoXasr0mN86LTCOfM2w6vIp3f2Zvlc8zmv4IFZ742mZXCLH1H0A1/0mRsj5iGJeRUPzQVHz6rxlz8kiaCDIhXRCSirR/TRiahxwgOHbrgv7kgugsdBapkmBBX5OsWakYFz+UCn9Fwf9uq/enVhKNn56Nq94p0WXTOl2nMKzVJb0gpBaWn14uH14/VOPxhzUh3GprW2FXJp5DXI2q8GrMK4EaHCkzm1gU5WVWbVPBQmfdpW6kCMlftsyDNACB5mZEmnQcT6mxH+xgQn+irLp34SpnUODkyhm9bV5hSDrhrzgRd3D8NVXf/YiZFWHRaa49kddrm+8=
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJluZNrFxN0dfBrJW4rebQnTjwFxP+WLoN1QnbjRoVvZ
+`,
+		},
+		{
+			name: "read keys from file list, absolute paths",
+			dir:  "/does/not/exist",
+			filenames: []string{
+				filepath.Join(cwd, "testdata/etcssh/ssh_host_rsa_key"),
+				filepath.Join(cwd, "testdata/etcssh/ssh_host_ed25519_key"),
+			},
+			expected: `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDNpxkQM9F1eTnfcxjLSqJ1W5v+e8x2jKpHPZdpB9Ug4OMD/F4lQi1Q7Ut+8L6Mnu1AlsahQGMSNCibITlTM+6Zk0UHpFZdaGz7v6lrMwcLP2bfcrvpbONZI1D0CG16VFTW3Gd7v5AdaqnaM4mog1+4C6K1SEwytX0YT1BBdBknIoM8thgZCYkZgJgnNoXasr0mN86LTCOfM2w6vIp3f2Zvlc8zmv4IFZ742mZXCLH1H0A1/0mRsj5iGJeRUPzQVHz6rxlz8kiaCDIhXRCSirR/TRiahxwgOHbrgv7kgugsdBapkmBBX5OsWakYFz+UCn9Fwf9uq/enVhKNn56Nq94p0WXTOl2nMKzVJb0gpBaWn14uH14/VOPxhzUh3GprW2FXJp5DXI2q8GrMK4EaHCkzm1gU5WVWbVPBQmfdpW6kCMlftsyDNACB5mZEmnQcT6mxH+xgQn+irLp34SpnUODkyhm9bV5hSDrhrzgRd3D8NVXf/YiZFWHRaa49kddrm+8=
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJluZNrFxN0dfBrJW4rebQnTjwFxP+WLoN1QnbjRoVvZ
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
 }
 
 func TestReadLocalUsers(t *testing.T) {
@@ -91,4 +136,39 @@ func TestReadLocalUsers(t *testing.T) {
 	}
 	assert.DeepEqual(t, actual, expected)
 	assert.Assert(t, actual[2].IsManagedByInfra())
+}
+
+func TestReadSSHDConfig(t *testing.T) {
+	dir := fs.NewDir(t, t.Name())
+	fs.Apply(t, dir,
+		fs.WithFile("sshd_config", fmt.Sprintf(`
+HostKey /etc/ssh/host_key_the_first
+
+Include %[1]v/included
+
+HostKey /etc/ssh/host_key_the_second
+
+`, dir.Path())),
+		fs.WithFile("included", `
+Include also_included
+
+HostKey /etc/ssh/host_key_the_third
+
+`),
+		fs.WithFile("also_included", `
+HostKey /etc/ssh/host_key_the_forth
+`))
+
+	actual, err := readSSHDConfig(dir.Join("sshd_config"), dir.Path())
+	assert.NilError(t, err)
+	expected := sshdConfig{
+		HostKeys: []string{
+			"/etc/ssh/host_key_the_first",
+			"/etc/ssh/host_key_the_forth",
+			"/etc/ssh/host_key_the_third",
+			"/etc/ssh/host_key_the_second",
+		},
+	}
+	assert.DeepEqual(t, actual, expected)
+
 }

--- a/internal/connector/ssh_test.go
+++ b/internal/connector/ssh_test.go
@@ -37,7 +37,8 @@ func TestUpdateLocalUsers(t *testing.T) {
 		{ID: 124, User: 2222, Privilege: "connect"},
 	}
 
-	err := updateLocalUsers(ctx, fakeClient, grants)
+	opts := SSHOptions{Group: "infra-users"}
+	err := updateLocalUsers(ctx, fakeClient, opts, grants)
 	assert.NilError(t, err)
 
 	actual, err := os.ReadFile(logFile)
@@ -45,7 +46,7 @@ func TestUpdateLocalUsers(t *testing.T) {
 
 	expected := `pkill '--uid' 'three333' 
 userdel '--remove' 'three333' 
-useradd '--comment' 'Ej,managed by infra' '-m' '-p' '*' 'two222' 
+useradd '--comment' 'Ej,managed by infra' '-m' '-p' '-g' 'infra-users' '*' 'two222' 
 `
 	assert.Equal(t, expected, string(actual))
 }

--- a/internal/linux/users.go
+++ b/internal/linux/users.go
@@ -62,10 +62,10 @@ func isRuneComma(r rune) bool {
 	return r == ','
 }
 
-func AddUser(user *api.User) error {
+func AddUser(user *api.User, group string) error {
 	args := []string{
 		"--comment", fmt.Sprintf("%v,%v", user.ID, sentinelManagedByInfra),
-		"-m", "-p", "*", user.SSHLoginName,
+		"-m", "-p", "-g", group, "*", user.SSHLoginName,
 	}
 	cmd := exec.Command("useradd", args...)
 	cmd.Stdout = logging.L


### PR DESCRIPTION
## Summary

Branched from #3622

Note: this PR sets the default `server.url` for both connectors to `https://api.infrahq.com`

This PR makes three improvements to the ssh connector:
1. Add all the users we create to an `infra-users` group (the name is configurable in the `connector.yaml`). This will allow us to use the following sshd config:

```
Match group infra-users
    AuthorizedKeysFile none
    PasswordAuthentication no
    AuthorizedKeysCommand /usr/sbin/infra sshd auth-keys %u %f
    AuthorizedKeysCommandUser nobody
```

2. Support reading the `HostKey` setting from `/etc/ssh/sshd_config` in case they are configured to a different path. This still doesn't support every option (ex: specifying public keys in this setting).

3. Add validation for config options, so that the user gets a better error message if one is not specified.

TODO:
* [x] support `Include` keyword in the sshd_config, in case `HostKey` is specified somewhere else. 
* [x] more test coverage for parsing the `sshd_config`