### PR TITLE
improve: password requirements

### DIFF
--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -191,8 +191,8 @@ func checkPasswordRequirements(db data.ReadTxn, password string) error {
 	}
 
 	requirements := []struct {
-		value         int
-		valueFunc     func(rune) bool
+		minCount      int
+		countFunc     func(rune) bool
 		singularError string
 		pluralError   string
 	}{
@@ -207,15 +207,15 @@ func checkPasswordRequirements(db data.ReadTxn, password string) error {
 
 	valid := true
 	for _, r := range requirements {
-		switch {
-		case r.value > 1:
-			requirementError = append(requirementError, fmt.Sprintf(r.pluralError, r.value))
-		case r.value > 0:
-			requirementError = append(requirementError, fmt.Sprintf(r.singularError, r.value))
+		if !hasMinimumCount(password, r.minCount, r.countFunc) {
+			valid = false
 		}
 
-		if !hasMinimumCount(password, r.value, r.valueFunc) {
-			valid = false
+		switch {
+		case r.minCount == 1:
+			requirementError = append(requirementError, fmt.Sprintf(r.singularError, r.minCount))
+		case r.minCount > 1:
+			requirementError = append(requirementError, fmt.Sprintf(r.pluralError, r.minCount))
 		}
 	}
 

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -174,10 +174,10 @@ func isSymbol(r rune) bool {
 	return (r >= '\u0020' && r <= '\u002F') || (r >= '\u003A' && r <= '\u0040') || (r >= '\u005B' && r <= '\u0060') || (r >= '\u007B' && r <= '\u007E')
 }
 
-func hasMinimumCount(min int, password string, check func(rune) bool) bool {
+func hasMinimumCount(password string, min int, minCheck func(rune) bool) bool {
 	var count int
 	for _, r := range password {
-		if check(r) {
+		if minCheck(r) {
 			count++
 		}
 	}
@@ -189,30 +189,38 @@ func checkPasswordRequirements(db data.ReadTxn, password string) error {
 	if err != nil {
 		return err
 	}
-	errs := make(validate.Error)
 
-	if !hasMinimumCount(settings.LowercaseMin, password, unicode.IsLower) {
-		errs["password"] = append(errs["password"], fmt.Sprintf("needs minimum %d lower case letters", settings.LowercaseMin))
+	requirements := []struct {
+		value         int
+		valueFunc     func(rune) bool
+		singularError string
+		pluralError   string
+	}{
+		{settings.LengthMin, func(r rune) bool { return true }, "%d character", "%d characters"},
+		{settings.LowercaseMin, unicode.IsLower, "%d lowercase letter", "%d lowercase letters"},
+		{settings.UppercaseMin, unicode.IsUpper, "%d uppercase letter", "%d uppercase letters"},
+		{settings.NumberMin, unicode.IsDigit, "%d number", "%d numbers"},
+		{settings.SymbolMin, isSymbol, "%d symbol", "%d symbols"},
 	}
 
-	if !hasMinimumCount(settings.UppercaseMin, password, unicode.IsUpper) {
-		errs["password"] = append(errs["password"], fmt.Sprintf("needs minimum %d upper case letters", settings.UppercaseMin))
+	requirementError := make([]string, 0)
+
+	valid := true
+	for _, r := range requirements {
+		switch {
+		case r.value > 1:
+			requirementError = append(requirementError, fmt.Sprintf(r.pluralError, r.value))
+		case r.value > 0:
+			requirementError = append(requirementError, fmt.Sprintf(r.singularError, r.value))
+		}
+
+		if !hasMinimumCount(password, r.value, r.valueFunc) {
+			valid = false
+		}
 	}
 
-	if !hasMinimumCount(settings.NumberMin, password, unicode.IsDigit) {
-		errs["password"] = append(errs["password"], fmt.Sprintf("needs minimum %d numbers", settings.NumberMin))
-	}
-
-	if !hasMinimumCount(settings.SymbolMin, password, isSymbol) {
-		errs["password"] = append(errs["password"], fmt.Sprintf("needs minimum %d symbols", settings.SymbolMin))
-	}
-
-	if len(password) < settings.LengthMin {
-		errs["password"] = append(errs["password"], fmt.Sprintf("needs minimum length of %d", settings.LengthMin))
-	}
-
-	if len(errs["password"]) > 0 {
-		return errs
+	if !valid {
+		return validate.Error{"password": requirementError}
 	}
 
 	return nil

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -8,56 +8,8 @@ import (
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/validate"
 )
-
-func TestSettingsPasswordRequirements(t *testing.T) {
-	c, db, _ := setupAccessTestContext(t)
-
-	username := "bruce@example.com"
-	user := &models.Identity{Name: username}
-	err := data.CreateIdentity(db, user)
-	assert.NilError(t, err)
-
-	_, err = CreateCredential(c, *user)
-	assert.NilError(t, err)
-
-	err = data.UpdateSettings(db, &models.Settings{
-		LengthMin: 8,
-	})
-	assert.NilError(t, err)
-	t.Run("Update user credentials fails if less than min length", func(t *testing.T) {
-		err := UpdateCredential(c, user, "", "short")
-		assert.ErrorContains(t, err, "validation failed: password")
-		assert.ErrorContains(t, err, "needs minimum length of 8")
-	})
-
-	// Test min length success
-	settings, err := data.GetSettings(db)
-	assert.NilError(t, err)
-	settings.LengthMin = 5
-	err = data.UpdateSettings(db, settings)
-	assert.NilError(t, err)
-	t.Run("Update user credentials passes if equal than min length", func(t *testing.T) {
-		err := UpdateCredential(c, user, "", "short")
-		assert.NilError(t, err)
-	})
-	t.Run("Update user credentials passes if equal than min length", func(t *testing.T) {
-		err := UpdateCredential(c, user, "", "longer")
-		assert.NilError(t, err)
-	})
-
-	// Test multiple failures
-	settings.LengthMin = 10
-	settings.SymbolMin = 1
-	err = data.UpdateSettings(db, settings)
-	assert.NilError(t, err)
-	t.Run("Update user credentials fails with multiple requirement failures", func(t *testing.T) {
-		err := UpdateCredential(c, user, "", "badpw")
-		assert.ErrorContains(t, err, "validation failed: password:")
-		assert.ErrorContains(t, err, "needs minimum 1 symbols")
-		assert.ErrorContains(t, err, "needs minimum length of 10")
-	})
-}
 
 func TestCreateCredential(t *testing.T) {
 	c, db, _ := setupAccessTestContext(t)
@@ -155,15 +107,15 @@ func TestUpdateCredentials(t *testing.T) {
 }
 
 func TestHasMinimumCount(t *testing.T) {
-	assert.Assert(t, !hasMinimumCount(2, "aB1!", unicode.IsLower))
-	assert.Assert(t, !hasMinimumCount(2, "aB1!", unicode.IsUpper))
-	assert.Assert(t, !hasMinimumCount(2, "aB1!", unicode.IsNumber))
-	assert.Assert(t, !hasMinimumCount(2, "aB1!", isSymbol))
+	assert.Assert(t, !hasMinimumCount("aB1!", 2, unicode.IsLower))
+	assert.Assert(t, !hasMinimumCount("aB1!", 2, unicode.IsUpper))
+	assert.Assert(t, !hasMinimumCount("aB1!", 2, unicode.IsNumber))
+	assert.Assert(t, !hasMinimumCount("aB1!", 2, isSymbol))
 
-	assert.Assert(t, hasMinimumCount(2, "aaBB11!!", unicode.IsLower))
-	assert.Assert(t, hasMinimumCount(2, "aaBB11!!", unicode.IsUpper))
-	assert.Assert(t, hasMinimumCount(2, "aaBB11!!", unicode.IsNumber))
-	assert.Assert(t, hasMinimumCount(2, "aaBB11!!", isSymbol))
+	assert.Assert(t, hasMinimumCount("aaBB11!!", 2, unicode.IsLower))
+	assert.Assert(t, hasMinimumCount("aaBB11!!", 2, unicode.IsUpper))
+	assert.Assert(t, hasMinimumCount("aaBB11!!", 2, unicode.IsNumber))
+	assert.Assert(t, hasMinimumCount("aaBB11!!", 2, isSymbol))
 }
 
 func TestIsSymbol(t *testing.T) {
@@ -176,4 +128,102 @@ func TestIsSymbol(t *testing.T) {
 	for _, ns := range notSymbols {
 		assert.Assert(t, !isSymbol(ns))
 	}
+}
+
+func TestCheckPasswordRequirements(t *testing.T) {
+	_, db, _ := setupAccessTestContext(t)
+
+	t.Run("default password requirements", func(t *testing.T) {
+		err := checkPasswordRequirements(db, "password")
+		assert.NilError(t, err)
+
+		err = checkPasswordRequirements(db, "passwor")
+		assert.DeepEqual(t, err, validate.Error{
+			"password": []string{"8 characters"},
+		})
+	})
+
+	t.Run("uppercase letter", func(t *testing.T) {
+		settings, err := data.GetSettings(db)
+		assert.NilError(t, err)
+
+		settings.UppercaseMin = 1
+		err = data.UpdateSettings(db, settings)
+		assert.NilError(t, err)
+
+		err = checkPasswordRequirements(db, "password")
+		assert.DeepEqual(t, err, validate.Error{
+			"password": []string{"8 characters", "1 uppercase letter"},
+		})
+	})
+
+	t.Run("number", func(t *testing.T) {
+		settings, err := data.GetSettings(db)
+		assert.NilError(t, err)
+
+		settings.NumberMin = 1
+		err = data.UpdateSettings(db, settings)
+		assert.NilError(t, err)
+
+		err = checkPasswordRequirements(db, "password")
+		assert.DeepEqual(t, err, validate.Error{
+			"password": []string{"8 characters", "1 uppercase letter", "1 number"},
+		})
+	})
+
+	t.Run("symbol", func(t *testing.T) {
+		settings, err := data.GetSettings(db)
+		assert.NilError(t, err)
+
+		settings.SymbolMin = 1
+		err = data.UpdateSettings(db, settings)
+		assert.NilError(t, err)
+
+		err = checkPasswordRequirements(db, "password")
+		assert.DeepEqual(t, err, validate.Error{
+			"password": []string{"8 characters", "1 uppercase letter", "1 number", "1 symbol"},
+		})
+	})
+
+	t.Run("more than 1 uppercase letter", func(t *testing.T) {
+		settings, err := data.GetSettings(db)
+		assert.NilError(t, err)
+
+		settings.UppercaseMin = 2
+		err = data.UpdateSettings(db, settings)
+		assert.NilError(t, err)
+
+		err = checkPasswordRequirements(db, "password")
+		assert.DeepEqual(t, err, validate.Error{
+			"password": []string{"8 characters", "2 uppercase letters", "1 number", "1 symbol"},
+		})
+	})
+
+	t.Run("more than 1 number", func(t *testing.T) {
+		settings, err := data.GetSettings(db)
+		assert.NilError(t, err)
+
+		settings.NumberMin = 2
+		err = data.UpdateSettings(db, settings)
+		assert.NilError(t, err)
+
+		err = checkPasswordRequirements(db, "password")
+		assert.DeepEqual(t, err, validate.Error{
+			"password": []string{"8 characters", "2 uppercase letters", "2 numbers", "1 symbol"},
+		})
+	})
+
+	t.Run("more than 1 symbol", func(t *testing.T) {
+		settings, err := data.GetSettings(db)
+		assert.NilError(t, err)
+
+		settings.SymbolMin = 2
+		err = data.UpdateSettings(db, settings)
+		assert.NilError(t, err)
+
+		err = checkPasswordRequirements(db, "password")
+		assert.DeepEqual(t, err, validate.Error{
+			"password": []string{"8 characters", "2 uppercase letters", "2 numbers", "2 symbols"},
+		})
+	})
 }

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -926,7 +926,7 @@ func TestAPI_UpdateUser(t *testing.T) {
 				assert.NilError(t, err)
 
 				expected := []api.FieldError{
-					{FieldName: "password", Errors: []string{"needs minimum length of 8"}},
+					{FieldName: "password", Errors: []string{"8 characters"}},
 				}
 				assert.DeepEqual(t, respBody.FieldErrors, expected)
 			},

--- a/ui/components/update-password.js
+++ b/ui/components/update-password.js
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 
+import { formatPasswordRequirements } from '../lib/login'
+
 export default function UpdatePassword({ oldPassword, user }) {
   const router = useRouter()
   const { next } = router.query
@@ -33,8 +35,12 @@ export default function UpdatePassword({ oldPassword, user }) {
       if (e.fieldErrors) {
         const errors = {}
         for (const error of e.fieldErrors) {
-          errors[error.fieldName.toLowerCase()] =
-            error.errors[0] || 'invalid value'
+          const fieldName = error.fieldName.toLowerCase()
+          if (fieldName === 'password') {
+            errors[fieldName] = formatPasswordRequirements(error.errors)
+          } else {
+            errors[fieldName] = error.errors[0] || 'invalid value'
+          }
         }
         setErrors(errors)
       } else {

--- a/ui/lib/login.js
+++ b/ui/lib/login.js
@@ -23,5 +23,23 @@ export function currentBaseDomain() {
   if (parts.length > 2) {
     parts.shift() // remove the org
   }
+
   return parts.join('.') // return the domain without the org
+}
+
+export function formatPasswordRequirements(requirements) {
+  return (
+    'needs at least ' +
+    requirements.reduce((value, currentValue, currentIndex) => {
+      return (
+        value +
+        (currentIndex === requirements.length - 1
+          ? requirements.length > 2
+            ? ', and '
+            : ' and '
+          : ', ') +
+        currentValue
+      )
+    })
+  )
 }

--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -441,7 +441,11 @@ function Password() {
             type='password'
             autoComplete='off'
             value={oldPassword}
-            onChange={e => setOldPassword(e.target.value)}
+            onChange={e => {
+              setOldPassword(e.target.value)
+              setErrors({})
+              setError('')
+            }}
             className={`mt-1 block w-full rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm ${
               errors.oldpassword ? 'border-red-500' : 'border-gray-300'
             }`}
@@ -463,7 +467,11 @@ function Password() {
             type='password'
             autoComplete='off'
             value={password}
-            onChange={e => setPassword(e.target.value)}
+            onChange={e => {
+              setPassword(e.target.value)
+              setErrors({})
+              setError('')
+            }}
             className={`mt-1 block w-full rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm ${
               errors.password ? 'border-red-500' : 'border-gray-300'
             }`}
@@ -482,7 +490,11 @@ function Password() {
             type='password'
             autoComplete='off'
             value={confirmPassword}
-            onChange={e => setConfirmPassword(e.target.value)}
+            onChange={e => {
+              setConfirmPassword(e.target.value)
+              setErrors({})
+              setError('')
+            }}
             className={`mt-1 block w-full rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm ${
               errors.confirmPassword ? 'border-red-500' : 'border-gray-300'
             }`}

--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -14,6 +14,7 @@ import { Menu } from '@headlessui/react'
 
 import { useUser } from '../../lib/hooks'
 import { sortBySubject } from '../../lib/grants'
+import { formatPasswordRequirements } from '../../lib/login'
 import Notification from '../../components/notification'
 import GrantForm from '../../components/grant-form'
 import Dashboard from '../../components/layouts/dashboard'
@@ -415,8 +416,12 @@ function Password() {
       if (e.fieldErrors) {
         const errors = {}
         for (const error of e.fieldErrors) {
-          errors[error.fieldName.toLowerCase()] =
-            error.errors[0] || 'invalid value'
+          const fieldName = error.fieldName.toLowerCase()
+          if (fieldName === 'password') {
+            errors[fieldName] = formatPasswordRequirements(error.errors)
+          } else {
+            errors[fieldName] = error.errors[0] || 'invalid value'
+          }
         }
         setErrors(errors)
       } else {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

After an error, enable the "Reset Password" button once field values are updated. Otherwise, the user needs to refresh in order to submit again.

Improve the error returned by a bad password update. The errors were previously nested inside `errors.password` as a list of strings but only the first is being displayed. This is incredibly annoying as a user as the password requirements are displayed one at a time. e.g. if  the organization requires 1 lowercase letter, 1 uppercase letter, and 1 number, only first unmet requirement will be displayed.

The change to the error string first groups all errors into a single string so it can be displayed in the UI. It then populates the error string with all password requirements, not just the unmet requirements so the user knows exactly what is required. The error string also uses the correct form instead of always using the plural form

![image](https://user-images.githubusercontent.com/2372640/208188001-2e7d66b0-7aca-423c-ad9c-bbcd181735f1.png)
