### PR TITLE
Add a default expiration time to all user public keys

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -105,4 +105,5 @@ type UserPublicKey struct {
 	KeyType string `json:"keyType"`
 	// Fingerprint is the SHA256 fingerprint of the public key.
 	Fingerprint string `json:"fingerprint" note:"SHA256 fingerprint of the key"`
+	Expires     Time   `json:"expires"`
 }

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1045,6 +1045,12 @@
                         "format": "date-time",
                         "type": "string"
                       },
+                      "expires": {
+                        "description": "formatted as an RFC3339 date-time",
+                        "example": "2022-03-14T09:48:00Z",
+                        "format": "date-time",
+                        "type": "string"
+                      },
                       "fingerprint": {
                         "description": "SHA256 fingerprint of the key",
                         "type": "string"
@@ -1392,6 +1398,12 @@
                   "format": "date-time",
                   "type": "string"
                 },
+                "expires": {
+                  "description": "formatted as an RFC3339 date-time",
+                  "example": "2022-03-14T09:48:00Z",
+                  "format": "date-time",
+                  "type": "string"
+                },
                 "fingerprint": {
                   "description": "SHA256 fingerprint of the key",
                   "type": "string"
@@ -1432,6 +1444,12 @@
       "UserPublicKey": {
         "properties": {
           "created": {
+            "description": "formatted as an RFC3339 date-time",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "expires": {
             "description": "formatted as an RFC3339 date-time",
             "example": "2022-03-14T09:48:00Z",
             "format": "date-time",

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -263,7 +263,6 @@ func provisionSSHKey(ctx context.Context, opts provisionSSHKeyOptions) (string, 
 		}
 
 		if userPublicKeyContains(opts.user.PublicKeys, existing.PublicKeyID) {
-			// TODO: check expiration when expiry is added
 			// key exists locally and in the API
 			return filename, nil
 		}

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/crypto/bcrypt"
@@ -240,6 +241,7 @@ func TestGetIdentity(t *testing.T) {
 			PublicKey:   "the-key",
 			KeyType:     "ssh-rsa",
 			Fingerprint: "the-fingerprint",
+			ExpiresAt:   time.Now().Add(time.Hour).Truncate(time.Millisecond),
 		}
 		err = AddUserPublicKey(db, bondKey)
 		assert.NilError(t, err)
@@ -286,6 +288,7 @@ func TestGetIdentity(t *testing.T) {
 					PublicKey:   "the-key",
 					KeyType:     "ssh-rsa",
 					Fingerprint: "the-fingerprint",
+					ExpiresAt:   bondKey.ExpiresAt,
 				},
 			}
 			assert.DeepEqual(t, *identity, expected, cmpTimeWithDBPrecision)
@@ -414,6 +417,7 @@ func TestListIdentities(t *testing.T) {
 				Fingerprint: "the-fingerprint",
 				KeyType:     "ssh-rsa",
 				PublicKey:   "the-public-key",
+				ExpiresAt:   time.Now().Add(time.Hour).Truncate(time.Millisecond),
 			}
 			assert.NilError(t, AddUserPublicKey(db, pubKey))
 

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -84,6 +84,7 @@ func migrations() []*migrator.Migration {
 		deviceFlowAuthRequestsAddUserIDProviderID(),
 		addDestinationCredentials(),
 		setGoogleSocialLoginDefaultID(),
+		addUserPublicKeyUserIDIndex(),
 		// next one here, then run `go test -run TestMigrations ./internal/server/data -update`
 	}
 }
@@ -1155,6 +1156,19 @@ func setGoogleSocialLoginDefaultID() *migrator.Migration {
 					WHERE provider_id = 0;
 			`, models.InternalGoogleProviderID)
 
+			return err
+		},
+	}
+}
+
+func addUserPublicKeyUserIDIndex() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2023-01-05T17:33",
+		Migrate: func(tx migrator.DB) error {
+			stmt := `CREATE INDEX IF NOT EXISTS idx_user_public_keys_user_id
+					ON user_public_keys USING btree (user_id) WHERE (deleted_at IS NULL)`
+
+			_, err := tx.Exec(stmt)
 			return err
 		},
 	}

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -997,6 +997,12 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 				assert.DeepEqual(t, expectedKey, accessKey)
 			},
 		},
+		{
+			label: testCaseLine("2023-01-05T17:33"),
+			expected: func(t *testing.T, tx WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -403,6 +403,8 @@ CREATE UNIQUE INDEX idx_providers_name ON providers USING btree (organization_id
 
 CREATE UNIQUE INDEX idx_user_public_keys_user_fingerprint ON user_public_keys USING btree (fingerprint) WHERE (deleted_at IS NULL);
 
+CREATE INDEX idx_user_public_keys_user_id ON user_public_keys USING btree (user_id) WHERE (deleted_at IS NULL);
+
 CREATE UNIQUE INDEX idx_user_ssh_login_name ON identities USING btree (organization_id, ssh_login_name) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX settings_org_id ON settings USING btree (organization_id) WHERE (deleted_at IS NULL);

--- a/internal/server/data/user_public_keys.go
+++ b/internal/server/data/user_public_keys.go
@@ -34,6 +34,7 @@ func listUserPublicKeys(tx ReadTxn, userID uid.ID) ([]models.UserPublicKey, erro
 	query.B("FROM user_public_keys")
 	query.B("WHERE deleted_at is null")
 	query.B("AND user_id = ?", userID)
+	query.B("AND expires_at > ?", time.Now())
 
 	rows, err := tx.Query(query.String(), query.Args...)
 	if err != nil {

--- a/internal/server/data/user_public_keys.go
+++ b/internal/server/data/user_public_keys.go
@@ -64,3 +64,14 @@ func DeleteUserPublicKeys(tx WriteTxn, userID uid.ID) error {
 	_, err := tx.Exec(stmt, time.Now(), userID)
 	return handleError(err)
 }
+
+func DeleteExpiredUserPublicKeys(tx WriteTxn) error {
+	now := time.Now()
+	query := querybuilder.New("UPDATE user_public_keys")
+	query.B("SET deleted_at = ?", now)
+	query.B("WHERE deleted_at is null")
+	query.B("AND expires_at <= ?", now)
+
+	_, err := tx.Exec(query.String(), query.Args...)
+	return err
+}

--- a/internal/server/models/identity.go
+++ b/internal/server/models/identity.go
@@ -78,5 +78,6 @@ func (u UserPublicKey) ToAPI() api.UserPublicKey {
 		PublicKey:   u.PublicKey,
 		KeyType:     u.KeyType,
 		Fingerprint: u.Fingerprint,
+		Expires:     api.Time(u.ExpiresAt),
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -247,6 +247,7 @@ func (s *Server) Run(ctx context.Context) error {
 	s.registerJob(ctx, data.DeleteExpiredDeviceFlowAuthRequests, 10*time.Minute)
 	s.registerJob(ctx, data.RemoveExpiredAccessKeys, 12*time.Hour)
 	s.registerJob(ctx, data.RemoveExpiredPasswordResetTokens, 15*time.Minute)
+	s.registerJob(ctx, data.DeleteExpiredUserPublicKeys, time.Hour)
 
 	if s.tel != nil {
 		group.Go(func() error {

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -179,6 +179,7 @@ func AddUserPublicKey(c *gin.Context, r *api.AddUserPublicKeyRequest) (*api.User
 		PublicKey:   base64.StdEncoding.EncodeToString(key.Marshal()),
 		KeyType:     key.Type(),
 		Fingerprint: ssh.FingerprintSHA256(key),
+		ExpiresAt:   time.Now().Add(12 * time.Hour),
 	}
 
 	if err := data.AddUserPublicKey(rCtx.DBTxn, userPublicKey); err != nil {


### PR DESCRIPTION
## Summary

Adds a 12 hour expiration time to all SSH keys that are uploaded to the API. We could make this longer, but 12 hours seems like long enough to avoid having to wait for multiple keys to be created in a single work day.

Expired keys are never returned by the API. A new background job soft-deletes the keys once they expire.

I also noticed that I had missed an index of `user_public_keys.user_id` which is used by `listUserPublicKeys`, so I added a migration for that as well.


## Related Issues

Resolves #3812
