### PR TITLE
Fix CI failure in acceptance tests

### DIFF
--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -134,6 +134,11 @@ jobs:
         env:
           RELEASE_NAME: 0.0.0
 
+      # the ./test module uses the main module, this is an easy way to use the
+      # dependencies from the main module
+      - name: Setup workspace
+        run: go work init . ./test
+
       - name: Start containers
         run: |
           head -c 32 < /dev/urandom > test/root.key


### PR DESCRIPTION
The e2e test suite was not running because its go.mod was not tidy. This workspace should inform Go to use the go.mod from the parent module.

Example failure on main: https://github.com/infrahq/infra/actions/runs/3839811288/jobs/6538079495
