### PR TITLE
Fix a few problems with local user removal in ssh connector

### DIFF
--- a/internal/connector/testdata/bin/pkill
+++ b/internal/connector/testdata/bin/pkill
@@ -1,3 +1,6 @@
 #!/usr/bin/env sh
 set -eu
 (echo -n "pkill "; printf "'%s' " "$@"; echo) >> ${TEST_CONNECTOR_USER_LOG_FILE}
+
+# user three333 has no processes running
+if [ "$4" = "three333" ]; then exit 1; fi

--- a/internal/connector/testdata/bin/userdel
+++ b/internal/connector/testdata/bin/userdel
@@ -1,3 +1,6 @@
 #!/usr/bin/env sh
 set -eu
 (echo -n "userdel "; printf "'%s' " "$@"; echo) >> ${TEST_CONNECTOR_USER_LOG_FILE}
+
+# simulate failing to remove a user
+if [ "$2" = "failremove" ]; then exit 8; fi

--- a/internal/connector/testdata/localusers-etcpasswd-remove-failed
+++ b/internal/connector/testdata/localusers-etcpasswd-remove-failed
@@ -1,5 +1,5 @@
 root:x:0:0:root:/root:/bin/ash
 adm:x:3:4::/var/adm:/sbin/nologin
+failremove:x:1004:1004:Zs,managed by infra:/home/failremove:/bin/bash
 one111:x:1001:1001:ka,managed by infra:/home/one111:/bin/bash
 three333:x:1003:1003:Zt,managed by infra:/home/three333:/bin/bash
-four444:x:1004:1004:Zs,managed by infra:/home/four444:/bin/bash


### PR DESCRIPTION

## Summary

1. Instead of exiting on the first error, attempt the rest of the operations and collect the error to be returned at the end. This ensures that one user in the wrong state doesn't block the creation and delete of all other users.

2. Ignore exit status 1 from pkill. The user being removed may not be running any processes, so pkill may exit with status 1 and that's ok. In the future we can look to implement this logic in Go, which might give us more granular information about why the operation failed.

3. Kill all processes before removing any users. This may give the processes time to exit before we try to remove the user. Removing the user will fail if they still have processes running. Also use SIGKILL instead of SIGTERM, which should also speed up process exit. With the fixes above it shouldn't be a problem if the `userdel` fails. We'll attempt it again on the next iteration of the reconcile loop.

It's also important to note that removing the user is not strictly necessary to prevent them from logging in. `sshd` does a synchronous check for grants, so a user will be unable to login immediately after the grant is removed, even if the connector has trouble removing the user.