### PR TITLE
Restore backwards compatibility for bootstrap config passwords and accessKeys 

### DIFF
--- a/internal/cmd/cliopts/config.go
+++ b/internal/cmd/cliopts/config.go
@@ -86,7 +86,6 @@ func DecodeConfig(target interface{}) mapstructure.DecoderConfig {
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToSliceHookFunc(","),
 			hookFlagValueSlice,
-			hookPrepareForDecode,
 			hookSetFromString,
 		),
 	}

--- a/internal/cmd/cliopts/hooks.go
+++ b/internal/cmd/cliopts/hooks.go
@@ -19,32 +19,6 @@ func hookFlagValueSlice(from reflect.Value, to reflect.Value) (interface{}, erro
 	return v.GetSlice(), nil
 }
 
-type PrepareForDecoder interface {
-	PrepareForDecode(data interface{}) error
-}
-
-// hookPrepareForDecode is a mapstructure.DecodeHookFuncValue that enables decoding
-// of any type that implements the PrepareForDecoder interface.
-//
-// Types that implement PrepareForDecoder can use the passed in data to set
-// concrete types on any polymorphic fields, which will allow mapstructure.Decode
-// to properly decode the config into the expected type.
-func hookPrepareForDecode(from reflect.Value, to reflect.Value) (interface{}, error) {
-	source := from.Interface()
-	unmapper, ok := to.Interface().(PrepareForDecoder)
-	if !ok {
-		if to.CanAddr() {
-			unmapper, ok = to.Addr().Interface().(PrepareForDecoder)
-		}
-		if !ok {
-			return source, nil
-		}
-	}
-
-	err := unmapper.PrepareForDecode(source)
-	return source, err
-}
-
 type FromString interface {
 	Set(string) error
 }

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -27,7 +27,7 @@ func TestUpdateKubeconfig(t *testing.T) {
 	serverOpts.BootstrapConfig.Users = []server.User{
 		{
 			Name:      "admin@local",
-			AccessKey: accessKey,
+			AccessKey: server.Secret(accessKey),
 			InfraRole: "admin",
 		},
 	}

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -64,7 +64,7 @@ func TestLoginCmd_Options(t *testing.T) {
 	opts.BootstrapConfig.Users = []server.User{
 		{
 			Name:      "admin@example.com",
-			AccessKey: adminAccessKey,
+			AccessKey: server.Secret(adminAccessKey),
 		},
 	}
 	srv, err := server.New(opts)
@@ -350,7 +350,7 @@ func TestLoginCmd_TLSVerify(t *testing.T) {
 	setupServerOptions(t, &opts)
 	accessKey := "0000000001.adminadminadminadmin1234"
 	opts.Users = []server.User{
-		{Name: "admin@example.com", AccessKey: accessKey},
+		{Name: "admin@example.com", AccessKey: server.Secret(accessKey)},
 	}
 	srv, err := server.New(opts)
 	assert.NilError(t, err)

--- a/internal/server/config_test.go
+++ b/internal/server/config_test.go
@@ -170,7 +170,7 @@ func TestLoadAccessKey(t *testing.T) {
 	s := setupServer(t)
 
 	// access key that we will attempt to assign to multiple users
-	testAccessKey := "aaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb"
+	testAccessKey := Secret("aaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb")
 
 	// create a user and assign them an access key
 	bob := &models.Identity{Name: "bob@example.com"}

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -59,7 +59,7 @@ func createOtherOrg(t *testing.T, db *data.DB) organizationData {
 func adminAccessKey(s *Server) string {
 	for _, id := range s.options.Users {
 		if id.Name == "admin@example.com" {
-			return id.AccessKey
+			return string(id.AccessKey)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Branched from #3951, related to https://github.com/infrahq/infra/issues/2186
Fixes #3333

This PR restores support for loading passwords and accessKeys from `file:`,  `env:`, or `plaintex:` prefix. Unlike the previous implementation, this one only handles those prefixes, so someone using a password that contains a colon will not be encounter an error about an unknown secret provider.

This new implementation is also much smaller (just 20 lines). If we find another solution for the bootstrap user we may be able to remove these in the future as well.

Also removes a mapstructure decode hook that was no longer used after the changes in https://github.com/infrahq/infra/pull/3950