### PR TITLE
fix: check user idp session on device login

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -91,13 +91,13 @@ func TestRequireInfraRole_GrantsFromGroupMembership(t *testing.T) {
 	err := data.CreateIdentity(db, tom)
 	assert.NilError(t, err)
 
-	_, err = data.CreateProviderUser(db, provider, tom)
+	user, err := data.CreateProviderUser(db, provider, tom)
 	assert.NilError(t, err)
 
 	err = data.CreateGroup(db, tomsGroup)
 	assert.NilError(t, err)
 
-	err = data.AssignIdentityToGroups(db, tom, provider, []string{tomsGroup.Name})
+	_, err = data.AssignIdentityToGroups(db, user, []string{tomsGroup.Name})
 	assert.NilError(t, err)
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -1,11 +1,7 @@
 package access
 
 import (
-	"context"
-	"fmt"
-	"net/http"
 	"testing"
-	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -13,7 +9,6 @@ import (
 	"github.com/infrahq/infra/internal/generate"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/internal/server/providers"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -119,131 +114,4 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	group, err = data.GetGroup(db, data.GetGroupOptions{ByID: group.ID})
 	assert.NilError(t, err)
 	assert.Equal(t, group.TotalUsers, 0)
-}
-
-// mockOIDC is a fake oidc identity provider
-type fakeOIDCImplementation struct {
-	UserInfoRevoked bool // when true returns an error fromt the user info endpoint
-}
-
-func (m *fakeOIDCImplementation) Validate(_ context.Context) error {
-	return nil
-}
-
-func (m *fakeOIDCImplementation) AuthServerInfo(_ context.Context) (*providers.AuthServerInfo, error) {
-	return &providers.AuthServerInfo{AuthURL: "example.com/v1/auth", ScopesSupported: []string{"openid", "email"}}, nil
-}
-
-func (m *fakeOIDCImplementation) ExchangeAuthCodeForProviderTokens(_ context.Context, _ string) (*providers.IdentityProviderAuth, error) {
-	return &providers.IdentityProviderAuth{
-		AccessToken:       "acc",
-		RefreshToken:      "ref",
-		AccessTokenExpiry: time.Now().Add(1 * time.Minute),
-		Email:             "hello@example.com",
-	}, nil
-}
-
-func (m *fakeOIDCImplementation) RefreshAccessToken(_ context.Context, providerUser *models.ProviderUser) (accessToken string, expiry *time.Time, err error) {
-	// never update
-	return string(providerUser.AccessToken), &providerUser.ExpiresAt, nil
-}
-
-func (m *fakeOIDCImplementation) GetUserInfo(_ context.Context, _ *models.ProviderUser) (*providers.UserInfoClaims, error) {
-	if m.UserInfoRevoked {
-		return nil, fmt.Errorf("user revoked")
-	}
-	return &providers.UserInfoClaims{}, nil
-}
-
-func TestUpdateIdentityInfoFromProvider(t *testing.T) {
-	// create the identity
-	c, db, infraProvider := setupAccessTestContext(t)
-
-	rCtx := GetRequestContext(c)
-	rCtx.Request = &http.Request{}
-
-	provider := &models.Provider{
-		Name:         "mockta",
-		URL:          "example.com",
-		ClientID:     "aaa",
-		ClientSecret: "bbb",
-		Kind:         models.ProviderKindOIDC,
-	}
-
-	err := data.CreateProvider(db, provider)
-	assert.NilError(t, err)
-
-	google := &models.Provider{
-		Model: models.Model{
-			ID: models.InternalGoogleProviderID,
-		},
-		Name:         "moogle",
-		URL:          "moogle.example.com",
-		ClientID:     "aaa",
-		ClientSecret: "bbb",
-		Kind:         models.ProviderKindGoogle,
-	}
-
-	t.Run("a revoked OIDC session revokes access keys created by provider login", func(t *testing.T) {
-		_, err = data.CreateProviderUser(db, provider, rCtx.Authenticated.User)
-		assert.NilError(t, err)
-		oidc := &fakeOIDCImplementation{UserInfoRevoked: true}
-
-		toBeRevoked := &models.AccessKey{IssuedFor: rCtx.Authenticated.User.ID, ProviderID: provider.ID}
-		_, err := data.CreateAccessKey(db, toBeRevoked)
-		assert.NilError(t, err)
-		shouldStayValid := &models.AccessKey{IssuedFor: rCtx.Authenticated.User.ID, ProviderID: infraProvider.ID}
-		_, err = data.CreateAccessKey(db, shouldStayValid)
-		assert.NilError(t, err)
-
-		rCtx.Authenticated.AccessKey = toBeRevoked
-
-		err = UpdateIdentityInfoFromProvider(rCtx, provider, oidc)
-		assert.ErrorContains(t, err, "user revoked")
-
-		_, err = data.GetAccessKeyByKeyID(db, toBeRevoked.KeyID)
-		assert.ErrorIs(t, err, internal.ErrNotFound)
-
-		_, err = data.GetAccessKeyByKeyID(db, shouldStayValid.KeyID)
-		assert.NilError(t, err)
-	})
-
-	t.Run("a revoked OIDC session revokes access keys created by social login", func(t *testing.T) {
-		_, err = data.CreateProviderUser(db, google, rCtx.Authenticated.User)
-		assert.NilError(t, err)
-		oidc := &fakeOIDCImplementation{UserInfoRevoked: true}
-
-		toBeRevoked := &models.AccessKey{IssuedFor: rCtx.Authenticated.User.ID, ProviderID: google.ID}
-		_, err := data.CreateAccessKey(db, toBeRevoked)
-		assert.NilError(t, err)
-		shouldStayValid := &models.AccessKey{IssuedFor: rCtx.Authenticated.User.ID, ProviderID: infraProvider.ID}
-		_, err = data.CreateAccessKey(db, shouldStayValid)
-		assert.NilError(t, err)
-
-		rCtx.Authenticated.AccessKey = toBeRevoked
-
-		err = UpdateIdentityInfoFromProvider(rCtx, google, oidc)
-		assert.ErrorContains(t, err, "user revoked")
-
-		_, err = data.GetAccessKeyByKeyID(db, toBeRevoked.KeyID)
-		assert.ErrorIs(t, err, internal.ErrNotFound)
-
-		_, err = data.GetAccessKeyByKeyID(db, shouldStayValid.KeyID)
-		assert.NilError(t, err)
-	})
-
-	t.Run("a valid OIDC session does not result in an error", func(t *testing.T) {
-		_, err = data.CreateProviderUser(db, provider, rCtx.Authenticated.User)
-		assert.NilError(t, err)
-		oidc := &fakeOIDCImplementation{}
-
-		key := &models.AccessKey{IssuedFor: rCtx.Authenticated.User.ID, ProviderID: provider.ID}
-		_, err := data.CreateAccessKey(db, key)
-		assert.NilError(t, err)
-
-		rCtx.Authenticated.AccessKey = key
-
-		err = UpdateIdentityInfoFromProvider(rCtx, provider, oidc)
-		assert.NilError(t, err)
-	})
 }

--- a/internal/server/authn/oidc.go
+++ b/internal/server/authn/oidc.go
@@ -94,10 +94,13 @@ func (a *OIDCAuthn) Authenticate(ctx context.Context, db *data.Transaction, requ
 	}
 
 	// update users attributes (such as groups) from the IDP
-	err = data.SyncProviderUser(ctx, db, identity, a.Provider, a.OIDCProviderClient)
+	groups, err := data.SyncProviderUser(ctx, db, providerUser, a.OIDCProviderClient)
 	if err != nil {
 		return AuthenticatedIdentity{}, fmt.Errorf("sync user on login: %w", err)
 	}
+
+	// the groups were set in the database, update the identity we have in memory here
+	identity.Groups = groups
 
 	return AuthenticatedIdentity{
 		Identity:      identity,

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -901,14 +901,15 @@ func TestAssignIdentityToGroups(t *testing.T) {
 				err = UpdateProviderUser(db, pu)
 				assert.NilError(t, err)
 
-				err = AssignIdentityToGroups(db, identity, provider, test.IncomingGroups)
+				result, err := AssignIdentityToGroups(db, pu, test.IncomingGroups)
 				assert.NilError(t, err)
 
-				// check the result
-				actual, err := ListGroups(db, ListGroupsOptions{ByGroupMember: identity.ID})
-				assert.NilError(t, err)
+				assert.DeepEqual(t, result, test.ExpectedGroups, cmpModelsGroupShallow)
 
-				assert.DeepEqual(t, actual, test.ExpectedGroups, cmpModelsGroupShallow)
+				// check the persisted result
+				persisted, err := ListGroups(db, ListGroupsOptions{ByGroupMember: identity.ID})
+				assert.NilError(t, err)
+				assert.DeepEqual(t, persisted, test.ExpectedGroups, cmpModelsGroupShallow)
 			})
 		}
 	})

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -259,6 +259,7 @@ func GetProviderUser(tx ReadTxn, providerID, identityID uid.ID) (*models.Provide
 	query.B(columnsForSelect(pu))
 	query.B("FROM")
 	query.B(pu.Table())
+	query.B("LEFT OUTER JOIN providers ON provider_users.provider_id = providers.id AND providers.organization_id = ?", tx.OrganizationID())
 	query.B("WHERE provider_id = ? and identity_id = ?", providerID, identityID)
 	err := tx.QueryRow(query.String(), query.Args...).Scan(pu.ScanFields()...)
 	if err != nil {
@@ -296,40 +297,31 @@ func ProvisionProviderUser(tx WriteTxn, user *models.ProviderUser) error {
 	return insert(tx, (*providerUserTable)(user))
 }
 
-func SyncProviderUser(ctx context.Context, tx WriteTxn, user *models.Identity, provider *models.Provider, oidcClient providers.OIDCClient) error {
-	providerUser, err := GetProviderUser(tx, provider.ID, user.ID)
+func SyncProviderUser(ctx context.Context, tx WriteTxn, user *models.ProviderUser, oidcClient providers.OIDCClient) ([]models.Group, error) {
+	accessToken, expiry, err := oidcClient.RefreshAccessToken(ctx, user)
 	if err != nil {
-		return err
-	}
-
-	accessToken, expiry, err := oidcClient.RefreshAccessToken(ctx, providerUser)
-	if err != nil {
-		return fmt.Errorf("refresh provider access: %w", err)
+		return nil, fmt.Errorf("refresh provider access: %w", err)
 	}
 
 	// update the stored access token if it was refreshed
-	if accessToken != string(providerUser.AccessToken) {
-		logging.Debugf("access token for user at provider %s was refreshed", providerUser.ProviderID)
+	if accessToken != string(user.AccessToken) {
+		logging.Debugf("access token for user at provider %s was refreshed", user.ProviderID)
 
-		providerUser.AccessToken = models.EncryptedAtRest(accessToken)
-		providerUser.ExpiresAt = *expiry
+		user.AccessToken = models.EncryptedAtRest(accessToken)
+		user.ExpiresAt = *expiry
 
-		err = UpdateProviderUser(tx, providerUser)
+		err = UpdateProviderUser(tx, user)
 		if err != nil {
-			return fmt.Errorf("update provider user on sync: %w", err)
+			return nil, fmt.Errorf("update provider user on sync: %w", err)
 		}
 	}
 
-	info, err := oidcClient.GetUserInfo(ctx, providerUser)
+	info, err := oidcClient.GetUserInfo(ctx, user)
 	if err != nil {
-		return fmt.Errorf("oidc user sync failed: %w", err)
+		return nil, fmt.Errorf("oidc user sync failed: %w", err)
 	}
 
-	if err := AssignIdentityToGroups(tx, user, provider, info.Groups); err != nil {
-		return fmt.Errorf("assign identity to groups: %w", err)
-	}
-
-	return nil
+	return AssignIdentityToGroups(tx, user, info.Groups)
 }
 
 type SCIMParameters struct {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"database/sql"
 	"encoding/base64"
 	"errors"
@@ -15,11 +14,9 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
-	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/authn"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/internal/server/providers"
 	"github.com/infrahq/infra/internal/server/redis"
 )
 
@@ -35,11 +32,6 @@ func (a *API) CreateToken(c *gin.Context, r *api.EmptyRequest) (*api.CreateToken
 
 	if rCtx.Authenticated.User == nil {
 		return nil, fmt.Errorf("no authenticated user")
-	}
-	err := a.UpdateIdentityInfoFromProvider(rCtx)
-	if err != nil {
-		// this will fail if the user was removed from the IDP, which means they no longer are a valid user
-		return nil, fmt.Errorf("%w: failed to update identity info from provider: %s", internal.ErrUnauthorized, err)
 	}
 	token, err := data.CreateIdentityToken(rCtx.DBTxn, rCtx.Authenticated.User.ID)
 	if err != nil {
@@ -123,7 +115,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 			}
 		}
 
-		providerClient, err := a.providerClient(c, provider, r.OIDC.RedirectURL)
+		providerClient, err := a.server.providerClient(c, provider, r.OIDC.RedirectURL)
 		if err != nil {
 			return nil, fmt.Errorf("login provider client: %w", err)
 		}
@@ -209,53 +201,4 @@ func (a *API) Logout(c *gin.Context, _ *api.EmptyRequest) (*api.EmptyResponse, e
 
 func (a *API) Version(c *gin.Context, r *api.EmptyRequest) (*api.Version, error) {
 	return &api.Version{Version: internal.FullVersion()}, nil
-}
-
-// UpdateIdentityInfoFromProvider calls the identity provider used to authenticate this user session to update their current information
-func (a *API) UpdateIdentityInfoFromProvider(rCtx access.RequestContext) error {
-	// does not need access check, this action is limited to the calling user
-	identity := rCtx.Authenticated.User
-	if identity == nil {
-		return errors.New("user does not have session with an identity provider")
-	}
-
-	var provider *models.Provider
-	if a.server.Google != nil && rCtx.Authenticated.AccessKey.ProviderID == a.server.Google.ID {
-		provider = a.server.Google
-	} else {
-		var err error
-		provider, err = data.GetProvider(rCtx.DBTxn, data.GetProviderOptions{
-			ByID: rCtx.Authenticated.AccessKey.ProviderID,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to get provider for user info: %w", err)
-		}
-
-		if provider.Kind == models.ProviderKindInfra {
-			// no external verification needed
-			logging.L.Trace().Msg("skipped verifying identity within infra provider, not required")
-			return nil
-		}
-	}
-
-	providerUser, err := data.GetProviderUser(rCtx.DBTxn, rCtx.Authenticated.AccessKey.ProviderID, identity.ID)
-	if err != nil {
-		return fmt.Errorf("failed to get provider user to update: %w", err)
-	}
-
-	oidc, err := a.providerClient(rCtx.Request.Context(), provider, providerUser.RedirectURL)
-	if err != nil {
-		return fmt.Errorf("update provider client: %w", err)
-	}
-
-	return access.UpdateIdentityInfoFromProvider(rCtx, provider, oidc)
-}
-
-func (a *API) providerClient(ctx context.Context, provider *models.Provider, redirectURL string) (providers.OIDCClient, error) {
-	if c := providers.OIDCClientFromContext(ctx); c != nil {
-		// oidc is added to the context during unit tests
-		return c, nil
-	}
-
-	return providers.NewOIDCClient(*provider, string(provider.ClientSecret), redirectURL), nil
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -27,7 +27,12 @@ type API struct {
 	openAPIDoc openapi3.T
 }
 
-func (a *API) CreateToken(c *gin.Context, r *api.EmptyRequest) (*api.CreateTokenResponse, error) {
+var createTokenRoute = route[api.EmptyRequest, *api.CreateTokenResponse]{
+	routeSettings: routeSettings{idpSync: true},
+	handler:       CreateToken,
+}
+
+func CreateToken(c *gin.Context, r *api.EmptyRequest) (*api.CreateTokenResponse, error) {
 	rCtx := getRequestContext(c)
 
 	if rCtx.Authenticated.User == nil {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -209,8 +209,11 @@ func requireAccessKey(c *gin.Context, db *data.Transaction, srv *Server) (access
 		// sync the identity info here to keep the UI session in sync with IDP session validity
 		if err := srv.syncIdentityInfo(context.Background(), db, identity, accessKey.ProviderID); err != nil {
 			deleteCookie(c.Writer, cookieAuthorizationName, c.Request.Host)
-			// TODO: log error here if not expected
-			logging.L.Debug().Err(err)
+			if errors.Is(err, ErrSyncFailed) {
+				logging.L.Debug().Err(err)
+			} else {
+				logging.L.Error().Err(err)
+			}
 			return u, AuthenticationError{Message: "session in identity provider expired or revoked"}
 		}
 

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -181,7 +181,7 @@ func (a *API) DeleteProvider(c *gin.Context, r *api.Resource) (*api.EmptyRespons
 // setProviderInfoFromServer checks information provided by an OIDC server
 func (a *API) setProviderInfoFromServer(c *gin.Context, provider *models.Provider) error {
 	// create a provider client to validate the server and get its info
-	oidc, err := a.providerClient(c, provider, "")
+	oidc, err := a.server.providerClient(c, provider, "")
 	if err != nil {
 		return fmt.Errorf("%w: %s", internal.ErrBadRequest, err)
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -56,7 +56,6 @@ func (s *Server) GenerateRoutes() Routes {
 
 	get(a, authn, "/api/users", a.ListUsers)
 	post(a, authn, "/api/users", a.CreateUser)
-	get(a, authn, "/api/users/:id", a.GetUser)
 	put(a, authn, "/api/users/:id", a.UpdateUser)
 	del(a, authn, "/api/users/:id", a.DeleteUser)
 	put(a, authn, "/api/users/public-key", AddUserPublicKey)
@@ -94,8 +93,12 @@ func (s *Server) GenerateRoutes() Routes {
 	put(a, authn, "/api/destinations/:id", a.UpdateDestination)
 	del(a, authn, "/api/destinations/:id", a.DeleteDestination)
 
-	post(a, authn, "/api/tokens", a.CreateToken)
 	post(a, authn, "/api/logout", a.Logout)
+
+	// auth required, org required, sync with IDP session on interval
+	authnSync := &routeGroup{RouterGroup: apiGroup.Group("/")}
+	get(a, authnSync, "/api/users/:id", a.GetUser) // the UI calls this endpoint to check session status
+	post(a, authnSync, "/api/tokens", a.CreateToken)
 
 	// SCIM inbound provisioning
 	add(a, authn, http.MethodGet, "/api/scim/v2/Users/:id", getProviderUsersRoute)
@@ -159,6 +162,7 @@ type routeSettings struct {
 	infraVersionHeaderOptional bool
 	authenticationOptional     bool
 	organizationOptional       bool
+	idpSync                    bool // when true the user session will be syncronized with the identity provider on a timed interval
 	txnOptions                 *sql.TxOptions
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -96,7 +96,7 @@ func (s *Server) GenerateRoutes() Routes {
 	post(a, authn, "/api/logout", a.Logout)
 
 	// auth required, org required, sync with IDP session on interval
-	authnSync := &routeGroup{RouterGroup: apiGroup.Group("/")}
+	authnSync := &routeGroup{RouterGroup: apiGroup.Group("/"), idpSync: true}
 	get(a, authnSync, "/api/users/:id", a.GetUser) // the UI calls this endpoint to check session status
 	post(a, authnSync, "/api/tokens", a.CreateToken)
 
@@ -177,6 +177,7 @@ type routeGroup struct {
 	*gin.RouterGroup
 	noAuthentication bool
 	noOrgRequired    bool
+	idpSync          bool
 }
 
 func add[Req, Res any](a *API, group *routeGroup, method, urlPath string, route route[Req, Res]) {
@@ -187,6 +188,7 @@ func add[Req, Res any](a *API, group *routeGroup, method, urlPath string, route 
 
 	route.authenticationOptional = group.noAuthentication
 	route.organizationOptional = group.noOrgRequired
+	route.idpSync = group.idpSync
 
 	if !route.omitFromDocs {
 		a.register(openAPIRouteDefinition(routeID, route))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -493,10 +493,6 @@ func (s *Server) syncIdentityInfo(ctx context.Context, tx *data.Transaction, ide
 		if err != nil {
 			return fmt.Errorf("update provider client: %w", err)
 		}
-		providerUser.LastUpdate = time.Now().UTC()
-		if err := data.UpdateProviderUser(tx, providerUser); err != nil {
-			return fmt.Errorf("update idp user: %w", err)
-		}
 
 		// update current identity provider groups and account status
 		_, err = data.SyncProviderUser(ctx, tx, providerUser, oidc)
@@ -514,6 +510,11 @@ func (s *Server) syncIdentityInfo(ctx context.Context, tx *data.Transaction, ide
 			}
 
 			return fmt.Errorf("%w: %s", ErrSyncFailed, err)
+		}
+
+		providerUser.LastUpdate = time.Now().UTC()
+		if err := data.UpdateProviderUser(tx, providerUser); err != nil {
+			return fmt.Errorf("update idp user: %w", err)
 		}
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -459,6 +459,8 @@ func configureEmail(options Options) {
 // This prevents hitting IDP rate limits.
 const providerUserUpdateThreshold = 120 * time.Minute
 
+var ErrSyncFailed = fmt.Errorf("user sync failed")
+
 // syncIdentityInfo calls the identity provider used to authenticate this user session to update their current information
 func (s *Server) syncIdentityInfo(ctx context.Context, tx *data.Transaction, identity *models.Identity, sessionProviderID uid.ID) error {
 	var provider *models.Provider
@@ -511,7 +513,7 @@ func (s *Server) syncIdentityInfo(ctx context.Context, tx *data.Transaction, ide
 				logging.Errorf("failed to delete provider user: %s", nestedErr)
 			}
 
-			return fmt.Errorf("sync user failed: %w", err)
+			return fmt.Errorf("%w: %s", ErrSyncFailed, err)
 		}
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,8 +25,10 @@ import (
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/email"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/server/providers"
 	"github.com/infrahq/infra/internal/server/redis"
 	"github.com/infrahq/infra/metrics"
+	"github.com/infrahq/infra/uid"
 )
 
 type Options struct {
@@ -450,4 +452,82 @@ func configureEmail(options Options) {
 	if len(options.SMTPServer) > 0 {
 		email.SMTPServer = options.SMTPServer
 	}
+}
+
+// providerUserUpdateThreshold is the duration of time that must pass before a
+// users session is attempted to be validated again with an external identity provider.
+// This prevents hitting IDP rate limits.
+const providerUserUpdateThreshold = 120 * time.Minute
+
+// syncIdentityInfo calls the identity provider used to authenticate this user session to update their current information
+func (s *Server) syncIdentityInfo(ctx context.Context, tx *data.Transaction, identity *models.Identity, sessionProviderID uid.ID) error {
+	var provider *models.Provider
+	if s.Google != nil && sessionProviderID == s.Google.ID {
+		provider = s.Google
+	} else {
+		var err error
+		provider, err = data.GetProvider(tx, data.GetProviderOptions{
+			ByID: sessionProviderID,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get provider for user info: %w", err)
+		}
+
+		if provider.Kind == models.ProviderKindInfra {
+			// no external verification needed
+			logging.L.Trace().Msg("skipped verifying identity within infra provider, not required")
+			return nil
+		}
+	}
+
+	providerUser, err := data.GetProviderUser(tx, provider.ID, identity.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get provider user to update: %w", err)
+	}
+
+	// if provider user was updated recently, skip checking this now to avoid hitting rate limits
+	if time.Since(providerUser.LastUpdate) > providerUserUpdateThreshold {
+		oidc, err := s.providerClient(ctx, provider, providerUser.RedirectURL)
+		if err != nil {
+			return fmt.Errorf("update provider client: %w", err)
+		}
+		providerUser.LastUpdate = time.Now().UTC()
+		if err := data.UpdateProviderUser(tx, providerUser); err != nil {
+			return fmt.Errorf("update idp user: %w", err)
+		}
+
+		// update current identity provider groups and account status
+		_, err = data.SyncProviderUser(ctx, tx, providerUser, oidc)
+		if err != nil {
+			if errors.Is(err, internal.ErrBadGateway) {
+				return err
+			}
+
+			if nestedErr := data.DeleteAccessKeys(tx, data.DeleteAccessKeysOptions{ByIssuedForID: providerUser.IdentityID, ByProviderID: providerUser.ProviderID}); nestedErr != nil {
+				logging.Errorf("failed to revoke invalid user session: %s", nestedErr)
+			}
+
+			if nestedErr := data.DeleteProviderUsers(tx, data.DeleteProviderUsersOptions{ByIdentityID: providerUser.IdentityID, ByProviderID: providerUser.ProviderID}); nestedErr != nil {
+				logging.Errorf("failed to delete provider user: %s", nestedErr)
+			}
+
+			return fmt.Errorf("sync user failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Server) providerClient(ctx context.Context, provider *models.Provider, redirectURL string) (providers.OIDCClient, error) {
+	if c := providers.OIDCClientFromContext(ctx); c != nil {
+		// oidc is added to the context during unit tests
+		return c, nil
+	}
+
+	if provider.ID == models.InternalGoogleProviderID {
+		// load the secret google information now, it is not set by default to avoid the possibility of returning this secret info externally
+		provider = s.Google
+	}
+
+	return providers.NewOIDCClient(*provider, string(provider.ClientSecret), redirectURL), nil
 }

--- a/internal/server/signup.go
+++ b/internal/server/signup.go
@@ -141,7 +141,7 @@ func handleSignupError(err error) error {
 }
 
 func (a *API) socialSignupUserAuth(c *gin.Context, provider *models.Provider, auth *authn.OIDCAuthn) (*providers.IdentityProviderAuth, error) {
-	providerClient, err := a.providerClient(c, provider, auth.RedirectURL)
+	providerClient, err := a.server.providerClient(c, provider, auth.RedirectURL)
 	if err != nil {
 		return nil, fmt.Errorf("sign-up provider client: %w", err)
 	}

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -114,6 +114,9 @@ func TestAPI_SignupSocial(t *testing.T) {
 	srv.options.EnableSignup = true
 	srv.options.BaseDomain = "exampledomain.com"
 	srv.Google = &models.Provider{
+		Model: models.Model{
+			ID: models.InternalGoogleProviderID,
+		},
 		Name:         "Moogle",
 		URL:          "example.com",
 		ClientID:     "aaa",

--- a/internal/server/tokens_test.go
+++ b/internal/server/tokens_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/internal/server/providers"
 )
 
 func TestAPI_CreateToken(t *testing.T) {
@@ -45,7 +44,7 @@ func TestAPI_CreateToken(t *testing.T) {
 				assert.Equal(t, resp.Code, http.StatusUnauthorized)
 			},
 		},
-		"infra provider user with valid access key": {
+		"success": {
 			setup: func(t *testing.T, req *http.Request) {
 				user := &models.Identity{
 					Name: "spike@example.com",
@@ -72,126 +71,6 @@ func TestAPI_CreateToken(t *testing.T) {
 				err := json.Unmarshal(resp.Body.Bytes(), respBody)
 				assert.NilError(t, err)
 				assert.Assert(t, respBody.Token != "")
-			},
-		},
-		"infra provider user with expired inactivity timeout on the access key": {
-			setup: func(t *testing.T, req *http.Request) {
-				user := &models.Identity{
-					Name: "spike2@example.com",
-				}
-				err := data.CreateIdentity(srv.DB(), user)
-				assert.NilError(t, err)
-				_, err = data.CreateProviderUser(srv.DB(), data.InfraProvider(srv.DB()), user)
-				assert.NilError(t, err)
-
-				key := &models.AccessKey{
-					IssuedFor:         user.ID,
-					ProviderID:        data.InfraProvider(srv.DB()).ID,
-					ExpiresAt:         time.Now().Add(10 * time.Second),
-					InactivityTimeout: time.Now(),
-				}
-				accessKey, err := data.CreateAccessKey(srv.DB(), key)
-				assert.NilError(t, err)
-
-				req.Header.Set("Authorization", "Bearer "+accessKey)
-			},
-			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.Equal(t, resp.Code, http.StatusUnauthorized)
-			},
-		},
-		"access key directly created for user not in infra provider": {
-			setup: func(t *testing.T, req *http.Request) {
-				user := &models.Identity{
-					Name: "faye@example.com",
-				}
-				err := data.CreateIdentity(srv.DB(), user)
-				assert.NilError(t, err)
-
-				key := &models.AccessKey{
-					IssuedFor:  user.ID,
-					ProviderID: data.InfraProvider(srv.DB()).ID,
-					ExpiresAt:  time.Now().Add(10 * time.Second),
-				}
-				accessKey, err := data.CreateAccessKey(srv.DB(), key)
-				assert.NilError(t, err)
-
-				req.Header.Set("Authorization", "Bearer "+accessKey)
-			},
-			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.Equal(t, resp.Code, http.StatusCreated)
-			},
-		},
-		"access key for valid idp user": {
-			setup: func(t *testing.T, req *http.Request) {
-				user := &models.Identity{
-					Name: "jet@example.com",
-				}
-				err := data.CreateIdentity(srv.DB(), user)
-				assert.NilError(t, err)
-
-				provider := &models.Provider{
-					Name: "mockta",
-					Kind: models.ProviderKindOIDC,
-				}
-				err = data.CreateProvider(srv.DB(), provider)
-				assert.NilError(t, err)
-
-				_, err = data.CreateProviderUser(srv.DB(), provider, user)
-				assert.NilError(t, err)
-
-				key := &models.AccessKey{
-					IssuedFor:  user.ID,
-					ProviderID: provider.ID,
-					ExpiresAt:  time.Now().Add(10 * time.Second),
-				}
-				accessKey, err := data.CreateAccessKey(srv.DB(), key)
-				assert.NilError(t, err)
-
-				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{})
-				*req = *req.WithContext(ctx)
-				req.Header.Set("Authorization", "Bearer "+accessKey)
-			},
-			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.Equal(t, resp.Code, http.StatusCreated)
-
-				respBody := &api.CreateTokenResponse{}
-				err := json.Unmarshal(resp.Body.Bytes(), respBody)
-				assert.NilError(t, err)
-				assert.Assert(t, respBody.Token != "")
-			},
-		},
-		"access key for revoked idp user": {
-			setup: func(t *testing.T, req *http.Request) {
-				user := &models.Identity{
-					Name: "ein@example.com",
-				}
-				err := data.CreateIdentity(srv.DB(), user)
-				assert.NilError(t, err)
-
-				provider := &models.Provider{
-					Name: "mockta-revoked-user",
-					Kind: models.ProviderKindOIDC,
-				}
-				err = data.CreateProvider(srv.DB(), provider)
-				assert.NilError(t, err)
-
-				_, err = data.CreateProviderUser(srv.DB(), provider, user)
-				assert.NilError(t, err)
-
-				key := &models.AccessKey{
-					IssuedFor:  user.ID,
-					ProviderID: provider.ID,
-					ExpiresAt:  time.Now().Add(10 * time.Second),
-				}
-				accessKey, err := data.CreateAccessKey(srv.DB(), key)
-				assert.NilError(t, err)
-
-				ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{UserInfoRevoked: true})
-				*req = *req.WithContext(ctx)
-				req.Header.Set("Authorization", "Bearer "+accessKey)
-			},
-			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.Equal(t, resp.Code, http.StatusUnauthorized)
 			},
 		},
 	}

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -184,7 +184,7 @@ func TestAPI_GetUser(t *testing.T) {
 				))
 				actual := jsonUnmarshal(t, resp.Body.String())
 
-				var cmpAPIUserJSON = gocmp.Options{
+				cmpAPIUserJSON := gocmp.Options{
 					gocmp.FilterPath(pathMapKey(`created`, `updated`, `lastSeenAt`), cmpApproximateTime),
 					gocmp.FilterPath(pathMapKey(`id`), cmpAnyValidUID),
 				}
@@ -967,7 +967,7 @@ func TestAddUserPublicKey(t *testing.T) {
 		tc.expected(t, resp)
 	}
 
-	var cmpAPIPublicKeyJSON = gocmp.Options{
+	cmpAPIPublicKeyJSON := gocmp.Options{
 		gocmp.FilterPath(pathMapKey(`created`), cmpApproximateTime),
 		gocmp.FilterPath(pathMapKey(`id`), cmpAnyValidUID),
 	}


### PR DESCRIPTION
- sync user session from external IDPs in middleware
- add sync cache for 120 minutes
- remove explicit IDP sync on token creation, this will slow the propagation of IDP changes
- attempt to make user sync logic easier to follow

## Summary
If a user's session in a provider was expired on device login this wasnt checked until an `infra tokens add` command was run. Check the user's session in the IDP on device flow login via the middleware, and get them to log back in if its gone stale, then they can proceed with the device flow as normal.

1. `infra login`
2. Users session is validated with IDP
3. If session is no longer valid, user must login again (in the browser)
4. User is returned to device flow and continues as usual

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Part of #3881 
