### PR TITLE
Add debian and redhat destination to SSH acceptance tests

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ nfpms:
     bindir: /usr/local/sbin
     contents:
       - src: package-files/systemd/infra.service
-        dst: /usr/lib/systemd/system/infra.service
+        dst: /lib/systemd/system/infra.service
         type: config
       - src: package-files/connector.example.yaml
         dst: /etc/infra/connector.example.yaml

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -37,11 +37,25 @@ services:
   destination_ubuntu:
     build:
       context: ./test
-      dockerfile: dockerfiles/Dockerfile.ubuntu
+      dockerfile: dockerfiles/Dockerfile.debian
+      args:
+        image_tag: ubuntu:22.10
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ..:/work
     privileged: true
     depends_on: [server]
-    ports:
-      - "127.0.0.1:8220:22"
+    ports: ["127.0.0.1:8220:22"]
+
+  destination_debian:
+    build:
+      context: ./test
+      dockerfile: dockerfiles/Dockerfile.debian
+      args:
+        image_tag: debian:11-slim
+    volumes:
+      - ..:/work
+    privileged: true
+    depends_on: [server]
+    stop_grace_period: 1s
+    ports: ["127.0.0.1:8221:22"]

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -59,3 +59,14 @@ services:
     depends_on: [server]
     stop_grace_period: 1s
     ports: ["127.0.0.1:8221:22"]
+
+  destination_redhat:
+    build:
+      context: ./test
+      dockerfile: dockerfiles/Dockerfile.redhat
+    volumes:
+      - ..:/work
+    privileged: true
+    depends_on: [server]
+    stop_grace_period: 1s
+    ports: ["127.0.0.1:8222:22"]

--- a/test/dockerfiles/Dockerfile.debian
+++ b/test/dockerfiles/Dockerfile.debian
@@ -1,9 +1,12 @@
 
-FROM ubuntu:22.10
+ARG image_tag=ubuntu:22.10
+FROM $image_tag
+
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN set -eux \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    && apt-get install --no-install-recommends -y \
       bash \
       systemd \
       systemd-sysv \

