### PR TITLE
maintain: additional protection around access key removal

### DIFF
--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -251,6 +251,9 @@ func DeleteAccessKeys(tx WriteTxn, opts DeleteAccessKeysOptions) error {
 	if opts.ByID == 0 && opts.ByIssuedForID == 0 && opts.ByProviderID == 0 {
 		return fmt.Errorf("DeleteAccessKeys requires an ID, IssuedForID, or ProviderID")
 	}
+	if opts.ByIssuedForID != 0 && opts.ByProviderID == 0 {
+		return fmt.Errorf("DeleteAccessKeys by IssuedForID requires ProviderID")
+	}
 	query := querybuilder.New("UPDATE access_keys")
 	query.B("SET deleted_at = ?", time.Now())
 	query.B("WHERE organization_id = ?", tx.OrganizationID())

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -348,7 +348,16 @@ func RemoveExpiredAccessKeys(tx WriteTxn) error {
 	query.B("WHERE deleted_at is null")
 	query.B("AND expires_at <= ?", time.Now().UTC().Add(-1*time.Hour)) // leave buffer so keys aren't immediately deleted on expiry.
 
-	_, err := tx.Exec(query.String(), query.Args...)
-	logging.L.Info().Msg("removed expired access key")
+	result, err := tx.Exec(query.String(), query.Args...)
+	if err != nil {
+		return err
+	}
+	count, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		logging.L.Info().Int64("count", count).Msg("removed expired access keys")
+	}
 	return err
 }

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/generate"
+	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data/querybuilder"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -348,5 +349,6 @@ func RemoveExpiredAccessKeys(tx WriteTxn) error {
 	query.B("AND expires_at <= ?", time.Now().UTC().Add(-1*time.Hour)) // leave buffer so keys aren't immediately deleted on expiry.
 
 	_, err := tx.Exec(query.String(), query.Args...)
+	logging.L.Info().Msg("removed expired access key")
 	return err
 }

--- a/internal/server/data/provider.go
+++ b/internal/server/data/provider.go
@@ -206,11 +206,6 @@ func DeleteProviders(db WriteTxn, opts DeleteProvidersOptions) error {
 		return fmt.Errorf("delete access keys: %w", err)
 	}
 
-	// delete any access keys used for SCIM
-	if err := DeleteAccessKeys(db, DeleteAccessKeysOptions{ByIssuedForID: id}); err != nil {
-		return fmt.Errorf("delete provider access keys: %w", err)
-	}
-
 	query := querybuilder.New(`UPDATE providers`)
 	query.B(`SET deleted_at = ?`, time.Now())
 	query.B(`WHERE deleted_at is null`)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -530,6 +530,8 @@ func (s *Server) syncIdentityInfo(ctx context.Context, tx *data.Transaction, ide
 				return err
 			}
 
+			logging.L.Info().Msg("user session expired, puring keys created for this session")
+
 			if nestedErr := data.DeleteAccessKeys(tx, data.DeleteAccessKeysOptions{ByIssuedForID: providerUser.IdentityID, ByProviderID: providerUser.ProviderID}); nestedErr != nil {
 				logging.Errorf("failed to revoke invalid user session: %s", nestedErr)
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -530,7 +530,7 @@ func (s *Server) syncIdentityInfo(ctx context.Context, tx *data.Transaction, ide
 				return err
 			}
 
-			logging.L.Info().Msg("user session expired, puring keys created for this session")
+			logging.L.Info().Msg("user session expired, pruning keys created for this session")
 
 			if nestedErr := data.DeleteAccessKeys(tx, data.DeleteAccessKeysOptions{ByIssuedForID: providerUser.IdentityID, ByProviderID: providerUser.ProviderID}); nestedErr != nil {
 				logging.Errorf("failed to revoke invalid user session: %s", nestedErr)


### PR DESCRIPTION
## Summary
Add some checks to prevent deleting more access keys than were intended, also add some logging to track down a bug where access keys are removed unexpectedly. 

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged