### PR TITLE
feat: build for chocolatey

### DIFF
--- a/.github/workflows/cd-binaries.yaml
+++ b/.github/workflows/cd-binaries.yaml
@@ -38,7 +38,12 @@ jobs:
         with:
           go-version: "1.19"
           cache: true
-      - uses: goreleaser/goreleaser-action@v4
+      - run: |
+          mkdir -p /opt/chocolatey
+          curl -fsSL https://github.com/chocolatey/choco/releases/download/1.2.0/chocolatey.v1.2.0.tar.gz | tar xz -C /opt/chocolatey
+          printf '#!/bin/sh\nmono /opt/chocolatey/choco.exe "$@"\n' >/usr/local/bin/choco
+          chmod +x /usr/local/bin/choco
+      - uses: goreleaser/goreleaser-action@v3
         with:
           distribution: goreleaser
           version: latest
@@ -47,6 +52,7 @@ jobs:
           RELEASE_NAME: ${{ needs.prepare.outputs.release-name }}
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
           GEMFURY_TOKEN: ${{ secrets.GORELEASER_GEMFURY_TOKEN }}
+          CHOCOLATEY_API_KEY: ${{ secrets.GORELEASER_CHOCOLATEY_API_KEY }}
       - uses: actions/upload-artifact@v3
         with:
           name: binaries

--- a/.github/workflows/cd-binaries.yaml
+++ b/.github/workflows/cd-binaries.yaml
@@ -1,6 +1,7 @@
 name: cd / binaries
 
 on:
+  pull_request:
   push:
     tags:
       - v*

--- a/.github/workflows/cd-binaries.yaml
+++ b/.github/workflows/cd-binaries.yaml
@@ -26,7 +26,7 @@ jobs:
       - id: release-name
         run: |
           RELEASE_NAME=${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '$(git describe --tags)' }}
-          echo "release-name=${RELEASE_NAME#v}" >>$GITHUB_OUTPUT
+          echo "release-name=$(echo ${RELEASE_NAME#v} | sed 's/-/+/')" >>$GITHUB_OUTPUT
 
   build:
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,6 +101,19 @@ scoop:
   homepage: https://infrahq.com
   description: Infra
   url_template: "https://github.com/infrahq/infra/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+chocolateys:
+  - ids: [zip]
+    owners: Infra Technologies, Inc.
+    authors: Infra Technologies, Inc. <contact@infrahq.com>
+    description: |
+      {{ .ProjectName }} installer. Visit https://docs.infrahq.com to get started.
+    project_url: https://infrahq.com
+    docs_url: https://docs.infrahq.com
+    project_source_url: https://github.com/infrahq/infra
+    bug_tracker_url: https://github.com/infrahq/infra/issues
+    copyright: 2022 Infra Technologies, Inc.
+    license_url: https://github.com/infrahq/infra/blob/main/LICENSE
+    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
 publishers:
   - name: gemfury
     ids: [packages]


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Chocolatey isn't liking the version string created by goreleaser. This shouldn't be a problem for tagged releases but main builds will fail.