### PR TITLE
fix: return social login provider for direct identity

### DIFF
--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -418,6 +418,19 @@ func TestDeleteProviders(t *testing.T) {
 			assert.NilError(t, err)
 		})
 
+		t.Run("user is not removed if there are social providerUsers", func(t *testing.T) {
+			tx := setup(t)
+
+			pu, err := CreateProviderUser(tx, &models.Provider{Model: models.Model{ID: models.InternalGoogleProviderID}}, user)
+			assert.NilError(t, err)
+
+			err = DeleteProviders(tx, DeleteProvidersOptions{ByID: providerDevelop.ID})
+			assert.NilError(t, err)
+
+			_, err = GetIdentity(tx, GetIdentityOptions{ByID: pu.IdentityID})
+			assert.NilError(t, err)
+		})
+
 		t.Run("delete in wrong org", func(t *testing.T) {
 			tx := setup(t)
 


### PR DESCRIPTION
- get identity pre-loading providers now returns the google social login provider also

## Summary
When deleting a custom provider if a user existed via a social login also the user was removed. This was because the social login does not exist in the database and was not returned from `GetIdentity`.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged