### PR TITLE
fix(ui): display more grants

### DIFF
--- a/ui/pages/destinations/[id]/index.js
+++ b/ui/pages/destinations/[id]/index.js
@@ -664,7 +664,7 @@ export default function DestinationDetail() {
   const { data: { items: users } = {} } = useSWR('/api/users?limit=1000')
   const { data: { items: groups } = {} } = useSWR('/api/groups?limit=1000')
   const { data: { items: grants } = {}, mutate } = useSWR(
-    `/api/grants?destination=${destination?.name}`
+    `/api/grants?destination=${destination?.name}&limit=1000`
   )
   const { data: { items: currentUserGrants } = {} } = useSWR(
     `/api/grants?user=${user?.id}&resource=${destination?.name}&showInherited=1&limit=1000`


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

default page is 100 which may not be enough to display grants for multiple namespaces, roles, users. the result can be extremely confusing since there's no way to see multiple pages

simply increasing the limit isn't ideal since it's just delaying the problem but there's no way to disable paging at the moment
