### PR TITLE
fix: no logout on bad login

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -48,9 +48,10 @@ func printTable(data interface{}, out io.Writer) {
 }
 
 type APIClientOpts struct {
-	Host      string
-	AccessKey string
-	Transport *http.Transport
+	Host                     string
+	AccessKey                string
+	Transport                *http.Transport
+	SkipLogoutOnUnauthorized bool
 }
 
 // Creates API Client options from the current config
@@ -95,7 +96,7 @@ func NewAPIClient(opts *APIClientOpts) (*api.Client, error) {
 	if opts.Host == "" || opts.Transport == nil {
 		return nil, fmt.Errorf("api client access key, host, and transport are required")
 	}
-	return &api.Client{
+	client := &api.Client{
 		Name:      "cli",
 		Version:   internal.Version,
 		URL:       "https://" + opts.Host,
@@ -104,8 +105,11 @@ func NewAPIClient(opts *APIClientOpts) (*api.Client, error) {
 			Timeout:   60 * time.Second,
 			Transport: opts.Transport,
 		},
-		OnUnauthorized: logoutCurrent,
-	}, nil
+	}
+	if !opts.SkipLogoutOnUnauthorized {
+		client.OnUnauthorized = logoutCurrent
+	}
+	return client, nil
 }
 
 func logoutCurrent() {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -296,7 +296,7 @@ func newLoginClient(cli *CLI, options loginCmdOptions) (loginClient, error) {
 	client, err := NewAPIClient(&APIClientOpts{
 		Host:                     options.Server,
 		Transport:                httpTransportForHostConfig(cfg),
-		SkipLogoutOnUnauthorized: true,
+		SkipLogoutOnUnauthorized: true, // if a user fails to login, any current sessions they have should remain active
 	},
 	)
 	if err != nil {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -294,8 +294,9 @@ func newLoginClient(cli *CLI, options loginCmdOptions) (loginClient, error) {
 		SkipTLSVerify:      options.SkipTLSVerify,
 	}
 	client, err := NewAPIClient(&APIClientOpts{
-		Host:      options.Server,
-		Transport: httpTransportForHostConfig(cfg),
+		Host:                     options.Server,
+		Transport:                httpTransportForHostConfig(cfg),
+		SkipLogoutOnUnauthorized: true,
 	},
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

A bad login attempt should not invalid a valid active session. This was regression caused by the `OnUnauthorized` callback which forces a logout on all `Unauthorized` API requests. It's still a good idea in most cases, just not for a bad login.

Resolves #3832
