### PR TITLE
fix: device flow base domain

### DIFF
--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -45,12 +45,12 @@ retry:
 		return nil, err
 	}
 
-	host := a.server.options.BaseDomain
+	var host string
 	if rctx.Authenticated.Organization != nil {
 		host = rctx.Authenticated.Organization.Domain
 	}
+
 	if host == "" {
-		// Default to the request hostname when in single tenant mode
 		host = rctx.Request.Host
 	}
 


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Device flow should never redirect to the base domain because it's not guaranteed it's valid. Instead, it should default to use the domain from the received request