### PR TITLE
maintain: change grants api change_by to use lower camel case

### DIFF
--- a/api/grant.go
+++ b/api/grant.go
@@ -13,7 +13,7 @@ type Grant struct {
 	ID uid.ID `json:"id" note:"ID of grant created" example:"3w9XyTrkzk"`
 
 	Created   Time   `json:"created"`
-	CreatedBy uid.ID `json:"created_by" note:"id of the user that created the grant"`
+	CreatedBy uid.ID `json:"createdBy" note:"id of the user that created the grant"`
 	Updated   Time   `json:"updated"`
 
 	User      uid.ID `json:"user,omitempty" note:"UserID for a user being granted access" example:"6hNnjfjVcc"`

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -56,7 +56,7 @@
             "format": "date-time",
             "type": "string"
           },
-          "created_by": {
+          "createdBy": {
             "description": "id of the user that created the grant",
             "example": "4yJ3n3D8E2",
             "format": "uid",
@@ -335,7 +335,7 @@
             "format": "date-time",
             "type": "string"
           },
-          "created_by": {
+          "createdBy": {
             "description": "id of the user that created the grant",
             "example": "4yJ3n3D8E2",
             "format": "uid",
@@ -431,7 +431,7 @@
                   "format": "date-time",
                   "type": "string"
                 },
-                "created_by": {
+                "createdBy": {
                   "description": "id of the user that created the grant",
                   "example": "4yJ3n3D8E2",
                   "format": "uid",

--- a/internal/server/migrations.go
+++ b/internal/server/migrations.go
@@ -92,6 +92,62 @@ func (a *API) addResponseRewrites() {
 			AccessKey:         newResponse.AccessKey,
 		}
 	})
+
+	type grantsV0_18_1 struct {
+		ID        uid.ID   `json:"id"`
+		Created   api.Time `json:"created"`
+		CreatedBy uid.ID   `json:"created_by"`
+		Updated   api.Time `json:"updated"`
+		User      uid.ID   `json:"user,omitempty"`
+		Group     uid.ID   `json:"group,omitempty"`
+		Privilege string   `json:"privilege"`
+		Resource  string   `json:"resource"`
+	}
+	addResponseRewrite(a, http.MethodGet, "/api/grants", "0.18.1", func(newResponse *api.ListResponse[api.Grant]) *api.ListResponse[grantsV0_18_1] {
+		return api.NewListResponse(newResponse.Items, newResponse.PaginationResponse, func(newResponseItem api.Grant) grantsV0_18_1 {
+			return grantsV0_18_1{
+				ID:        newResponseItem.ID,
+				Created:   newResponseItem.Created,
+				CreatedBy: newResponseItem.CreatedBy,
+				Updated:   newResponseItem.Updated,
+				User:      newResponseItem.User,
+				Group:     newResponseItem.Group,
+				Privilege: newResponseItem.Privilege,
+				Resource:  newResponseItem.Resource,
+			}
+		})
+	})
+	addResponseRewrite(a, http.MethodGet, "/api/grants/:id", "0.18.1", func(newResponse *api.Grant) *grantsV0_18_1 {
+		return &grantsV0_18_1{
+			ID:        newResponse.ID,
+			Created:   newResponse.Created,
+			CreatedBy: newResponse.CreatedBy,
+			Updated:   newResponse.Updated,
+			User:      newResponse.User,
+			Group:     newResponse.Group,
+			Privilege: newResponse.Privilege,
+			Resource:  newResponse.Resource,
+		}
+	})
+	type createGrantsV0_18_1 struct {
+		*grantsV0_18_1 `json:",inline"`
+		WasCreated     bool `json:"wasCreated"`
+	}
+	addResponseRewrite(a, http.MethodPost, "/api/grants", "0.18.1", func(newResponse *api.CreateGrantResponse) *createGrantsV0_18_1 {
+		return &createGrantsV0_18_1{
+			grantsV0_18_1: &grantsV0_18_1{
+				ID:        newResponse.ID,
+				Created:   newResponse.Created,
+				CreatedBy: newResponse.CreatedBy,
+				Updated:   newResponse.Updated,
+				User:      newResponse.User,
+				Group:     newResponse.Group,
+				Privilege: newResponse.Privilege,
+				Resource:  newResponse.Resource,
+			},
+			WasCreated: newResponse.WasCreated,
+		}
+	})
 	// all response migrations go here
 }
 


### PR DESCRIPTION
## Summary

The `created_by` field when creating/listing grants should be  in lower camel case (i.e. `createdBy`) similar to each of the other fields.

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


