### PR TITLE
Add request timeout to connector API requests

### DIFF
--- a/internal/cmd/sshauthkeys.go
+++ b/internal/cmd/sshauthkeys.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -87,6 +88,7 @@ func runSSHDAuthKeys(cli *CLI, logger zerolog.Logger, opts sshAuthKeysOptions) e
 
 	client := config.APIClient()
 	client.Name = "ssh-auth-keys-cmd"
+	client.HTTP.Timeout = time.Minute
 
 	user, err := verifyUsernameAndFingerprint(ctx, logger, client, opts)
 	if err != nil {


### PR DESCRIPTION
## Summary

@pdevine noticed that when his laptop resumed from suspend, the connector running in a kube pod would often stay in a disconnected state.

I believe the reason for this is a missing request timeout on the HTTP client used by the connector. We have a 1 minute timeout in the CLI, but the connector did not set a timeout.

This PR adds request timeouts to the Infra API operations performed by the connector. `sshd auth-keys` only makes short lived requests, so we can set a 1 minute timeout on the `http.Client` (like we do for other CLI commands).

The connector makes  some blocking requests, so for those calls we have to set a timeout using context. For updating grants I set the timeout to 6 minutes, which gives us 5 minutes to block on updates, and another 2 minutes to update the destination. For updating the destination in the Infra API I used a timeout of 2 minutes for the full operation. It makes more than one API call to both the Kube API and the Infra API, so I think we want to give it more time.

We could alternatively give each API call its own timeout, but I think that's harder to maintain, and doesn't really provide benefit over a single timeout for the full operation.

I don't know of a good way to test this in unit tests, so maybe someone can try this out with suspend to see if it fixes the problem for them.