### PR TITLE
maintain: allow create grants to take usernames

### DIFF
--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -188,7 +188,7 @@ func getGrantFromGrantRequest(c *gin.Context, r api.GrantRequest) (*models.Grant
 			}
 			return nil, err
 		}
-		subject = uid.NewIdentityPolymorphicID(group.ID)
+		subject = uid.NewGroupPolymorphicID(group.ID)
 	case r.User != 0:
 		subject = uid.NewIdentityPolymorphicID(r.User)
 	case r.Group != 0:

--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -83,22 +83,12 @@ func (a *API) GetGrant(c *gin.Context, r *api.Resource) (*api.Grant, error) {
 }
 
 func (a *API) CreateGrant(c *gin.Context, r *api.GrantRequest) (*api.CreateGrantResponse, error) {
-	var subject uid.PolymorphicID
-
-	switch {
-	case r.User != 0:
-		subject = uid.NewIdentityPolymorphicID(r.User)
-	case r.Group != 0:
-		subject = uid.NewGroupPolymorphicID(r.Group)
+	grant, err := getGrantFromGrantRequest(c, *r)
+	if err != nil {
+		return nil, err
 	}
 
-	grant := &models.Grant{
-		Subject:   subject,
-		Resource:  r.Resource,
-		Privilege: r.Privilege,
-	}
-
-	err := access.CreateGrant(c, grant)
+	err = access.CreateGrant(c, grant)
 	var ucerr data.UniqueConstraintError
 
 	if errors.As(err, &ucerr) {

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -940,6 +940,21 @@ func TestAPI_CreateGrant(t *testing.T) {
 	err = data.CreateIdentity(srv.DB(), &someUser)
 	assert.NilError(t, err)
 
+	createGroup := func(t *testing.T, name string, users ...uid.ID) uid.ID {
+		t.Helper()
+		group := &models.Group{Name: name}
+
+		err := data.CreateGroup(srv.DB(), group)
+		assert.NilError(t, err)
+
+		err = data.AddUsersToGroup(srv.DB(), group.ID, users)
+		assert.NilError(t, err)
+
+		return group.ID
+	}
+
+	someGroup := createGroup(t, "awesome-group", someUser.ID)
+
 	supportAdmin := models.Identity{Name: "support-admin@example.com"}
 	err = data.CreateIdentity(srv.DB(), &supportAdmin)
 	assert.NilError(t, err)
@@ -1099,6 +1114,59 @@ func TestAPI_CreateGrant(t *testing.T) {
 				{
 					"code": 400,
 					"message": "bad request: couldn't find userName 'someone@random.org'"
+				}`)
+				actual := jsonUnmarshal(t, resp.Body.String())
+				assert.DeepEqual(t, actual, expected, cmpAPIGrantJSON)
+			},
+		},
+		"success w/ groupname": {
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			body: api.GrantRequest{
+				GroupName: "awesome-group",
+				Privilege: models.InfraViewRole,
+				Resource:  "some-resource",
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusCreated)
+
+				expected := jsonUnmarshal(t, fmt.Sprintf(`
+				{
+					"id": "<any-valid-uid>",
+					"createdBy": "%[1]v",
+					"privilege": "%[2]v",
+					"resource": "some-resource",
+					"group": "%[3]v",
+					"created": "%[4]v",
+					"updated": "%[4]v",
+					"wasCreated": true
+				}`,
+					accessKey.IssuedFor,
+					models.InfraViewRole,
+					someGroup.String(),
+					time.Now().UTC().Format(time.RFC3339),
+				))
+				actual := jsonUnmarshal(t, resp.Body.String())
+				assert.DeepEqual(t, actual, expected, cmpAPIGrantJSON)
+			},
+		},
+		"failure w/ groupname": {
+			setup: func(t *testing.T, req *http.Request) {
+				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
+			},
+			body: api.GrantRequest{
+				GroupName: "fake-group",
+				Privilege: models.InfraAdminRole,
+				Resource:  "random-cluster",
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusBadRequest)
+
+				expected := jsonUnmarshal(t, `
+				{
+					"code": 400,
+					"message": "bad request: couldn't find groupName 'fake-group'"
 				}`)
 				actual := jsonUnmarshal(t, resp.Body.String())
 				assert.DeepEqual(t, actual, expected, cmpAPIGrantJSON)
@@ -1504,7 +1572,7 @@ func TestAPI_UpdateGrants(t *testing.T) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 
 				grantToAdd := models.Grant{
-					Subject:   uid.NewIdentityPolymorphicID(group.ID),
+					Subject:   uid.NewGroupPolymorphicID(group.ID),
 					Privilege: models.InfraAdminRole,
 					Resource:  "another-cluster3",
 				}


### PR DESCRIPTION
## Summary

This change fixes the `POST /api/grants` endpoint to allow it to take a user name for the subject similar to how the `PATCH /api/grants` endpoint works. Currently the endpoint will fail incorrectly with a 500 error.


## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)

