### PR TITLE
Check that all API parameters use camel case

### DIFF
--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -534,10 +534,12 @@ func removeString(seq []string, name string) []string {
 
 func getFieldName(f reflect.StructField, parent reflect.Type) string {
 	if name, ok := f.Tag.Lookup("form"); ok {
+		validateFieldName(name)
 		return name
 	}
 
 	if name, ok := f.Tag.Lookup("uri"); ok {
+		validateFieldName(name)
 		return name
 	}
 
@@ -548,8 +550,21 @@ func getFieldName(f reflect.StructField, parent reflect.Type) string {
 		if name == "-" {
 			return ""
 		}
+		validateFieldName(name)
 		return name
 	}
 
 	panic(fmt.Sprintf("field %q of struct %q must have a tag (json, form, or uri) with a name or '-'", f.Name, parent.Name()))
+}
+
+func validateFieldName(name string) {
+	// temporary allow list
+	switch name {
+	case "unique_id":
+		return
+	}
+
+	if strings.Contains(name, "_") || strings.Contains(name, "-") {
+		panic(fmt.Sprintf("Use camelCase for field name %v", name))
+	}
 }


### PR DESCRIPTION
## Summary

This PR adds some validation to our OpenAPI document generation to catch when we use the wrong form of a parameter name. All our of parameters should use `camelCase` for consistently.

The document generation always runs in CI, so we'll catch this panic as a test failure in dev before merging any PRs.

I added a temporary allow list for the two fields that don't conform to the convention, which we'll remove once they are fixed.

I believe the parameter name always comes from `getFieldName`, so it should be safe to validate it here for now.

Related to #3590, and #3768 
