### PR TITLE
fix: allow user to remove own password login

### DIFF
--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -132,11 +132,12 @@ func UpdateProviderUser(tx WriteTxn, providerUser *models.ProviderUser) error {
 }
 
 type ListProviderUsersOptions struct {
-	ByProviderID   uid.ID
-	ByIdentityID   uid.ID
-	ByIdentityIDs  []uid.ID
-	HideInactive   bool
-	SCIMParameters *SCIMParameters
+	ByProviderID    uid.ID
+	ByNotProviderID uid.ID
+	ByIdentityID    uid.ID
+	ByIdentityIDs   []uid.ID
+	HideInactive    bool
+	SCIMParameters  *SCIMParameters
 }
 
 func ListProviderUsers(tx ReadTxn, opts ListProviderUsersOptions) ([]models.ProviderUser, error) {
@@ -155,6 +156,9 @@ func ListProviderUsers(tx ReadTxn, opts ListProviderUsersOptions) ([]models.Prov
 	query.B("WHERE 1=1") // this is always true, used to make the logic of adding clauses simpler by always appending them with an AND
 	if opts.ByProviderID != 0 {
 		query.B("AND provider_id = ?", opts.ByProviderID)
+	}
+	if opts.ByNotProviderID != 0 {
+		query.B("AND provider_id != ?", opts.ByNotProviderID)
 	}
 	if opts.ByIdentityID != 0 {
 		query.B("AND identity_id = ?", opts.ByIdentityID)

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -343,9 +343,11 @@ export default function Users() {
                 }
               )
 
-              // can only delete users that exist within Infra which are not the currently logged in user
+              // can only delete Infra users where password authn is the only authn method
               if (
-                info.row.original.id === user?.id ||
+                (info.row.original.id === user?.id &&
+                  info.row.original.providerNames?.filter(n => n != 'infra')
+                    .length == 0) ||
                 !info.row.original.providerNames?.includes('infra')
               ) {
                 return null


### PR DESCRIPTION
If another login method exists, e.g. an identity provider, the user should be able to remove their own password. A side effect is a non-admin user can remove their own password, if another authn method exists for that user.

Resolves #3912 