### PR TITLE
fix: add validation rules to password reqs

### DIFF
--- a/api/settings.go
+++ b/api/settings.go
@@ -1,13 +1,25 @@
 package api
 
+import "github.com/infrahq/infra/internal/validate"
+
 type Settings struct {
 	PasswordRequirements PasswordRequirements `json:"passwordRequirements"`
 }
 
 type PasswordRequirements struct {
-	LowercaseMin int `json:"lowercaseMin"`
-	UppercaseMin int `json:"uppercaseMin"`
-	NumberMin    int `json:"numberMin"`
-	SymbolMin    int `json:"symbolMin"`
-	LengthMin    int `json:"lengthMin"`
+	LengthMin    int `json:"lengthMin" note:"Minimum password length. Must be at least 8 characters."`
+	LowercaseMin int `json:"lowercaseMin" note:"Minimum number of lowercase ASCII letters."`
+	UppercaseMin int `json:"uppercaseMin" note:"Minimum number of uppercase ASCII letters."`
+	NumberMin    int `json:"numberMin" note:"Minimum number of numbers."`
+	SymbolMin    int `json:"symbolMin" note:"Minimum number of symbols."`
+}
+
+func (s Settings) ValidationRules() []validate.ValidationRule {
+	return nil
+}
+
+func (r PasswordRequirements) ValidationRules() []validate.ValidationRule {
+	return []validate.ValidationRule{
+		validate.IntRule{Name: "lengthMin", Value: r.LengthMin, Min: validate.Int(8)},
+	}
 }

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1256,22 +1256,28 @@
           "passwordRequirements": {
             "properties": {
               "lengthMin": {
+                "description": "Minimum password length. Must be at least 8 characters.",
                 "format": "int",
+                "minimum": 8,
                 "type": "integer"
               },
               "lowercaseMin": {
+                "description": "Minimum number of lowercase ASCII letters.",
                 "format": "int",
                 "type": "integer"
               },
               "numberMin": {
+                "description": "Minimum number of numbers.",
                 "format": "int",
                 "type": "integer"
               },
               "symbolMin": {
+                "description": "Minimum number of symbols.",
                 "format": "int",
                 "type": "integer"
               },
               "uppercaseMin": {
+                "description": "Minimum number of uppercase ASCII letters.",
                 "format": "int",
                 "type": "integer"
               }
@@ -6372,22 +6378,28 @@
                   "passwordRequirements": {
                     "properties": {
                       "lengthMin": {
+                        "description": "Minimum password length. Must be at least 8 characters.",
                         "format": "int",
+                        "minimum": 8,
                         "type": "integer"
                       },
                       "lowercaseMin": {
+                        "description": "Minimum number of lowercase ASCII letters.",
                         "format": "int",
                         "type": "integer"
                       },
                       "numberMin": {
+                        "description": "Minimum number of numbers.",
                         "format": "int",
                         "type": "integer"
                       },
                       "symbolMin": {
+                        "description": "Minimum number of symbols.",
                         "format": "int",
                         "type": "integer"
                       },
                       "uppercaseMin": {
+                        "description": "Minimum number of uppercase ASCII letters.",
                         "format": "int",
                         "type": "integer"
                       }

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -3,7 +3,6 @@ package access
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"unicode"
 
 	"github.com/gin-gonic/gin"
@@ -169,10 +168,10 @@ func GetRequestContext(c *gin.Context) RequestContext {
 	return RequestContext{}
 }
 
-// list of valid special chars is from OWASP, wikipedia
-func isValidSymbol(letter rune) bool {
-	match, _ := regexp.MatchString(fmt.Sprintf(`(.*[ !"#$%%&'()*+,-./\:;<=>?@^_{}|~%s%s]){1,}`, regexp.QuoteMeta(`/\[]`), "`"), string(letter))
-	return match
+// list of special charaters from OWASP:
+// https://owasp.org/www-community/password-special-characters
+func isSymbol(r rune) bool {
+	return (r >= '\u0020' && r <= '\u002F') || (r >= '\u003A' && r <= '\u0040') || (r >= '\u005B' && r <= '\u0060') || (r >= '\u007B' && r <= '\u007E')
 }
 
 func hasMinimumCount(min int, password string, check func(rune) bool) bool {
@@ -204,7 +203,7 @@ func checkPasswordRequirements(db data.ReadTxn, password string) error {
 		errs["password"] = append(errs["password"], fmt.Sprintf("needs minimum %d numbers", settings.NumberMin))
 	}
 
-	if !hasMinimumCount(settings.SymbolMin, password, isValidSymbol) {
+	if !hasMinimumCount(settings.SymbolMin, password, isSymbol) {
 		errs["password"] = append(errs["password"], fmt.Sprintf("needs minimum %d symbols", settings.SymbolMin))
 	}
 

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -154,211 +154,26 @@ func TestUpdateCredentials(t *testing.T) {
 	})
 }
 
-func TestLowercaseRequirements(t *testing.T) {
-	result := hasMinimumCount(2, "a", unicode.IsLower)
-	assert.Equal(t, result, false)
+func TestHasMinimumCount(t *testing.T) {
+	assert.Assert(t, !hasMinimumCount(2, "aB1!", unicode.IsLower))
+	assert.Assert(t, !hasMinimumCount(2, "aB1!", unicode.IsUpper))
+	assert.Assert(t, !hasMinimumCount(2, "aB1!", unicode.IsNumber))
+	assert.Assert(t, !hasMinimumCount(2, "aB1!", isSymbol))
 
-	result = hasMinimumCount(2, "A", unicode.IsLower)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "ab", unicode.IsLower)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "AB", unicode.IsLower)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "Ab", unicode.IsLower)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "abc", unicode.IsLower)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "abC", unicode.IsLower)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "AbC", unicode.IsLower)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "aBc", unicode.IsLower)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "", unicode.IsLower)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "!$!@#23", unicode.IsLower)
-	assert.Equal(t, result, false)
+	assert.Assert(t, hasMinimumCount(2, "aaBB11!!", unicode.IsLower))
+	assert.Assert(t, hasMinimumCount(2, "aaBB11!!", unicode.IsUpper))
+	assert.Assert(t, hasMinimumCount(2, "aaBB11!!", unicode.IsNumber))
+	assert.Assert(t, hasMinimumCount(2, "aaBB11!!", isSymbol))
 }
 
