### PR TITLE
fix: print the client version in forward error

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -483,7 +483,7 @@ func ServerCompatible(ctx context.Context, client *Client) error {
 		return nil // result inconclusive
 	}
 	if ahead {
-		return fmt.Errorf("client version (%s) is ahead of server version (%s)", apiVersion, srv.Version)
+		return fmt.Errorf("client version (%s) is ahead of server version (%s)", client.Version, srv.Version)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
This was printing the apiVersion rather than the CLI version. Fix to output the client version.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
