### PR TITLE
Prevent the creation of destinations with name infra

### DIFF
--- a/api/destination.go
+++ b/api/destination.go
@@ -63,6 +63,8 @@ func (r CreateDestinationRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validateDestinationName(r.Name),
 		validate.Required("name", r.Name),
+		validate.ReservedStrings("name", r.Name, []string{"infra"}),
+
 		// Allow "" for versions 0.16.1 and prior
 		// TODO: make this required in the future
 		validate.Enum("kind", r.Kind, []string{"kubernetes", "ssh", ""}),

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -30,7 +30,7 @@ func list(cli *CLI) error {
 		return err
 	}
 
-	user, destinations, grants, err := getUserDestinationGrants(client, "kubernetes")
+	user, destinations, grants, err := getUserDestinationGrants(client, "")
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -54,6 +54,7 @@ func TestListCmd(t *testing.T) {
 	_, err = c.CreateDestination(ctx, &api.CreateDestinationRequest{
 		UniqueID: "space",
 		Name:     "space",
+		Kind:     "kubernetes",
 		Connection: api.DestinationConnection{
 			URL: "http://localhost:10123/",
 			CA:  destinationCA,
@@ -64,6 +65,7 @@ func TestListCmd(t *testing.T) {
 	_, err = c.CreateDestination(ctx, &api.CreateDestinationRequest{
 		UniqueID: "moon",
 		Name:     "moon",
+		Kind:     "ssh",
 		Connection: api.DestinationConnection{
 			URL: "http://localhost:10124/",
 			CA:  destinationCA,

--- a/internal/server/destination_test.go
+++ b/internal/server/destination_test.go
@@ -102,6 +102,30 @@ func TestAPI_CreateDestination(t *testing.T) {
 				assert.DeepEqual(t, respBody.FieldErrors, expected)
 			},
 		},
+		{
+			name: "failed with reserved names",
+			setup: func(t *testing.T) api.CreateDestinationRequest {
+				return api.CreateDestinationRequest{
+					Name: "infra",
+					Connection: api.DestinationConnection{
+						URL: "cluster.production.example",
+						CA:  "the-ca",
+					},
+				}
+			},
+			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, resp.Code, http.StatusBadRequest, resp.Body.String())
+
+				respBody := &api.Error{}
+				err := json.Unmarshal(resp.Body.Bytes(), respBody)
+				assert.NilError(t, err)
+
+				expected := []api.FieldError{
+					{FieldName: "name", Errors: []string{"infra is reserved and can not be used"}},
+				}
+				assert.DeepEqual(t, respBody.FieldErrors, expected)
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

Fixes #3780

Also fixes a small bug in `infra list`, so that it shows destinations of all kinds (not just kubernetes).