### PR TITLE
fix: explicitly output '' when ref is a tag

### DIFF
--- a/.github/workflows/cd-binaries.yaml
+++ b/.github/workflows/cd-binaries.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --snapshot ${{ startsWith(github.ref, 'refs/tags/') || '--skip-publish' }}
+          args: release --rm-dist --snapshot --skip-publish=${{ !startsWith(github.ref, 'refs/tags/') }}
         env:
           RELEASE_NAME: ${{ needs.prepare.outputs.release-name }}
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

The expression outputs the result of the `startsWith` when ref matches a tag which is an invalid input to goreleaser. Instead, set the `--skip-publish` flag explicitly