### PR TITLE
use goreleaser to publish artifacts

### DIFF
--- a/.github/workflows/cd-binaries.yaml
+++ b/.github/workflows/cd-binaries.yaml
@@ -42,53 +42,12 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --skip-publish --snapshot
+          args: release --rm-dist --snapshot ${{ startsWith(github.ref, 'refs/tags/') || '--skip-publish' }}
         env:
           RELEASE_NAME: ${{ needs.prepare.outputs.release-name }}
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GEMFURY_TOKEN: ${{ secrets.GORELEASER_GEMFURY_TOKEN }}
       - uses: actions/upload-artifact@v3
         with:
           name: binaries
           path: dist/
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: [prepare, build]
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: binaries
-      - run: |
-          # fail fast if the release does not exist
-          gh release view v${{ needs.prepare.outputs.release-name }} || exit 1
-          gh release upload v${{ needs.prepare.outputs.release-name }} *.txt *.zip *.deb *.rpm
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-  update-repos:
-    runs-on: ubuntu-latest
-    needs: [prepare, publish]
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    strategy:
-      matrix:
-        repos:
-          - repo: infrahq/homebrew-tap
-            script: update-tap.sh
-            commit-prefix: "Homebrew tap"
-          - repo: infrahq/scoop
-            script: update-scoop.sh
-            commit-prefix: "Scoop"
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          repository: ${{ matrix.repos.repo }}
-          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-      - run: |
-          git config --global user.name infrahq-ci
-          git config --global user.email contact@infrahq.com
-          sh ${{ matrix.repos.script }} ${{ needs.prepare.outputs.release-name }}
-          PACKAGE=$(git status --porcelain | awk '{ print $2 }')
-          git add $PACKAGE
-          git commit -m "${{ matrix.repos.commit-prefix }} update for ${PACKAGE%.*} version ${{ needs.prepare.outputs.release-name }}"
-          git push origin @:refs/heads/main

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,11 +8,12 @@ project_name: infra
 builds:
   - id: infra
     ldflags:
-      - -s -w
-        -X github.com/infrahq/infra/internal.Branch={{ .Branch }}
-        -X github.com/infrahq/infra/internal.Version={{ .Version }}
-        -X github.com/infrahq/infra/internal.Commit={{ .FullCommit }}
-        -X github.com/infrahq/infra/internal.Date={{ .Date }}
+      - -s
+      - -w
+      - -X github.com/infrahq/infra/internal.Branch={{ .Branch }}
+      - -X github.com/infrahq/infra/internal.Version={{ .Version }}
+      - -X github.com/infrahq/infra/internal.Commit={{ .FullCommit }}
+      - -X github.com/infrahq/infra/internal.Date={{ .Date }}
     binary: infra
     main: ./main.go
     goos:
@@ -57,6 +58,39 @@ archives:
       amd64: x86_64
     files:
       - none*
+brews:
+  - tap:
+      owner: infrahq
+      name: homebrew-tap
+    commit_author:
+      name: infra-ci
+      email: contact@infrahq.com
+    homepage: https://infrahq.com
+    description: Infra
+    url_template: "https://github.com/infrahq/infra/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    install: |
+      bin.install "infra"
+      output = Utils.popen_read("#{bin}/infra completion bash")
+      (bash_completion/"infra").write output
+      output = Utils.popen_read("#{bin}/infra completion zsh")
+      (zsh_completion/"_infra").write output
+      output = Utils.popen_read("#{bin}/infra completion fish")
+      (fish_completion/"infra.fish").write output
+scoop:
+  bucket:
+    owner: infrahq
+    name: scoop
+  commit_author:
+    name: infra-ci
+    email: contact@infrahq.com
+  homepage: https://infrahq.com
+  description: Infra
+  url_template: "https://github.com/infrahq/infra/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+publishers:
+  - name: gemfury
+    ids: [packages]
+    dir: "{{ dir .ArtifactPath }}"
+    cmd: curl -F package=@{{ .ArtifactName }} https://{{ .Env.GEMFURY_TOKEN }}@push.fury.io/infrahq/
 checksum:
   name_template: "{{ .ProjectName }}-checksums.txt"
 snapshot:


### PR DESCRIPTION
There will soon be a need to publish more artifact. Replace the custom publishing actions with goreleaser which will also handle the other ways of publishing (AUR, Chocolatey)