### PR TITLE
fix: no gmail allowed domains

### DIFF
--- a/api/organization.go
+++ b/api/organization.go
@@ -68,6 +68,7 @@ func (r UpdateOrganizationRequest) ValidationRules() []validate.ValidationRule {
 				},
 				FirstCharacterRange: validate.AlphaNumeric,
 				RequiredCharacters:  []rune{'.'},
+				DenyList:            []string{"gmail.com", "googlemail.com"},
 			},
 		},
 	}

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -30,6 +30,9 @@ type StringRule struct {
 
 	// RequiredCharacters must be present in the string
 	RequiredCharacters []rune
+
+	// the string cannot be one of these string
+	DenyList []string
 }
 
 func String(name, value string, minLength, maxLength int, charset []CharRange) StringRule {
@@ -125,6 +128,15 @@ func (s StringRule) Validate() *Failure {
 		for _, c := range s.RequiredCharacters {
 			if !strings.ContainsRune(value, c) {
 				add("%q is required in value", c)
+				break
+			}
+		}
+	}
+
+	if len(s.DenyList) > 0 {
+		for _, deny := range s.DenyList {
+			if value == deny {
+				add("%q is not an allowed value", value)
 				break
 			}
 		}

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -124,21 +124,17 @@ func (s StringRule) Validate() *Failure {
 		}
 	}
 
-	if len(s.RequiredCharacters) > 0 {
-		for _, c := range s.RequiredCharacters {
-			if !strings.ContainsRune(value, c) {
-				add("%q is required in value", c)
-				break
-			}
+	for _, c := range s.RequiredCharacters {
+		if !strings.ContainsRune(value, c) {
+			add("%q is required in value", c)
+			break
 		}
 	}
 
-	if len(s.DenyList) > 0 {
-		for _, deny := range s.DenyList {
-			if value == deny {
-				add("%q is not an allowed value", value)
-				break
-			}
+	for _, deny := range s.DenyList {
+		if value == deny {
+			add("%q is not an allowed value", value)
+			break
 		}
 	}
 

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -23,6 +23,7 @@ func (s StringExample) ValidationRules() []ValidationRule {
 			CharacterRanges:     []CharRange{AlphabetLower, AlphabetUpper},
 			FirstCharacterRange: []CharRange{AlphabetLower},
 			RequiredCharacters:  []rune{'a'},
+			DenyList:            []string{"repudiate"},
 		},
 	}
 }
@@ -85,6 +86,17 @@ func TestStringRule_Validate(t *testing.T) {
 		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
 		expected := Error{
 			"strField": {"'a' is required in value"},
+		}
+		assert.DeepEqual(t, verr, expected)
+	})
+	t.Run("denied value is rejected", func(t *testing.T) {
+		r := StringExample{Field: "repudiate"}
+		err := Validate(r)
+
+		var verr Error
+		assert.Assert(t, errors.As(err, &verr), "wrong type %T", err)
+		expected := Error{
+			"strField": {"\"repudiate\" is not an allowed value"},
 		}
 		assert.DeepEqual(t, verr, expected)
 	})


### PR DESCRIPTION
## Summary
To protect an org from being incorrectly configured block "gmail.com" and "googlemail.com" allowed domains.

<img width="718" alt="Screen Shot 2023-01-09 at 10 23 13 AM" src="https://user-images.githubusercontent.com/5853428/211380264-c93cc749-112c-47bb-809b-1e13293f9b65.png">

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged