### PR TITLE
fix: set social provider id

### DIFF
--- a/internal/access/signup.go
+++ b/internal/access/signup.go
@@ -110,6 +110,7 @@ func Signup(c *gin.Context, keyExpiresAt time.Time, baseDomain string, details *
 	case details.Social != nil:
 		// sign-up with social (google)
 		user := &models.ProviderUser{
+			ProviderID:   models.InternalGoogleProviderID,
 			Email:        details.Social.IDPAuth.Email,
 			RedirectURL:  details.Social.RedirectURL,
 			AccessToken:  models.EncryptedAtRest(details.Social.IDPAuth.AccessToken),


### PR DESCRIPTION
## Summary
This got missed on rebasing the "non-zero" social login provider ID change. It will now display the correct provider for the admin that signs up an org using social login.
<!-- Include a summary of the change and/or why it's necessary. -->

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged

## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3905 
