### PR TITLE
fix: disable snapshot in tag builds

### DIFF
--- a/.github/workflows/cd-binaries.yaml
+++ b/.github/workflows/cd-binaries.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --snapshot --skip-publish=${{ !startsWith(github.ref, 'refs/tags/') }}
+          args: release --rm-dist --snapshot=${{ !startsWith(github.ref, 'refs/tags/') }}
         env:
           RELEASE_NAME: ${{ needs.prepare.outputs.release-name }}
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`--snapshot` enables `--skip-publish`. Without `--snapshot`, the version will be determined by the Git tag