### PR TITLE
Reduce server config to only bootstrapping of user and credentials

### DIFF
--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -55,7 +55,7 @@ func TestConnector_Run_Kubernetes(t *testing.T) {
 	dir := t.TempDir()
 	serverOpts := defaultServerOptions(dir)
 	setupServerOptions(t, &serverOpts)
-	serverOpts.Config = server.Config{
+	serverOpts.BootstrapConfig = server.BootstrapConfig{
 		Users: []server.User{
 			{Name: "admin@example.com", AccessKey: "0000000001.adminadminadminadmin1234"},
 			{Name: "connector", AccessKey: "0000000002.connectorconnectorconnec"},

--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -29,8 +29,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
+	k8sapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/certs"
 	"github.com/infrahq/infra/internal/cmd/types"
@@ -58,11 +59,8 @@ func TestConnector_Run_Kubernetes(t *testing.T) {
 		Users: []server.User{
 			{Name: "admin@example.com", AccessKey: "0000000001.adminadminadminadmin1234"},
 			{Name: "connector", AccessKey: "0000000002.connectorconnectorconnec"},
-		},
-		Grants: []server.Grant{
-			{User: "user1@example.com", Resource: "testing.ns1", Role: "admin"},
-			{User: "user2@example.com", Resource: "testing", Role: "view"},
-			{Group: "group1@example.com", Resource: "testing.ns1", Role: "logs"},
+			{Name: "user1@example.com"},
+			{Name: "user2@example.com"},
 		},
 	}
 
@@ -76,12 +74,21 @@ func TestConnector_Run_Kubernetes(t *testing.T) {
 	ctx := context.Background()
 	runAndWait(ctx, t, srv.Run)
 
+	err = data.CreateGroup(srv.DB(), &models.Group{Name: "group1@example.com"})
+	assert.NilError(t, err)
+
+	createGrants(t, srv.DB(),
+		api.GrantRequest{UserName: "user1@example.com", Resource: "testing.ns1", Privilege: "admin"},
+		api.GrantRequest{UserName: "user2@example.com", Resource: "testing", Privilege: "view"},
+		api.GrantRequest{GroupName: "group1@example.com", Resource: "testing.ns1", Privilege: "logs"},
+	)
+
 	kubeconfig := path.Join(dir, "kubeconfig")
 	os.Setenv("KUBECONFIG", kubeconfig)
-	err = clientcmd.WriteToFile(api.Config{
-		Clusters:       map[string]*api.Cluster{"test": {Server: kubeSrv.URL, CertificateAuthorityData: certs.PEMEncodeCertificate(kubeSrv.Certificate().Raw)}},
-		Contexts:       map[string]*api.Context{"test": {Cluster: "test", AuthInfo: "test"}},
-		AuthInfos:      map[string]*api.AuthInfo{"test": {Token: "auth-token"}},
+	err = clientcmd.WriteToFile(k8sapi.Config{
+		Clusters:       map[string]*k8sapi.Cluster{"test": {Server: kubeSrv.URL, CertificateAuthorityData: certs.PEMEncodeCertificate(kubeSrv.Certificate().Raw)}},
+		Contexts:       map[string]*k8sapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+		AuthInfos:      map[string]*k8sapi.AuthInfo{"test": {Token: "auth-token"}},
 		CurrentContext: "test",
 	}, kubeconfig)
 

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/server/data"
+	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
+)
+
+func createGrants(t *testing.T, tx data.WriteTxn, grants ...api.GrantRequest) {
+	t.Helper()
+	for i, g := range grants {
+		var subject uid.PolymorphicID
+		switch {
+		case g.User != 0:
+			subject = uid.NewIdentityPolymorphicID(g.User)
+		case g.Group != 0:
+			subject = uid.NewGroupPolymorphicID(g.Group)
+		case g.UserName != "":
+			u, err := data.GetIdentity(tx, data.GetIdentityOptions{ByName: g.UserName})
+			assert.NilError(t, err, "grant %v", i)
+			subject = uid.NewIdentityPolymorphicID(u.ID)
+		case g.GroupName != "":
+			group, err := data.GetGroup(tx, data.GetGroupOptions{ByName: g.GroupName})
+			assert.NilError(t, err, "grant %v", i)
+			subject = uid.NewGroupPolymorphicID(group.ID)
+		}
+
+		err := data.CreateGrant(tx, &models.Grant{
+			Subject:   subject,
+			Resource:  g.Resource,
+			Privilege: g.Privilege,
+		})
+		assert.NilError(t, err, "grant %v", i)
+	}
+}

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -28,7 +28,7 @@ func TestUpdateKubeconfig(t *testing.T) {
 		{
 			Name:      "admin@local",
 			AccessKey: accessKey,
-			Role:      "admin",
+			InfraRole: "admin",
 		},
 	}
 

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -24,29 +24,20 @@ func TestUpdateKubeconfig(t *testing.T) {
 	serverOpts := defaultServerOptions(home)
 	setupServerOptions(t, &serverOpts)
 	accessKey := "aaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb"
-	serverOpts.Config.Users = []server.User{
+	serverOpts.BootstrapConfig.Users = []server.User{
 		{
 			Name:      "admin@local",
 			AccessKey: accessKey,
+			Role:      "admin",
 		},
 	}
-	serverOpts.Config.Grants = []server.Grant{
-		{
-			User:     "admin@local",
-			Resource: "infra",
-			Role:     "admin",
-		},
-		{
-			User:     "admin@local",
-			Resource: "my-first-kubernetes-cluster",
-		},
-		{
-			User:     "admin@local",
-			Resource: "my-first-ssh-server",
-		},
-	}
+
 	srv, err := server.New(serverOpts)
 	assert.NilError(t, err)
+
+	createGrants(t, srv.DB(),
+		api.GrantRequest{UserName: "admin@local", Resource: "my-first-kubernetes-cluster", Privilege: "connect"},
+		api.GrantRequest{UserName: "admin@local", Resource: "my-first-ssh-server", Privilege: "connect"})
 
 	ctx := context.Background()
 	runAndWait(ctx, t, srv.Run)

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -25,7 +25,7 @@ func TestListCmd(t *testing.T) {
 	opts := defaultServerOptions(dir)
 	opts.BootstrapConfig = server.BootstrapConfig{
 		Users: []server.User{
-			{Name: "admin", AccessKey: "0000000001.adminadminadminadmin1234", Role: "admin"},
+			{Name: "admin", AccessKey: "0000000001.adminadminadminadmin1234", InfraRole: "admin"},
 			{Name: "nogrants@example.com", AccessKey: "0000000002.notadminsecretnotadmin02"},
 			{Name: "manygrants@example.com", AccessKey: "0000000003.notadminsecretnotadmin03"},
 		},

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -25,15 +25,9 @@ func TestListCmd(t *testing.T) {
 	opts := defaultServerOptions(dir)
 	opts.Config = server.Config{
 		Users: []server.User{
-			{Name: "admin", AccessKey: "0000000001.adminadminadminadmin1234"},
+			{Name: "admin", AccessKey: "0000000001.adminadminadminadmin1234", Role: "admin"},
 			{Name: "nogrants@example.com", AccessKey: "0000000002.notadminsecretnotadmin02"},
 			{Name: "manygrants@example.com", AccessKey: "0000000003.notadminsecretnotadmin03"},
-		},
-		Grants: []server.Grant{
-			{User: "admin", Resource: "infra", Role: "admin"},
-			{User: "manygrants@example.com", Resource: "space", Role: "explorer"},
-			{User: "manygrants@example.com", Resource: "moon", Role: "inhabitant"},
-			{User: "manygrants@example.com", Resource: "infra-this-is-not", Role: "view"},
 		},
 	}
 	setupServerOptions(t, &opts)
@@ -42,6 +36,12 @@ func TestListCmd(t *testing.T) {
 
 	ctx := context.Background()
 	runAndWait(ctx, t, srv.Run)
+
+	createGrants(t, srv.DB(),
+		api.GrantRequest{UserName: "manygrants@example.com", Resource: "space", Privilege: "explorer"},
+		api.GrantRequest{UserName: "manygrants@example.com", Resource: "moon", Privilege: "inhabitant"},
+		api.GrantRequest{UserName: "manygrants@example.com", Resource: "infra-this-is-not", Privilege: "view"},
+	)
 
 	clientOpts := &APIClientOpts{
 		Host:      srv.Addrs.HTTPS.String(),

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -23,7 +23,7 @@ func TestListCmd(t *testing.T) {
 	t.Setenv("KUBECONFIG", kubeConfigPath)
 
 	opts := defaultServerOptions(dir)
-	opts.Config = server.Config{
+	opts.BootstrapConfig = server.BootstrapConfig{
 		Users: []server.User{
 			{Name: "admin", AccessKey: "0000000001.adminadminadminadmin1234", Role: "admin"},
 			{Name: "nogrants@example.com", AccessKey: "0000000002.notadminsecretnotadmin02"},

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -61,7 +61,7 @@ func TestLoginCmd_Options(t *testing.T) {
 	opts := defaultServerOptions(dir)
 	setupServerOptions(t, &opts)
 	adminAccessKey := "aaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb"
-	opts.Config.Users = []server.User{
+	opts.BootstrapConfig.Users = []server.User{
 		{
 			Name:      "admin@example.com",
 			AccessKey: adminAccessKey,

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -124,18 +124,12 @@ func TestServerCmd_LoadOptions(t *testing.T) {
 			name: "env vars with config file",
 			setup: func(t *testing.T, cmd *cobra.Command) {
 				content := `
-grants:
-  - user: user1
-    resource: infra
-    role: admin
-  - user: user2
-    resource: infra
-    role: admin
 
 users:
   - name: username
     accessKey: access-key
     password: the-password
+    role: admin
 `
 				dir := fs.NewDir(t, t.Name(),
 					fs.WithFile("cfg.yaml", content))
@@ -153,11 +147,12 @@ users:
 				expected.DBConnectionString = "host=db port=5432 user=postgres dbname=postgres password=postgres"
 				expected.DBEncryptionKey = "/root.key"
 				expected.Config.Users = []server.User{
-					{Name: "username", AccessKey: "access-key", Password: "the-password"},
-				}
-				expected.Config.Grants = []server.Grant{
-					{User: "user1", Resource: "infra", Role: "admin"},
-					{User: "user2", Resource: "infra", Role: "admin"},
+					{
+						Name:      "username",
+						AccessKey: "access-key",
+						Password:  "the-password",
+						Role:      "admin",
+					},
 				}
 				return expected
 			},
@@ -215,18 +210,11 @@ ui:
   enabled: false # default is true
   proxyURL: "1.2.3.4:5151"
 
-grants:
-  - user: user1
-    resource: infra
-    role: admin
-  - group: group1
-    resource: production
-    role: special
-
 users:
   - name: username
     accessKey: access-key
     password: the-password
+    role: admin
 
 redis:
   host: myredis
@@ -303,23 +291,12 @@ api:
 					},
 
 					Config: server.Config{
-						Grants: []server.Grant{
-							{
-								User:     "user1",
-								Resource: "infra",
-								Role:     "admin",
-							},
-							{
-								Group:    "group1",
-								Resource: "production",
-								Role:     "special",
-							},
-						},
 						Users: []server.User{
 							{
 								Name:      "username",
 								AccessKey: "access-key",
 								Password:  "the-password",
+								Role:      "admin",
 							},
 						},
 					},

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -146,7 +146,7 @@ users:
 				expected.TLS.CAPrivateKey = "file:foo/ca.key"
 				expected.DBConnectionString = "host=db port=5432 user=postgres dbname=postgres password=postgres"
 				expected.DBEncryptionKey = "/root.key"
-				expected.Config.Users = []server.User{
+				expected.BootstrapConfig.Users = []server.User{
 					{
 						Name:      "username",
 						AccessKey: "access-key",
@@ -290,7 +290,7 @@ api:
 						},
 					},
 
-					Config: server.Config{
+					BootstrapConfig: server.BootstrapConfig{
 						Users: []server.User{
 							{
 								Name:      "username",

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -129,7 +129,7 @@ users:
   - name: username
     accessKey: access-key
     password: the-password
-    role: admin
+    infraRole: admin
 `
 				dir := fs.NewDir(t, t.Name(),
 					fs.WithFile("cfg.yaml", content))
@@ -151,7 +151,7 @@ users:
 						Name:      "username",
 						AccessKey: "access-key",
 						Password:  "the-password",
-						Role:      "admin",
+						InfraRole: "admin",
 					},
 				}
 				return expected
@@ -214,7 +214,7 @@ users:
   - name: username
     accessKey: access-key
     password: the-password
-    role: admin
+    infraRole: admin
 
 redis:
   host: myredis
@@ -296,7 +296,7 @@ api:
 								Name:      "username",
 								AccessKey: "access-key",
 								Password:  "the-password",
-								Role:      "admin",
+								InfraRole: "admin",
 							},
 						},
 					},

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -509,6 +509,30 @@ func TestServerCmd_DeprecatedConfig(t *testing.T) {
 			},
 			expectedErr: "dbEncryptionKeyProvider is no longer supported",
 		},
+		{
+			name: "grants",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				content := `grants: []`
+
+				dir := fs.NewDir(t, t.Name(),
+					fs.WithFile("cfg.yaml", content))
+
+				t.Setenv("INFRA_SERVER_CONFIG_FILE", dir.Join("cfg.yaml"))
+			},
+			expectedErr: "grants can no longer be defined from config",
+		},
+		{
+			name: "providers",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				content := `providers: []`
+
+				dir := fs.NewDir(t, t.Name(),
+					fs.WithFile("cfg.yaml", content))
+
+				t.Setenv("INFRA_SERVER_CONFIG_FILE", dir.Join("cfg.yaml"))
+			},
+			expectedErr: "providers can no longer be defined from config",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -215,12 +215,6 @@ ui:
   enabled: false # default is true
   proxyURL: "1.2.3.4:5151"
 
-providers:
-  - name: okta
-    url: https://dev-okta.com/
-    clientID: client-id
-    clientSecret: the-secret
-
 grants:
   - user: user1
     resource: infra
@@ -309,14 +303,6 @@ api:
 					},
 
 					Config: server.Config{
-						Providers: []server.Provider{
-							{
-								Name:         "okta",
-								URL:          "https://dev-okta.com/",
-								ClientID:     "client-id",
-								ClientSecret: "the-secret",
-							},
-						},
 						Grants: []server.Grant{
 							{
 								User:     "user1",

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -29,7 +29,7 @@ func TestSSHHostsCmd(t *testing.T) {
 
 	srvDir := t.TempDir()
 	opts := defaultServerOptions(srvDir)
-	opts.Config = server.Config{
+	opts.BootstrapConfig = server.BootstrapConfig{
 		Users: []server.User{
 			{
 				Name:      "admin@example.com",
@@ -343,7 +343,7 @@ func TestProvisionSSHKey(t *testing.T) {
 
 	srvDir := t.TempDir()
 	opts := defaultServerOptions(srvDir)
-	opts.Config = server.Config{
+	opts.BootstrapConfig = server.BootstrapConfig{
 		Users: []server.User{
 			{Name: "admin@example.com", AccessKey: "0000000001.adminadminadminadmin1234"},
 			{Name: "anyuser@example.com", AccessKey: "0000000002.notadminsecretnotadmin02"},

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -34,7 +34,7 @@ func TestSSHHostsCmd(t *testing.T) {
 			{
 				Name:      "admin@example.com",
 				AccessKey: "0000000001.adminadminadminadmin1234",
-				Role:      "admin",
+				InfraRole: "admin",
 			},
 			{
 				Name:      "anyuser@example.com",

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -31,12 +31,15 @@ func TestSSHHostsCmd(t *testing.T) {
 	opts := defaultServerOptions(srvDir)
 	opts.Config = server.Config{
 		Users: []server.User{
-			{Name: "admin@example.com", AccessKey: "0000000001.adminadminadminadmin1234"},
-			{Name: "anyuser@example.com", AccessKey: "0000000002.notadminsecretnotadmin02"},
-		},
-		Grants: []server.Grant{
-			{User: "admin@example.com", Resource: "infra", Role: "admin"},
-			{User: "anyuser@example.com", Resource: "prodhost", Role: "connect"},
+			{
+				Name:      "admin@example.com",
+				AccessKey: "0000000001.adminadminadminadmin1234",
+				Role:      "admin",
+			},
+			{
+				Name:      "anyuser@example.com",
+				AccessKey: "0000000002.notadminsecretnotadmin02",
+			},
 		},
 	}
 	setupServerOptions(t, &opts)
@@ -45,6 +48,9 @@ func TestSSHHostsCmd(t *testing.T) {
 
 	ctx := context.Background()
 	runAndWait(ctx, t, srv.Run)
+
+	createGrants(t, srv.DB(),
+		api.GrantRequest{UserName: "anyuser@example.com", Resource: "prodhost", Privilege: "connect"})
 
 	client, err := NewAPIClient(&APIClientOpts{
 		AccessKey: "0000000001.adminadminadminadmin1234",

--- a/internal/cmd/sshauthkeys_test.go
+++ b/internal/cmd/sshauthkeys_test.go
@@ -30,7 +30,7 @@ func TestSSHDAuthKeysCmd(t *testing.T) {
 	})
 
 	opts := defaultServerOptions(home)
-	opts.Config = server.Config{
+	opts.BootstrapConfig = server.BootstrapConfig{
 		Users: []server.User{
 			{
 				Name:      "admin@example.com",

--- a/internal/cmd/sshauthkeys_test.go
+++ b/internal/cmd/sshauthkeys_test.go
@@ -35,7 +35,7 @@ func TestSSHDAuthKeysCmd(t *testing.T) {
 			{
 				Name:      "admin@example.com",
 				AccessKey: "0000000001.adminadminadminadmin1234",
-				Role:      "admin",
+				InfraRole: "admin",
 			},
 			{Name: "connector", AccessKey: "0000000003.connectorsecretconnector"},
 			{Name: "anyuser@example.com", AccessKey: "0000000002.notadminsecretnotadmin02"},

--- a/internal/cmd/users_test.go
+++ b/internal/cmd/users_test.go
@@ -229,7 +229,7 @@ func TestUsersCmd_EditPassword(t *testing.T) {
 
 	opts := defaultServerOptions(dir)
 	setupServerOptions(t, &opts)
-	opts.Config.Users = []server.User{
+	opts.BootstrapConfig.Users = []server.User{
 		{
 			Name:     "admin@local",
 			Password: "password",

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -610,25 +610,12 @@ func (s Server) loadConfig(config Config) error {
 }
 
 func (s Server) loadGrants(db data.WriteTxn, grants []Grant) error {
-	keep := make([]uid.ID, 0, len(grants))
-
 	for _, g := range grants {
-		grant, err := s.loadGrant(db, g)
+		_, err := s.loadGrant(db, g)
 		if err != nil {
 			return err
 		}
-
-		keep = append(keep, grant.ID)
 	}
-
-	// remove any grant previously defined by config
-	if err := data.DeleteGrants(db, data.DeleteGrantsOptions{
-		NotIDs:      keep,
-		ByCreatedBy: models.CreatedBySystem,
-	}); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -700,27 +687,12 @@ func (Server) loadGrant(db data.WriteTxn, input Grant) (*models.Grant, error) {
 }
 
 func (s Server) loadUsers(db data.WriteTxn, users []User) error {
-	keep := make([]uid.ID, 0, len(users)+1)
-
 	for _, i := range users {
-		user, err := s.loadUser(db, i)
+		_, err := s.loadUser(db, i)
 		if err != nil {
 			return err
 		}
-
-		keep = append(keep, user.ID)
 	}
-
-	// remove any users previously defined by config
-	opts := data.DeleteIdentitiesOptions{
-		ByProviderID: data.InfraProvider(db).ID,
-		ByNotIDs:     keep,
-		CreatedBy:    models.CreatedBySystem,
-	}
-	if err := data.DeleteIdentities(db, opts); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-type Config struct {
+type BootstrapConfig struct {
 	DefaultOrganizationDomain string
 	Users                     []User
 }
@@ -39,7 +39,7 @@ func (u User) ValidationRules() []validate.ValidationRule {
 	}
 }
 
-func (c Config) ValidationRules() []validate.ValidationRule {
+func (c BootstrapConfig) ValidationRules() []validate.ValidationRule {
 	// no-op implement to satisfy the interface
 	return nil
 }
@@ -553,7 +553,7 @@ func getKindFromUnstructured(data interface{}) string {
 	return ""
 }
 
-func (s Server) loadConfig(config Config) error {
+func (s Server) loadConfig(config BootstrapConfig) error {
 	if err := validate.Validate(config); err != nil {
 		return err
 	}

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -12,40 +12,13 @@ import (
 	"github.com/infrahq/secrets"
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/internal/server/providers"
 	"github.com/infrahq/infra/internal/validate"
 	"github.com/infrahq/infra/uid"
 )
-
-type Provider struct {
-	Name         string
-	URL          string
-	ClientID     string
-	ClientSecret string
-	Kind         string
-	AuthURL      string
-	Scopes       []string
-
-	// fields used to directly query an external API
-	PrivateKey       string
-	ClientEmail      string
-	DomainAdminEmail string
-}
-
-func (p Provider) ValidationRules() []validate.ValidationRule {
-	return []validate.ValidationRule{
-		api.ValidateName(p.Name),
-		validate.Required("name", p.Name),
-		validate.Required("url", p.URL),
-		validate.Required("clientID", p.ClientID),
-		validate.Required("clientSecret", p.ClientSecret),
-	}
-}
 
 type Grant struct {
 	User     string
@@ -78,7 +51,6 @@ func (u User) ValidationRules() []validate.ValidationRule {
 
 type Config struct {
 	DefaultOrganizationDomain string
-	Providers                 []Provider
 	Grants                    []Grant
 	Users                     []User
 }
@@ -618,26 +590,6 @@ func (s Server) loadConfig(config Config) error {
 		}
 	}
 
-	// inject internal infra provider
-	config.Providers = append(config.Providers, Provider{
-		Name: models.InternalInfraProviderName,
-		Kind: models.ProviderKindInfra.String(),
-	})
-
-	config.Users = append(config.Users, User{
-		Name: models.InternalInfraConnectorIdentityName,
-	})
-
-	config.Grants = append(config.Grants, Grant{
-		User:     models.InternalInfraConnectorIdentityName,
-		Role:     models.InfraConnectorRole,
-		Resource: "infra",
-	})
-
-	if err := s.loadProviders(tx, config.Providers); err != nil {
-		return fmt.Errorf("load providers: %w", err)
-	}
-
 	// extract users from grants and add them to users
 	for _, g := range config.Grants {
 		switch {
@@ -655,108 +607,6 @@ func (s Server) loadConfig(config Config) error {
 	}
 
 	return tx.Commit()
-}
-
-func (s Server) loadProviders(db data.WriteTxn, providers []Provider) error {
-	keep := []uid.ID{}
-
-	for _, p := range providers {
-		provider, err := s.loadProvider(db, p)
-		if err != nil {
-			return err
-		}
-
-		keep = append(keep, provider.ID)
-	}
-
-	// remove any provider previously defined by config
-	if err := data.DeleteProviders(db, data.DeleteProvidersOptions{
-		CreatedBy: models.CreatedBySystem,
-		NotIDs:    keep,
-	}); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s Server) loadProvider(db data.WriteTxn, input Provider) (*models.Provider, error) {
-	// provider kind is an optional field
-	kind, err := models.ParseProviderKind(input.Kind)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse provider in config load: %w", err)
-	}
-
-	clientSecret, err := secrets.GetSecret(input.ClientSecret, s.secrets)
-	if err != nil {
-		return nil, fmt.Errorf("could not load provider client secret: %w", err)
-	}
-
-	provider, err := data.GetProvider(db, data.GetProviderOptions{ByName: input.Name})
-	if err != nil {
-		if !errors.Is(err, internal.ErrNotFound) {
-			return nil, err
-		}
-
-		provider := &models.Provider{
-			Name:         input.Name,
-			URL:          input.URL,
-			ClientID:     input.ClientID,
-			ClientSecret: models.EncryptedAtRest(clientSecret),
-			AuthURL:      input.AuthURL,
-			Scopes:       input.Scopes,
-			Kind:         kind,
-			CreatedBy:    models.CreatedBySystem,
-
-			PrivateKey:       models.EncryptedAtRest(input.PrivateKey),
-			ClientEmail:      input.ClientEmail,
-			DomainAdminEmail: input.DomainAdminEmail,
-		}
-
-		if provider.Kind != models.ProviderKindInfra {
-			// only call the provider to resolve info if it is not known
-			if input.AuthURL == "" && len(input.Scopes) == 0 {
-				providerClient := providers.NewOIDCClient(*provider, clientSecret, "")
-				authServerInfo, err := providerClient.AuthServerInfo(context.Background())
-				if err != nil {
-					if errors.Is(err, context.DeadlineExceeded) {
-						return nil, fmt.Errorf("%w: %s", internal.ErrBadGateway, err)
-					}
-					return nil, err
-				}
-
-				provider.AuthURL = authServerInfo.AuthURL
-				provider.Scopes = authServerInfo.ScopesSupported
-			}
-
-			// check that the scopes we need are set
-			supportedScopes := make(map[string]bool)
-			for _, s := range provider.Scopes {
-				supportedScopes[s] = true
-			}
-			if !supportedScopes["openid"] || !supportedScopes["email"] {
-				return nil, fmt.Errorf("required scopes 'openid' and 'email' not found on provider %q", input.Name)
-			}
-		}
-
-		if err := data.CreateProvider(db, provider); err != nil {
-			return nil, err
-		}
-
-		return provider, nil
-	}
-
-	// provider already exists, update it
-	provider.URL = input.URL
-	provider.ClientID = input.ClientID
-	provider.ClientSecret = models.EncryptedAtRest(clientSecret)
-	provider.Kind = kind
-
-	if err := data.UpdateProvider(db, provider); err != nil {
-		return nil, err
-	}
-
-	return provider, nil
 }
 
 func (s Server) loadGrants(db data.WriteTxn, grants []Grant) error {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -30,7 +30,7 @@ type User struct {
 	Name      string
 	AccessKey string
 	Password  string
-	Role      string
+	InfraRole string
 }
 
 func (u User) ValidationRules() []validate.ValidationRule {
@@ -642,7 +642,7 @@ func (s Server) loadUser(db data.WriteTxn, input User) error {
 		return err
 	}
 
-	if err := loadGrant(db, identity.ID, input.Role); err != nil {
+	if err := loadGrant(db, identity.ID, input.InfraRole); err != nil {
 		return err
 	}
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -585,7 +585,7 @@ func loadGrant(tx data.WriteTxn, userID uid.ID, role string) error {
 	if role == "" {
 		return nil
 	}
-	grant, err := data.GetGrant(tx, data.GetGrantOptions{
+	_, err := data.GetGrant(tx, data.GetGrantOptions{
 		BySubject:   uid.NewIdentityPolymorphicID(userID),
 		ByResource:  access.ResourceInfraAPI,
 		ByPrivilege: role,
@@ -594,7 +594,7 @@ func loadGrant(tx data.WriteTxn, userID uid.ID, role string) error {
 		return err
 	}
 
-	grant = &models.Grant{
+	grant := &models.Grant{
 		Subject:   uid.NewIdentityPolymorphicID(userID),
 		Resource:  access.ResourceInfraAPI,
 		Privilege: role,

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -293,14 +293,14 @@ func TestSecretProvider_PrepareForDecode_IntegrationWithDecode(t *testing.T) {
 func TestLoadConfigEmpty(t *testing.T) {
 	s := setupServer(t)
 
-	err := s.loadConfig(Config{})
+	err := s.loadConfig(BootstrapConfig{})
 	assert.NilError(t, err)
 }
 
 func TestLoadConfigWithUsers(t *testing.T) {
 	s := setupServer(t)
 
-	config := Config{
+	config := BootstrapConfig{
 		Users: []User{
 			{
 				Name: "bob@example.com",
@@ -350,7 +350,7 @@ func TestLoadConfigWithUsers(t *testing.T) {
 func TestLoadConfigUpdate(t *testing.T) {
 	s := setupServer(t)
 
-	config := Config{
+	config := BootstrapConfig{
 		Users: []User{
 			{
 				Name: "r2d2@example.com",
@@ -406,7 +406,7 @@ func TestLoadConfigUpdate(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, int64(1), accessKeys) // c3po
 
-	updatedConfig := Config{
+	updatedConfig := BootstrapConfig{
 		Users: []User{
 			{
 				Name: "c3po@example.com",

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -353,13 +353,13 @@ func TestLoadConfigUpdate(t *testing.T) {
 	config := BootstrapConfig{
 		Users: []User{
 			{
-				Name: "r2d2@example.com",
-				Role: "admin",
+				Name:      "r2d2@example.com",
+				InfraRole: "admin",
 			},
 			{
 				Name:      "c3po@example.com",
 				AccessKey: "TllVlekkUz.NFnxSlaPQLosgkNsyzaMttfC",
-				Role:      "view",
+				InfraRole: "view",
 			},
 			{
 				Name:     "sarah@email.com",
@@ -409,8 +409,8 @@ func TestLoadConfigUpdate(t *testing.T) {
 	updatedConfig := BootstrapConfig{
 		Users: []User{
 			{
-				Name: "c3po@example.com",
-				Role: "admin",
+				Name:      "c3po@example.com",
+				InfraRole: "admin",
 			},
 		},
 	}

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -250,15 +250,6 @@ type DeleteGrantsOptions struct {
 	// BySubject instructs DeleteGrants to delete all grants that match this
 	// subject. When set other fields below this on this struct are ignored.
 	BySubject uid.PolymorphicID
-
-	// ByCreatedBy instructs DeleteGrants to delete all the grants that were
-	// created by this user. Can be used with NotIDs
-	ByCreatedBy uid.ID
-	// NotIDs instructs DeleteGrants to exclude any grants with these IDs to
-	// be excluded. In other words, these IDs will not be deleted, even if they
-	// match ByCreatedBy.
-	// Can only be used with ByCreatedBy.
-	NotIDs []uid.ID
 }
 
 func DeleteGrants(tx WriteTxn, opts DeleteGrantsOptions) error {
@@ -273,12 +264,6 @@ func DeleteGrants(tx WriteTxn, opts DeleteGrantsOptions) error {
 		query.B("id = ?", opts.ByID)
 	case opts.BySubject != "":
 		query.B("subject = ?", opts.BySubject)
-	case opts.ByCreatedBy != 0:
-		query.B("created_by = ?", opts.ByCreatedBy)
-		if len(opts.NotIDs) > 0 {
-			query.B("AND id NOT IN")
-			queryInClause(query, opts.NotIDs)
-		}
 	default:
 		return fmt.Errorf("DeleteGrants requires an ID to delete")
 	}

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -174,35 +174,6 @@ func TestDeleteGrants(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Equal(t, len(actual), 1)
 		})
-		t.Run("by created_by and not ids", func(t *testing.T) {
-			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
-
-			createdBy := uid.ID(9234)
-			grant1 := &models.Grant{Subject: "i:any1", Privilege: "view", Resource: "any", CreatedBy: createdBy}
-			grant2 := &models.Grant{Subject: "i:any2", Privilege: "view", Resource: "any", CreatedBy: createdBy}
-			toKeep1 := &models.Grant{Subject: "i:any3", Privilege: "view", Resource: "any", CreatedBy: createdBy}
-			toKeep2 := &models.Grant{Subject: "i:any4", Privilege: "view", Resource: "any"}
-			createGrants(t, tx, grant1, grant2, toKeep1, toKeep2)
-
-			err := DeleteGrants(tx, DeleteGrantsOptions{
-				ByCreatedBy: createdBy,
-				NotIDs:      []uid.ID{toKeep1.ID},
-			})
-			assert.NilError(t, err)
-
-			actual, err := ListGrants(tx, ListGrantsOptions{ByDestination: "any"})
-			assert.NilError(t, err)
-			expected := []models.Grant{
-				{Model: models.Model{ID: toKeep1.ID}},
-				{Model: models.Model{ID: toKeep2.ID}},
-			}
-			assert.DeepEqual(t, actual, expected, cmpModelByID)
-
-			maxIndex, err := GrantsMaxUpdateIndex(tx, GrantsMaxUpdateIndexOptions{ByDestination: "any"})
-			assert.NilError(t, err)
-			assert.Equal(t, maxIndex, startUpdateIndex+6) // 4 inserts, 2 deletes
-			startUpdateIndex = maxIndex
-		})
 		t.Run("notify", func(t *testing.T) {
 			g := models.Grant{
 				Subject:   "i:1234567",

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -395,12 +395,10 @@ func SetIdentityVerified(tx WriteTxn, token string) error {
 type ListIdentityOptions struct {
 	ByID                   uid.ID
 	ByIDs                  []uid.ID
-	ByNotIDs               []uid.ID
 	ByName                 string
 	ByPublicKeyFingerprint string
 	ByNotName              string
 	ByGroupID              uid.ID
-	CreatedBy              uid.ID
 	Pagination             *Pagination
 	LoadGroups             bool
 	LoadProviders          bool
@@ -408,9 +406,6 @@ type ListIdentityOptions struct {
 }
 
 func ListIdentities(tx ReadTxn, opts ListIdentityOptions) ([]models.Identity, error) {
-	if len(opts.ByNotIDs) > 0 && opts.CreatedBy == 0 {
-		return nil, fmt.Errorf("ListIdentities by 'not IDs' requires 'created by'")
-	}
 	identities := &identitiesTable{}
 	query := querybuilder.New("SELECT")
 	query.B(columnsForSelect(identities))
@@ -443,13 +438,6 @@ func ListIdentities(tx ReadTxn, opts ListIdentityOptions) ([]models.Identity, er
 	}
 	if opts.ByGroupID != 0 {
 		query.B("AND identities_groups.group_id = ?", opts.ByGroupID)
-	}
-	if opts.CreatedBy != 0 {
-		query.B("AND identities.created_by = ?", opts.CreatedBy)
-		if len(opts.ByNotIDs) > 0 {
-			query.B("AND identities.id NOT IN ")
-			queryInClause(query, opts.ByNotIDs)
-		}
 	}
 	query.B("ORDER BY identities.name ASC")
 	if opts.Pagination != nil {
@@ -630,8 +618,6 @@ func UpdateIdentity(tx WriteTxn, identity *models.Identity) error {
 type DeleteIdentitiesOptions struct {
 	ByID         uid.ID
 	ByIDs        []uid.ID
-	ByNotIDs     []uid.ID
-	CreatedBy    uid.ID
 	ByProviderID uid.ID
 }
 
@@ -640,10 +626,8 @@ func DeleteIdentities(tx WriteTxn, opts DeleteIdentitiesOptions) error {
 		return fmt.Errorf("DeleteIdentities requires a provider ID")
 	}
 	listOpts := ListIdentityOptions{
-		ByID:      opts.ByID,
-		ByIDs:     opts.ByIDs,
-		ByNotIDs:  opts.ByNotIDs,
-		CreatedBy: opts.CreatedBy,
+		ByID:  opts.ByID,
+		ByIDs: opts.ByIDs,
 	}
 	toDelete, err := ListIdentities(tx, listOpts)
 	if err != nil {

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -87,15 +87,6 @@ type ListProvidersOptions struct {
 	ExcludeInfraProvider bool
 	ByIDs                []uid.ID
 
-	// CreatedBy instructs DeleteProviders to delete all the providers that were
-	// created by this user. Can be used with NotIDs.
-	CreatedBy uid.ID
-	// NotIDs instructs DeleteProviders to exclude any providers with these IDs to
-	// be excluded. In other words, these IDs will not be deleted, even if they
-	// match CreatedBy.
-	// Can only be used with CreatedBy.
-	NotIDs []uid.ID
-
 	Pagination *Pagination
 }
 
@@ -119,13 +110,6 @@ func ListProviders(tx ReadTxn, opts ListProvidersOptions) ([]models.Provider, er
 	if len(opts.ByIDs) > 0 {
 		query.B("AND id IN")
 		queryInClause(query, opts.ByIDs)
-	}
-	if opts.CreatedBy != 0 {
-		query.B("AND created_by = ?", opts.CreatedBy)
-		if len(opts.NotIDs) > 0 {
-			query.B("AND id NOT IN")
-			queryInClause(query, opts.NotIDs)
-		}
 	}
 
 	query.B("ORDER BY name ASC")
@@ -157,91 +141,74 @@ type DeleteProvidersOptions struct {
 	// ByID instructs DeleteProviders to delete the provider matching this ID.
 	// When non-zero all other fields on this struct will be ignored
 	ByID uid.ID
-
-	// CreatedBy instructs DeleteProviders to delete all the providers that were
-	// created by this user. Can be used with NotIDs.
-	CreatedBy uid.ID
-	// NotIDs instructs DeleteProviders to exclude any providers with these IDs to
-	// be excluded. In other words, these IDs will not be deleted, even if they
-	// match CreatedBy.
-	// Can only be used with CreatedBy.
-	NotIDs []uid.ID
 }
 
+// TODO: accept only id instead of options struct
 func DeleteProviders(db WriteTxn, opts DeleteProvidersOptions) error {
-	var toDelete []models.Provider
-	if opts.ByID != 0 {
-		if provider, _ := GetProvider(db, GetProviderOptions{ByID: opts.ByID}); provider != nil {
-			toDelete = []models.Provider{*provider}
-		}
-	} else {
-		var err error
-		toDelete, err = ListProviders(db, ListProvidersOptions{
-			CreatedBy: opts.CreatedBy,
-			NotIDs:    opts.NotIDs,
-		})
+	if opts.ByID == 0 {
+		return fmt.Errorf("an ID is required to delete provider")
+	}
+	_, err := GetProvider(db, GetProviderOptions{ByID: opts.ByID})
+	switch {
+	case errors.Is(err, internal.ErrNotFound):
+		return nil // already deleted
+	case err != nil:
+		return err
+	}
+
+	id := opts.ByID
+
+	providerUsers, err := ListProviderUsers(db, ListProviderUsersOptions{ByProviderID: id})
+	if err != nil {
+		return fmt.Errorf("listing provider users: %w", err)
+	}
+
+	// if a user has no other providers, we need to remove the user.
+	userIDsToDelete := []uid.ID{}
+	for _, providerUser := range providerUsers {
+		user, err := GetIdentity(db, GetIdentityOptions{ByID: providerUser.IdentityID, LoadProviders: true})
 		if err != nil {
-			return fmt.Errorf("listing providers: %w", err)
+			if errors.Is(err, internal.ErrNotFound) {
+				continue
+			}
+			return fmt.Errorf("get user: %w", err)
+		}
+
+		if len(user.Providers) == 1 && user.Providers[0].ID == id {
+			userIDsToDelete = append(userIDsToDelete, user.ID)
 		}
 	}
 
-	ids := make([]uid.ID, 0)
-	for _, p := range toDelete {
-		ids = append(ids, p.ID)
-
-		providerUsers, err := ListProviderUsers(db, ListProviderUsersOptions{ByProviderID: p.ID})
-		if err != nil {
-			return fmt.Errorf("listing provider users: %w", err)
+	if len(userIDsToDelete) > 0 {
+		opts := DeleteIdentitiesOptions{
+			ByProviderID: id,
+			ByIDs:        userIDsToDelete,
 		}
-
-		// if a user has no other providers, we need to remove the user.
-		userIDsToDelete := []uid.ID{}
-		for _, providerUser := range providerUsers {
-			user, err := GetIdentity(db, GetIdentityOptions{ByID: providerUser.IdentityID, LoadProviders: true})
-			if err != nil {
-				if errors.Is(err, internal.ErrNotFound) {
-					continue
-				}
-				return fmt.Errorf("get user: %w", err)
-			}
-
-			if len(user.Providers) == 1 && user.Providers[0].ID == p.ID {
-				userIDsToDelete = append(userIDsToDelete, user.ID)
-			}
+		if err := DeleteIdentities(db, opts); err != nil {
+			return fmt.Errorf("delete users: %w", err)
 		}
+	}
 
-		if len(userIDsToDelete) > 0 {
-			opts := DeleteIdentitiesOptions{
-				ByProviderID: p.ID,
-				ByIDs:        userIDsToDelete,
-			}
-			if err := DeleteIdentities(db, opts); err != nil {
-				return fmt.Errorf("delete users: %w", err)
-			}
-		}
+	if err := DeleteProviderUsers(db, DeleteProviderUsersOptions{ByProviderID: id}); err != nil {
+		return fmt.Errorf("delete provider users: %w", err)
+	}
 
-		if err := DeleteProviderUsers(db, DeleteProviderUsersOptions{ByProviderID: p.ID}); err != nil {
-			return fmt.Errorf("delete provider users: %w", err)
-		}
+	if err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByProviderID: id}); err != nil {
+		return fmt.Errorf("delete access keys: %w", err)
+	}
 
-		if err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByProviderID: p.ID}); err != nil {
-			return fmt.Errorf("delete access keys: %w", err)
-		}
-
-		// delete any access keys used for SCIM
-		if err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByIssuedForID: p.ID}); err != nil {
-			return fmt.Errorf("delete provider access keys: %w", err)
-		}
+	// delete any access keys used for SCIM
+	if err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByIssuedForID: id}); err != nil {
+		return fmt.Errorf("delete provider access keys: %w", err)
 	}
 
 	query := querybuilder.New(`UPDATE providers`)
 	query.B(`SET deleted_at = ?`, time.Now())
 	query.B(`WHERE deleted_at is null`)
 	query.B(`AND organization_id = ?`, db.OrganizationID())
-	query.B(`AND id IN`)
-	queryInClause(query, ids)
-	_, err := db.Exec(query.String(), query.Args...)
-	return err
+	query.B(`AND id = ?`, id)
+	_, err = db.Exec(query.String(), query.Args...)
+	return handleError(err)
 }
 
 type providersCount struct {

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -217,16 +217,6 @@ func TestListProviders(t *testing.T) {
 			expected := []models.Provider{*providerInfra, *providerDev}
 			assert.DeepEqual(t, expected, actual, cmpModelByID)
 		})
-		t.Run("created by and notIDs", func(t *testing.T) {
-			actual, err := ListProviders(db, ListProvidersOptions{
-				CreatedBy: 777,
-				NotIDs:    []uid.ID{providerDev.ID},
-			})
-			assert.NilError(t, err)
-
-			expected := []models.Provider{*providerProd}
-			assert.DeepEqual(t, expected, actual, cmpModelByID)
-		})
 		t.Run("pagination", func(t *testing.T) {
 			page := Pagination{Page: 2, Limit: 2}
 			actual, err := ListProviders(db, ListProvidersOptions{Pagination: &page})

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -72,7 +72,7 @@ func withAdminUser(_ *testing.T, opts *Options) {
 	opts.Users = append(opts.Users, User{
 		Name:      "admin@example.com",
 		AccessKey: "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb",
-		Role:      "admin",
+		InfraRole: "admin",
 	})
 }
 
@@ -80,7 +80,7 @@ func withSupportAdminGrant(_ *testing.T, opts *Options) {
 	opts.Users = append(opts.Users, User{
 		Name:      "admin@example.com",
 		AccessKey: "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb",
-		Role:      "support-admin",
+		InfraRole: "support-admin",
 	})
 }
 

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -72,19 +72,15 @@ func withAdminUser(_ *testing.T, opts *Options) {
 	opts.Users = append(opts.Users, User{
 		Name:      "admin@example.com",
 		AccessKey: "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb",
-	})
-	opts.Grants = append(opts.Grants, Grant{
-		User:     "admin@example.com",
-		Role:     "admin",
-		Resource: "infra",
+		Role:      "admin",
 	})
 }
 
 func withSupportAdminGrant(_ *testing.T, opts *Options) {
-	opts.Grants = append(opts.Grants, Grant{
-		User:     "admin@example.com",
-		Role:     "support-admin",
-		Resource: "infra",
+	opts.Users = append(opts.Users, User{
+		Name:      "admin@example.com",
+		AccessKey: "BlgpvURSGF.NdcemBdzxLTGIcjPXwPoZNrb",
+		Role:      "support-admin",
 	})
 }
 

--- a/internal/server/options_migrations.go
+++ b/internal/server/options_migrations.go
@@ -19,7 +19,7 @@ func (o OptionsDiffV0dot1) applyToV0dot2(base *Options) {
 	logging.Warnf("updated server options from version 0.1 to 0.2")
 
 	base.Version = 0.2
-	base.Config.Users = o.Identities
+	base.BootstrapConfig.Users = o.Identities
 }
 
 type OptionsDiffV0dot2 struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -101,6 +101,8 @@ type Options struct {
 // longer supported.
 type DeprecatedConfig struct {
 	DBEncryptionKeyProvider string
+	Providers               any
+	Grants                  any
 }
 
 type ListenerOptions struct {
@@ -170,6 +172,14 @@ func New(options Options) (*Server, error) {
 	if options.DBEncryptionKeyProvider != "" && options.DBEncryptionKeyProvider != "native" {
 		return nil, errors.New("dbEncryptionKeyProvider is no longer supported, " +
 			"use a file for the root key and set dbEncryptionKey to the path of the file")
+	}
+	if options.Grants != nil {
+		return nil, fmt.Errorf("grants can no longer be defined from config. " +
+			"Please use https://github.com/infrahq/terraform-provider-infra or the API")
+	}
+	if options.Providers != nil {
+		return nil, fmt.Errorf("providers can no longer be defined from config. " +
+			"Please use https://github.com/infrahq/terraform-provider-infra or the API")
 	}
 
 	server := newServer(options)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,7 +84,7 @@ type Options struct {
 	Keys    []KeyProvider
 	Secrets []SecretProvider
 
-	Config
+	BootstrapConfig
 
 	Addr ListenerOptions
 	UI   UIOptions
@@ -234,7 +234,7 @@ func New(options Options) (*Server, error) {
 		}
 	}
 
-	if err := server.loadConfig(server.options.Config); err != nil {
+	if err := server.loadConfig(server.options.BootstrapConfig); err != nil {
 		return nil, fmt.Errorf("configs: %w", err)
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -53,7 +53,7 @@ func setupServer(t *testing.T, ops ...func(*testing.T, *Options)) *Server {
 	err := loadDefaultSecretConfig(s.secrets)
 	assert.NilError(t, err)
 
-	err = s.loadConfig(s.options.Config)
+	err = s.loadConfig(s.options.BootstrapConfig)
 	assert.NilError(t, err)
 
 	s.metricsRegistry = prometheus.NewRegistry()
@@ -413,7 +413,7 @@ func TestServer_PersistSignupUser(t *testing.T) {
 	checkAuthenticated()
 
 	// reload server config
-	err = s.loadConfig(s.options.Config)
+	err = s.loadConfig(s.options.BootstrapConfig)
 	assert.NilError(t, err)
 
 	// retry the authenticated endpoint

--- a/test/dockerfiles/server.yaml
+++ b/test/dockerfiles/server.yaml
@@ -2,7 +2,7 @@
 users:
   - name: admin@example.com
     accessKey: aaaaaaaaaa.000000000000000000000000
-    role: admin
+    infraRole: admin
   - name: connector
     accessKey: dest000001.ubuntuubuntuubuntuubuntu
   - name: connector

--- a/test/dockerfiles/server.yaml
+++ b/test/dockerfiles/server.yaml
@@ -2,6 +2,7 @@
 users:
   - name: admin@example.com
     accessKey: aaaaaaaaaa.000000000000000000000000
+    role: admin
   - name: connector
     accessKey: dest000001.ubuntuubuntuubuntuubuntu
   - name: connector
@@ -10,9 +11,3 @@ users:
     accessKey: dest000003.redhatredhatredhatredhat
   - name: anyuser@example.com
     accessKey: ababababab.000000000000000000000001
-
-
-grants:
-  - user: admin@example.com
-    resource: infra
-    role: admin

--- a/test/go.mod
+++ b/test/go.mod
@@ -13,7 +13,7 @@ require (
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
-	github.com/getkin/kin-openapi v0.111.0 // indirect
+	github.com/getkin/kin-openapi v0.112.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -6,8 +6,8 @@ github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/getkin/kin-openapi v0.111.0 h1:zspOcFKBCQOY8d9Yockcbit8iVR2hco9qLaoQoj7kmw=
-github.com/getkin/kin-openapi v0.111.0/go.mod h1:QtwUNt0PAAgIIBEvFWYfB7dfngxtAaqCX1zYHMZDeK8=
+github.com/getkin/kin-openapi v0.112.0 h1:lnLXx3bAG53EJVI4E/w0N8i1Y/vUZUEsnrXkgnfn7/Y=
+github.com/getkin/kin-openapi v0.112.0/go.mod h1:QtwUNt0PAAgIIBEvFWYfB7dfngxtAaqCX1zYHMZDeK8=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=


### PR DESCRIPTION
## Summary

Implements most of what was proposed in #3915. 

Not done, still pending further discussion:
* `User.Password` has not been removed - it's used by helm
* `SupportAdminGroups` has not been added yet
* the access key expiration time is still set to 10 years

I'd like to address those in separate follow up PRs. 

If a self-hosted install of Infra includes `grants` or `providers`  the server will refuse to start and the error message will inform the user what needs to change.

Helm changes in https://github.com/infrahq/helm-charts/pull/17