### PR TITLE
fix: update version to use semver metadata instead prerelease

### DIFF
--- a/.github/workflows/cd-binaries.yaml
+++ b/.github/workflows/cd-binaries.yaml
@@ -26,7 +26,7 @@ jobs:
       - id: release-name
         run: |
           RELEASE_NAME=${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '$(git describe --tags)' }}
-          echo "release-name=${RELEASE_NAME#v}" >>$GITHUB_OUTPUT
+          echo "release-name=$(echo ${RELEASE_NAME#v} | sed 's/-/+/')" >>$GITHUB_OUTPUT
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

semver's prerelease, the part after the first `-`, is inherently a lower than the released version. `git describe` outputs `<tag>-<commits since tag>-<checksum>` so any commit after the tag will have a lower version than the tag. 

Instead, modify the output so the string is `<tag>+<commits since tag>-<checksum>` which is also a better representation of this info.

```
$ infra login infra.infrahq.lvh.me
  Logging in to infra.infrahq.lvh.me
Error: client version (0.20.0) is ahead of server version (0.20.0-30-gd394a245), download the CLI version that matches your server, reference https://infrahq.com/docs/messages/cli-versions
```