### PR TITLE
Improve error output from infra ssh

### DIFF
--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -615,3 +615,54 @@ func keyIDsFromKeysConfig(t *testing.T, filename string) []string {
 	}
 	return actual
 }
+
+func TestMkdirAll(t *testing.T) {
+	tmp := t.TempDir()
+
+	filename := filepath.Join(tmp, "isafile")
+	_, err := os.Create(filename)
+	assert.NilError(t, err)
+	defer os.Remove(filename)
+
+	type testCase struct {
+		name        string
+		path        string
+		expectedErr string
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		err := mkdirAll(tc.path)
+		if tc.expectedErr == "" {
+			assert.NilError(t, err)
+			return
+		}
+		assert.ErrorContains(t, err, tc.expectedErr)
+	}
+
+	testCases := []testCase{
+		{
+			name: "directory does not exist",
+			path: filepath.Join(tmp, "newdir"),
+		},
+		{
+			name: "directory exists",
+			path: tmp,
+		},
+		{
+			name:        "file exists at path",
+			path:        filename,
+			expectedErr: filename + ", the path already exists as a regular file",
+		},
+		{
+			name:        "file exists in parent path",
+			path:        filepath.Join(filename, "newdir"),
+			expectedErr: filename + ", the path already exists as a regular file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

@pdevine realized that if someone has an SSH key called infra, it's possible that key exists at `~/.ssh/infra`, which would prevent us from using that path as a directory. The error message would be hidden from users, so they wouldn't understand why their SSH was prompting them for either a password or to verify the host key.

This PR fixes that problem by:
1. improving the error message in this case, making it explicit that there is a file in the way
2. actually printing this error message to stderr (instead of hiding it in debug logs)

I created #3927 for the remaining problems
