### PR TITLE
fix: only template out kubeconfig for k8s destinations

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -171,15 +171,5 @@ func syncKubeConfig(_ context.Context) error {
 	}
 	client.Name = "agent"
 
-	user, destinations, grants, err := getUserDestinationGrants(client, "kubernetes")
-	if err != nil {
-		return fmt.Errorf("list grants: %w", err)
-	}
-
-	if err := writeKubeconfig(user, destinations, grants); err != nil {
-		return fmt.Errorf("update kubeconfig file: %w", err)
-	}
-
-	logging.L.Info().Msg("finished kubeconfig sync")
-	return nil
+	return updateKubeconfig(client)
 }

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/logging"
-	"github.com/infrahq/infra/uid"
 )
 
 func clientConfig() clientcmd.ClientConfig {
@@ -59,19 +57,8 @@ func kubernetesSetContext(cli *CLI, cluster, namespace string) error {
 	return nil
 }
 
-func updateKubeConfig(client *api.Client, id uid.ID) error {
-	ctx := context.TODO()
-	destinations, err := listAll(ctx, client.ListDestinations, api.ListDestinationsRequest{})
-	if err != nil {
-		return err
-	}
-
-	user, err := client.GetUser(ctx, id)
-	if err != nil {
-		return err
-	}
-
-	grants, err := listAll(ctx, client.ListGrants, api.ListGrantsRequest{User: id, ShowInherited: true})
+func updateKubeconfig(client *api.Client) error {
+	user, destinations, grants, err := getUserDestinationGrants(client, "kubernetes")
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -14,7 +15,111 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/server"
 )
+
+func TestUpdateKubeconfig(t *testing.T) {
+	home := setupEnv(t)
+
+	serverOpts := defaultServerOptions(home)
+	setupServerOptions(t, &serverOpts)
+	accessKey := "aaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb"
+	serverOpts.Config.Users = []server.User{
+		{
+			Name:      "admin@local",
+			AccessKey: accessKey,
+		},
+	}
+	serverOpts.Config.Grants = []server.Grant{
+		{
+			User:     "admin@local",
+			Resource: "infra",
+			Role:     "admin",
+		},
+		{
+			User:     "admin@local",
+			Resource: "my-first-kubernetes-cluster",
+			// Role: "admin",
+		},
+		{
+			User:     "admin@local",
+			Resource: "my-first-ssh-server",
+			// Role: "admin",
+		},
+	}
+	srv, err := server.New(serverOpts)
+	assert.NilError(t, err)
+
+	ctx := context.Background()
+	runAndWait(ctx, t, srv.Run)
+
+	clientOpts := &APIClientOpts{
+		AccessKey: accessKey,
+		Host:      srv.Addrs.HTTPS.String(),
+		Transport: httpTransportForHostConfig(&ClientHostConfig{SkipTLSVerify: true}),
+	}
+	client, err := NewAPIClient(clientOpts)
+	assert.NilError(t, err)
+
+	runStep(t, "create K8s destinations", func(t *testing.T) {
+		_, err := client.CreateDestination(ctx, &api.CreateDestinationRequest{
+			Name: "my-first-kubernetes-cluster",
+			Kind: "kubernetes",
+			Connection: api.DestinationConnection{
+				URL: "destination-connection-url",
+				CA:  "destination-connection-certificate",
+			},
+		})
+		assert.NilError(t, err)
+	})
+
+	runStep(t, "create SSH destinations", func(t *testing.T) {
+		_, err := client.CreateDestination(ctx, &api.CreateDestinationRequest{
+			Name: "my-first-ssh-server",
+			Kind: "ssh",
+			Connection: api.DestinationConnection{
+				URL: "destination-connection-url",
+				CA:  "destination-connection-certificate",
+			},
+		})
+		assert.NilError(t, err)
+	})
+
+	runStep(t, "setup client config", func(t *testing.T) {
+		users, err := client.ListUsers(ctx, api.ListUsersRequest{Name: "admin@local"})
+		assert.NilError(t, err)
+		assert.Equal(t, users.Count, 1)
+		assert.Equal(t, users.Items[0].Name, "admin@local")
+
+		clientConfig := newTestClientConfigForServer(srv, api.User{ID: users.Items[0].ID}, accessKey)
+		err = writeConfig(&clientConfig)
+		assert.NilError(t, err)
+	})
+
+	runStep(t, "update kubeconfig", func(t *testing.T) {
+		err := updateKubeconfig(client)
+		assert.NilError(t, err)
+
+		actualKubeconfig, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+
+		assert.DeepEqual(t, actualKubeconfig.Contexts, map[string]*clientcmdapi.Context{
+			"infra:my-first-kubernetes-cluster": {
+				AuthInfo: "admin@local",
+				Cluster:  "infra:my-first-kubernetes-cluster",
+			},
+		}, cmpKubeconfig)
+		assert.DeepEqual(t, actualKubeconfig.Clusters, map[string]*clientcmdapi.Cluster{
+			"infra:my-first-kubernetes-cluster": {
+				Server:                   "https://destination-connection-url",
+				CertificateAuthorityData: []byte("destination-connection-certificate"),
+			},
+		}, cmpKubeconfig)
+		assert.DeepEqual(t, actualKubeconfig.AuthInfos, map[string]*clientcmdapi.AuthInfo{
+			"admin@local": {},
+		}, cmpKubeconfig)
+	})
+}
 
 func TestWriteKubeconfig(t *testing.T) {
 	user := api.User{Name: "user"}
@@ -75,14 +180,6 @@ func TestWriteKubeconfig(t *testing.T) {
 		"user": {},
 	}
 
-	kubeConfigCmpOpts := []cmp.Option{
-		cmpopts.EquateEmpty(),
-		cmpopts.IgnoreFields(clientcmdapi.Context{}, "LocationOfOrigin"),
-		cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "LocationOfOrigin"),
-		cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"),
-		cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "Exec"),
-	}
-
 	t.Run("OneNamespace", func(t *testing.T) {
 		expectedContexts := map[string]*clientcmdapi.Context{
 			"infra:connected": {
@@ -94,9 +191,9 @@ func TestWriteKubeconfig(t *testing.T) {
 
 		actual := run(t, api.Grant{Resource: "connected.namespace"})
 
-		assert.DeepEqual(t, actual.Contexts, expectedContexts, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.Clusters, expectedClusters, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, kubeConfigCmpOpts...)
+		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
+		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
+		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, cmpKubeconfig)
 	})
 
 	t.Run("MultipleNamespaces", func(t *testing.T) {
@@ -116,9 +213,9 @@ func TestWriteKubeconfig(t *testing.T) {
 
 		actual := run(t, grants...)
 
-		assert.DeepEqual(t, actual.Contexts, expectedContexts, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.Clusters, expectedClusters, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, kubeConfigCmpOpts...)
+		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
+		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
+		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, cmpKubeconfig)
 	})
 
 	t.Run("DefaultNamespace", func(t *testing.T) {
@@ -135,9 +232,9 @@ func TestWriteKubeconfig(t *testing.T) {
 
 		actual := run(t, grants...)
 
-		assert.DeepEqual(t, actual.Contexts, expectedContexts, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.Clusters, expectedClusters, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, kubeConfigCmpOpts...)
+		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
+		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
+		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, cmpKubeconfig)
 	})
 
 	t.Run("DefaultAndMultipleNamespaces", func(t *testing.T) {
@@ -157,9 +254,9 @@ func TestWriteKubeconfig(t *testing.T) {
 
 		actual := run(t, grants...)
 
-		assert.DeepEqual(t, actual.Contexts, expectedContexts, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.Clusters, expectedClusters, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, kubeConfigCmpOpts...)
+		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
+		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
+		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, cmpKubeconfig)
 	})
 
 	t.Run("Cluster", func(t *testing.T) {
@@ -172,9 +269,9 @@ func TestWriteKubeconfig(t *testing.T) {
 
 		actual := run(t, api.Grant{Resource: "connected"})
 
-		assert.DeepEqual(t, actual.Contexts, expectedContexts, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.Clusters, expectedClusters, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, kubeConfigCmpOpts...)
+		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
+		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
+		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, cmpKubeconfig)
 	})
 
 	t.Run("ClusterAndDefaultNamespace", func(t *testing.T) {
@@ -192,9 +289,9 @@ func TestWriteKubeconfig(t *testing.T) {
 
 		actual := run(t, grants...)
 
-		assert.DeepEqual(t, actual.Contexts, expectedContexts, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.Clusters, expectedClusters, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, kubeConfigCmpOpts...)
+		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
+		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
+		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, cmpKubeconfig)
 	})
 
 	t.Run("ClusterAndMultipleNamespaces", func(t *testing.T) {
@@ -214,9 +311,9 @@ func TestWriteKubeconfig(t *testing.T) {
 
 		actual := run(t, grants...)
 
-		assert.DeepEqual(t, actual.Contexts, expectedContexts, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.Clusters, expectedClusters, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, kubeConfigCmpOpts...)
+		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
+		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
+		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, cmpKubeconfig)
 	})
 
 	t.Run("OmitUnavailableClusters", func(t *testing.T) {
@@ -235,9 +332,9 @@ func TestWriteKubeconfig(t *testing.T) {
 
 		actual := run(t, grants...)
 
-		assert.DeepEqual(t, actual.Contexts, expectedContexts, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.Clusters, expectedClusters, kubeConfigCmpOpts...)
-		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, kubeConfigCmpOpts...)
+		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
+		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
+		assert.DeepEqual(t, actual.AuthInfos, expectedAuthInfos, cmpKubeconfig)
 	})
 }
 
@@ -339,4 +436,12 @@ func TestSafelyWriteConfigToFile(t *testing.T) {
 		// if the file name contains this string it was the temp file
 		assert.Assert(t, !strings.Contains(file.Name(), "infra-kube-config"))
 	}
+}
+
+var cmpKubeconfig = cmp.Options{
+	cmpopts.EquateEmpty(),
+	cmpopts.IgnoreFields(clientcmdapi.Context{}, "LocationOfOrigin"),
+	cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "LocationOfOrigin"),
+	cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "LocationOfOrigin"),
+	cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "Exec"),
 }

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -39,12 +39,10 @@ func TestUpdateKubeconfig(t *testing.T) {
 		{
 			User:     "admin@local",
 			Resource: "my-first-kubernetes-cluster",
-			// Role: "admin",
 		},
 		{
 			User:     "admin@local",
 			Resource: "my-first-ssh-server",
-			// Role: "admin",
 		},
 	}
 	srv, err := server.New(serverOpts)

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -30,7 +30,7 @@ func list(cli *CLI) error {
 		return err
 	}
 
-	user, destinations, grants, err := getUserDestinationGrants(client, "")
+	_, destinations, grants, err := getUserDestinationGrants(client, "")
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func list(cli *CLI) error {
 		cli.Output("You have not been granted access to any active destinations")
 	}
 
-	return writeKubeconfig(user, destinations, grants)
+	return updateKubeconfig(client)
 }
 
 func destinationForResourceExists(resource string, destinations []api.Destination) bool {

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -217,7 +217,7 @@ func login(cli *CLI, options loginCmdOptions) error {
 		return err
 	}
 
-	if err := updateKubeConfig(lc.APIClient, loginRes.UserID); err != nil {
+	if err := updateKubeconfig(lc.APIClient); err != nil {
 		return err
 	}
 

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -27,12 +27,7 @@ $ infra use development.kube-system`,
 				return err
 			}
 
-			config, err := currentHostConfig()
-			if err != nil {
-				return err
-			}
-
-			err = updateKubeConfig(client, config.UserID)
+			err = updateKubeconfig(client)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Only K8s destinations should get entries in kubeconfig.

Resolves #3920 
