### PR TITLE
Remove validate.String function

### DIFF
--- a/api/deviceflow.go
+++ b/api/deviceflow.go
@@ -14,7 +14,21 @@ type ApproveDeviceFlowRequest struct {
 
 func (adfr *ApproveDeviceFlowRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		validate.String("userCode", adfr.UserCode, 8, 9, append(validate.DeviceFlowUserCode, validate.CharRange{Low: '-', High: '-'})),
+		validate.StringRule{
+			Name:      "userCode",
+			Value:     adfr.UserCode,
+			MinLength: 8,
+			MaxLength: 9,
+			CharacterRanges: []validate.CharRange{
+				{Low: 'B', High: 'D'},
+				{Low: 'F', High: 'H'},
+				{Low: 'J', High: 'N'},
+				{Low: 'P', High: 'T'},
+				{Low: 'V', High: 'X'},
+				{Low: 'Z', High: 'Z'},
+				{Low: '-', High: '-'},
+			},
+		},
 	}
 }
 
@@ -32,7 +46,13 @@ type DeviceFlowStatusRequest struct {
 
 func (pdfr *DeviceFlowStatusRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
-		validate.String("deviceCode", pdfr.DeviceCode, 38, 38, validate.AlphaNumeric),
+		validate.StringRule{
+			Name:            "deviceCode",
+			Value:           pdfr.DeviceCode,
+			MinLength:       38,
+			MaxLength:       38,
+			CharacterRanges: validate.AlphaNumeric,
+		},
 	}
 }
 

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -13,7 +13,6 @@ const (
 	CharsetAlphaNumericNoVowels = "0123456789BCDFGHJKLMNPQRSTVWXYZbcdfghjklmnpqrstvwxyz" // For user-facing areas, to avoid profanity
 	CharsetNumbers              = "0123456789"
 	CharsetPassword             = CharsetAlphaNumeric + `!@#$%^&*()_+-=[]|;:,./<>?`
-	CharsetDeviceFlowUserCode   = "BCDFGHJKLMNPQRSTVWXZ" // no vowels to avoid spelling words
 )
 
 // CryptoRandom generates a cryptographically-safe random number. defaults to alphanumeric charset.

--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -18,12 +18,14 @@ import (
 
 const DeviceCodeExpirySeconds = 600
 
+const CharsetDeviceFlowUserCode = "BCDFGHJKLMNPQRSTVWXZ" // no vowels to avoid spelling words
+
 func (a *API) StartDeviceFlow(c *gin.Context, req *api.EmptyRequest) (*api.DeviceFlowResponse, error) {
 	rctx := getRequestContext(c)
 	tries := 0
 retry:
 	tries++
-	userCode, err := generate.CryptoRandom(8, generate.CharsetDeviceFlowUserCode)
+	userCode, err := generate.CryptoRandom(8, CharsetDeviceFlowUserCode)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -32,16 +32,6 @@ type StringRule struct {
 	RequiredCharacters []rune
 }
 
-func String(name, value string, minLength, maxLength int, charset []CharRange) StringRule {
-	return StringRule{
-		Name:            name,
-		Value:           value,
-		MinLength:       minLength,
-		MaxLength:       maxLength,
-		CharacterRanges: charset,
-	}
-}
-
 type CharRange struct {
 	Low  rune
 	High rune
@@ -58,15 +48,14 @@ func (r CharRange) String() string {
 }
 
 var (
-	AlphabetLower      = CharRange{Low: 'a', High: 'z'}
-	AlphabetUpper      = CharRange{Low: 'A', High: 'Z'}
-	Numbers            = CharRange{Low: '0', High: '9'}
-	Dash               = CharRange{Low: '-', High: '-'}
-	Underscore         = CharRange{Low: '_', High: '_'}
-	Dot                = CharRange{Low: '.', High: '.'}
-	AtSign             = CharRange{Low: '@', High: '@'}
-	AlphaNumeric       = []CharRange{AlphabetLower, AlphabetUpper, Numbers}
-	DeviceFlowUserCode = []CharRange{{Low: 'B', High: 'D'}, {Low: 'F', High: 'H'}, {Low: 'J', High: 'N'}, {Low: 'P', High: 'T'}, {Low: 'V', High: 'X'}, {Low: 'Z', High: 'Z'}}
+	AlphabetLower = CharRange{Low: 'a', High: 'z'}
+	AlphabetUpper = CharRange{Low: 'A', High: 'Z'}
+	Numbers       = CharRange{Low: '0', High: '9'}
+	Dash          = CharRange{Low: '-', High: '-'}
+	Underscore    = CharRange{Low: '_', High: '_'}
+	Dot           = CharRange{Low: '.', High: '.'}
+	AtSign        = CharRange{Low: '@', High: '@'}
+	AlphaNumeric  = []CharRange{AlphabetLower, AlphabetUpper, Numbers}
 )
 
 func (s StringRule) DescribeSchema(parent *openapi3.Schema) {


### PR DESCRIPTION
## Summary

Functions with more than 3 arguments are hard to use, especially when many of the arguments are the same type.

Generally the solution to more args is to create a struct as the single argument. In this case we already have a struct, so we can simply remove the function.

Also resolve a TODO by removing the use of validate and using regular switch/case statement.

Also move some constants to the once place they are used.