### PR TITLE
fix: truncate over limit error to seconds

### DIFF
--- a/internal/server/redis/limit.go
+++ b/internal/server/redis/limit.go
@@ -18,7 +18,7 @@ type OverLimitError struct {
 }
 
 func (e OverLimitError) Error() string {
-	return fmt.Sprintf("over limit; retry after %v", e.RetryAfter)
+	return fmt.Sprintf("over limit; retry after %v", e.RetryAfter.Truncate(time.Second))
 }
 
 type Limiter struct {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

It's not necessary to report sub-second in over limit error