### PR TITLE
Remove public keys when the user is deleted

### DIFF
--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -648,7 +648,7 @@ func deleteReferencesToIdentities(tx WriteTxn, providerID uid.ID, toDelete []mod
 		if err := DeleteAccessKeys(tx, DeleteAccessKeysOptions{ByIssuedForID: i.ID, ByProviderID: providerID}); err != nil {
 			return nil, fmt.Errorf("delete identity access keys: %w", err)
 		}
-		if err := deleteUserPublicKeys(tx, i.ID); err != nil {
+		if err := DeleteUserPublicKeys(tx, i.ID); err != nil {
 			return nil, fmt.Errorf("delete identity public keys: %w", err)
 		}
 

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -342,7 +342,7 @@ func GetIdentity(tx ReadTxn, opts GetIdentityOptions) (*models.Identity, error) 
 
 	// TODO: use a join?
 	if opts.LoadPublicKeys {
-		identity.PublicKeys, err = userPublicKeys(tx, identity.ID)
+		identity.PublicKeys, err = listUserPublicKeys(tx, identity.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -458,7 +458,7 @@ func ListIdentities(tx ReadTxn, opts ListIdentityOptions) ([]models.Identity, er
 	// TODO: use a join?
 	if opts.LoadPublicKeys {
 		for i, identity := range result {
-			result[i].PublicKeys, err = userPublicKeys(tx, identity.ID)
+			result[i].PublicKeys, err = listUserPublicKeys(tx, identity.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -648,6 +648,10 @@ func deleteReferencesToIdentities(tx WriteTxn, providerID uid.ID, toDelete []mod
 		if err := DeleteAccessKeys(tx, DeleteAccessKeysOptions{ByIssuedForID: i.ID, ByProviderID: providerID}); err != nil {
 			return nil, fmt.Errorf("delete identity access keys: %w", err)
 		}
+		if err := deleteUserPublicKeys(tx, i.ID); err != nil {
+			return nil, fmt.Errorf("delete identity public keys: %w", err)
+		}
+
 		if providerID == InfraProvider(tx).ID {
 			// if an identity does not have credentials in the Infra provider this won't be found, but we can proceed
 			credential, err := GetCredentialByUserID(tx, i.ID)

--- a/internal/server/data/user_public_keys.go
+++ b/internal/server/data/user_public_keys.go
@@ -58,8 +58,8 @@ func AddUserPublicKey(tx WriteTxn, key *models.UserPublicKey) error {
 	return insert(tx, (*userPublicKeysTable)(key))
 }
 
-func deleteUserPublicKeys(tx WriteTxn, userID uid.ID) error {
-	stmt := "UPDATE user_public_keys SET deleted_at = ? WHERE user_id = ?"
+func DeleteUserPublicKeys(tx WriteTxn, userID uid.ID) error {
+	stmt := "UPDATE user_public_keys SET deleted_at = ? WHERE deleted_at is null AND user_id = ?"
 	_, err := tx.Exec(stmt, time.Now(), userID)
 	return handleError(err)
 }

--- a/internal/server/data/user_public_keys.go
+++ b/internal/server/data/user_public_keys.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/internal/server/models"
@@ -26,7 +27,7 @@ func (t *userPublicKeysTable) ScanFields() []any {
 	return []any{&t.CreatedAt, &t.DeletedAt, &t.ExpiresAt, &t.Fingerprint, &t.ID, &t.KeyType, &t.Name, &t.PublicKey, &t.UpdatedAt, &t.UserID}
 }
 
-func userPublicKeys(tx ReadTxn, userID uid.ID) ([]models.UserPublicKey, error) {
+func listUserPublicKeys(tx ReadTxn, userID uid.ID) ([]models.UserPublicKey, error) {
 	table := userPublicKeysTable{}
 	query := querybuilder.New("SELECT")
 	query.B(columnsForSelect(table))
@@ -51,6 +52,14 @@ func AddUserPublicKey(tx WriteTxn, key *models.UserPublicKey) error {
 		return fmt.Errorf("fingerprint is required")
 	case key.KeyType == "":
 		return fmt.Errorf("key type is required")
+	case key.PublicKey == "":
+		return fmt.Errorf("public key is required")
 	}
 	return insert(tx, (*userPublicKeysTable)(key))
+}
+
+func deleteUserPublicKeys(tx WriteTxn, userID uid.ID) error {
+	stmt := "UPDATE user_public_keys SET deleted_at = ? WHERE user_id = ?"
+	_, err := tx.Exec(stmt, time.Now(), userID)
+	return handleError(err)
 }

--- a/internal/server/data/user_public_keys_test.go
+++ b/internal/server/data/user_public_keys_test.go
@@ -22,7 +22,7 @@ func TestListUserPublicKeys(t *testing.T) {
 				UserID:      other.ID,
 				PublicKey:   "the-other-public-key",
 				KeyType:     "ssh-rsa",
-				Fingerprint: "the-fingerprint",
+				Fingerprint: "the-other-fingerprint",
 			}
 			err := AddUserPublicKey(tx, otherKey)
 			assert.NilError(t, err)
@@ -69,8 +69,7 @@ func TestListUserPublicKeys(t *testing.T) {
 
 			actual, err := listUserPublicKeys(tx, user.ID)
 			assert.NilError(t, err)
-			expected := []models.UserPublicKey{}
-			assert.DeepEqual(t, actual, expected)
+			assert.Equal(t, len(actual), 0)
 		})
 	})
 }

--- a/internal/server/data/user_public_keys_test.go
+++ b/internal/server/data/user_public_keys_test.go
@@ -9,36 +9,69 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func TestUserPublicKeys(t *testing.T) {
+func TestListUserPublicKeys(t *testing.T) {
 	runDBTests(t, func(t *testing.T, db *DB) {
-		tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+		t.Run("all", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 
-		user := &models.Identity{Name: "main@example.com"}
-		other := &models.Identity{Name: "other@example.com"}
-		createIdentities(t, tx, user, other)
+			user := &models.Identity{Name: "main@example.com"}
+			other := &models.Identity{Name: "other@example.com"}
+			createIdentities(t, tx, user, other)
 
-		publicKey := &models.UserPublicKey{
-			UserID:      user.ID,
-			PublicKey:   "the-public-key",
-			KeyType:     "ssh-rsa",
-			Fingerprint: "the-fingerprint",
-		}
-		err := AddUserPublicKey(tx, publicKey)
-		assert.NilError(t, err)
+			otherKey := &models.UserPublicKey{
+				UserID:      other.ID,
+				PublicKey:   "the-other-public-key",
+				KeyType:     "ssh-rsa",
+				Fingerprint: "the-fingerprint",
+			}
+			err := AddUserPublicKey(tx, otherKey)
+			assert.NilError(t, err)
 
-		second := &models.UserPublicKey{
-			UserID:      user.ID,
-			PublicKey:   "the-public-key-2",
-			KeyType:     "ssh-rsa",
-			Fingerprint: "the-fingerprint-2",
-		}
-		err = AddUserPublicKey(tx, second)
-		assert.NilError(t, err)
+			publicKey := &models.UserPublicKey{
+				UserID:      user.ID,
+				PublicKey:   "the-public-key",
+				KeyType:     "ssh-rsa",
+				Fingerprint: "the-fingerprint",
+			}
+			err = AddUserPublicKey(tx, publicKey)
+			assert.NilError(t, err)
 
-		actual, err := userPublicKeys(tx, user.ID)
-		assert.NilError(t, err)
-		expected := []models.UserPublicKey{*publicKey, *second}
-		assert.DeepEqual(t, actual, expected, cmpTimeWithDBPrecision)
+			second := &models.UserPublicKey{
+				UserID:      user.ID,
+				PublicKey:   "the-public-key-2",
+				KeyType:     "ssh-rsa",
+				Fingerprint: "the-fingerprint-2",
+			}
+			err = AddUserPublicKey(tx, second)
+			assert.NilError(t, err)
+
+			actual, err := listUserPublicKeys(tx, user.ID)
+			assert.NilError(t, err)
+			expected := []models.UserPublicKey{*publicKey, *second}
+			assert.DeepEqual(t, actual, expected, cmpTimeWithDBPrecision)
+		})
+		t.Run("deleted", func(t *testing.T) {
+			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
+
+			user := &models.Identity{Name: "main@example.com"}
+			createIdentities(t, tx, user)
+
+			publicKey := &models.UserPublicKey{
+				UserID:      user.ID,
+				PublicKey:   "the-public-key",
+				KeyType:     "ssh-rsa",
+				Fingerprint: "the-fingerprint",
+			}
+			err := AddUserPublicKey(tx, publicKey)
+			assert.NilError(t, err)
+
+			assert.NilError(t, DeleteUserPublicKeys(tx, user.ID))
+
+			actual, err := listUserPublicKeys(tx, user.ID)
+			assert.NilError(t, err)
+			expected := []models.UserPublicKey{}
+			assert.DeepEqual(t, actual, expected)
+		})
 	})
 }
 


### PR DESCRIPTION
## Summary

Branched from #3826, this PR fixes two problems:

1. we were never removing a users public keys. Now they are removed when the user is deleted.
2. the test cases in `TestProvisionSSHKey` depended on the previous test cases having run for the count of expected keys. Now that we have a way to delete the keys, the test cases no longer depend on each other.

Also two other small cleanups, renamed a data function to include the word `list` (to match other similar functions), and add a check that a `UserPublicKey` has a non-zero value for the public key before saving it. 