### PR TITLE
fix: remove allowed domains

### DIFF
--- a/api/organization.go
+++ b/api/organization.go
@@ -6,12 +6,11 @@ import (
 )
 
 type Organization struct {
-	ID             uid.ID   `json:"id"`
-	Name           string   `json:"name"`
-	Created        Time     `json:"created"`
-	Updated        Time     `json:"updated"`
-	Domain         string   `json:"domain"`
-	AllowedDomains []string `json:"allowedDomains" note:"domains which can be used to login to this organization" example:"['example.com', 'infrahq.com']"`
+	ID      uid.ID `json:"id"`
+	Name    string `json:"name"`
+	Created Time   `json:"created"`
+	Updated Time   `json:"updated"`
+	Domain  string `json:"domain"`
 }
 
 type GetOrganizationRequest struct {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -828,16 +828,6 @@
           "items": {
             "items": {
               "properties": {
-                "allowedDomains": {
-                  "description": "domains which can be used to login to this organization",
-                  "example": "['example.com', 'infrahq.com']",
-                  "items": {
-                    "description": "domains which can be used to login to this organization",
-                    "example": "['example.com', 'infrahq.com']",
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
                 "created": {
                   "description": "formatted as an RFC3339 date-time",
                   "example": "2022-03-14T09:48:00Z",
@@ -1141,16 +1131,6 @@
       },
       "Organization": {
         "properties": {
-          "allowedDomains": {
-            "description": "domains which can be used to login to this organization",
-            "example": "['example.com', 'infrahq.com']",
-            "items": {
-              "description": "domains which can be used to login to this organization",
-              "example": "['example.com', 'infrahq.com']",
-              "type": "string"
-            },
-            "type": "array"
-          },
           "created": {
             "description": "formatted as an RFC3339 date-time",
             "example": "2022-03-14T09:48:00Z",

--- a/internal/server/authn/oidc.go
+++ b/internal/server/authn/oidc.go
@@ -6,11 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/data"
-	"github.com/infrahq/infra/internal/server/email"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/server/providers"
 )
@@ -20,10 +17,9 @@ type oidcAuthn struct {
 	RedirectURL        string
 	Code               string
 	OIDCProviderClient providers.OIDCClient
-	AllowedDomains     []string
 }
 
-func NewOIDCAuthentication(provider *models.Provider, redirectURL string, code string, oidcProviderClient providers.OIDCClient, allowedDomains []string) (LoginMethod, error) {
+func NewOIDCAuthentication(provider *models.Provider, redirectURL string, code string, oidcProviderClient providers.OIDCClient) (LoginMethod, error) {
 	if provider == nil {
 		return nil, fmt.Errorf("nil provider in oidc authentication")
 	}
@@ -32,7 +28,6 @@ func NewOIDCAuthentication(provider *models.Provider, redirectURL string, code s
 		RedirectURL:        redirectURL,
 		Code:               code,
 		OIDCProviderClient: oidcProviderClient,
-		AllowedDomains:     allowedDomains,
 	}, nil
 }
 
@@ -45,25 +40,6 @@ func (a *oidcAuthn) Authenticate(ctx context.Context, db *data.Transaction, requ
 		}
 
 		return AuthenticatedIdentity{}, fmt.Errorf("exhange code for tokens: %w", err)
-	}
-
-	if a.Provider.ID == 0 {
-		// this is a social login, check if they can access this org
-		domain, err := email.Domain(idpAuth.Email)
-		if err != nil {
-			return AuthenticatedIdentity{}, err
-		}
-		if !slices.Contains(a.AllowedDomains, domain) {
-			// check if the user has been added manually
-			_, err := data.GetIdentity(db, data.GetIdentityOptions{ByName: idpAuth.Email})
-			if err != nil {
-				if errors.Is(err, internal.ErrNotFound) {
-					return AuthenticatedIdentity{}, fmt.Errorf("%s is not an allowed email domain or existing user", domain)
-				}
-				// someting else went wrong getting the user
-				return AuthenticatedIdentity{}, fmt.Errorf("check user identity on social oidc login: %w", err)
-			}
-		}
 	}
 
 	identity, err := data.GetIdentity(db, data.GetIdentityOptions{ByName: idpAuth.Email, LoadGroups: true})

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -110,7 +110,6 @@ func (d *DB) Query(query string, args ...any) (*sql.Rows, error) {
 	rows, err := d.DB.Query(query, args...)
 	logQuery(query, err, start, -1)
 	return rows, err
-
 }
 
 func (d *DB) QueryRow(query string, args ...any) *sql.Row {
@@ -267,10 +266,9 @@ func initialize(db *DB) error {
 	switch {
 	case errors.Is(err, internal.ErrNotFound):
 		org = &models.Organization{
-			Model:          models.Model{ID: defaultOrganizationID},
-			Name:           "Default",
-			CreatedBy:      models.CreatedBySystem,
-			AllowedDomains: []string{},
+			Model:     models.Model{ID: defaultOrganizationID},
+			Name:      "Default",
+			CreatedBy: models.CreatedBySystem,
 		}
 		if err := CreateOrganization(tx, org); err != nil {
 			return fmt.Errorf("failed to create default organization: %w", err)

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -81,6 +81,7 @@ func migrations() []*migrator.Migration {
 		addUserPubicKeysTable(),
 		addUserSSHLoginName(),
 		makeIdxEmailsProvidersUnique(),
+		removeAllowedDomainsFromOrganizationsTable(),
 		// next one here
 	}
 }
@@ -1049,6 +1050,19 @@ func makeIdxEmailsProvidersUnique() *migrator.Migration {
 				CREATE UNIQUE INDEX IF NOT EXISTS idx_emails_providers_identities ON provider_users (email, provider_id, identity_id)`
 			_, err := tx.Exec(stmt)
 			return err
+		},
+	}
+}
+
+func removeAllowedDomainsFromOrganizationsTable() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2022-12-07T11:00",
+		Migrate: func(tx migrator.DB) error {
+			stmt := `ALTER TABLE organizations DROP COLUMN IF EXISTS allowed_domains`
+			if _, err := tx.Exec(stmt); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 }

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -911,6 +911,12 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 				// schema changes are tested with schema comparison
 			},
 		},
+		{
+			label: testCaseLine(removeAllowedDomainsFromOrganizationsTable().ID),
+			expected: func(t *testing.T, db WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -16,15 +16,15 @@ func (organizationsTable) Table() string {
 }
 
 func (o organizationsTable) Columns() []string {
-	return []string{"created_at", "created_by", "deleted_at", "domain", "id", "name", "updated_at", "allowed_domains"}
+	return []string{"created_at", "created_by", "deleted_at", "domain", "id", "name", "updated_at"}
 }
 
 func (o organizationsTable) Values() []any {
-	return []any{o.CreatedAt, o.CreatedBy, o.DeletedAt, o.Domain, o.ID, o.Name, o.UpdatedAt, o.AllowedDomains}
+	return []any{o.CreatedAt, o.CreatedBy, o.DeletedAt, o.Domain, o.ID, o.Name, o.UpdatedAt}
 }
 
 func (o *organizationsTable) ScanFields() []any {
-	return []any{&o.CreatedAt, &o.CreatedBy, &o.DeletedAt, &o.Domain, &o.ID, &o.Name, &o.UpdatedAt, &o.AllowedDomains}
+	return []any{&o.CreatedAt, &o.CreatedBy, &o.DeletedAt, &o.Domain, &o.ID, &o.Name, &o.UpdatedAt}
 }
 
 // CreateOrganization creates a new organization, and initializes it with

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -14,10 +14,9 @@ import (
 func TestCreateOrganization(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
 		org := &models.Organization{
-			Name:           "syndicate",
-			Domain:         "syndicate-123",
-			CreatedBy:      777,
-			AllowedDomains: models.CommaSeparatedStrings{"example.com", "infrahq.com"},
+			Name:      "syndicate",
+			Domain:    "syndicate-123",
+			CreatedBy: 777,
 		}
 
 		err := CreateOrganization(db, org)
@@ -34,10 +33,9 @@ func TestCreateOrganization(t *testing.T) {
 				CreatedAt: time.Now(),
 				UpdatedAt: time.Now(),
 			},
-			Name:           "syndicate",
-			Domain:         "syndicate-123",
-			CreatedBy:      777,
-			AllowedDomains: models.CommaSeparatedStrings{"example.com", "infrahq.com"},
+			Name:      "syndicate",
+			Domain:    "syndicate-123",
+			CreatedBy: 777,
 		}
 		assert.DeepEqual(t, expected, actual, cmpModel)
 
@@ -106,14 +104,12 @@ func TestGetOrganization(t *testing.T) {
 		tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 
 		first := &models.Organization{
-			Name:           "first",
-			Domain:         "first.example.com",
-			AllowedDomains: []string{},
+			Name:   "first",
+			Domain: "first.example.com",
 		}
 		deleted := &models.Organization{
-			Name:           "deleted",
-			Domain:         "none.example.com",
-			AllowedDomains: []string{},
+			Name:   "deleted",
+			Domain: "none.example.com",
 		}
 		deleted.DeletedAt.Valid = true
 		deleted.DeletedAt.Time = time.Now()
@@ -157,9 +153,8 @@ func TestUpdateOrganization(t *testing.T) {
 				CreatedAt: past,
 				UpdatedAt: past,
 			},
-			Name:           "second",
-			Domain:         "second.example.com",
-			AllowedDomains: []string{},
+			Name:   "second",
+			Domain: "second.example.com",
 		}
 		err := CreateOrganization(db, org)
 		assert.NilError(t, err)
@@ -168,7 +163,6 @@ func TestUpdateOrganization(t *testing.T) {
 		updated.Domain = "third.example.com"
 		updated.Name = "next"
 		updated.CreatedBy = 7123
-		updated.AllowedDomains = []string{"example.com"}
 
 		err = UpdateOrganization(tx, &updated)
 		assert.NilError(t, err)
@@ -182,10 +176,9 @@ func TestUpdateOrganization(t *testing.T) {
 				CreatedAt: past,
 				UpdatedAt: time.Now(),
 			},
-			Name:           "next",
-			Domain:         "third.example.com",
-			CreatedBy:      7123,
-			AllowedDomains: []string{"example.com"},
+			Name:      "next",
+			Domain:    "third.example.com",
+			CreatedBy: 7123,
 		}
 		assert.DeepEqual(t, expected, actual, cmpModel)
 	})
@@ -196,19 +189,16 @@ func TestListOrganizations(t *testing.T) {
 		tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 
 		first := &models.Organization{
-			Name:           "first",
-			Domain:         "first.example.com",
-			AllowedDomains: []string{},
+			Name:   "first",
+			Domain: "first.example.com",
 		}
 		second := &models.Organization{
-			Name:           "second",
-			Domain:         "second.example.com",
-			AllowedDomains: []string{},
+			Name:   "second",
+			Domain: "second.example.com",
 		}
 		deleted := &models.Organization{
-			Name:           "deleted",
-			Domain:         "none.example.com",
-			AllowedDomains: []string{},
+			Name:   "deleted",
+			Domain: "none.example.com",
 		}
 		deleted.DeletedAt.Valid = true
 		deleted.DeletedAt.Time = time.Now()

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -208,8 +208,7 @@ CREATE TABLE organizations (
     deleted_at timestamp with time zone,
     name text,
     created_by bigint,
-    domain text,
-    allowed_domains text DEFAULT ''::text
+    domain text
 );
 
 CREATE TABLE password_reset_tokens (

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -90,24 +90,13 @@ func (a *API) signup(c *gin.Context, r *api.SignupRequest) (*api.SignupResponse,
 		return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)
 	}
 
-	allowedSocialLoginDomain, err := email.Domain(r.Name)
-	if err != nil {
-		// this should be caught by request validation before we hit this
-		return nil, fmt.Errorf("%w: %s", internal.ErrBadRequest, err)
-	}
-	if allowedSocialLoginDomain == "gmail.com" || allowedSocialLoginDomain == "googlemail.com" {
-		// the admin will have to manually specify this later, default to no allowed domains
-		allowedSocialLoginDomain = ""
-	}
-
 	keyExpires := time.Now().UTC().Add(a.server.options.SessionDuration)
 
 	suDetails := access.SignupDetails{
 		Name:     r.Name,
 		Password: r.Password,
 		Org: &models.Organization{
-			Name:           r.Org.Name,
-			AllowedDomains: []string{allowedSocialLoginDomain},
+			Name: r.Org.Name,
 		},
 		SubDomain: r.Org.Subdomain,
 	}
@@ -227,7 +216,6 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 			r.OIDC.RedirectURL,
 			r.OIDC.Code,
 			providerClient,
-			rCtx.Authenticated.Organization.AllowedDomains,
 		)
 		if err != nil {
 			return nil, err

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -286,18 +285,6 @@ var cmpAnyStringSuffix = gocmp.Comparer(func(x, y interface{}) bool {
 	}
 
 	return xs == ys
-})
-
-// cmpEquateEmptySlice is a gocmp.Option that evalutes any empty slice as equal regardless of their types, then falls back to deep comparison
-var cmpEquateEmptySlice = gocmp.Comparer(func(x, y interface{}) bool {
-	xs, _ := x.([]any)
-	ys, _ := y.([]any)
-
-	if len(xs) == len(ys) {
-		return true
-	}
-
-	return reflect.DeepEqual(xs, ys)
 })
 
 // cmpAnyValidAccessKey is a gocmp.Option that allows a field to match any valid access key

--- a/internal/server/models/organization.go
+++ b/internal/server/models/organization.go
@@ -8,21 +8,19 @@ import (
 type Organization struct {
 	Model
 
-	Name           string
-	Domain         string
-	AllowedDomains CommaSeparatedStrings // the email domains that are allowed to login to this org
+	Name   string
+	Domain string
 
 	CreatedBy uid.ID
 }
 
 func (o *Organization) ToAPI() *api.Organization {
 	return &api.Organization{
-		ID:             o.ID,
-		Name:           o.Name,
-		Created:        api.Time(o.CreatedAt),
-		Updated:        api.Time(o.UpdatedAt),
-		Domain:         o.Domain,
-		AllowedDomains: o.AllowedDomains,
+		ID:      o.ID,
+		Name:    o.Name,
+		Created: api.Time(o.CreatedAt),
+		Updated: api.Time(o.UpdatedAt),
+		Domain:  o.Domain,
 	}
 }
 

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -156,20 +156,17 @@ func TestAPI_GetOrganization(t *testing.T) {
 						"name": "%[2]v",
 						"created": "%[3]v",
 						"updated": "%[3]v",
-						"domain": "%[4]v",
-						"allowedDomains": "%[5]v"
+						"domain": "%[4]v"
 					}`,
 					srv.db.DefaultOrg.ID.String(),
 					srv.db.DefaultOrg.Name,
 					time.Now().UTC().Format(time.RFC3339),
 					srv.db.DefaultOrg.Domain,
-					srv.db.DefaultOrg.AllowedDomains,
 				))
 				actual := jsonUnmarshal(t, resp.Body.String())
 
 				cmpAPIOrganizationJSON := gocmp.Options{
 					gocmp.FilterPath(pathMapKey(`created`, `updated`), cmpApproximateTime),
-					gocmp.FilterPath(pathMapKey(`allowedDomains`), cmpEquateEmptySlice),
 				}
 				assert.DeepEqual(t, actual, expected, cmpAPIOrganizationJSON)
 			},

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -199,7 +199,6 @@ func TestAPI_Signup(t *testing.T) {
 
 				assert.Equal(t, respBody.User.Name, "admin@example.com")
 				assert.Equal(t, respBody.Organization.Name, "acme")
-				assert.DeepEqual(t, respBody.Organization.AllowedDomains, []string{"example.com"})
 				userID := respBody.User.ID
 				orgID := respBody.Organization.ID
 
@@ -265,7 +264,6 @@ func TestAPI_Signup(t *testing.T) {
 
 				assert.Equal(t, respBody.User.Name, "example@gmail.com")
 				assert.Equal(t, respBody.Organization.Name, "acme-goog")
-				assert.DeepEqual(t, respBody.Organization.AllowedDomains, []string{""}) // this is empty by default for gmail
 			},
 		},
 		{
@@ -287,7 +285,6 @@ func TestAPI_Signup(t *testing.T) {
 
 				assert.Equal(t, respBody.User.Name, "example@googlemail.com")
 				assert.Equal(t, respBody.Organization.Name, "acme-googmail")
-				assert.DeepEqual(t, respBody.Organization.AllowedDomains, []string{""}) // this is empty by default for gmail
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
With the current implementation of Google login "allowed domains" are an unnecessary complication. Removing them for now in favor of specifically inviting users, or automatically pulling user information from Google.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3834 
