### PR TITLE
maintain(cmd): simplify user password prompt

### DIFF
--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -377,7 +377,7 @@ func addGrant(cli *CLI, cmdOptions grantsCmdOptions) error {
 	}
 
 	if userID == 0 && cmdOptions.UserName != "" {
-		user, err := createUser(ctx, client, cmdOptions.UserName)
+		user, err := client.CreateUser(ctx, &api.CreateUserRequest{Name: cmdOptions.UserName})
 		if err != nil {
 			if api.ErrorStatusCode(err) == 403 {
 				logging.Debugf("%s", err.Error())

--- a/internal/cmd/users_test.go
+++ b/internal/cmd/users_test.go
@@ -18,23 +18,6 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func TestCheckPasswordRequirements(t *testing.T) {
-	err := checkPasswordRequirements("")("password")
-	assert.NilError(t, err)
-
-	err = checkPasswordRequirements("")("short")
-	assert.NilError(t, err)
-
-	err = checkPasswordRequirements("")("")
-	assert.ErrorContains(t, err, "Value is required")
-
-	err = checkPasswordRequirements("password")("password")
-	assert.ErrorContains(t, err, "input must be different than the current password")
-
-	err = checkPasswordRequirements("password")(nil)
-	assert.ErrorContains(t, err, "unexpected type for password")
-}
-
 func TestUsersCmd(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

- gotos make it harder to trace the code so replace them with loops
- remove most password validation since it will be done by the server