### PR TITLE
Fix infra ssh_config

### DIFF
--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -327,7 +327,7 @@ const infraDestinationSSHConfig = `
 
 # This file is managed by Infra. Do not edit!
 
-Match {{ .Hostname }}
+Host {{ .Hostname }}
     IdentityFile ~/.ssh/infra/key
     IdentitiesOnly yes
     UserKnownHostsFile ~/.ssh/infra/known_hosts

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -85,7 +85,7 @@ func TestSSHHostsCmd(t *testing.T) {
 
 # This file is managed by Infra. Do not edit!
 
-Match 127.12.12.1
+Host 127.12.12.1
     IdentityFile ~/.ssh/infra/key
     IdentitiesOnly yes
     UserKnownHostsFile ~/.ssh/infra/known_hosts


### PR DESCRIPTION
The match needs to be either `Match host` or `Host`. I got those mixed up in an earlier commit. I'm not sure how I missed this in manual testing, but apparently I did.

Once the experience has stabalized we'll get some end-to-end tests setup that will coverage the integration with `ssh` and `sshd`.