### PR TITLE
Add AuthenticationError to provide an error message in some cases

### DIFF
--- a/internal/server/authn_test.go
+++ b/internal/server/authn_test.go
@@ -38,7 +38,7 @@ func TestServerLimitsAccessWithTemporaryPassword(t *testing.T) {
 	}
 
 	resp1 := tryOtherURL()
-	assert.Equal(t, http.StatusUnauthorized, resp1.Code)
+	assert.Equal(t, http.StatusForbidden, resp1.Code)
 
 	// change password
 	changePassword(t, routes, key, loginResp.UserID, resp.OneTimePassword, "balloons")

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -912,13 +912,13 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 			},
 		},
 		{
-			label: testCaseLine(addDestinationCredentials().ID),
+			label: testCaseLine(deviceFlowAuthRequestsAddUserIDProviderID().ID),
 			expected: func(t *testing.T, db WriteTxn) {
 				// schema changes are tested with schema comparison
 			},
 		},
 		{
-			label: testCaseLine(deviceFlowAuthRequestsAddUserIDProviderID().ID),
+			label: testCaseLine(addDestinationCredentials().ID),
 			expected: func(t *testing.T, db WriteTxn) {
 				// schema changes are tested with schema comparison
 			},

--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -150,7 +150,7 @@ func (a *API) ApproveDeviceFlow(c *gin.Context, req *api.ApproveDeviceFlowReques
 	rctx := getRequestContext(c)
 
 	if !rctx.Authenticated.AccessKey.Scopes.Includes(models.ScopeAllowCreateAccessKey) {
-		return nil, fmt.Errorf("%w: access key missing scope '%s'", internal.ErrUnauthorized, models.ScopeAllowCreateAccessKey)
+		return nil, fmt.Errorf("%w: access key missing scope '%s'", access.ErrNotAuthorized, models.ScopeAllowCreateAccessKey)
 	}
 
 	dfar, err := data.GetDeviceFlowAuthRequest(rctx.DBTxn, data.GetDeviceFlowAuthRequestOptions{ByUserCode: strings.Replace(req.UserCode, "-", "", 1)})

--- a/internal/server/deviceflow_test.go
+++ b/internal/server/deviceflow_test.go
@@ -108,7 +108,7 @@ func TestDeviceFlow(t *testing.T) {
 	resp = request(t, "POST", "http://"+org.Domain+"/api/device/approve", keyNotscoped, api.ApproveDeviceFlowRequest{
 		UserCode: dfResp.UserCode,
 	}, nil)
-	assert.Assert(t, resp.Result().StatusCode == http.StatusUnauthorized, fmt.Sprintf("http status code %d: %s", resp.Result().StatusCode, resp.Body))
+	assert.Equal(t, resp.Result().StatusCode, http.StatusForbidden, (*responseDebug)(resp))
 
 	// approve with scopes
 	resp = request(t, "POST", "http://"+org.Domain+"/api/device/approve", key, api.ApproveDeviceFlowRequest{

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -30,7 +30,6 @@ func sendAPIError(c *gin.Context, err error) {
 
 	var validationError validate.Error
 	var uniqueConstraintError data.UniqueConstraintError
-	var authzError access.AuthorizationError
 	var overLimitError redis.OverLimitError
 	var authnError AuthenticationError
 	var apiError api.Error
@@ -58,9 +57,9 @@ func sendAPIError(c *gin.Context, err error) {
 		// this means the key was once valid, so include some extra details
 		resp.Message = fmt.Sprintf("%s: %s", internal.ErrUnauthorized, err)
 
-	case errors.As(err, &authzError):
+	case errors.Is(err, access.ErrNotAuthorized):
 		resp.Code = http.StatusForbidden
-		resp.Message = authzError.Error()
+		resp.Message = err.Error()
 
 	case errors.As(err, &uniqueConstraintError):
 		*resp = newAPIErrorForUniqueConstraintError(uniqueConstraintError, err.Error())

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -78,6 +78,13 @@ func TestSendAPIError(t *testing.T) {
 			},
 		},
 		{
+			err: fmt.Errorf("wrapped: %w", access.ErrNotAuthorized),
+			result: api.Error{
+				Code:    http.StatusForbidden,
+				Message: "wrapped: not authorized",
+			},
+		},
+		{
 			err:    internal.ErrNotFound,
 			result: api.Error{Code: http.StatusNotFound, Message: "record not found"},
 		},

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -41,6 +41,10 @@ func TestSendAPIError(t *testing.T) {
 			result: api.Error{Code: http.StatusUnauthorized, Message: "unauthorized"},
 		},
 		{
+			err:    AuthenticationError{Message: "this message is ok"},
+			result: api.Error{Code: http.StatusUnauthorized, Message: "this message is ok"},
+		},
+		{
 			err: validate.Error{"fieldname": []string{"is required"}},
 			result: api.Error{
 				Code:    http.StatusBadRequest,

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -208,7 +208,7 @@ func TestRequireAccessKey(t *testing.T) {
 				return r
 			},
 			expected: func(t *testing.T, _ access.Authenticated, err error) {
-				assert.ErrorIs(t, err, data.ErrAccessKeyExpired)
+				assert.Error(t, err, "access key has expired")
 			},
 		},
 		"AccessKeyInvalidKey": {
@@ -266,7 +266,7 @@ func TestRequireAccessKey(t *testing.T) {
 				return r
 			},
 			expected: func(t *testing.T, _ access.Authenticated, err error) {
-				assert.ErrorContains(t, err, "valid token not found in request")
+				assert.ErrorContains(t, err, "authentication is required")
 			},
 		},
 		"EmptyAuthentication": {
@@ -276,7 +276,7 @@ func TestRequireAccessKey(t *testing.T) {
 				return r
 			},
 			expected: func(t *testing.T, _ access.Authenticated, err error) {
-				assert.ErrorContains(t, err, "valid token not found in request")
+				assert.ErrorContains(t, err, "authentication is required")
 			},
 		},
 		"EmptySpaceAuthentication": {
@@ -286,7 +286,7 @@ func TestRequireAccessKey(t *testing.T) {
 				return r
 			},
 			expected: func(t *testing.T, _ access.Authenticated, err error) {
-				assert.ErrorContains(t, err, "valid token not found in request")
+				assert.ErrorContains(t, err, "authentication is required")
 			},
 		},
 		"EmptyCookieAuthentication": {
@@ -306,7 +306,7 @@ func TestRequireAccessKey(t *testing.T) {
 				return r
 			},
 			expected: func(t *testing.T, _ access.Authenticated, err error) {
-				assert.ErrorContains(t, err, "skipped validating empty token")
+				assert.ErrorContains(t, err, "bearer token was missing")
 			},
 		},
 	}

--- a/internal/server/organizations.go
+++ b/internal/server/organizations.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/models"
 )
@@ -29,7 +28,7 @@ func (a *API) GetOrganization(c *gin.Context, r *api.GetOrganizationRequest) (*a
 	if r.ID.IsSelf {
 		iden := access.GetRequestContext(c).Authenticated.Organization
 		if iden == nil {
-			return nil, fmt.Errorf("%w: no user is logged in", internal.ErrUnauthorized)
+			return nil, fmt.Errorf("no authenticated user")
 		}
 		r.ID.ID = iden.ID
 	}

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
@@ -51,7 +50,7 @@ func (a *API) GetUser(c *gin.Context, r *api.GetUserRequest) (*api.User, error) 
 	if r.ID.IsSelf {
 		iden := access.GetRequestContext(c).Authenticated.User
 		if iden == nil {
-			return nil, fmt.Errorf("%w: no user is logged in", internal.ErrUnauthorized)
+			return nil, fmt.Errorf("no authenticated user")
 		}
 		r.ID.ID = iden.ID
 	}


### PR DESCRIPTION
Resolves #3837

This PR  adds `AuthenticationError` to send a bit more detail about authentication failures. In some cases we don't want to provide any information, but in a few cases we can safely provide a bit more information to tell the user why the request failed.

`internal.ErrUnauthorized` will continue to log the real error at `INFO` level and return no information in the response (other than the status code), where as `AuthenticationError` will log at `DEBUG` level (like other API errors), and provide some hard coded error message to the user. The few cases I found that were safe to return more information are:
1. no authentication was provided, we can say "authentication is required"
2. the access key expired, we can say that it was expired, because the key can not be used anymore

In a few cases I changed the error from `401` (not authenticated) to `403` (not authorized), because the error happens after the user was authenticated. In these cases we can safely tell the user why the operation failed, because they have already authenticated themselves.