### PR TITLE
fix: get refresh token on google login

### DIFF
--- a/ui/pages/login/index.js
+++ b/ui/pages/login/index.js
@@ -17,7 +17,7 @@ import LoginLayout from '../../components/layouts/login'
 import UpdatePassword from '../../components/update-password'
 
 function oidcLogin(
-  { baseDomain, loginDomain, id, clientID, authURL, scopes },
+  { baseDomain, loginDomain, id, clientID, authURL, scopes, kind },
   next
 ) {
   window.localStorage.setItem('providerID', id)
@@ -49,9 +49,22 @@ function oidcLogin(
   }
   window.localStorage.setItem('redirectURL', redirectURL)
 
-  document.location.href = `${authURL}?redirect_uri=${redirectURL}&client_id=${clientID}&response_type=code&scope=${scopes.join(
-    '+'
-  )}&state=${state}`
+  const sendTo = new URL(authURL)
+  // URL searchParams add query parameters to a URL
+  sendTo.searchParams.append('redirect_uri', redirectURL)
+  sendTo.searchParams.append('client_id', clientID)
+  sendTo.searchParams.append('response_type', 'code')
+  sendTo.searchParams.append('scope', scopes.join(' '))
+  sendTo.searchParams.append('state', state)
+
+  if (kind === 'google') {
+    // google only sends a refresh token when a user consents, always prompt so we always get the ref token
+    sendTo.searchParams.append('prompt', 'consent')
+    // also need to specify offline access in the case of Google to get a refresh token
+    sendTo.searchParams.append('access_type', 'offline')
+  }
+
+  document.location.href = sendTo.href
 }
 
 function Providers({ baseDomain, loginDomain, providers }) {


### PR DESCRIPTION
## Summary
In order to extend get a refresh token from Google additional parameters must be specified on OIDC login. This was done in the CLI but the UI was out of sync here.

Add the required parameters for Google sign-up and login to get a refresh token from Google.

This change is made in 2 places. #3909 removes the duplicate code.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3917 
