### PR TITLE
Make destination.UniqueID an optional string in the DB

### DIFF
--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -20,11 +20,11 @@ func (d destinationsTable) Columns() []string {
 }
 
 func (d destinationsTable) Values() []any {
-	return []any{d.ConnectionCA, d.ConnectionURL, d.CreatedAt, d.DeletedAt, d.ID, d.Kind, d.LastSeenAt, d.Name, d.OrganizationID, d.Resources, d.Roles, d.UniqueID, d.UpdatedAt, d.Version}
+	return []any{d.ConnectionCA, d.ConnectionURL, d.CreatedAt, d.DeletedAt, d.ID, d.Kind, d.LastSeenAt, d.Name, d.OrganizationID, d.Resources, d.Roles, (optionalString)(d.UniqueID), d.UpdatedAt, d.Version}
 }
 
 func (d *destinationsTable) ScanFields() []any {
-	return []any{&d.ConnectionCA, &d.ConnectionURL, &d.CreatedAt, &d.DeletedAt, &d.ID, &d.Kind, &d.LastSeenAt, &d.Name, &d.OrganizationID, &d.Resources, &d.Roles, &d.UniqueID, &d.UpdatedAt, &d.Version}
+	return []any{&d.ConnectionCA, &d.ConnectionURL, &d.CreatedAt, &d.DeletedAt, &d.ID, &d.Kind, &d.LastSeenAt, &d.Name, &d.OrganizationID, &d.Resources, &d.Roles, (*optionalString)(&d.UniqueID), &d.UpdatedAt, &d.Version}
 }
 
 func validateDestination(dest *models.Destination) error {

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -74,6 +74,23 @@ func TestCreateDestination(t *testing.T) {
 			expected := UniqueConstraintError{Table: "destinations", Column: "uniqueID"}
 			assert.DeepEqual(t, ucErr, expected)
 		})
+		t.Run("multiple missing uniqueID", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			destination := &models.Destination{
+				Name: "kubernetes",
+				Kind: "kubernetes",
+			}
+			err := CreateDestination(tx, destination)
+			assert.NilError(t, err)
+
+			second := &models.Destination{
+				Name: "dev",
+				Kind: "kubernetes",
+			}
+			err = CreateDestination(tx, second)
+			assert.NilError(t, err)
+		})
 	})
 }
 
@@ -125,6 +142,28 @@ func TestUpdateDestination(t *testing.T) {
 				Version:            "0.100.2",
 			}
 			assert.DeepEqual(t, actual, expected, cmpModel)
+		})
+		t.Run("multiple missing uniqueID", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			destination := &models.Destination{
+				Name: "kubernetes",
+				Kind: "kubernetes",
+			}
+			err := CreateDestination(tx, destination)
+			assert.NilError(t, err)
+
+			second := &models.Destination{
+				Name:     "dev",
+				Kind:     "kubernetes",
+				UniqueID: "something",
+			}
+			err = CreateDestination(tx, second)
+			assert.NilError(t, err)
+
+			second.UniqueID = ""
+			err = UpdateDestination(tx, second)
+			assert.NilError(t, err)
 		})
 	})
 }

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -531,7 +531,7 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 			expected: func(t *testing.T, tx WriteTxn) {
 				stmt := `SELECT id, name, domain FROM organizations`
 				org := &models.Organization{}
-				err := tx.QueryRow(stmt).Scan(&org.ID, &org.Name, (*nullString)(&org.Domain))
+				err := tx.QueryRow(stmt).Scan(&org.ID, &org.Name, (*optionalString)(&org.Domain))
 				assert.NilError(t, err)
 
 				expected := &models.Organization{
@@ -1101,13 +1101,4 @@ func writeSchema(t *testing.T, raw string) {
 	// nolint:gosec
 	err = os.WriteFile("schema.sql", out.Bytes(), 0o644)
 	assert.NilError(t, err)
-}
-
-type nullString string
-
-func (n *nullString) Scan(value any) error {
-	ns := &sql.NullString{}
-	err := ns.Scan(value)
-	*n = nullString(ns.String)
-	return err
 }

--- a/internal/server/data/types.go
+++ b/internal/server/data/types.go
@@ -1,0 +1,36 @@
+package data
+
+import (
+	"database/sql"
+	"database/sql/driver"
+)
+
+// optionalString has the behaviour of sql.NullString. A null entry
+// in a database column is scanned as the empty string, and an empty string
+// is saved as a null. Instead of using sql.NullString as the field,
+// optionalString allows us to wrap a regular string field on a struct.
+// With optionalString you lose the Valid field which identifies if the database
+// had a null or an empty value, but in most cases we don't care about that
+// difference. If you need it, use sql.NullString instead.
+//
+// optionalString should be used when a field is optional. It must be used if there
+// is a unique constraint on the optional field.
+type optionalString string
+
+func (s *optionalString) Scan(value any) error {
+	if value == nil {
+		return nil
+	}
+
+	var ns sql.NullString
+	err := ns.Scan(value)
+	*s = (optionalString)(ns.String)
+	return err
+}
+
+func (s optionalString) Value() (driver.Value, error) {
+	if s == "" {
+		return nil, nil
+	}
+	return string(s), nil
+}


### PR DESCRIPTION
## Summary

@mxyng noticed this problem while trying out SSH destinations.

We previously made destination.UniqueID an optional string in the API, but because we have a unique constraint on this field, only a single destination was able to omit the uniqueID. Currently we are saving an empty string for the value.

This fixes the issue by saving a null in the field. A null omits the row from the index, which prevents the conflict on uniqueID.

We currently have a destination with an empty uniqueID in dev. That destination will either get updated on the next deploy with this change, or we can delete it.

Both of the test cases added here failed before the change.
