### PR TITLE
fix: update password requirements

### DIFF
--- a/internal/server/models/settings.go
+++ b/internal/server/models/settings.go
@@ -31,7 +31,7 @@ func (s *Settings) ToAPI() *api.Settings {
 }
 
 func (s *Settings) SetFromAPI(a *api.Settings) {
-	s.LengthMin = a.PasswordRequirements.LowercaseMin
+	s.LengthMin = a.PasswordRequirements.LengthMin
 	s.UppercaseMin = a.PasswordRequirements.UppercaseMin
 	s.LowercaseMin = a.PasswordRequirements.LowercaseMin
 	s.SymbolMin = a.PasswordRequirements.SymbolMin

--- a/internal/server/models/settings_test.go
+++ b/internal/server/models/settings_test.go
@@ -1,0 +1,77 @@
+package models
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+)
+
+func TestSettingsSetFromAPI(t *testing.T) {
+	type testCase struct {
+		api.PasswordRequirements
+		Settings
+	}
+
+	cases := map[string]testCase{
+		"length": {
+			PasswordRequirements: api.PasswordRequirements{
+				LengthMin: 16,
+			},
+			Settings: Settings{
+				LengthMin: 16,
+			},
+		},
+		"lowercase": {
+			PasswordRequirements: api.PasswordRequirements{
+				LowercaseMin: 1,
+			},
+			Settings: Settings{
+				LowercaseMin: 1,
+			},
+		},
+		"uppercase": {
+			PasswordRequirements: api.PasswordRequirements{
+				UppercaseMin: 1,
+			},
+			Settings: Settings{
+				UppercaseMin: 1,
+			},
+		},
+		"number": {
+			PasswordRequirements: api.PasswordRequirements{
+				NumberMin: 1,
+			},
+			Settings: Settings{
+				NumberMin: 1,
+			},
+		},
+		"symbol": {
+			PasswordRequirements: api.PasswordRequirements{
+				SymbolMin: 1,
+			},
+			Settings: Settings{
+				SymbolMin: 1,
+			},
+		},
+		"mixed": {
+			PasswordRequirements: api.PasswordRequirements{
+				LengthMin:    8,
+				LowercaseMin: 1,
+				UppercaseMin: 1,
+			},
+			Settings: Settings{
+				LengthMin:    8,
+				LowercaseMin: 1,
+				UppercaseMin: 1,
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		var actual Settings
+		actual.SetFromAPI(&api.Settings{PasswordRequirements: testCase.PasswordRequirements})
+		assert.DeepEqual(t, actual, testCase.Settings)
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The update password requirements endpoint incorrectly sets minimum length