### PR TITLE
Fix latency caused by high volumes of requests from the same user

### DIFF
--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -77,6 +77,7 @@ func IsAuthorized(rCtx RequestContext, requiredRole ...string) error {
 	if user == nil {
 		return fmt.Errorf("no authenticated user")
 	}
+
 	grants, err := data.ListGrants(rCtx.DBTxn, data.ListGrantsOptions{
 		Pagination:                 &data.Pagination{Limit: 1},
 		BySubject:                  uid.NewIdentityPolymorphicID(user.ID),

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -329,10 +329,10 @@ func updateAccessKeyLastSeenAt(tx WriteTxn, key *models.AccessKey) error {
 	query := querybuilder.New("UPDATE access_keys SET")
 	query.B(columnsForUpdate(table), table.Values()...)
 	query.B("WHERE deleted_at is null")
-	query.B("AND id = ?", table.Primary())
 	query.B("AND organization_id = ?", key.OrganizationID)
 	// only update if the row has not changed since the SELECT
 	query.B("AND updated_at = ?", origUpdatedAt)
+	query.B("AND id IN (SELECT id from access_keys WHERE id = ? FOR UPDATE SKIP LOCKED)", table.Primary())
 
 	_, err := tx.Exec(query.String(), query.Args...)
 	return handleError(err)

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -73,10 +73,10 @@ func UpdateDestinationLastSeenAt(tx WriteTxn, dest *models.Destination) error {
 	query := querybuilder.New("UPDATE destinations SET")
 	query.B(columnsForUpdate(table), table.Values()...)
 	query.B("WHERE deleted_at is null")
-	query.B("AND id = ?", table.Primary())
 	query.B("AND organization_id = ?", dest.OrganizationID)
 	// only update if the row has not changed since the SELECT
 	query.B("AND updated_at = ?", origUpdatedAt)
+	query.B("AND id IN (SELECT id from destinations WHERE id = ? FOR UPDATE SKIP LOCKED)", table.Primary())
 
 	_, err := tx.Exec(query.String(), query.Args...)
 	return handleError(err)

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -51,6 +51,37 @@ func UpdateDestination(tx WriteTxn, destination *models.Destination) error {
 	return update(tx, (*destinationsTable)(destination))
 }
 
+// UpdateDestinationLastSeenAt sets dest.LastSeenAt to now and then updates the
+// user row in the database. Updates are throttled to once every 2 seconds.
+// If the destination was updated recently, or the database row is already locked, the
+// update will be skipped.
+//
+// Unlike most functions in this package, this function uses dest.OrganizationID
+// not tx.OrganizationID.
+func UpdateDestinationLastSeenAt(tx WriteTxn, dest *models.Destination) error {
+	if time.Since(dest.LastSeenAt) < lastSeenUpdateThreshold {
+		return nil
+	}
+
+	origUpdatedAt := dest.UpdatedAt
+	dest.LastSeenAt = time.Now()
+	if err := dest.OnUpdate(); err != nil {
+		return err
+	}
+
+	table := (*destinationsTable)(dest)
+	query := querybuilder.New("UPDATE destinations SET")
+	query.B(columnsForUpdate(table), table.Values()...)
+	query.B("WHERE deleted_at is null")
+	query.B("AND id = ?", table.Primary())
+	query.B("AND organization_id = ?", dest.OrganizationID)
+	// only update if the row has not changed since the SELECT
+	query.B("AND updated_at = ?", origUpdatedAt)
+
+	_, err := tx.Exec(query.String(), query.Args...)
+	return handleError(err)
+}
+
 type GetDestinationOptions struct {
 	// ByID instructs GetDestination to return the row matching this ID. When
 	// this value is set, all other fields on this strut will be ignored
@@ -60,6 +91,10 @@ type GetDestinationOptions struct {
 	ByUniqueID string
 	// ByName instructs GetDestination to return the row matching this name.
 	ByName string
+
+	// FromOrganization is the organization ID of the provider. When set to a
+	// non-zero value the organization ID from the transaction is ignored.
+	FromOrganization uid.ID
 }
 
 func GetDestination(tx ReadTxn, opts GetDestinationOptions) (*models.Destination, error) {
@@ -67,7 +102,13 @@ func GetDestination(tx ReadTxn, opts GetDestinationOptions) (*models.Destination
 	query := querybuilder.New("SELECT")
 	query.B(columnsForSelect(destination))
 	query.B("FROM destinations")
-	query.B("WHERE deleted_at is null AND organization_id = ?", tx.OrganizationID())
+	query.B("WHERE deleted_at is null")
+
+	orgID := opts.FromOrganization
+	if orgID == 0 {
+		orgID = tx.OrganizationID()
+	}
+	query.B("AND organization_id = ?", orgID)
 
 	switch {
 	case opts.ByID != 0:

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -52,7 +52,7 @@ func UpdateDestination(tx WriteTxn, destination *models.Destination) error {
 }
 
 // UpdateDestinationLastSeenAt sets dest.LastSeenAt to now and then updates the
-// user row in the database. Updates are throttled to once every 2 seconds.
+// row in the database. Updates are throttled to once every 2 seconds.
 // If the destination was updated recently, or the database row is already locked, the
 // update will be skipped.
 //

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -228,6 +228,13 @@ func TestGetDestination(t *testing.T) {
 			_, err := GetDestination(db, GetDestinationOptions{ByID: deleted.ID})
 			assert.ErrorIs(t, err, internal.ErrNotFound)
 		})
+		t.Run("from other organization", func(t *testing.T) {
+			_, err := GetDestination(db, GetDestinationOptions{
+				ByID:             destination.ID,
+				FromOrganization: 723,
+			})
+			assert.ErrorIs(t, err, internal.ErrNotFound)
+		})
 	})
 }
 

--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -660,10 +660,10 @@ func UpdateIdentityLastSeenAt(tx WriteTxn, user *models.Identity) error {
 	query := querybuilder.New("UPDATE identities SET")
 	query.B(columnsForUpdate(table), table.Values()...)
 	query.B("WHERE deleted_at is null")
-	query.B("AND id = ?", table.Primary())
 	query.B("AND organization_id = ?", user.OrganizationID)
 	// only update if the row has not changed since the SELECT
 	query.B("AND updated_at = ?", origUpdatedAt)
+	query.B("AND id IN (SELECT id from identities WHERE id = ? FOR UPDATE SKIP LOCKED)", table.Primary())
 
 	_, err := tx.Exec(query.String(), query.Args...)
 	return handleError(err)

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -290,6 +290,13 @@ func TestGetIdentity(t *testing.T) {
 			}
 			assert.DeepEqual(t, *identity, expected, cmpTimeWithDBPrecision)
 		})
+		t.Run("from other organization", func(t *testing.T) {
+			_, err := GetIdentity(db, GetIdentityOptions{
+				ByID:             bond.ID,
+				FromOrganization: 71234,
+			})
+			assert.ErrorIs(t, err, internal.ErrNotFound)
+		})
 	})
 }
 

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -54,6 +54,10 @@ type GetProviderOptions struct {
 	// KindInfra instructs GetProvider to return the infra provider. There should
 	// only ever be a single provider with this kind for each org.
 	KindInfra bool
+
+	// FromOrganization is the organization ID of the provider. When set to a
+	// non-zero value the organization ID from the transaction is ignored.
+	FromOrganization uid.ID
 }
 
 func GetProvider(tx ReadTxn, opts GetProviderOptions) (*models.Provider, error) {
@@ -62,7 +66,12 @@ func GetProvider(tx ReadTxn, opts GetProviderOptions) (*models.Provider, error) 
 	query.B(columnsForSelect(provider))
 	query.B("FROM providers")
 	query.B("WHERE deleted_at is null")
-	query.B("AND organization_id = ?", tx.OrganizationID())
+
+	orgID := opts.FromOrganization
+	if orgID == 0 {
+		orgID = tx.OrganizationID()
+	}
+	query.B("AND organization_id = ?", orgID)
 
 	switch {
 	case opts.ByID != 0:

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -142,6 +142,13 @@ func TestGetProvider(t *testing.T) {
 			_, err := GetProvider(db, GetProviderOptions{ByName: "does-not-exist"})
 			assert.ErrorIs(t, err, internal.ErrNotFound)
 		})
+		t.Run("from other organization", func(t *testing.T) {
+			_, err := GetProvider(db, GetProviderOptions{
+				ByName:           "okta-development",
+				FromOrganization: 71234,
+			})
+			assert.ErrorIs(t, err, internal.ErrNotFound)
+		})
 	})
 }
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -20,8 +19,8 @@ import (
 	"github.com/infrahq/infra/internal/server/redis"
 )
 
