### PR TITLE
draft: infra connector --setup=ssh

### DIFF
--- a/internal/cmd/connector.go
+++ b/internal/cmd/connector.go
@@ -14,6 +14,7 @@ import (
 
 func newConnectorCmd() *cobra.Command {
 	var configFilename string
+	options := defaultConnectorOptions()
 
 	cmd := &cobra.Command{
 		Use:    "connector",
@@ -23,7 +24,6 @@ func newConnectorCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			logging.UseServerLogger()
 
-			options := defaultConnectorOptions()
 			err := cliopts.Load(&options, cliopts.Options{
 				Filename:  configFilename,
 				EnvPrefix: "INFRA_CONNECTOR",
@@ -57,6 +57,11 @@ func newConnectorCmd() *cobra.Command {
 					return err
 				}
 			}
+
+			if options.SetupKind != "" {
+				return connector.RunSetup(options)
+			}
+
 			return runConnector(cmd.Context(), options)
 		},
 	}
@@ -68,6 +73,8 @@ func newConnectorCmd() *cobra.Command {
 	cmd.Flags().String("ca-cert", "", "Path to CA certificate file")
 	cmd.Flags().String("ca-key", "", "Path to CA key file")
 	cmd.Flags().Bool("server-skip-tls-verify", false, "Skip verifying server TLS certificates")
+	cmd.Flags().StringVar(&options.SetupKind, "setup", "", "Setup and start the connector")
+	cmd.Flags().Lookup("setup").NoOptDefVal = "ssh"
 
 	return cmd
 }

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -61,6 +61,8 @@ type Options struct {
 
 	SSH SSHOptions
 
+	SetupKind string
+
 	// Kubernetes specific options below here
 	CACert types.StringOrFile
 	CAKey  types.StringOrFile

--- a/internal/connector/setup.go
+++ b/internal/connector/setup.go
@@ -1,0 +1,110 @@
+package connector
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+
+	"golang.org/x/exp/slices"
+	"gopkg.in/yaml.v3"
+
+	"github.com/infrahq/infra/internal/logging"
+)
+
+func RunSetup(opts Options) error {
+	switch opts.SetupKind {
+	case "ssh":
+		opts.Kind = "ssh"
+	default:
+		return fmt.Errorf("unexpected value for setup: %v", opts.SetupKind)
+	}
+
+	if err := validateOptionsSSH(opts); err != nil {
+		// TODO: improve error message
+		return err
+	}
+
+	if _, err := user.LookupGroup(opts.SSH.Group); err != nil {
+		return fmt.Errorf("group %v does not exist, create it or set ssh.group", opts.SSH.Group)
+	}
+
+	if _, err := os.Stat(opts.SSH.SSHDConfigPath); err != nil {
+		return fmt.Errorf("file %v does not exist or is not readable, set ssh.sshd_config_path to the sshd_config used by the ssh server, or run setup with sudo",
+			opts.SSH.SSHDConfigPath)
+	}
+
+	config, err := readSSHDConfig(opts.SSH.SSHDConfigPath, "/etc/ssh")
+	if err != nil {
+		return err
+	}
+
+	keys, err := readSSHHostKeys(config.HostKeys, "/etc/ssh")
+	if err != nil {
+		return err
+	}
+
+	printSSHOptions(opts, keys)
+
+	// TODO: prompt for confirmation? Or do we error earlier if there are problems?
+	filename := "/etc/infra/connector.yaml"
+	if err := writeConfig(opts, filename); err != nil {
+		return err
+	}
+
+	if !slices.Contains(config.Includes, "/etc/ssh/sshd_config.d/*.conf") {
+		logging.L.Warn().Msg(
+			"sshd_config does not have expected wildcard include for /etc/ssh/sshd_config.d/*.conf. " +
+				"You need to include /etc/infra/sshd_config.")
+	} else {
+		fmt.Println("copying infra sshd config to /etc/ssh/sshd_config.d/infra.conf")
+		raw, err := os.ReadFile("/etc/infra/sshd_config")
+		if err != nil {
+			return err
+		}
+
+		err = os.WriteFile("/etc/ssh/sshd_config.d/infra.conf", raw, 0o600)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("\nTesting sshd_config with sshd -t")
+	// TODO: would be nice to use -T -C <user> if we had a user in the right group
+	// TODO: should we inspect the printed config to ensure it's correct?
+	if err := execCmd("sshd", "-t"); err != nil {
+		return fmt.Errorf("sshd config test failed: %w", err)
+	}
+
+	fmt.Println("\nStarting and enabling the infra systemd service")
+	if err := execCmd("systemctl", "start", "infra"); err != nil {
+		return fmt.Errorf("failed to start systemd service: %w", err)
+	}
+	if err := execCmd("systemctl", "enable", "infra"); err != nil {
+		return fmt.Errorf("failed to enable systemd service: %w", err)
+	}
+	return nil
+}
+
+// TODO: include host key filenames
+// TODO: include endpointAddr
+func printSSHOptions(opts Options, keys *hostKeys) {
+	// TODO:
+}
+
+// TODO: how to specify target filename?
+// TODO: how to omit irrelevant sections of the config?
+func writeConfig(opts Options, filename string) error {
+	fh, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	return yaml.NewEncoder(fh).Encode(opts)
+}
+
+func execCmd(command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/connector/ssh_test.go
+++ b/internal/connector/ssh_test.go
@@ -104,9 +104,10 @@ func TestReadSSHHostKeys(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		hostKeys, err := readSSHHostKeys(tc.filenames, tc.dir)
+		actual, err := readSSHHostKeys(tc.filenames, tc.dir)
 		assert.NilError(t, err)
-		assert.DeepEqual(t, hostKeys, tc.expected)
+		assert.DeepEqual(t, actual.Values, tc.expected)
+		// TODO: assert filenames
 	}
 
 	cwd, err := os.Getwd()


### PR DESCRIPTION
## Summary

This is a rough draft of an `infra connector --setup=ssh` command. Still lots of TODOs to resolve, and it's completely untested, but I think the rough structure is there.

TODO:
* [ ] make sure connector.yaml is only readable by root