### PR TITLE
delete grants for a destination when deleting the destination

### DIFF
--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -181,14 +181,7 @@ func DeleteDestination(tx WriteTxn, id uid.ID) error {
 		return handleError(err)
 	}
 
-	query := querybuilder.New("UPDATE grants")
-	query.B("SET deleted_at = ?,", time.Now())
-	query.B("update_index = nextval('seq_update_index')")
-	query.B("WHERE organization_id = ? AND", tx.OrganizationID())
-	query.B("deleted_at is null")
-	grantsByDestination(query, dest.Name)
-
-	_, err = tx.Exec(query.String(), query.Args...)
+	err = DeleteGrants(tx, DeleteGrantsOptions{ByDestination: dest.Name})
 	if err != nil {
 		return handleError(err)
 	}

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -333,11 +333,27 @@ func TestDeleteDestination(t *testing.T) {
 		dest := &models.Destination{Name: "kube", UniqueID: "1111", Kind: "kubernetes"}
 		createDestinations(t, tx, dest)
 
-		err := DeleteDestination(tx, dest.ID)
+		g1 := models.Grant{
+			Subject:   "i:1234567",
+			Privilege: "view",
+			Resource:  "kube",
+		}
+		err := CreateGrant(tx, &g1)
+		assert.NilError(t, err)
+
+		actual, err := ListGrants(tx, ListGrantsOptions{ByDestination: "kube"})
+		assert.NilError(t, err)
+		assert.Equal(t, len(actual), 1)
+
+		err = DeleteDestination(tx, dest.ID)
 		assert.NilError(t, err)
 
 		_, err = GetDestination(tx, GetDestinationOptions{ByID: dest.ID})
 		assert.ErrorIs(t, err, internal.ErrNotFound)
+
+		actual, err = ListGrants(tx, ListGrantsOptions{ByDestination: "kube"})
+		assert.NilError(t, err)
+		assert.Equal(t, len(actual), 0)
 	})
 }
 

--- a/internal/server/destination_test.go
+++ b/internal/server/destination_test.go
@@ -193,21 +193,35 @@ func TestAPI_DeleteDestination(t *testing.T) {
 			},
 		},
 		{
-			name: "success delete w/ grants",
+			name: "grants w/ more destinations",
 			setup: func(t *testing.T, req *http.Request) {
-				g1 := &models.Grant{
-					Subject:   "i:7654321",
-					Privilege: "cluster-admin",
-					Resource:  "wow",
+				grants := []*models.Grant{
+					{
+						Subject:   "i:7654321",
+						Privilege: "view",
+						Resource:  "wow",
+					},
+					{
+						Subject:   "i:7654321",
+						Privilege: "view",
+						Resource:  "wow.awesome",
+					},
+					{
+						Subject:   "i:7654321",
+						Privilege: "view",
+						Resource:  "anotherthing",
+					},
 				}
-				assert.NilError(t, data.CreateGrant(srv.db, g1))
+				for _, g := range grants {
+					assert.NilError(t, data.CreateGrant(srv.db, g))
+				}
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusNoContent, (*responseDebug)(resp))
 
-				grants, err := data.ListGrants(srv.db, data.ListGrantsOptions{ByDestination: "wow"})
+				grants, err := data.ListGrants(srv.db, data.ListGrantsOptions{BySubject: "i:7654321"})
 				assert.NilError(t, err)
-				assert.Equal(t, len(grants), 0)
+				assert.Equal(t, len(grants), 1)
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

This change removes any grants for a destination when the destination is deleted.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Nothing sensitive logged


## Related Issues

Resolves #3800 
