### PR TITLE
fix: only set namespace if specified in use

### DIFF
--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -43,7 +43,9 @@ func kubernetesSetContext(cli *CLI, cluster, namespace string) error {
 		return fmt.Errorf("context not found: %v", friendlyName)
 	}
 
-	kubeContext.Namespace = namespace
+	if namespace != "" {
+		kubeContext.Namespace = namespace
+	}
 
 	kubeConfig.CurrentContext = contextName
 	kubeConfig.Contexts[contextName] = kubeContext

--- a/internal/cmd/use_test.go
+++ b/internal/cmd/use_test.go
@@ -156,4 +156,34 @@ func TestUse(t *testing.T) {
 		assert.ErrorContains(t, err, `"infra use" requires exactly 1 argument`)
 		assert.ErrorContains(t, err, `Usage:  infra use`)
 	})
+
+	t.Run("use cluster does not change namespace", func(t *testing.T) {
+		setup(t)
+
+		err := Run(context.Background(), "use", "cluster.namespace")
+		assert.NilError(t, err)
+
+		kubeconfig, err := clientConfig().RawConfig()
+		assert.NilError(t, err)
+
+		assert.Equal(t, len(kubeconfig.Clusters), 1)
+		assert.Equal(t, len(kubeconfig.Contexts), 1)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 1)
+		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster")
+		assert.Equal(t, kubeconfig.Contexts[kubeconfig.CurrentContext].Namespace, "namespace")
+		assert.Assert(t, is.Contains(kubeconfig.AuthInfos, "testuser@example.com"))
+
+		err = Run(context.Background(), "use", "cluster")
+		assert.NilError(t, err)
+
+		kubeconfig, err = clientConfig().RawConfig()
+		assert.NilError(t, err)
+
+		assert.Equal(t, len(kubeconfig.Clusters), 1)
+		assert.Equal(t, len(kubeconfig.Contexts), 1)
+		assert.Equal(t, len(kubeconfig.AuthInfos), 1)
+		assert.Equal(t, kubeconfig.CurrentContext, "infra:cluster")
+		assert.Equal(t, kubeconfig.Contexts[kubeconfig.CurrentContext].Namespace, "namespace")
+		assert.Assert(t, is.Contains(kubeconfig.AuthInfos, "testuser@example.com"))
+	})
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`infra use cluster` with a cluster unsets context namespace which isn't expected. Instead if the namespace isn't specified, only switch the context. If a namespace is specified, set the namespace accordingly.