-func TestUppercaseRequirements(t *testing.T) {
-	result := hasMinimumCount(2, "a", unicode.IsUpper)
-	assert.Equal(t, result, false)
+func TestIsSymbol(t *testing.T) {
+	symbols := " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+	for _, s := range symbols {
+		assert.Assert(t, isSymbol(s))
+	}
 
-	result = hasMinimumCount(2, "A", unicode.IsUpper)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "ab", unicode.IsUpper)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "AB", unicode.IsUpper)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "Ab", unicode.IsUpper)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "abc", unicode.IsUpper)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "abC", unicode.IsUpper)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "AbC", unicode.IsUpper)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "aBc", unicode.IsUpper)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "", unicode.IsUpper)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "!$!@#23", unicode.IsUpper)
-	assert.Equal(t, result, false)
-}
-
-func TestNumberRequirements(t *testing.T) {
-	result := hasMinimumCount(2, "abc", unicode.IsNumber)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "aBc", unicode.IsNumber)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "", unicode.IsNumber)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "!$!@#", unicode.IsNumber)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "!$!@#23", unicode.IsNumber)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "!$!@#23123", unicode.IsNumber)
-	assert.Equal(t, result, true)
-}
-
-func TestSymbolRequirements(t *testing.T) {
-	result := hasMinimumCount(2, "", isValidSymbol)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "abAB", isValidSymbol)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "abc!", isValidSymbol)
-	assert.Equal(t, result, false)
-
-	result = hasMinimumCount(2, "  ", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "!!", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, `""`, isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, `##`, isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, `$$`, isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, `%%`, isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "&&", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "''", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "((", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "))", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "**", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "++", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, ",,", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "--", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "..", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "))", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "//", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "::", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, ";;", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "<<", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "==", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, ">>", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "??", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "@@", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "^^", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "__", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "{{", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "}}", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "||", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "~~", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, "~~", isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, `//`, isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, `\\`, isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, `[[`, isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, `]]`, isValidSymbol)
-	assert.Equal(t, result, true)
-
-	result = hasMinimumCount(2, `@$%@#ss`, isValidSymbol)
-	assert.Equal(t, result, true)
+	notSymbols := "abcABC123"
+	for _, ns := range notSymbols {
+		assert.Assert(t, !isSymbol(ns))
+	}
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Add basic validation to Settings requests to prevent setting bad password requirements

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [ ] Wrote appropriate unit tests
- [ ] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [ ] Updated associated configuration where necessary
- [ ] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [ ] Nothing sensitive logged
- [ ] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3874 
