### PR TITLE
Add area/destinations/ssh label to github

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -41,6 +41,8 @@
   color: "F9D0C4"
 - name: "area/destinations/kubernetes"
   color: "F9D0C4"
+- name: "area/destinations/ssh"
+  color: "F9D0C4"
 - name: "area/providers"
   color: "F9D0C4"
 - name: "area/providers/okta"

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -19,6 +19,10 @@
 - name: "kind/question"
   color: "D4C5F9"
   description: A request for more information.
+- name: "kind/epic"
+  color: "D4C5F9"
+- name: "kind/security"
+  color: "D4C5F9"
 
 
 - name: "area/documentation"
@@ -75,12 +79,10 @@
 - name: "status/wip"
   color: "dddddd"
   description: The pull request is a work in progress.
-  from_name: "wip"
 
 - name: "status/stale"
   description: Used by actions/stale to mark an issue or PR as stale.
   color: "dddddd"
-  from_name: "Stale"
 - name: "status/never-stale"
   color: "dddddd"
   description: Indicates to actions/stale that the issue or PR should never be marked stale.


### PR DESCRIPTION
## Summary

We manage github labels with this yaml file.

I also added a couple of the missing kind labels, and removed the `from_name` for labels that were already renamed.