### PR TITLE
Inline and reduce database encryption at-rest logic

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -92,7 +92,6 @@ func defaultServerOptions(infraDir string) server.Options {
 		Version:                  0.3, // update this as the config version changes
 		TLSCache:                 filepath.Join(infraDir, "cache"),
 		DBEncryptionKey:          filepath.Join(infraDir, "sqlite3.db.key"),
-		DBEncryptionKeyProvider:  "native",
 		EnableTelemetry:          true,
 		SessionDuration:          24 * time.Hour * 30, // 30 days
 		SessionInactivityTimeout: 24 * time.Hour * 3,  // 3 days

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -175,7 +175,6 @@ sessionDuration: 3m
 sessionInactivityTimeout: 1m
 
 dbEncryptionKey: /this-is-the-path
-dbEncryptionKeyProvider: the-provider
 dbHost: the-host
 dbPort: 5432
 dbName: infradbname
@@ -257,14 +256,13 @@ api:
 					SessionDuration:          3 * time.Minute,
 					SessionInactivityTimeout: 1 * time.Minute,
 
-					DBEncryptionKey:         "/this-is-the-path",
-					DBEncryptionKeyProvider: "the-provider",
-					DBHost:                  "the-host",
-					DBPort:                  5432,
-					DBParameters:            "sslmode=require",
-					DBPassword:              "env:POSTGRES_DB_PASSWORD",
-					DBUsername:              "infra",
-					DBName:                  "infradbname",
+					DBEncryptionKey: "/this-is-the-path",
+					DBHost:          "the-host",
+					DBPort:          5432,
+					DBParameters:    "sslmode=require",
+					DBPassword:      "env:POSTGRES_DB_PASSWORD",
+					DBUsername:      "infra",
+					DBName:          "infradbname",
 
 					BaseDomain:         "foo.example.com",
 					LoginDomainPrefix:  "login",
@@ -399,8 +397,10 @@ func TestServerCmd_WithSecretsConfig(t *testing.T) {
 	pgDriver := database.PostgresDriver(t, "_cmd")
 	patchRunServer(t, noServerRun)
 
+	rootKeyPath := filepath.Join(t.TempDir(), "root.key")
 	content := `
       dbConnectionString: ` + pgDriver.DSN + `
+      dbEncryptionKey: ` + rootKeyPath + `
       addr:
         http: "127.0.0.1:0"
         https: "127.0.0.1:0"

--- a/internal/server/data/data.go
+++ b/internal/server/data/data.go
@@ -25,9 +25,7 @@ import (
 type NewDBOptions struct {
 	DSN string
 
-	EncryptionKeyProvider EncryptionKeyProvider
-	RootKeyID             string
-
+	RootKeyFilePath    string
 	MaxOpenConnections int
 	MaxIdleConnections int
 	MaxIdleTimeout     time.Duration
@@ -50,10 +48,10 @@ func NewDB(dbOpts NewDBOptions) (*DB, error) {
 	opts := migrator.Options{
 		InitSchema: initializeSchema,
 		LoadKey: func(tx migrator.DB) error {
-			if dbOpts.EncryptionKeyProvider == nil {
+			if dbOpts.RootKeyFilePath == "" {
 				return nil
 			}
-			return loadDBKey(tx, dbOpts.EncryptionKeyProvider, dbOpts.RootKeyID)
+			return loadDBKey(tx, dbOpts.RootKeyFilePath)
 		},
 	}
 	m := migrator.New(tx, opts, migrations())

--- a/internal/server/data/encrypt/keys.go
+++ b/internal/server/data/encrypt/keys.go
@@ -1,0 +1,73 @@
+package encrypt
+
+import (
+	"fmt"
+	"os"
+)
+
+var (
+	keyBlockSizeInBits  = 256
+	keyBlockSizeInBytes = keyBlockSizeInBits / 8
+	algorithmAESGCM     = "aesgcm"
+)
+
+func CreateRootKey(filename string) error {
+	rootKey, err := cryptoRandRead(keyBlockSizeInBytes)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filename, rootKey, 0o600)
+}
+
+func CreateDataKey(rootKeyPath string) (*SymmetricKey, error) {
+	rootKey, err := os.ReadFile(rootKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	fullRootKey := &SymmetricKey{
+		unencrypted: rootKey,
+		Algorithm:   algorithmAESGCM,
+	}
+
+	dataKey, err := cryptoRandRead(keyBlockSizeInBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	encDataKey, err := Seal(fullRootKey, dataKey)
+	if err != nil {
+		return nil, fmt.Errorf("sealing: %w", err)
+	}
+
+	return &SymmetricKey{
+		unencrypted: dataKey,
+		Encrypted:   encDataKey,
+		Algorithm:   algorithmAESGCM,
+		RootKeyID:   rootKeyPath,
+	}, nil
+}
+
+func DecryptDataKey(rootKeyPath string, keyData []byte) (*SymmetricKey, error) {
+	rootKey, err := os.ReadFile(rootKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("getting root key: %w", err)
+	}
+
+	fullRootKey := &SymmetricKey{
+		unencrypted: rootKey,
+		Algorithm:   algorithmAESGCM,
+	}
+
+	unsealed, err := Unseal(fullRootKey, keyData)
+	if err != nil {
+		return nil, fmt.Errorf("unsealing: %w", err)
+	}
+
+	return &SymmetricKey{
+		unencrypted: unsealed,
+		Encrypted:   keyData,
+		Algorithm:   algorithmAESGCM,
+		RootKeyID:   rootKeyPath,
+	}, nil
+}

--- a/internal/server/data/encrypt/seal.go
+++ b/internal/server/data/encrypt/seal.go
@@ -1,0 +1,279 @@
+package encrypt
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+type SymmetricKey struct {
+	// unencrypted is the unencrypted data. This field *MUST NOT* be persisted.
+	unencrypted []byte
+	// Encrypted is the encrypted data.
+	Encrypted []byte `json:"key"`
+	// Algorithm is the algorithm used for encryption.
+	Algorithm string `json:"alg"`
+	// RootKeyId is the ID of the root key used to encrypt the data key.
+	RootKeyID string `json:"rkid"`
+}
+
+// cryptoRandRead is a safe read from crypto/rand, checking errors and number of bytes read, erroring if we don't get enough
+func cryptoRandRead(length int) ([]byte, error) {
+	b := make([]byte, length)
+
+	i, err := rand.Read(b)
+	if err != nil {
+		return nil, fmt.Errorf("crypto/rand read: %w", err)
+	}
+
+	if i != length {
+		return nil, fmt.Errorf("could not read %d random characters from crypto/rand, only got %d", length, i)
+	}
+
+	return b, nil
+}
+
+// SealRaw encrypts plaintext with a decrypted data key and returns it in a raw binary format
+// TODO: unexport or inline?
+func SealRaw(key *SymmetricKey, plain []byte) ([]byte, error) {
+	if len(key.unencrypted) == 0 {
+		return nil, errors.New("missing key")
+	}
+
+	if len(key.unencrypted) != 32 {
+		return nil, errors.New("expected 256 bit key size")
+	}
+
+	blk, err := aes.NewCipher(key.unencrypted)
+	if err != nil {
+		return nil, err
+	}
+
+	aesgcm, err := cipher.NewGCM(blk)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce, err := cryptoRandRead(aesgcm.NonceSize())
+	if err != nil {
+		return nil, fmt.Errorf("generating nonce: %w", err)
+	}
+
+	encrypted := aesgcm.Seal(nil, nonce, plain, nil)
+
+	keyID, err := checksum(key.Encrypted)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := encryptedPayload{
+		KeyID:      keyID,
+		Ciphertext: encrypted,
+		Algorithm:  key.Algorithm,
+		RootKeyID:  key.RootKeyID,
+		Nonce:      nonce,
+	}
+
+	marshalledPayload, err := marshalPayload(&payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return marshalledPayload, nil
+}
+
+// Seal encrypts plaintext with a decrypted data key and returns it in base64
+func Seal(key *SymmetricKey, plain []byte) ([]byte, error) {
+	marshalled, err := SealRaw(key, plain)
+	if err != nil {
+		return nil, err
+	}
+
+	encoded := make([]byte, base64.RawStdEncoding.EncodedLen(len(marshalled)))
+	base64.RawStdEncoding.Encode(encoded, marshalled)
+
+	return encoded, nil
+}
+
+// UnsealRaw decrypts ciphertext with a decrypted data key and returns a raw binary format
+// TODO: unexport or inline?
+func UnsealRaw(key *SymmetricKey, encrypted []byte) ([]byte, error) {
+	if len(key.unencrypted) == 0 {
+		return nil, errors.New("missing key")
+	}
+
+	payload := &encryptedPayload{}
+	if err := unmarshalPayload(encrypted, payload); err != nil {
+		return nil, fmt.Errorf("unmarshalling: %w", err)
+	}
+
+	ck, err := checksum(key.Encrypted)
+	if err != nil {
+		return nil, err
+	}
+
+	if !bytes.Equal(ck, payload.KeyID) {
+		return nil, fmt.Errorf("supplied key cannot decrypt this message; wrong key was used")
+	}
+
+	blk, err := aes.NewCipher(key.unencrypted)
+	if err != nil {
+		return nil, fmt.Errorf("creating cipher: %w", err)
+	}
+
+	aesgcm, err := cipher.NewGCM(blk)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+
+	plaintext, err := aesgcm.Open(nil, payload.Nonce, payload.Ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("opening seal: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// Unseal decrypts base64-encoded ciphertext with a decrypted data key
+func Unseal(key *SymmetricKey, encoded []byte) ([]byte, error) {
+	encryptedPayload := make([]byte, base64.RawStdEncoding.DecodedLen(len(encoded)))
+
+	_, err := base64.RawStdEncoding.Decode(encryptedPayload, encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decoding payload: %w", err)
+	}
+
+	return UnsealRaw(key, encryptedPayload)
+}
+
+func checksum(b []byte) ([]byte, error) {
+	keyIDChecksum := sha256.New()
+
+	ln, err := keyIDChecksum.Write(b)
+	if err != nil {
+		return nil, fmt.Errorf("creating checksum: %w", err)
+	}
+
+	if ln != len(b) {
+		return nil, fmt.Errorf("checksum write len")
+	}
+
+	return keyIDChecksum.Sum(nil)[:4], nil
+}
+
+type encryptedPayload struct {
+	Ciphertext []byte // base64 encoded
+	Algorithm  string // name of the algorithm used to encrypt the Ciphertext
+	KeyID      []byte // A unique identifier for the key used. Could be checksum or a version number
+	RootKeyID  string // id of the root key the Key field is encrypted with
+	Nonce      []byte // must be crypto-random unique every time, size = block size
+}
+
+func unmarshalPayload(mp []byte, p *encryptedPayload) error {
+	b := bytes.NewBuffer(mp)
+
+	var ln uint32
+	if err := binary.Read(b, binary.BigEndian, &ln); err != nil {
+		return err
+	}
+
+	p.Ciphertext = make([]byte, ln)
+	if err := binary.Read(b, binary.BigEndian, &p.Ciphertext); err != nil {
+		return err
+	}
+
+	var length uint8
+	if err := binary.Read(b, binary.BigEndian, &length); err != nil {
+		return err
+	}
+
+	alg := make([]byte, length)
+	if err := binary.Read(b, binary.BigEndian, &alg); err != nil {
+		return err
+	}
+
+	p.Algorithm = string(alg)
+
+	if err := binary.Read(b, binary.BigEndian, &length); err != nil {
+		return err
+	}
+
+	p.KeyID = make([]byte, length)
+	if err := binary.Read(b, binary.BigEndian, &p.KeyID); err != nil {
+		return err
+	}
+
+	if err := binary.Read(b, binary.BigEndian, &length); err != nil {
+		return err
+	}
+
+	rootKeyID := make([]byte, length)
+	if err := binary.Read(b, binary.BigEndian, &rootKeyID); err != nil {
+		return err
+	}
+
+	p.RootKeyID = string(rootKeyID)
+
+	if err := binary.Read(b, binary.BigEndian, &length); err != nil {
+		return err
+	}
+
+	p.Nonce = make([]byte, length)
+	if err := binary.Read(b, binary.BigEndian, &p.Nonce); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func marshalPayload(p *encryptedPayload) ([]byte, error) {
+	b := bytes.NewBuffer(nil)
+
+	if err := binary.Write(b, binary.BigEndian, uint32(len(p.Ciphertext))); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(b, binary.BigEndian, p.Ciphertext); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(b, binary.BigEndian, uint8(len(p.Algorithm))); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(b, binary.BigEndian, []byte(p.Algorithm)); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(b, binary.BigEndian, uint8(len(p.KeyID))); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(b, binary.BigEndian, p.KeyID); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(b, binary.BigEndian, uint8(len(p.RootKeyID))); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(b, binary.BigEndian, []byte(p.RootKeyID)); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(b, binary.BigEndian, uint8(len(p.Nonce))); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Write(b, binary.BigEndian, p.Nonce); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}

--- a/internal/server/data/encrypt/seal_test.go
+++ b/internal/server/data/encrypt/seal_test.go
@@ -1,0 +1,39 @@
+package encrypt
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSealAndUnseal(t *testing.T) {
+	tmp := t.TempDir()
+	rootKeyPath := filepath.Join(tmp, "root-key")
+	assert.NilError(t, CreateRootKey(rootKeyPath))
+
+	key, err := CreateDataKey(rootKeyPath)
+	assert.NilError(t, err)
+
+	secretMessage := "This is the message"
+	encrypted, err := Seal(key, []byte(secretMessage))
+	assert.NilError(t, err)
+
+	unsealed, err := Unseal(key, encrypted)
+	assert.NilError(t, err)
+	assert.Equal(t, secretMessage, string(unsealed))
+}
+
+func TestDecryptDataKey(t *testing.T) {
+	tmp := t.TempDir()
+	rootKeyPath := filepath.Join(tmp, "root-key")
+	assert.NilError(t, CreateRootKey(rootKeyPath))
+
+	dataKey, err := CreateDataKey(rootKeyPath)
+	assert.NilError(t, err)
+
+	actual, err := DecryptDataKey(rootKeyPath, dataKey.Encrypted)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, actual.unencrypted, dataKey.unencrypted)
+}

--- a/internal/server/data/encryption_key.go
+++ b/internal/server/data/encryption_key.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	mathrand "math/rand"
 
-	"github.com/infrahq/secrets"
-
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/data/encrypt"
 	"github.com/infrahq/infra/internal/server/data/migrator"
@@ -77,11 +75,6 @@ func GetEncryptionKeyByName(tx StdlibTxn, name string) (*models.EncryptionKey, e
 		return nil, handleError(err)
 	}
 	return (*models.EncryptionKey)(table), nil
-}
-
-type EncryptionKeyProvider interface {
-	GenerateDataKey(rootKeyID string) (*secrets.SymmetricKey, error)
-	DecryptDataKey(rootKeyID string, keyData []byte) (*secrets.SymmetricKey, error)
 }
 
 var dbKeyName = "dbkey"

--- a/internal/server/data/encryption_key.go
+++ b/internal/server/data/encryption_key.go
@@ -8,6 +8,7 @@ import (
 	"github.com/infrahq/secrets"
 
 	"github.com/infrahq/infra/internal"
+	"github.com/infrahq/infra/internal/server/data/encrypt"
 	"github.com/infrahq/infra/internal/server/data/migrator"
 	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/internal/server/models"
@@ -85,16 +86,16 @@ type EncryptionKeyProvider interface {
 
 var dbKeyName = "dbkey"
 
-func loadDBKey(tx StdlibTxn, provider EncryptionKeyProvider, rootKeyId string) error {
+func loadDBKey(tx StdlibTxn, rootKeyPath string) error {
 	keyRec, err := GetEncryptionKeyByName(tx, dbKeyName)
 	if err != nil {
 		if errors.Is(err, internal.ErrNotFound) {
-			return createDBKey(tx, provider, rootKeyId)
+			return createDataKey(tx, rootKeyPath)
 		}
 		return err
 	}
 
-	sKey, err := provider.DecryptDataKey(rootKeyId, keyRec.Encrypted)
+	sKey, err := encrypt.DecryptDataKey(rootKeyPath, keyRec.Encrypted)
 	if err != nil {
 		return err
 	}
@@ -103,8 +104,8 @@ func loadDBKey(tx StdlibTxn, provider EncryptionKeyProvider, rootKeyId string) e
 	return nil
 }
 
-func createDBKey(tx StdlibTxn, provider EncryptionKeyProvider, rootKeyId string) error {
-	sKey, err := provider.GenerateDataKey(rootKeyId)
+func createDataKey(tx StdlibTxn, rootKeyPath string) error {
+	sKey, err := encrypt.CreateDataKey(rootKeyPath)
 	if err != nil {
 		return err
 	}

--- a/internal/server/models/encryption.go
+++ b/internal/server/models/encryption.go
@@ -4,7 +4,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 
-	"github.com/infrahq/secrets"
+	"github.com/infrahq/infra/internal/server/data/encrypt"
 )
 
 // EncryptedAtRest defines a field that knows how to encrypt and decrypt itself with Gorm
@@ -12,7 +12,7 @@ import (
 type EncryptedAtRest string
 
 // SymmetricKey is the key used to encrypt and decrypt this field.
-var SymmetricKey *secrets.SymmetricKey
+var SymmetricKey *encrypt.SymmetricKey
 
 // SkipSymmetricKey is used for tests that specifically want to avoid field encryption
 var SkipSymmetricKey bool
@@ -26,7 +26,7 @@ func (s EncryptedAtRest) Encrypt() (string, error) {
 		return "", fmt.Errorf("models.SymmetricKey is not set")
 	}
 
-	b, err := secrets.Seal(SymmetricKey, []byte(s))
+	b, err := encrypt.Seal(SymmetricKey, []byte(s))
 	if err != nil {
 		return "", fmt.Errorf("sealing secret field: %w", err)
 	}
@@ -47,7 +47,7 @@ func decrypt(s string) (string, error) {
 		return "", fmt.Errorf("models.SymmetricKey is not set")
 	}
 
-	b, err := secrets.Unseal(SymmetricKey, []byte(s))
+	b, err := encrypt.Unseal(SymmetricKey, []byte(s))
 	if err != nil {
 		return "", fmt.Errorf("unsealing secret field: %w", err)
 	}

--- a/internal/server/models/encryption_test.go
+++ b/internal/server/models/encryption_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -51,10 +50,8 @@ func TestEncryptedAtRest(t *testing.T) {
 
 	assert.Assert(t, "don't tell" != result)
 	assert.Assert(t, "" != result)
-	assert.Assert(t, is.Len(result, 88)) // encrypts to this many bytes
 
 	m2 := &StructForTesting{}
-
 	err = db.QueryRow(`SELECT a_secret FROM struct_for_testings where id = ?`, id).Scan(&m2.ASecret)
 	assert.NilError(t, err)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -90,6 +90,15 @@ type Options struct {
 	API  APIOptions
 
 	DB data.NewDBOptions
+
+	DeprecatedConfig
+}
+
+// DeprecatedConfig contains fields that are no longer used by server, but loading
+// values for these fields allows us to error when a config file value is no
+// longer supported.
+type DeprecatedConfig struct {
+	DBEncryptionKeyProvider string
 }
 
 type ListenerOptions struct {
@@ -154,6 +163,11 @@ func newServer(options Options) *Server {
 func New(options Options) (*Server, error) {
 	if options.EnableSignup && options.BaseDomain == "" {
 		return nil, errors.New("cannot enable signup without setting base domain")
+	}
+
+	if options.DBEncryptionKeyProvider != "" && options.DBEncryptionKeyProvider != "native" {
+		return nil, errors.New("dbEncryptionKeyProvider is no longer supported, " +
+			"use a file for the root key and set dbEncryptionKey to the path of the file")
 	}
 
 	server := newServer(options)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -169,13 +169,7 @@ func New(options Options) (*Server, error) {
 		return nil, fmt.Errorf("postgres dsn: %w", err)
 	}
 	options.DB.DSN = dsn
-
-	dbKeyProvider, ok := server.keys[options.DBEncryptionKeyProvider]
-	if !ok {
-		return nil, fmt.Errorf("key provider %s not configured", options.DBEncryptionKeyProvider)
-	}
-	options.DB.EncryptionKeyProvider = dbKeyProvider
-	options.DB.RootKeyID = options.DBEncryptionKey
+	options.DB.RootKeyFilePath = options.DBEncryptionKey
 
 	db, err := data.NewDB(options.DB)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -113,9 +113,8 @@ func TestServer_Run(t *testing.T) {
 
 	dir := t.TempDir()
 	opts := Options{
-		DBEncryptionKeyProvider: "native",
-		DBEncryptionKey:         filepath.Join(dir, "sqlite3.db.key"),
-		TLSCache:                filepath.Join(dir, "tlscache"),
+		DBEncryptionKey: filepath.Join(dir, "root.key"),
+		TLSCache:        filepath.Join(dir, "tlscache"),
 		TLS: TLSOptions{
 			CA:           types.StringOrFile(golden.Get(t, "pki/ca.crt")),
 			CAPrivateKey: string(golden.Get(t, "pki/ca.key")),
@@ -210,11 +209,10 @@ func TestServer_Run_UIProxy(t *testing.T) {
 
 	dir := t.TempDir()
 	opts := Options{
-		DBEncryptionKeyProvider: "native",
-		DBEncryptionKey:         filepath.Join(dir, "sqlite3.db.key"),
-		TLSCache:                filepath.Join(dir, "tlscache"),
-		EnableSignup:            true,
-		BaseDomain:              "example.com",
+		DBEncryptionKey: filepath.Join(dir, "root.key"),
+		TLSCache:        filepath.Join(dir, "tlscache"),
+		EnableSignup:    true,
+		BaseDomain:      "example.com",
 		TLS: TLSOptions{
 			CA:           types.StringOrFile(golden.Get(t, "pki/ca.crt")),
 			CAPrivateKey: string(golden.Get(t, "pki/ca.key")),

--- a/internal/testing/patch/patch.go
+++ b/internal/testing/patch/patch.go
@@ -7,9 +7,11 @@ we have them, we need to patch them in tests.
 package patch
 
 import (
-	"github.com/infrahq/secrets"
+	"path/filepath"
+
 	"gotest.tools/v3/assert"
 
+	"github.com/infrahq/infra/internal/server/data/encrypt"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
@@ -24,11 +26,11 @@ type TestingT interface {
 // This function modifies global state, it must not be used with t.Parallel.
 func ModelsSymmetricKey(t TestingT) {
 	t.Helper()
-	sp := secrets.NewFileSecretProviderFromConfig(secrets.FileConfig{Path: t.TempDir()})
 
-	rootKey := "db_at_rest"
-	kp := secrets.NewNativeKeyProvider(sp)
-	key, err := kp.GenerateDataKey(rootKey)
+	rootKeyPath := filepath.Join(t.TempDir(), "db_at_rest")
+	assert.NilError(t, encrypt.CreateRootKey(rootKeyPath))
+
+	key, err := encrypt.CreateDataKey(rootKeyPath)
 	assert.NilError(t, err)
 
 	models.SymmetricKey = key


### PR DESCRIPTION
## Summary

In #1653 secrets were extracted to a library. Part of the logic that moved to that library was sealing and unsealing of sensitive values that are stored in the database.

This PR moves just the bits used for database encryption at-rest  from `github.com/infrahq/secrets` to `./internal/server/data/encrypt`. We don't need this code in a library since it's only used in this one place, and moving it inline makes it easier to change.

At the same time the implementation is reduced a bit by removing "key providers". Instead, the "native key provider" implementation is used, which reads the root key from a file. I believe this is the only mechanism that we are using for the root key. We can support other mechanism in the future using the same mechanism we do for other secret values (load from env or file).

This change is being done in preparation for removing the rest of the secret loading from config (#2186).

## Related Issues

Related to #2186