--- a/test/dockerfiles/Dockerfile.redhat
+++ b/test/dockerfiles/Dockerfile.redhat
@@ -1,0 +1,13 @@
+ARG image_tag=redhat/ubi9:latest
+FROM $image_tag
+
+RUN set -eux \
+   rm -rf /etc/systemd/system/*.wants/* \
+      /lib/systemd/system/local-fs.target.wants/* \
+      /lib/systemd/system/multi-user.target.wants/* \
+      /lib/systemd/system/sockets.target.wants/*initctl* \
+      /lib/systemd/system/sockets.target.wants/*udev* \
+      /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
+      /lib/systemd/system/systemd-update-utmp*
+
+CMD ["/sbin/init"]

--- a/test/dockerfiles/install-debian.sh
+++ b/test/dockerfiles/install-debian.sh
@@ -2,19 +2,18 @@
 
 set -eu -o pipefail
 
-echo "Running Infra connector install on Ubuntu"
+echo "Running Infra connector install on $DESTINATION_NAME"
 
 PACKAGE_PATH=/work/dist/infra_0.0.0_amd64.deb
-DESTINATION_ADDR=127.0.0.1:8220
 INFRA_SERVER_URL=test-server-1
-INFRA_ACCESS_KEY=dest000001.ubuntuubuntuubuntuubuntu
 
 
 # step=install-package
-dpkg -i "${PACKAGE_PATH}"
-apt-get update && apt-get install --no-install-recommends -y openssh-server
-mkdir -p /run/sshd
+apt-get update && apt-get install --no-install-recommends -y \
+    openssh-server procps
 
+dpkg -i "${PACKAGE_PATH}"
+mkdir -p /run/sshd
 
 # step=write-sshd-config
 cat << EOF > /etc/ssh/sshd_config.d/infra.conf
@@ -29,7 +28,7 @@ EOF
 # step=write-connector.yaml
 cat << EOF > /etc/infra/connector.yaml
 kind: ssh
-name: ubuntu
+name: $DESTINATION_NAME
 endpointAddr: "$DESTINATION_ADDR"
 server:
   url: "$INFRA_SERVER_URL"
@@ -37,11 +36,9 @@ server:
   trustedCertificate: /work/internal/server/testdata/pki/ca.crt
 EOF
 
-echo "Starting infra service"
 
+echo "Starting infra service"
 systemctl start infra
 
-
 echo "Starting sshd service"
-
 systemctl start ssh

--- a/test/dockerfiles/install-redhat.sh
+++ b/test/dockerfiles/install-redhat.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+echo "Running Infra connector install on $DESTINATION_NAME"
+
+PACKAGE_PATH=/work/dist/infra-0.0.0.x86_64.rpm
+INFRA_SERVER_URL=test-server-1
+
+
+# step=install-package
+yum install -y openssh-server
+yum install -y "${PACKAGE_PATH}"
+
+# step=write-sshd-config
+cat << EOF > /etc/ssh/sshd_config.d/infra.conf
+Match group infra-users
+    AuthorizedKeysFile none
+    PasswordAuthentication no
+    AuthorizedKeysCommand /usr/local/sbin/infra sshd auth-keys %u %f
+    AuthorizedKeysCommandUser nobody
+EOF
+
+
+# step=write-connector.yaml
+cat << EOF > /etc/infra/connector.yaml
+kind: ssh
+name: $DESTINATION_NAME
+endpointAddr: "$DESTINATION_ADDR"
+server:
+  url: "$INFRA_SERVER_URL"
+  accessKey: "$INFRA_ACCESS_KEY"
+  trustedCertificate: /work/internal/server/testdata/pki/ca.crt
+EOF
+
+
+echo "Starting infra service"
+systemctl start infra
+
+echo "Starting sshd service"
+systemctl start sshd

--- a/test/dockerfiles/server.yaml
+++ b/test/dockerfiles/server.yaml
@@ -4,6 +4,8 @@ users:
     accessKey: aaaaaaaaaa.000000000000000000000000
   - name: connector
     accessKey: dest000001.ubuntuubuntuubuntuubuntu
+  - name: connector
+    accessKey: dest000002.debiandebiandebiandebian
   - name: anyuser@example.com
     accessKey: ababababab.000000000000000000000001
 

--- a/test/dockerfiles/server.yaml
+++ b/test/dockerfiles/server.yaml
@@ -6,6 +6,8 @@ users:
     accessKey: dest000001.ubuntuubuntuubuntuubuntu
   - name: connector
     accessKey: dest000002.debiandebiandebiandebian
+  - name: connector
+    accessKey: dest000003.redhatredhatredhatredhat
   - name: anyuser@example.com
     accessKey: ababababab.000000000000000000000001
 

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -4,4 +4,14 @@ set -eu -o pipefail
 TTY=
 if [ -t 1 ]; then TTY=-t; fi
 
-docker exec -i $TTY test-destination_ubuntu-1 /work/test/dockerfiles/install-ubuntu.sh
+docker exec -i $TTY \
+  -e DESTINATION_NAME=ubuntu \
+  -e DESTINATION_ADDR=127.0.0.1:8220 \
+  -e INFRA_ACCESS_KEY=dest000001.ubuntuubuntuubuntuubuntu \
+  test-destination_ubuntu-1 /work/test/dockerfiles/install-debian.sh
+
+docker exec -i $TTY \
+  -e DESTINATION_NAME=debian \
+  -e DESTINATION_ADDR=127.0.0.1:8221 \
+  -e INFRA_ACCESS_KEY=dest000002.debiandebiandebiandebian \
+  test-destination_debian-1 /work/test/dockerfiles/install-debian.sh

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -15,3 +15,9 @@ docker exec -i $TTY \
   -e DESTINATION_ADDR=127.0.0.1:8221 \
   -e INFRA_ACCESS_KEY=dest000002.debiandebiandebiandebian \
   test-destination_debian-1 /work/test/dockerfiles/install-debian.sh
+
+docker exec -i $TTY \
+  -e DESTINATION_NAME=redhat \
+  -e DESTINATION_ADDR=127.0.0.1:8222 \
+  -e INFRA_ACCESS_KEY=dest000003.redhatredhatredhatredhat \
+  test-destination_redhat-1 /work/test/dockerfiles/install-redhat.sh

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -48,6 +48,14 @@ func TestSSHDestination(t *testing.T) {
 			port:        "8221",
 		})
 	})
+
+	t.Run("redhat", func(t *testing.T) {
+		testSSHDestination(t, testCase{
+			adminClient: adminClient,
+			destination: "redhat",
+			port:        "8222",
+		})
+	})
 }
 
 type testCase struct {

--- a/test/ssh_test.go
+++ b/test/ssh_test.go
@@ -18,11 +18,10 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func TestSSHDestination(t *testing.T) {
-	ctx := context.Background()
+var infraServerURL = "https://localhost:4443"
+var infraServerCAFile = "../internal/server/testdata/pki/ca.crt"
 
-	infraServerURL := "https://localhost:4443"
-	infraServerCAFile := "../internal/server/testdata/pki/ca.crt"
+func TestSSHDestination(t *testing.T) {
 	adminClient := api.Client{
 		Name:      "testing",
 		Version:   "0.0.1",
@@ -34,9 +33,36 @@ func TestSSHDestination(t *testing.T) {
 		},
 	}
 
+	t.Run("ubuntu", func(t *testing.T) {
+		testSSHDestination(t, testCase{
+			adminClient: adminClient,
+			destination: "ubuntu",
+			port:        "8220",
+		})
+	})
+
+	t.Run("debian", func(t *testing.T) {
+		testSSHDestination(t, testCase{
+			adminClient: adminClient,
+			destination: "debian",
+			port:        "8221",
+		})
+	})
+}
+
+type testCase struct {
+	adminClient api.Client
+	destination string
+	port        string
+}
+
+func testSSHDestination(t *testing.T, tc testCase) {
+	ctx := context.Background()
+	adminClient := tc.adminClient
+
 	poll.WaitOn(t, func(t poll.LogT) poll.Result {
 		dests, err := adminClient.ListDestinations(ctx,
-			api.ListDestinationsRequest{Name: "ubuntu"})
+			api.ListDestinationsRequest{Name: tc.destination})
 		switch {
 		case err != nil:
 			return poll.Error(err)
@@ -73,7 +99,7 @@ func TestSSHDestination(t *testing.T) {
 
 	sshArgs := func(args ...string) []string {
 		return append([]string{
-			"-p", "8220",
+			"-p", tc.port,
 			"-o", "StrictHostKeyChecking=yes",
 			"-o", "PasswordAuthentication=no",
 			"-F", sshConfig,
@@ -100,7 +126,7 @@ func TestSSHDestination(t *testing.T) {
 	runStep(t, "succeeds with a grant", func(t *testing.T) {
 		resp, err := adminClient.CreateGrant(ctx, &api.GrantRequest{
 			UserName:  "anyuser@example.com",
-			Resource:  "ubuntu",
+			Resource:  tc.destination,
 			Privilege: "connect",
 		})
 		assert.NilError(t, err)


### PR DESCRIPTION
## Summary

Adds `debian:11-slim` and `redhat/ubi9:latest` destinations, and runs the same tests against them.

A few small changes were required, comments inline