### PR TITLE
fix: load only social provider if not present elsewhere

### DIFF
--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -337,11 +337,13 @@ func GetIdentity(tx ReadTxn, opts GetIdentityOptions) (*models.Identity, error) 
 				}
 			}
 
-			providers, err := ListProviders(tx, ListProvidersOptions{ByIDs: providerIDs})
-			if err != nil {
-				return nil, fmt.Errorf("list providers for identity: %w", err)
+			if len(providerIDs) > 0 {
+				providers, err := ListProviders(tx, ListProvidersOptions{ByIDs: providerIDs})
+				if err != nil {
+					return nil, fmt.Errorf("list providers for identity: %w", err)
+				}
+				identity.Providers = append(identity.Providers, providers...)
 			}
-			identity.Providers = append(identity.Providers, providers...)
 		}
 	}
 

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -48,8 +48,8 @@ func createIdentities(t *testing.T, db WriteTxn, identities ...*models.Identity)
 			_, err = CreateProviderUser(db, InfraProvider(db), user)
 			assert.NilError(t, err, user.Name)
 		} else {
-			for _, p := range user.Providers {
-				_, err = CreateProviderUser(db, &p, user)
+			for i := range user.Providers {
+				_, err = CreateProviderUser(db, &user.Providers[i], user)
 				assert.NilError(t, err, user.Name)
 			}
 		}

--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -19,6 +19,7 @@ import GrantForm from '../../components/grant-form'
 import Dashboard from '../../components/layouts/dashboard'
 import DeleteModal from '../../components/delete-modal'
 import Table from '../../components/table'
+import { googleSocialLoginID } from '../../lib/providers'
 
 const CREATE_ACCESS_KEY_SCOPE = 'create-key'
 const CONNECTOR_USER = 'connector'
@@ -675,7 +676,7 @@ function Providers() {
       <div className='mt-3 flex min-h-0 flex-1 flex-col'>
         <Table
           href={row => `/settings/providers/${row.original.id}`}
-          data={providers?.filter(p => p.id !== '')} // remove google login provider
+          data={providers?.filter(p => p.id !== googleSocialLoginID)} // remove google login provider
           empty='No providers'
           columns={[
             {


### PR DESCRIPTION
## Summary
Cleaning up two bugs I found while testing session syncing.

1. When updating the Google provider ID I missed omitting from the providers table in the UI.
2. When a user only existed in as a Google social login all providers were returned on their user.

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged