### PR TITLE
Fix a bug in config loading

### DIFF
--- a/internal/cmd/cliopts/flat.go
+++ b/internal/cmd/cliopts/flat.go
@@ -67,6 +67,13 @@ func (w *flatSourceWalker) Exit(loc reflectwalk.Location) error {
 	return nil
 }
 
+func (w *flatSourceWalker) SliceElem(_ int, value reflect.Value) error {
+	if value.Type().Kind() == reflect.Struct || isPtrToStruct(value) {
+		w.location = append(w.location, "")
+	}
+	return nil
+}
+
 func (w *flatSourceWalker) Struct(value reflect.Value) error {
 	if !value.CanAddr() {
 		// TODO: what is this case?
@@ -95,6 +102,10 @@ func (w *flatSourceWalker) StructField(field reflect.StructField, value reflect.
 		w.location = append(w.location, w.fieldNameFormat(field.Name))
 	}
 	return nil
+}
+
+func (w *flatSourceWalker) Slice(reflect.Value) error {
+	return nil // no-op to satisfy an interface
 }
 
 func (w *flatSourceWalker) matchName(key string, fieldName string) bool {


### PR DESCRIPTION
I ran into this problem while working on #3865

A slice of structs was causing the location of the configuration value to be incorrect. There were multiple "exits" which removes the `INFRA_SERVER` item from the location. This resulting in any configuration after a slice of structs to not be loaded.

This bug impacted loading of env variables and command line flags, but only when some values were previously loaded from a config file. Using only a config file, or only env vars would have previously worked.

The test added in this commit was failing before the fix.
