### PR TITLE
Remove gin.Context from handling of cookies

### DIFF
--- a/internal/server/cookie_test.go
+++ b/internal/server/cookie_test.go
@@ -8,16 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"gotest.tools/v3/assert"
-
-	"github.com/infrahq/infra/internal/access"
-	"github.com/infrahq/infra/internal/server/models"
 )
 
 func TestResendAuthCookie(t *testing.T) {
 	baseDomain := "example.com"
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	req := &http.Request{
 		Host:   fmt.Sprintf("dev.%s", baseDomain),
 		Header: make(http.Header),
@@ -33,25 +28,21 @@ func TestResendAuthCookie(t *testing.T) {
 		Secure:   true,
 		HttpOnly: true,
 	})
-	c.Request = req
-	rCtx := access.RequestContext{
-		Request: c.Request,
-		Authenticated: access.Authenticated{
-			AccessKey: &models.AccessKey{
-				ExpiresAt: time.Now().Add(5 * time.Minute),
-			},
-		},
-	}
-	c.Set(access.RequestContextKey, rCtx)
 
-	bearer := exchangeSignupCookieForSession(c, Options{SessionDuration: 1 * time.Minute, BaseDomain: baseDomain})
+	resp := httptest.NewRecorder()
+	bearer := exchangeSignupCookieForSession(
+		req,
+		resp,
+		Options{SessionDuration: 1 * time.Minute, BaseDomain: baseDomain})
 	assert.Equal(t, "aaa", bearer)
+	assert.Equal(t, len(resp.Header()["Set-Cookie"]), 2)
+	cookies := resp.Header()["Set-Cookie"]
 
-	assert.Equal(t, len(c.Writer.Header()["Set-Cookie"]), 2)
-
-	matched, err := regexp.MatchString("auth=aaa; Path=/; Domain=dev.example.com; Max-Age=\\d\\d; HttpOnly; SameSite=Strict", c.Writer.Header()["Set-Cookie"][0])
+	matched, err := regexp.MatchString(
+		"auth=aaa; Path=/; Domain=dev.example.com; Max-Age=\\d\\d; HttpOnly; SameSite=Strict",
+		cookies[0])
 	assert.NilError(t, err)
 	assert.Assert(t, matched)
 
-	assert.Equal(t, "signup=; Path=/; Domain=example.com; Max-Age=0; HttpOnly; Secure", c.Writer.Header()["Set-Cookie"][1])
+	assert.Equal(t, "signup=; Path=/; Domain=example.com; Max-Age=0; HttpOnly; Secure", cookies[1])
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -129,7 +129,7 @@ func (a *API) signup(c *gin.Context, r *api.SignupRequest) (*api.SignupResponse,
 		Domain:  a.server.options.BaseDomain,
 		Expires: time.Now().Add(1 * time.Minute),
 	}
-	setCookie(c, cookie)
+	setCookie(c.Request, c.Writer, cookie)
 
 	a.t.User(identity.ID.String(), r.Name)
 	a.t.Org(suDetails.Org.ID.String(), identity.ID.String(), suDetails.Org.Name, suDetails.Org.Domain)
@@ -264,7 +264,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 		Domain:  c.Request.Host,
 		Expires: result.AccessKey.ExpiresAt,
 	}
-	setCookie(c, cookie)
+	setCookie(c.Request, c.Writer, cookie)
 
 	key := result.AccessKey
 	a.t.User(key.IssuedFor.String(), result.User.Name)
@@ -291,7 +291,7 @@ func (a *API) Logout(c *gin.Context, _ *api.EmptyRequest) (*api.EmptyResponse, e
 		return nil, err
 	}
 
-	deleteCookie(c, cookieAuthorizationName, c.Request.Host)
+	deleteCookie(c.Writer, cookieAuthorizationName, c.Request.Host)
 	return nil, nil
 }
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -274,7 +274,7 @@ func reqBearerToken(c *gin.Context, opts Options) (string, error) {
 		 Signup takes priority over the auth cookie to ensure a new signup always get the correct session.
 		 If this isn't a new org, check for the 'auth' cookie which contains an access key.
 		*/
-		cookie := exchangeSignupCookieForSession(c, opts)
+		cookie := exchangeSignupCookieForSession(c.Request, c.Writer, opts)
 		if cookie == "" {
 			logging.L.Trace().Msg("sign-up cookie not found, falling back to auth cookie")
 


### PR DESCRIPTION
## Summary

Related to #2796

I found this on a stale branch, so thought I'd PR it. We were only using `gin.Context` as a way to get at the stdlib `http.Request` and `http.ResponseWriter`.

We could add `http.ResponseWriter` to our `RequestContext`, but it's used in so few places it might be better to handle it like this as separate args.
