### PR TITLE
Two small improvements to api server

### DIFF
--- a/docs/dev/api-versioned-handlers.md
+++ b/docs/dev/api-versioned-handlers.md
@@ -12,8 +12,7 @@ endpoint.
 
 1. Find the appropriate `API.addPreviousVersionHandlers<Type>` function in
    `internal/server`. If one does not exist for the type you are changing, create it and
-   call it from the same 2 locations as the other `API.addPreviousVersionHandlers<Type>`
-   functions.
+   call it from the same place in `server.GenerateRoutes`.
 2. If the request or response struct are changing, create a copy of that struct with
    the current infra version as a suffix. For example, if the `api.Grant` struct is
    being changed, and the current version is `v0.20.2`, the copy of the existing struct

--- a/internal/server/backgroundjobs.go
+++ b/internal/server/backgroundjobs.go
@@ -16,14 +16,7 @@ import (
 // transaction passed to this job will not have an OrganizationID.
 type BackgroundJobFunc func(tx data.WriteTxn) error
 
-func (s *Server) registerJob(ctx context.Context, job BackgroundJobFunc, every time.Duration) {
-	s.routines = append(s.routines, routine{
-		run:  jobWrapper(ctx, s.db, job, every),
-		stop: func() {}, // uses the context to stop
-	})
-}
-
-func jobWrapper(ctx context.Context, db *data.DB, job BackgroundJobFunc, every time.Duration) func() error {
+func backgroundJob(ctx context.Context, db *data.DB, job BackgroundJobFunc, every time.Duration) func() error {
 	return func() error {
 		t := time.NewTicker(every)
 		funcName := getFuncName(job)

--- a/internal/server/backgroundjobs_test.go
+++ b/internal/server/backgroundjobs_test.go
@@ -63,7 +63,7 @@ func TestJobWrapper(t *testing.T) {
 	}
 
 	g := errgroup.Group{}
-	fn := jobWrapper(ctx, db, job, time.Millisecond)
+	fn := backgroundJob(ctx, db, job, time.Millisecond)
 	g.Go(fn)
 	<-chReady
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/square/go-jose.v2"
 	"gotest.tools/v3/assert"
 
@@ -176,12 +177,11 @@ var cmpWellKnownJWKsJSON = gocmp.Options{
 }
 
 func TestAPI_AddPreviousVersionHandlers_Order(t *testing.T) {
-	a := API{}
-	a.addPreviousVersionHandlersAccessKey()
-	a.addPreviousVersionHandlersSignup()
-	a.addPreviousVersionHandlersGrants()
+	srv := newServer(Options{})
+	srv.metricsRegistry = prometheus.NewRegistry()
+	routes := srv.GenerateRoutes()
 
-	for routeID, versions := range a.versions {
+	for routeID, versions := range routes.api.versions {
 		prev := semver.MustParse("0.0.0")
 		for _, v := range versions {
 			assert.Assert(t, prev.LessThan(v.version),

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -25,6 +25,7 @@ import (
 type Routes struct {
 	http.Handler
 	OpenAPIDocument openapi3.T
+	api             *API
 }
 
 // GenerateRoutes constructs a http.Handler for the primary http and https servers.
@@ -147,7 +148,7 @@ func (s *Server) GenerateRoutes() Routes {
 	// This is a limitation because we serve the UI from / instead of a specific
 	// path prefix.
 	registerUIRoutes(router, s.options.UI)
-	return Routes{Handler: router, OpenAPIDocument: a.openAPIDoc}
+	return Routes{Handler: router, OpenAPIDocument: a.openAPIDoc, api: a}
 }
 
 type HandlerFunc[Req, Res any] func(c *gin.Context, req *Req) (Res, error)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -260,10 +260,10 @@ func (s *Server) Options() Options {
 func (s *Server) Run(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
 
-	s.registerJob(ctx, data.DeleteExpiredDeviceFlowAuthRequests, 10*time.Minute)
-	s.registerJob(ctx, data.RemoveExpiredAccessKeys, 12*time.Hour)
-	s.registerJob(ctx, data.RemoveExpiredPasswordResetTokens, 15*time.Minute)
-	s.registerJob(ctx, data.DeleteExpiredUserPublicKeys, time.Hour)
+	group.Go(backgroundJob(ctx, s.db, data.DeleteExpiredDeviceFlowAuthRequests, 10*time.Minute))
+	group.Go(backgroundJob(ctx, s.db, data.RemoveExpiredAccessKeys, 12*time.Hour))
+	group.Go(backgroundJob(ctx, s.db, data.RemoveExpiredPasswordResetTokens, 15*time.Minute))
+	group.Go(backgroundJob(ctx, s.db, data.DeleteExpiredUserPublicKeys, time.Hour))
 
 	if s.tel != nil {
 		group.Go(func() error {


### PR DESCRIPTION
I missed these in earlier PRs. Best viewed by individual commit.

1. Make the test for versioned handlers more reliable by allowing it to get the map of handlers from `GenerateRoutes`. This should always match production and avoid the scenario where someone forgets to update the test.
2. Remove another function for background jobs, and pass the jobs directly to `group.Go`.