### PR TITLE
Fix build on windows

### DIFF
--- a/internal/cmd/sshauthkeys.go
+++ b/internal/cmd/sshauthkeys.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	logsyslog "log/syslog"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -60,11 +59,10 @@ func newSSHDAuthKeysCmd(cli *CLI) *cobra.Command {
 
 func setupLogger(cli *CLI) zerolog.Logger {
 	out := []io.Writer{cli.Stderr}
-	// TODO: log to stderr if this fails?
-	syslog, _ := logsyslog.New(logsyslog.LOG_AUTH|logsyslog.LOG_WARNING, "infra-ssh")
-	if syslog != nil {
-		out = append(out, zerolog.SyslogLevelWriter(syslog))
+	if syslog := newSyslogLogger(); syslog != nil {
+		out = append(out, syslog)
 	}
+
 	return zerolog.New(zerolog.MultiLevelWriter(out...))
 }
 

--- a/internal/cmd/sshauthkeys_unix.go
+++ b/internal/cmd/sshauthkeys_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package cmd
+
+import (
+	logsyslog "log/syslog"
+
+	"github.com/rs/zerolog"
+)
+
+func newSyslogLogger() zerolog.LevelWriter {
+	// TODO: log to stderr if this fails?
+	syslog, _ := logsyslog.New(logsyslog.LOG_AUTH|logsyslog.LOG_WARNING, "infra-ssh")
+	if syslog != nil {
+		return zerolog.SyslogLevelWriter(syslog)
+	}
+	return nil
+}

--- a/internal/cmd/sshauthkeys_windows.go
+++ b/internal/cmd/sshauthkeys_windows.go
@@ -1,0 +1,7 @@
+package cmd
+
+import "github.com/rs/zerolog"
+
+func newSyslogLogger() zerolog.LevelWriter {
+	return nil
+}


### PR DESCRIPTION
By putting syslog behind a build flag

Test with this:
```
GOOS=windows go build .
```
It was able to build a windows binary, so I guess this worked.