### PR TITLE
fix: print selected login option

### DIFF
--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -87,6 +87,6 @@ func newCLI(ctx context.Context) *CLI {
 	return &CLI{
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Stderr: newStderr(os.Stderr),
 	}
 }

--- a/internal/cmd/cli_unix.go
+++ b/internal/cmd/cli_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"io"
+)
+
+func newStderr(w io.Writer) io.Writer {
+	return w
+}

--- a/internal/cmd/cli_windows.go
+++ b/internal/cmd/cli_windows.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"io"
+
+	"github.com/muesli/termenv"
+)
+
+type ansiConsole struct {
+	io.Writer
+}
+
+func newStderr(w io.Writer) io.Writer {
+	return ansiConsole{w}
+}
+
+func (a ansiConsole) Write(p []byte) (int, error) {
+	mode, err := termenv.EnableWindowsANSIConsole()
+	if err != nil {
+		return 0, err
+	}
+	defer termenv.RestoreWindowsConsole(mode)
+	return a.Writer.Write(p)
+}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -123,6 +123,8 @@ func login(cli *CLI, options loginCmdOptions) error {
 	options.Server = strings.TrimPrefix(options.Server, "https://")
 	options.Server = strings.TrimPrefix(options.Server, "http://")
 
+	fmt.Fprintf(cli.Stderr, "  Logging in to %s\n", termenv.String(options.Server).Bold().String())
+
 	if len(options.TrustedCertificate) == 0 {
 		// Attempt to find a previously trusted certificate
 		for _, hc := range config.Hosts {
@@ -143,6 +145,8 @@ func login(cli *CLI, options loginCmdOptions) error {
 	case options.AccessKey != "":
 		loginReq.AccessKey = options.AccessKey
 	case options.User != "":
+		fmt.Fprintf(cli.Stderr, "  Logging in as user %s\n", termenv.String(options.User).Bold().String())
+
 		if options.Password == "" {
 			if options.NonInteractive {
 				return Error{Message: "Non-interactive login requires setting the INFRA_PASSWORD environment variable"}
@@ -231,7 +235,7 @@ func loginToInfra(cli *CLI, lc loginClient, loginReq *api.LoginRequest, noAgent 
 			return err
 		}
 
-		fmt.Fprintf(os.Stderr, "  Updated password\n")
+		fmt.Fprintf(cli.Stderr, "  Updated password\n")
 	}
 
 	if err := updateInfraConfig(lc, loginRes); err != nil {
@@ -456,8 +460,8 @@ func deviceFlowLogin(ctx context.Context, client *api.Client, cli *CLI) (*api.Lo
 	url := resp.VerificationURI + "?code=" + resp.UserCode
 
 	// display to user
-	cli.Output("Navigate to " + url + " and verify your code:\n")
-	cli.Output("\t\t" + resp.UserCode + "\n")
+	fmt.Fprintf(cli.Stderr, "  Navigate to %s and verify your code:\n\n", termenv.String(url).Underline().String())
+	fmt.Fprintf(cli.Stderr, "\t\t%s\n\n", termenv.String(resp.UserCode).Bold().String())
 
 	// we don't care if this fails. some devices won't be able to open the browser
 	_ = browser.OpenURL(url)

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/opt"
-	"gotest.tools/v3/golden"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/infrahq/infra/api"
@@ -541,6 +540,8 @@ func TestLoginCmd_TLSVerify(t *testing.T) {
 		expected := &ClientConfig{ClientConfigVersion: clientConfigVersion}
 		assert.DeepEqual(t, cfg, expected, cmpopts.EquateEmpty())
 
-		golden.Assert(t, bufs.Stderr.String(), t.Name())
+		assert.Assert(t, strings.Contains(bufs.Stderr.String(), "TLS fingerprint from server does not match the trusted fingerprint."))
+		assert.Assert(t, strings.Contains(bufs.Stderr.String(), "Trusted: BA::D0::FF"))
+		assert.Assert(t, strings.Contains(bufs.Stderr.String(), "Server:  C8:73:E3:27:2C:EA:48:00:FA:40:66:1A:3E:97:D8:59:5E:1F:70:8E:83:9F:79:CF:22:04:C8:64:39:40:5B:73"))
 	})
 }

--- a/internal/cmd/testdata/TestLoginCmd_TLSVerify/login_with_wrong_fingerprint
+++ b/internal/cmd/testdata/TestLoginCmd_TLSVerify/login_with_wrong_fingerprint
@@ -1,5 +1,0 @@
-
-[1mWARNING[0m TLS fingerprint from server does not match the trusted fingerprint.
-
-Trusted: BA::D0::FF
-Server:  C8:73:E3:27:2C:EA:48:00:FA:40:66:1A:3E:97:D8:59:5E:1F:70:8E:83:9F:79:CF:22:04:C8:64:39:40:5B:73


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

With removal of login prompts, it's become confusing when using username and password login options, in particular when set with environment variables. This PR adds a few informational outputs to help the user trace which option is currently being used.

### Device flow (Default)
![image](https://user-images.githubusercontent.com/2372640/206253306-096b548c-499f-43a3-ad30-cca40ef9355d.png)

### User with password prompt
![image](https://user-images.githubusercontent.com/2372640/206253570-d5024075-1b71-46a2-bf58-16ec8a8db9cd.png)

### User with password from env var
![image](https://user-images.githubusercontent.com/2372640/206254676-b30aa180-bb50-4d02-86b7-258a7f701ca0.png)

