### PR TITLE
Improve ssh local key management

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -318,6 +318,10 @@ func (c Client) GetOrganization(ctx context.Context, id uid.ID) (*Organization, 
 	return get[Organization](ctx, c, fmt.Sprintf("/api/organizations/%s", id), Query{})
 }
 
+func (c Client) GetOrganizationSelf(ctx context.Context) (*Organization, error) {
+	return get[Organization](ctx, c, "/api/organizations/self", Query{})
+}
+
 func (c Client) CreateOrganization(ctx context.Context, req *CreateOrganizationRequest) (*Organization, error) {
 	return post[Organization](ctx, c, "/api/organizations", req)
 }

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -158,7 +158,11 @@ func setupDestinationSSHConfig(ctx context.Context, cli *CLI, destination *api.D
 	infraSSHDir := filepath.Join(homeDir, ".ssh/infra")
 	_ = os.MkdirAll(infraSSHDir, 0o700)
 
-	opts, err := defaultClientOpts()
+	hostCfg, err := currentHostConfig()
+	if err != nil {
+		return err
+	}
+	opts, err := apiClientFromHostConfig(hostCfg)
 	if err != nil {
 		return err
 	}
@@ -167,7 +171,19 @@ func setupDestinationSSHConfig(ctx context.Context, cli *CLI, destination *api.D
 		return err
 	}
 
-	if err := provisionSSHKey(ctx, cli, client, infraSSHDir); err != nil {
+	user, err := client.GetUserSelf(ctx)
+	if err != nil {
+		return err
+	}
+
+	keyFilename, err := provisionSSHKey(ctx, provisionSSHKeyOptions{
+		cli:         cli,
+		client:      client,
+		hostConfig:  hostCfg,
+		infraSSHDir: infraSSHDir,
+		user:        user,
+	})
+	if err != nil {
 		return fmt.Errorf("create ssh keypair: %w", err)
 	}
 
@@ -175,64 +191,105 @@ func setupDestinationSSHConfig(ctx context.Context, cli *CLI, destination *api.D
 		return fmt.Errorf("write known hosts: %w", err)
 	}
 
-	user, err := client.GetUserSelf(ctx)
-	if err != nil {
-		return err
-	}
-
-	if err := writeDestinationSSHConfig(infraSSHDir, destination, user); err != nil {
+	if err := writeDestinationSSHConfig(infraSSHDir, destination, user, keyFilename); err != nil {
 		return fmt.Errorf("write infra ssh config: %w", err)
 	}
 	return nil
 }
 
-func provisionSSHKey(ctx context.Context, cli *CLI, client *api.Client, infraSSHDir string) error {
-	keyFilename := filepath.Join(infraSSHDir, "key")
+type provisionSSHKeyOptions struct {
+	cli         *CLI
+	client      *api.Client
+	infraSSHDir string
+	hostConfig  *ClientHostConfig
+	user        *api.User
+}
 
-	// TODO: check expiration
-	// TODO: check the key exists in the API
-	if fileExists(keyFilename) {
-		return nil
+func provisionSSHKey(ctx context.Context, opts provisionSSHKeyOptions) (string, error) {
+	keysCfg, err := readKeysConfig(opts.infraSSHDir)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		keysCfg = &keysConfig{}
+	case err != nil:
+		return "", err
 	}
 
-	fmt.Fprintf(cli.Stderr, "Creating a new RSA 4096 bit key pair in %v\n", keyFilename)
+	org, err := opts.client.GetOrganizationSelf(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	keysDir := filepath.Join(opts.infraSSHDir, "keys")
+	existingKeys := matchingPublicKeys(keysCfg, opts.hostConfig, org.ID)
+	for _, existing := range existingKeys {
+		filename := filepath.Join(keysDir, existing.PublicKeyID)
+		if !fileExists(filename) || !fileExists(filename+".pub") {
+			// key doesn't exist locally
+			continue
+		}
+
+		if userPublicKeyContains(opts.user.PublicKeys, existing.PublicKeyID) {
+			// TODO: check expiration when expiry is added
+			// key exists locally and in the API
+			return filename, nil
+		}
+
+		// key doesn't exist in the API
+		// TODO: delete the local key file, and remove it from keysConfig
+	}
+
+	_ = os.MkdirAll(keysDir, 0o700)
+	fmt.Fprintf(opts.cli.Stderr, "Creating a new RSA 4096 bit key pair in %v\n", keysDir)
 
 	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
-		return fmt.Errorf("generate key pair: %w", err)
+		return "", fmt.Errorf("generate key pair: %w", err)
 	}
 
+	sshPubKey, err := ssh.NewPublicKey(&priv.PublicKey)
+	if err != nil {
+		return "", err
+	}
+
+	pubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+	hostname, _ := os.Hostname()
+	resp, err := opts.client.AddUserPublicKey(ctx, &api.AddUserPublicKeyRequest{
+		Name:      hostname,
+		PublicKey: string(pubKeyBytes),
+	})
+	if err != nil {
+		return "", fmt.Errorf("upload public key: %w", err)
+	}
+
+	keyFilename := filepath.Join(keysDir, resp.ID.String())
 	fh, err := os.OpenFile(keyFilename, os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0o600)
 	if err != nil {
-		return err
+		return "", err
 	}
 	block := &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(priv),
 	}
 	if err := pem.Encode(fh, block); err != nil {
-		return err
+		return "", err
 	}
 	if err := fh.Close(); err != nil {
-		return err
+		return "", err
 	}
-
-	sshPubKey, err := ssh.NewPublicKey(&priv.PublicKey)
-	if err != nil {
-		return err
-	}
-
-	pubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
 	if err := os.WriteFile(keyFilename+".pub", pubKeyBytes, 0o600); err != nil {
-		return err
+		return "", err
 	}
 
-	hostname, _ := os.Hostname()
-	_, err = client.AddUserPublicKey(ctx, &api.AddUserPublicKeyRequest{
-		Name:      hostname,
-		PublicKey: string(pubKeyBytes),
+	keysCfg.Keys = append(keysCfg.Keys, localPublicKey{
+		Server:         opts.hostConfig.Host,
+		OrganizationID: org.ID.String(),
+		UserID:         opts.hostConfig.UserID.String(),
+		PublicKeyID:    resp.ID.String(),
 	})
-	return err
+	if err := writeKeysConfig(opts.infraSSHDir, keysCfg); err != nil {
+		return "", fmt.Errorf("write keys config: %w", err)
+	}
+	return keyFilename, nil
 }
 
 func fileExists(filename string) bool {
@@ -328,7 +385,7 @@ const infraDestinationSSHConfig = `
 # This file is managed by Infra. Do not edit!
 
 Host {{ .Hostname }}
-    IdentityFile ~/.ssh/infra/key
+    IdentityFile {{ .KeyFilename }}
     IdentitiesOnly yes
     UserKnownHostsFile ~/.ssh/infra/known_hosts
     User {{ .Username }}
@@ -369,7 +426,12 @@ func hasInfraMatchLine(sshConfig io.Reader) bool {
 	return false
 }
 
-func writeDestinationSSHConfig(infraSSHDir string, destination *api.Destination, user *api.User) error {
+func writeDestinationSSHConfig(
+	infraSSHDir string,
+	destination *api.Destination,
+	user *api.User,
+	keyFilename string,
+) error {
 	filename := filepath.Join(infraSSHDir, "config")
 	fh, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
@@ -378,9 +440,10 @@ func writeDestinationSSHConfig(infraSSHDir string, destination *api.Destination,
 
 	host, port := splitHostPortSSH(destination.Connection.URL)
 	data := map[string]any{
-		"Username": user.SSHLoginName,
-		"Hostname": host,
-		"Port":     port,
+		"Username":    user.SSHLoginName,
+		"Hostname":    host,
+		"Port":        port,
+		"KeyFilename": keyFilename,
 	}
 	if err := infraDestinationSSHConfigTemplate.Execute(fh, data); err != nil {
 		return err

--- a/internal/cmd/ssh_keys.go
+++ b/internal/cmd/ssh_keys.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/uid"
+)
+
+type keysConfig struct {
+	Keys []localPublicKey
+}
+
+type localPublicKey struct {
+	// Server is the host:port of the Infra API server where this key was
+	// uploaded. This value matches the Host value stored in ClientConfig.
+	Server string
+	// OrganizationID is the organization ID where this key was uploaded.
+	OrganizationID string
+	// UserID is the infra user ID of the user who uploaded this public key.
+	UserID string
+	// PublicKeyID is the Infra ID of the UserPublicKey. It's also used as the
+	// name of the local file which should store the private and public key pair.
+	PublicKeyID string
+}
+
+// readKeysConfig reads ~/.ssh/infra/keys.json and returns the contents.
+func readKeysConfig(infraSSHDir string) (*keysConfig, error) {
+	filename := filepath.Join(infraSSHDir, "keys.json")
+	fh, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close() // read-only file
+
+	result := &keysConfig{}
+	err = json.NewDecoder(fh).Decode(result)
+	return result, err
+}
+
+func writeKeysConfig(infraSSHDir string, cfg *keysConfig) error {
+	filename := filepath.Join(infraSSHDir, "keys.json")
+	fh, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+
+	if err := json.NewEncoder(fh).Encode(cfg); err != nil {
+		_ = fh.Close() // prefer the write error over the close error
+		return err
+	}
+	return fh.Close()
+}
+
+// matchingPublicKeys looks for any keys in cfg that match the hostCfg and OrgID,
+// and returns the list of matching keys. Returns nil if none match.
+func matchingPublicKeys(cfg *keysConfig, hostCfg *ClientHostConfig, orgID uid.ID) []localPublicKey {
+	var result []localPublicKey
+	for _, publicKey := range cfg.Keys {
+		if publicKey.Server != hostCfg.Host || publicKey.UserID != hostCfg.UserID.String() {
+			continue
+		}
+		if publicKey.OrganizationID != orgID.String() {
+			continue
+		}
+		result = append(result, publicKey)
+	}
+	return result
+}
+
+func userPublicKeyContains(keys []api.UserPublicKey, id string) bool {
+	for _, key := range keys {
+		if key.ID.String() == id {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Resolves #3811

Track key pairs in a local file so that when keys are deleted or expire from the API, we can remove the local keys as well. 

This will ensure that when someone runs `ssh` for an infra destination, the Infra CLI will generate a key when necessary, and skip generating a key when one exists.

The logic in `provisionSSHKey` changes so that it uploads to the API first, and then uses the ID in the response as the filename for the key.