### PR TITLE
fix: remove duplicate group names

### DIFF
--- a/internal/server/data/identity.go
+++ b/internal/server/data/identity.go
@@ -52,6 +52,14 @@ func diff(x, y []string) []string {
 	return difference
 }
 
+func deduplicate(groups []string) []string {
+	uniqueGroups := make(map[string]bool)
+	for _, g := range groups {
+		uniqueGroups[g] = true
+	}
+	return maps.Keys(uniqueGroups)
+}
+
 // AssignIdentityToGroups updates the identity's group membership relations based on the provider user's groups
 // and returns the identity's current groups after the update has persisted them
 func AssignIdentityToGroups(tx WriteTxn, user *models.ProviderUser, newGroups []string) ([]models.Group, error) {
@@ -59,6 +67,8 @@ func AssignIdentityToGroups(tx WriteTxn, user *models.ProviderUser, newGroups []
 	if err != nil {
 		return nil, err
 	}
+
+	newGroups = deduplicate(newGroups)
 
 	oldGroups := user.Groups
 	groupsToBeRemoved := diff(oldGroups, newGroups)

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -889,6 +889,20 @@ func TestAssignIdentityToGroups(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:           "test where the user has duplicate groups",
+			StartingGroups: []string{"foo"},
+			ExistingGroups: []string{"foo"},
+			IncomingGroups: []string{"foo2", "foo2"},
+			ExpectedGroups: []models.Group{
+				{
+					Name: "foo2",
+					OrganizationMember: models.OrganizationMember{
+						OrganizationID: 1000,
+					},
+				},
+			},
+		},
 	}
 
 	runDBTests(t, func(t *testing.T, db *DB) {


### PR DESCRIPTION
## Summary
If there are 2 groups with the same name returned for a user, then a duplicate group error would be returned on group creation. Prevent this by removing duplicate group names.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged