### PR TITLE
improve: use cli.Stderr consistently

### DIFF
--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -24,7 +24,7 @@ func clientConfig() clientcmd.ClientConfig {
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
 }
 
-func kubernetesSetContext(cluster, namespace string) error {
+func kubernetesSetContext(cli *CLI, cluster, namespace string) error {
 	config := clientConfig()
 
 	kubeConfig, err := config.RawConfig()
@@ -53,7 +53,7 @@ func kubernetesSetContext(cluster, namespace string) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "Switched to context %q.\n", friendlyName)
+	fmt.Fprintf(cli.Stderr, "Switched to context %q.\n", friendlyName)
 	return nil
 }
 

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -40,10 +40,10 @@ $ infra use development.kube-system`,
 			parts := strings.Split(destination, ".")
 
 			if len(parts) == 1 {
-				return kubernetesSetContext(destination, "")
+				return kubernetesSetContext(cli, destination, "")
 			}
 
-			return kubernetesSetContext(parts[0], parts[1])
+			return kubernetesSetContext(cli, parts[0], parts[1])
 		},
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`cli.Stderr` should be used to write additional information to the console. https://github.com/infrahq/infra/pull/3825 adds handling for windows such that it can support ANSI style so it should be used for consistency