-func handleInfraDestinationHeader(rCtx access.RequestContext, headers http.Header) error {
-	opts := data.GetDestinationOptions{}
+func handleInfraDestinationHeader(tx *data.Transaction, authned access.Authenticated, headers http.Header) error {
+	opts := data.GetDestinationOptions{FromOrganization: authned.User.OrganizationID}
 	if name := headers.Get(headerInfraDestinationName); name != "" {
 		opts.ByName = name
 	} else if uniqueID := headers.Get(headerInfraDestinationUniqueID); uniqueID != "" {
@@ -30,7 +29,7 @@ func handleInfraDestinationHeader(rCtx access.RequestContext, headers http.Heade
 		return nil // no header
 	}
 
-	destination, err := data.GetDestination(rCtx.DBTxn, opts)
+	destination, err := data.GetDestination(tx, opts)
 	switch {
 	case errors.Is(err, internal.ErrNotFound):
 		return nil // destination does not exist yet
@@ -38,12 +37,13 @@ func handleInfraDestinationHeader(rCtx access.RequestContext, headers http.Heade
 		return err
 	}
 
-	// only save if there's significant difference between LastSeenAt and Now
-	if time.Since(destination.LastSeenAt) > lastSeenUpdateThreshold {
-		destination.LastSeenAt = time.Now()
-		if err := access.UpdateDestination(rCtx, destination); err != nil {
-			return fmt.Errorf("failed to update destination lastSeenAt: %w", err)
-		}
+	rCtx := access.RequestContext{Authenticated: authned, DBTxn: tx}
+	roles := []string{models.InfraConnectorRole, models.InfraAdminRole}
+	if err := access.IsAuthorized(rCtx, roles...); err != nil {
+		return access.HandleAuthErr(err, "destination", "update", roles...)
+	}
+	if err := data.UpdateDestinationLastSeenAt(tx, destination); err != nil {
+		return fmt.Errorf("failed to update destination lastSeenAt: %w", err)
 	}
 	return nil
 }
@@ -67,18 +67,13 @@ const (
 // If the request identifies an organization (which is required for most routes)
 // a rate limit will be applied to all requests from the same organization.
 func authenticateRequest(c *gin.Context, route routeSettings, srv *Server) (access.Authenticated, error) {
-	tx, err := srv.db.Begin(c.Request.Context(), nil)
-	if err != nil {
-		return access.Authenticated{}, err
-	}
-	defer logError(tx.Rollback, "failed to rollback middleware transaction")
-
-	authned, err := requireAccessKey(c, tx, srv)
+	db := srv.DB()
+	authned, err := requireAccessKey(c, db, srv)
 	if !route.authenticationOptional && err != nil {
 		return authned, err
 	}
 
-	org, err := validateOrgMatchesRequest(c.Request, tx, authned.Organization)
+	org, err := validateOrgMatchesRequest(c.Request, db, authned.Organization)
 	if err != nil {
 		return authned, err
 	}
@@ -106,15 +101,9 @@ func authenticateRequest(c *gin.Context, route routeSettings, srv *Server) (acce
 	}
 
 	if authned.User != nil {
-		tx = tx.WithOrgID(authned.Organization.ID)
-		rCtx := access.RequestContext{DBTxn: tx, Authenticated: authned}
-		if err := handleInfraDestinationHeader(rCtx, c.Request.Header); err != nil {
+		if err := handleInfraDestinationHeader(db, authned, c.Request.Header); err != nil {
 			return authned, err
 		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return authned, err
 	}
 
 	if authned.User != nil && route.idpSync {
@@ -122,41 +111,32 @@ func authenticateRequest(c *gin.Context, route routeSettings, srv *Server) (acce
 			// this should be caught during development
 			return authned, fmt.Errorf("idp sync requires authentication")
 		}
-		tx2, err := srv.db.Begin(c.Request.Context(), nil)
+		tx, err := srv.db.Begin(c.Request.Context(), nil)
 		if err != nil {
 			return authned, err
 		}
-		defer logError(tx2.Rollback, "failed to rollback identity provider sync transaction")
-		tx2 = tx2.WithOrgID(authned.Organization.ID)
+		defer logError(tx.Rollback, "failed to rollback identity provider sync transaction")
+		tx = tx.WithOrgID(authned.Organization.ID)
 		// sync the identity info here to keep the UI session in sync with IDP session validity
-		if err := srv.syncIdentityInfo(context.Background(), tx2, authned.User, authned.AccessKey.ProviderID); err != nil {
+		if err := srv.syncIdentityInfo(context.Background(), tx, authned.User, authned.AccessKey.ProviderID); err != nil {
 			deleteCookie(c.Writer, cookieAuthorizationName, c.Request.Host)
 			if errors.Is(err, ErrSyncFailed) {
 				logging.L.Debug().Err(err)
 			} else {
 				logging.L.Error().Err(err)
 			}
-			if err = tx2.Commit(); err != nil {
+			if err = tx.Commit(); err != nil {
 				logging.L.Error().Err(err)
 			}
 			return authned, AuthenticationError{Message: "session in identity provider expired or revoked"}
 		}
-		if err = tx2.Commit(); err != nil {
+		if err = tx.Commit(); err != nil {
 			return authned, err
 		}
 	}
 
 	return authned, nil
 }
-
-// lastSeenUpdateThreshold is the duration of time that must pass before a
-// LastSeenAt value for a user or destination is updated again. This prevents
-// excessive writes when a single user performs many requests in a short
-// period of time.
-//
-// If you change this value, you may also want to change the threshold in
-// data.ValidateRequestAccessKey.
-const lastSeenUpdateThreshold = 2 * time.Second
 
 // validateOrgMatchesRequest checks that if both the accessKeyOrg and the org
 // from the request are set they have the same ID. If only one is set no
@@ -184,7 +164,7 @@ func validateOrgMatchesRequest(req *http.Request, tx data.ReadTxn, accessKeyOrg 
 }
 
 // requireAccessKey checks the bearer token is present and valid
-func requireAccessKey(c *gin.Context, db *data.Transaction, srv *Server) (access.Authenticated, error) {
+func requireAccessKey(c *gin.Context, db data.WriteTxn, srv *Server) (access.Authenticated, error) {
 	var u access.Authenticated
 
 	bearer, err := reqBearerToken(c, srv.options)
@@ -212,29 +192,27 @@ func requireAccessKey(c *gin.Context, db *data.Transaction, srv *Server) (access
 		return u, fmt.Errorf("access key org lookup: %w", err)
 	}
 
-	// now that the org is loaded scope all db calls to that org
-	// TODO: set the orgID explicitly in the options passed to GetIdentity to
-	// remove the need for this WithOrgID.
-	db = db.WithOrgID(org.ID)
-
 	// either this access key was issued for a user or for an identity provider to do SCIM
 	if accessKey.IssuedFor == accessKey.ProviderID {
 		// this access key was issued for SCIM for an identity provider, validate the provider still exists
-		_, err := data.GetProvider(db, data.GetProviderOptions{ByID: accessKey.IssuedFor})
+		_, err := data.GetProvider(db, data.GetProviderOptions{
+			ByID:             accessKey.IssuedFor,
+			FromOrganization: accessKey.OrganizationID,
+		})
 		if err != nil {
 			return u, fmt.Errorf("provider for access key: %w", err)
 		}
 	} else {
 		// the typical case, this is an access key for a user, validate the user still exists
-		identity, err := data.GetIdentity(db, data.GetIdentityOptions{ByID: accessKey.IssuedFor})
+		identity, err := data.GetIdentity(db, data.GetIdentityOptions{
+			ByID:             accessKey.IssuedFor,
+			FromOrganization: accessKey.OrganizationID,
+		})
 		if err != nil {
 			return u, fmt.Errorf("identity for access key: %w", err)
 		}
-		if time.Since(identity.LastSeenAt) > lastSeenUpdateThreshold {
-			identity.LastSeenAt = time.Now().UTC()
-			if err = data.UpdateIdentity(db, identity); err != nil {
-				return u, fmt.Errorf("identity update fail: %w", err)
-			}
+		if err = data.UpdateIdentityLastSeenAt(db, identity); err != nil {
+			return u, fmt.Errorf("identity update fail: %w", err)
 		}
 		u.User = identity
 	}


### PR DESCRIPTION
## Summary

Fixes #3944

This PR fixes the request latency by avoiding the database row lock that was causing the contention. The `UPDATE` queries for `LastSeenAt` are changed to use `WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED)`.  If two requests are received at roughly the same time, the first request to run `UPDATE` will perform the update. The second request will match no rows, so won't acquire a lock. These new queries also use `WHERE updated_at = ?` to prevent clobbering previous updates.

We use this same pattern in 3 places: access keys, users, and destinations. This PR updates all 3 to use the same approach.

There is one more small bug fix in here as well.  I'll add more comments inline to explain the changes. 

The first commit in this PR attempted to fix the problem by removing the transaction. That did fix the problem, but doubled the request latency in the common case. So I restored the transaction and worked to fix the queries.

### Testing

I wasn't able to reproduce the exact scenario without introducing a sleep. I believe that's because in tests our database runs on the same host, so there is no network latency between the API server and the DB.

[dnephin/test-case](https://github.com/infrahq/infra/compare/dnephin/test-case) adds a test case and a 200ms sleep in the middle of the middleware transaction. When this test is run on `main` the elapsed times range from 20 seconds down to 200ms. When it's run on this branch the elapsed times are in the range of 500ms down to 200ms. I believe this shows the changes here fix the problem because the worse case scenario decreases from 20s to 500ms.

TODO:
* [x] more test coverage of the new `FromOrganization` query option