### PR TITLE
fix: index provider user emails with identity ID

### DIFF
--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -80,6 +80,7 @@ func migrations() []*migrator.Migration {
 		updateAccessKeysTimeoutColumn(),
 		addUserPubicKeysTable(),
 		addUserSSHLoginName(),
+		makeIdxEmailsProvidersUnique(),
 		// next one here
 	}
 }
@@ -1035,6 +1036,19 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_user_ssh_login_name ON identities
 				}
 			}
 			return nil
+		},
+	}
+}
+
+func makeIdxEmailsProvidersUnique() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-12-01T11:36",
+		Migrate: func(tx migrator.DB) error {
+			stmt := `
+				DROP INDEX IF EXISTS idx_emails_providers;
+				CREATE UNIQUE INDEX IF NOT EXISTS idx_emails_providers_identities ON provider_users (email, provider_id, identity_id)`
+			_, err := tx.Exec(stmt)
+			return err
 		},
 	}
 }

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -905,6 +905,12 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 				assert.Equal(t, user.OrganizationID, uid.ID(22))
 			},
 		},
+		{
+			label: testCaseLine(makeIdxEmailsProvidersUnique().ID),
+			expected: func(t *testing.T, db WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -347,7 +347,7 @@ CREATE INDEX idx_device_flow_auth_requests_expires_at ON device_flow_auth_reques
 
 CREATE UNIQUE INDEX idx_dfar_user_code ON device_flow_auth_requests USING btree (user_code) WHERE (deleted_at IS NULL);
 
-CREATE UNIQUE INDEX idx_emails_providers ON provider_users USING btree (email, provider_id);
+CREATE UNIQUE INDEX idx_emails_providers_identities ON provider_users USING btree (email, provider_id, identity_id);
 
 CREATE UNIQUE INDEX idx_encryption_keys_key_id ON encryption_keys USING btree (key_id);
 


### PR DESCRIPTION
## Summary
While testing Google social login I found this index can conflict now, due to the Google login not having a provider ID. Updating the index to include the identity ID to make sure it is unique.

This index is only used by SCIM filters.

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades