### PR TITLE
Demonstrate a CLI focused on credentials without losing admin functionality

### DIFF
--- a/internal/cmd/about.go
+++ b/internal/cmd/about.go
@@ -18,11 +18,10 @@ type triangle struct {
 
 func newAboutCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "about",
-		Short:   "Display information about Infra",
-		Args:    NoArgs,
-		GroupID: groupOther,
-		Hidden:  false,
+		Use:    "about",
+		Short:  "Display information about Infra",
+		Args:   NoArgs,
+		Hidden: false,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return about()
 		},

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -27,6 +27,8 @@ func Run(ctx context.Context, args ...string) error {
 	cli := newCLI(ctx)
 	cmd := NewRootCmd(cli)
 	cmd.SetArgs(args)
+	cmd.SetErr(cli.Stderr)
+	cmd.SetOut(cli.Stdout)
 	return cmd.ExecuteContext(ctx)
 }
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -170,6 +170,7 @@ func httpTransportForHostConfig(config *ClientHostConfig) *http.Transport {
 const (
 	groupCore       = "group-core"
 	groupManagement = "group-management"
+	groupServices   = "group-services"
 )
 
 func NewRootCmd(cli *CLI) *cobra.Command {
@@ -209,6 +210,10 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 		&cobra.Group{
 			ID:    groupManagement,
 			Title: "Admin commands:",
+		},
+		&cobra.Group{
+			ID:    groupServices,
+			Title: "Service commands:",
 		})
 
 	rootCmd.AddCommand(

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -175,6 +175,8 @@ const (
 func NewRootCmd(cli *CLI) *cobra.Command {
 	cobra.EnableCommandSorting = false
 
+	var showAdminHelp bool
+
 	rootCmd := &cobra.Command{
 		Use:               "infra",
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
@@ -189,6 +191,14 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 			}
 			return nil
 		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if showAdminHelp {
+				cmd.SetUsageFunc(nil) // hide our custom template
+				fmt.Fprintln(cli.Stdout, cmd.UsageString())
+				return nil
+			}
+			return nil
+		},
 	}
 
 	rootCmd.AddGroup(
@@ -198,7 +208,7 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 		},
 		&cobra.Group{
 			ID:    groupManagement,
-			Title: "Management commands:",
+			Title: "Admin commands:",
 		})
 
 	rootCmd.AddCommand(
@@ -231,6 +241,7 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 	rootCmd.PersistentFlags().Bool("help", false, "Display help")
 	rootCmd.PersistentFlags().StringVar(&cli.RootOptions.LogLevel, "log-level", "info", "Show logs when running the command [error, warn, info, debug]")
 	rootCmd.PersistentFlags().BoolVar(&cli.RootOptions.SkipAPIVersionCheck, "skip-version-check", false, "Skip checking if the CLI is ahead of the server version")
+	rootCmd.Flags().BoolVar(&showAdminHelp, "help-admin", false, "Show help for admin commands")
 
 	rootCmd.AddCommand(newAboutCmd())
 	rootCmd.AddCommand(newCompletionsCmd())
@@ -282,6 +293,5 @@ Flags:
 Global Flags:
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
 
-Use "infra --help-admin" for more information about admin commands.
 Use "{{.CommandPath}} [command] --help" for more information about a command.
 `

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -243,7 +243,6 @@ func NewRootCmd(cli *CLI) *cobra.Command {
 	rootCmd.SetHelpCommandGroupID(groupOther)
 	rootCmd.AddCommand(newAboutCmd())
 	rootCmd.AddCommand(newCompletionsCmd())
-	rootCmd.SetUsageTemplate(usageTemplate())
 	return rootCmd
 }
 
@@ -254,34 +253,4 @@ func addNonInteractiveFlag(flags *pflag.FlagSet, bind *bool) {
 
 func addFormatFlag(flags *pflag.FlagSet, bind *string) {
 	flags.StringVar(bind, "format", "", "Output format [json|yaml]")
-}
-
-func usageTemplate() string {
-	return `Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
-
-Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
-
-Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
-
-Available Commands:{{end}}{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{range $group := .Groups}}
-
-{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
-
-Flags:
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
-
-Global Flags:
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
-
-Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
-
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
-`
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -187,15 +186,31 @@ func TestInvalidSessions(t *testing.T) {
 	})
 }
 
-func TestRootCmd_UsageTemplate(t *testing.T) {
+func TestRootCmd_HelpText(t *testing.T) {
 	ctx := context.Background()
-	cmd := NewRootCmd(newCLI(ctx))
+	ctx, bufs := PatchCLI(ctx)
 
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	assert.NilError(t, cmd.Usage())
+	err := Run(ctx, "--help")
+	assert.NilError(t, err)
 
-	golden.Assert(t, buf.String(), "expected-usage")
+	golden.Assert(t, bufs.Stdout.String(), "expected-help-root")
+}
+
+// This is to test any non-root command. If use is removed, change this test
+// to a different non-root command.
+func TestLoginCmd_HelpText(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	ctx := context.Background()
+	ctx, bufs := PatchCLI(ctx)
+
+	err := Run(ctx, "login", "--help")
+	assert.NilError(t, err)
+
+	golden.Assert(t, bufs.Stdout.String(), "expected-help-use")
+
 }
 
 // TestCmdDoesNotUsePersistentPreRun because if any subcommand sets a

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -187,13 +187,20 @@ func TestInvalidSessions(t *testing.T) {
 }
 
 func TestRootCmd_HelpText(t *testing.T) {
-	ctx := context.Background()
-	ctx, bufs := PatchCLI(ctx)
-
-	err := Run(ctx, "--help")
-	assert.NilError(t, err)
-
-	golden.Assert(t, bufs.Stdout.String(), "expected-help-root")
+	t.Run("default help", func(t *testing.T) {
+		ctx := context.Background()
+		ctx, bufs := PatchCLI(ctx)
+		err := Run(ctx, "--help")
+		assert.NilError(t, err)
+		golden.Assert(t, bufs.Stdout.String(), "expected-help-root")
+	})
+	t.Run("admin help", func(t *testing.T) {
+		ctx := context.Background()
+		ctx, bufs := PatchCLI(ctx)
+		err := Run(ctx, "--help-admin")
+		assert.NilError(t, err)
+		golden.Assert(t, bufs.Stdout.String(), "expected-help-admin")
+	})
 }
 
 // This is to test any non-root command. If use is removed, change this test

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -209,8 +209,7 @@ func TestLoginCmd_HelpText(t *testing.T) {
 	err := Run(ctx, "login", "--help")
 	assert.NilError(t, err)
 
-	golden.Assert(t, bufs.Stdout.String(), "expected-help-use")
-
+	golden.Assert(t, bufs.Stdout.String(), "expected-help-login")
 }
 
 // TestCmdDoesNotUsePersistentPreRun because if any subcommand sets a

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -50,7 +50,6 @@ To load completions for every new session, run:
 and source this file from your PowerShell profile.
 `, `infra`),
 		DisableFlagsInUseLine: true,
-		GroupID:               groupOther,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Run: func(cmd *cobra.Command, args []string) {
 			shell := filepath.Base(os.Getenv("SHELL"))

--- a/internal/cmd/connector.go
+++ b/internal/cmd/connector.go
@@ -16,10 +16,10 @@ func newConnectorCmd() *cobra.Command {
 	var configFilename string
 
 	cmd := &cobra.Command{
-		Use:    "connector",
-		Short:  "Start the Infra connector",
-		Args:   NoArgs,
-		Hidden: true,
+		Use:     "connector",
+		Short:   "Start the Infra connector",
+		Args:    NoArgs,
+		GroupID: groupServices,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			logging.UseServerLogger()
 

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -13,10 +13,9 @@ import (
 
 func newInfoCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
-		Use:     "info",
-		Short:   "Display the info about the current session",
-		Args:    NoArgs,
-		GroupID: groupOther,
+		Use:   "info",
+		Short: "Display the info about the current session",
+		Args:  NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return info(cli)
 		},

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -21,10 +21,10 @@ func newServerCmd() *cobra.Command {
 	var configFilename string
 
 	cmd := &cobra.Command{
-		Use:    "server",
-		Short:  "Start Infra server",
-		Args:   NoArgs,
-		Hidden: true,
+		Use:     "server",
+		Short:   "Start the Infra server",
+		Args:    NoArgs,
+		GroupID: groupServices,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			logging.UseServerLogger()
 

--- a/internal/cmd/testdata/expected-help-admin
+++ b/internal/cmd/testdata/expected-help-admin
@@ -1,0 +1,22 @@
+Usage:
+  infra [flags]
+  infra [command]
+
+Admin commands:
+  destinations Manage destinations
+  grants       Manage access to resources
+  users        Manage user identities
+  groups       Manage groups of identities
+  keys         Manage access keys
+  providers    Manage identity providers
+
+Service commands:
+  server       Run the infra server
+  connector    Run the infra connector
+
+Flags:
+      --help                 Display help
+      --log-level string     Show logs when running the command [error, warn, info, debug] (default "info")
+      --skip-version-check   Skip checking if the CLI is ahead of the server version
+
+Use "infra [command] --help" for more information about a command.

--- a/internal/cmd/testdata/expected-help-admin
+++ b/internal/cmd/testdata/expected-help-admin
@@ -16,6 +16,10 @@ Admin commands:
   keys         Manage access keys
   providers    Manage identity providers
 
+Service commands:
+  server       Start the Infra server
+  connector    Start the Infra connector
+
 Additional Commands:
   info         Display the info about the current session
   version      Display the Infra version

--- a/internal/cmd/testdata/expected-help-admin
+++ b/internal/cmd/testdata/expected-help-admin
@@ -2,6 +2,12 @@ Usage:
   infra [flags]
   infra [command]
 
+Core commands:
+  login        Login to Infra
+  logout       Log out of Infra
+  list         List accessible destinations
+  use          Access a destination
+
 Admin commands:
   destinations Manage destinations
   grants       Manage access to resources
@@ -10,13 +16,18 @@ Admin commands:
   keys         Manage access keys
   providers    Manage identity providers
 
-Service commands:
-  server       Run the infra server
-  connector    Run the infra connector
+Additional Commands:
+  info         Display the info about the current session
+  version      Display the Infra version
+  about        Display information about Infra
+  completion   Generate shell auto-completion for the CLI
+  help         Help about any command
 
 Flags:
       --help                 Display help
+      --help-admin           Show help for admin commands
       --log-level string     Show logs when running the command [error, warn, info, debug] (default "info")
       --skip-version-check   Skip checking if the CLI is ahead of the server version
 
 Use "infra [command] --help" for more information about a command.
+

--- a/internal/cmd/testdata/expected-help-login
+++ b/internal/cmd/testdata/expected-help-login
@@ -1,0 +1,36 @@
+Login to Infra
+
+Usage:
+  infra login [SERVER] [flags]
+
+Examples:
+# Login
+infra login example.infrahq.com
+
+# Login with username and password (prompt for password)
+infra login example.infrahq.com --user user@example.com
+
+# Login with access key
+export INFRA_SERVER=example.infrahq.com
+export INFRA_ACCESS_KEY=2vrEbqFEUr.jtTlxkgYdvghJNdEa8YoUxN0
+infra login example.infrahq.com
+
+# Login with username and password
+export INFRA_SERVER=example.infrahq.com
+export INFRA_USER=user@example.com
+export INFRA_PASSWORD=p4ssw0rd
+infra login
+
+Flags:
+      --key string                       Login with an access key
+      --no-agent                         Skip starting the Infra agent in the background
+      --non-interactive                  Disable all prompts for input (default true)
+      --skip-tls-verify                  Skip verifying server TLS certificates
+      --tls-trusted-cert filepath        TLS certificate or CA used by the server
+      --tls-trusted-fingerprint string   SHA256 fingerprint of the server TLS certificate
+      --user string                      User email
+
+Global Flags:
+      --help                 Display help
+      --log-level string     Show logs when running the command [error, warn, info, debug] (default "info")
+      --skip-version-check   Skip checking if the CLI is ahead of the server version

--- a/internal/cmd/testdata/expected-help-root
+++ b/internal/cmd/testdata/expected-help-root
@@ -1,5 +1,4 @@
 Usage:
-  infra [flags]
   infra [command]
 
 Core commands:
@@ -8,24 +7,16 @@ Core commands:
   list         List accessible destinations
   use          Access a destination
 
-Management commands:
-  destinations Manage destinations
-  grants       Manage access to resources
-  users        Manage user identities
-  groups       Manage groups of identities
-  keys         Manage access keys
-  providers    Manage identity providers
-
 Other commands:
   info         Display the info about the current session
   version      Display the Infra version
   about        Display information about Infra
   completion   Generate shell auto-completion for the CLI
-  help         Help about any command
 
 Flags:
       --help                 Display help
       --log-level string     Show logs when running the command [error, warn, info, debug] (default "info")
       --skip-version-check   Skip checking if the CLI is ahead of the server version
 
+Use "infra --help-admin" for more information about admin commands.
 Use "infra [command] --help" for more information about a command.

--- a/internal/cmd/testdata/expected-help-root
+++ b/internal/cmd/testdata/expected-help-root
@@ -15,8 +15,8 @@ Other commands:
 
 Flags:
       --help                 Display help
+      --help-admin           Show help for admin commands
       --log-level string     Show logs when running the command [error, warn, info, debug] (default "info")
       --skip-version-check   Skip checking if the CLI is ahead of the server version
 
-Use "infra --help-admin" for more information about admin commands.
 Use "infra [command] --help" for more information about a command.

--- a/internal/cmd/testdata/expected-help-root
+++ b/internal/cmd/testdata/expected-help-root
@@ -21,6 +21,7 @@ Other commands:
   version      Display the Infra version
   about        Display information about Infra
   completion   Generate shell auto-completion for the CLI
+  help         Help about any command
 
 Flags:
       --help                 Display help

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -14,10 +14,9 @@ import (
 
 func newVersionCmd(cli *CLI) *cobra.Command {
 	return &cobra.Command{
-		Use:     "version",
-		Short:   "Display the Infra version",
-		GroupID: groupOther,
-		Args:    NoArgs,
+		Use:   "version",
+		Short: "Display the Infra version",
+		Args:  NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return version(cli)
 		},


### PR DESCRIPTION
## Summary

This is only a rough draft. Opening it as a PR to demonstrate the approach. 

This goal here is to allow us to focus the CLI primarily on users looking to connect to infrastructure, without losing the big value we get from a CLI for admin. The general approach is to make the default `--help` (and `infra help`) output focused only on "core" commands. These are the commands we expect users to run most of the time. We can adjust the groups to add or remove commands as we need.

We can further focus this on core commands by removing some of the "other commands".

There's also a new `--help-admin` flag, that allows someone to see all the commands. This shows the commands we previously had under "Management commands", and also "service commands" like `server` and `connector`. We don't need to keep all of these admin commands, but this allows us to keep a few of the high value ones (like `infra grants`) that we need for getting started, and that users will need for runbooks.

For a preview of the help output, see the files in this PR under `internal/cmd/testdata`.

While working on this I realized that the custom template we had previously was now the default from upstream, so I removed the existing custom template, and reduced the new one to only the parts we need. There may still be a couple small things we can remove.