### PR TITLE
ci: only run -race on main and when there is a label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -90,3 +90,6 @@
 - name: "action/fuzz"
   color: "dddddd"
   description: Run fuzzing on this pull request.
+- name: "action/race"
+  color: "dddddd"
+  description: Enable the Go race detector in subsequent test runs of this pull request.

--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -62,10 +62,14 @@ jobs:
           go-version: "1.19"
           cache: true
       - run: go mod download -x
-      - run: go install gotest.tools/gotestsum@v1.8.0
+      - run: go install gotest.tools/gotestsum@v1.8.2
+
+      - name: Conditionally enable -race
+        if: ${{ github.ref_name == 'main' || contains(github.event.pull_request.labels.*.name, 'action/race') }}
+        run: echo "GO_TEST_RACE=-race" >> $GITHUB_ENV
 
       - name: go test
-        run: ~/go/bin/gotestsum -ftestname -- -race ./...
+        run: ~/go/bin/gotestsum -ftestname -- ${GO_TEST_RACE:-}  ./...
         env:
           POSTGRESQL_CONNECTION: "host=localhost port=5432 user=postgres dbname=postgres password=password123"
 


### PR DESCRIPTION
## Summary

The `-race` flag to `go test` enables the go race detector. The race detector is great for finding bugs, but also adds a lot of runtime to our test run (about 2x). This PR changes our CI so that we only run `-race` on `main` (or when the `actions/race` label is set on the PR). This should speed up test runs in most PRs, and still gives us a reliable way to catch data races.

I'll be testing the config a bit to get the condition right.  