### PR TITLE
refactor: update user/credential

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -258,8 +258,8 @@ func (c Client) CreateUser(ctx context.Context, req *CreateUserRequest) (*Create
 	return post[CreateUserResponse](ctx, c, "/api/users", req)
 }
 
-func (c Client) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*User, error) {
-	return put[User](ctx, c, fmt.Sprintf("/api/users/%s", req.ID.String()), req)
+func (c Client) UpdateUser(ctx context.Context, req *UpdateUserRequest) (*UpdateUserResponse, error) {
+	return put[UpdateUserResponse](ctx, c, fmt.Sprintf("/api/users/%s", req.ID.String()), req)
 }
 
 func (c Client) DeleteUser(ctx context.Context, id uid.ID) error {

--- a/api/user.go
+++ b/api/user.go
@@ -68,8 +68,12 @@ type UpdateUserRequest struct {
 func (r UpdateUserRequest) ValidationRules() []validate.ValidationRule {
 	return []validate.ValidationRule{
 		validate.Required("id", r.ID),
-		validate.Required("password", r.Password),
 	}
+}
+
+type UpdateUserResponse struct {
+	User
+	OneTimePassword string `json:"oneTimePassword,omitempty"`
 }
 
 func (req ListUsersRequest) SetPage(page int) Paginatable {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -1351,6 +1351,99 @@
           }
         }
       },
+      "UpdateUserResponse": {
+        "properties": {
+          "created": {
+            "description": "Date the user was created",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "User ID",
+            "example": "4ACFkc434M",
+            "format": "uid",
+            "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+            "type": "string"
+          },
+          "lastSeenAt": {
+            "description": "Date the user was last seen",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the user",
+            "example": "bob@example.com",
+            "type": "string"
+          },
+          "oneTimePassword": {
+            "type": "string"
+          },
+          "providerNames": {
+            "description": "List of providers this user belongs to",
+            "example": "['okta']",
+            "items": {
+              "description": "List of providers this user belongs to",
+              "example": "['okta']",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "publicKeys": {
+            "description": "List of the users public keys",
+            "items": {
+              "description": "List of the users public keys",
+              "properties": {
+                "created": {
+                  "description": "formatted as an RFC3339 date-time",
+                  "example": "2022-03-14T09:48:00Z",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "expires": {
+                  "description": "formatted as an RFC3339 date-time",
+                  "example": "2022-03-14T09:48:00Z",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "fingerprint": {
+                  "description": "SHA256 fingerprint of the key",
+                  "type": "string"
+                },
+                "id": {
+                  "example": "4yJ3n3D8E2",
+                  "format": "uid",
+                  "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+                  "type": "string"
+                },
+                "keyType": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "sshLoginName": {
+            "description": "Username for SSH destinations",
+            "example": "bob",
+            "type": "string"
+          },
+          "updated": {
+            "description": "Date the user was updated",
+            "example": "2022-03-14T09:48:00Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        }
+      },
       "User": {
         "properties": {
           "created": {
@@ -7325,9 +7418,6 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "password"
-                ],
                 "type": "object"
               }
             }
@@ -7388,7 +7478,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "$ref": "#/components/schemas/UpdateUserResponse"
                 }
               }
             },

--- a/internal/access/credential.go
+++ b/internal/access/credential.go
@@ -12,156 +12,153 @@ import (
 
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/generate"
-	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/validate"
 )
 
-func CreateCredential(c *gin.Context, user models.Identity) (string, error) {
-	db, err := RequireInfraRole(c, models.InfraAdminRole)
+func CreateCredential(c *gin.Context, user *models.Identity) (string, error) {
+	tx, err := RequireInfraRole(c, models.InfraAdminRole)
 	if err != nil {
 		return "", HandleAuthErr(err, "user", "create", models.InfraAdminRole)
 	}
 
-	tmpPassword, err := generate.CryptoRandom(12, generate.CharsetPassword)
+	password, err := generate.CryptoRandom(12, generate.CharsetPassword)
 	if err != nil {
-		return "", fmt.Errorf("generate: %w", err)
+		return "", fmt.Errorf("crypto random: %w", err)
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(tmpPassword), bcrypt.DefaultCost)
-	if err != nil {
-		return "", fmt.Errorf("hash: %w", err)
-	}
-
-	userCredential := &models.Credential{
-		IdentityID:      user.ID,
-		PasswordHash:    hash,
+	credential := &models.Credential{
 		OneTimePassword: true,
 	}
 
-	if err := data.CreateCredential(db, userCredential); err != nil {
+	if err := createCredential(tx, user, credential, password); err != nil {
 		return "", err
 	}
 
-	_, err = data.CreateProviderUser(db, data.InfraProvider(db), &user)
-	if err != nil {
-		return "", fmt.Errorf("creating provider user: %w", err)
-	}
-
-	return tmpPassword, nil
+	return password, err
 }
 
+func createCredential(tx *data.Transaction, user *models.Identity, credential *models.Credential, password string) error {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Errorf("generate from password: %w", err)
+	}
+
+	credential.IdentityID = user.ID
+	credential.PasswordHash = hash
+
+	if err := data.CreateCredential(tx, credential); err != nil {
+		return fmt.Errorf("create credential: %w", err)
+	}
+
+	if _, err = data.CreateProviderUser(tx, data.InfraProvider(tx), user); err != nil {
+		return fmt.Errorf("create provider user: %w", err)
+	}
+
+	return nil
+}
+
+// ResetCredential resets a user's password to a specified value. If the input value is empty, a password
+// is randomly generated. No matter the input, the new password is one-time use and must be changed by the user.
+func ResetCredential(c *gin.Context, user *models.Identity, newPassword string) (string, error) {
+	tx, err := RequireInfraRole(c, models.InfraAdminRole)
+	if err != nil {
+		return "", HandleAuthErr(err, "user", "update", models.InfraAdminRole)
+	}
+
+	if newPassword == "" {
+		password, err := generate.CryptoRandom(12, generate.CharsetPassword)
+		if err != nil {
+			return "", fmt.Errorf("crypto random: %w", err)
+		}
+
+		newPassword = password
+	}
+
+	credential, err := data.GetCredentialByUserID(tx, user.ID)
+	switch {
+	case errors.Is(err, internal.ErrNotFound):
+		if err := createCredential(tx, user, &models.Credential{OneTimePassword: true}, newPassword); err != nil {
+			return "", err
+		}
+
+		return newPassword, nil
+	case err != nil:
+		return "", fmt.Errorf("get credential: %w", err)
+	}
+
+	credential.OneTimePassword = true
+
+	if err := updateCredential(tx, credential, newPassword); err != nil {
+		return "", err
+	}
+
+	return newPassword, nil
+}
+
+// UpdateCredential updates a user's password to a specified valued. In order to update the user's password,
+// specified requirements must be met:
+//
+// 1. The old password hash must match value stored in the database
+// 2. The new password must meet the password policy defined for the organization
 func UpdateCredential(c *gin.Context, user *models.Identity, oldPassword, newPassword string) error {
 	rCtx := GetRequestContext(c)
-	isSelf := isIdentitySelf(rCtx, data.GetIdentityOptions{ByID: user.ID})
+	tx := GetRequestContext(c).DBTxn
 
-	// anyone can update their own credentials, so check authorization when not self
-	if !isSelf {
-		err := IsAuthorized(rCtx, models.InfraAdminRole)
-		if err != nil {
-			return HandleAuthErr(err, "user", "update", models.InfraAdminRole)
-		}
+	errs := make(validate.Error)
+
+	credential, err := data.GetCredentialByUserID(tx, user.ID)
+	if err != nil {
+		return fmt.Errorf("get credential: %w", err)
 	}
 
-	// Users have to supply their old password to change their existing password
-	if isSelf {
-		if oldPassword == "" {
-			errs := make(validate.Error)
-			errs["oldPassword"] = append(errs["oldPassword"], "is required")
-			return errs
-		}
-
-		userCredential, err := data.GetCredentialByUserID(rCtx.DBTxn, user.ID)
-		if err != nil {
-			return fmt.Errorf("existing credential: %w", err)
-		}
-
-		// compare the stored hash of the user's password and the hash of the presented password
-		err = bcrypt.CompareHashAndPassword(userCredential.PasswordHash, []byte(oldPassword))
-		if err != nil {
-			// this probably means the password was wrong
-			logging.L.Trace().Err(err).Msg("bcrypt comparison with oldpassword/newpassword failed")
-
-			errs := make(validate.Error)
-			errs["oldPassword"] = append(errs["oldPassword"], "invalid oldPassword")
-			return errs
-		}
-
+	// compare the stored hash of the user's password and the hash of the presented password
+	if err := bcrypt.CompareHashAndPassword(credential.PasswordHash, []byte(oldPassword)); err != nil {
+		errs["oldPassword"] = append(errs["oldPassword"], "invalid password")
+		return errs
 	}
 
-	if err := updateCredential(c, user, newPassword, isSelf); err != nil {
+	if err := checkPasswordRequirements(tx, newPassword); err != nil {
 		return err
 	}
 
-	if !isSelf {
-		// if the request is from an admin, the infra user may not exist yet, so create the
-		// provider_user if it's missing.
-		_, _ = data.CreateProviderUser(rCtx.DBTxn, data.InfraProvider(rCtx.DBTxn), user)
+	credential.OneTimePassword = false
+
+	if err := updateCredential(tx, credential, newPassword); err != nil {
+		return err
+	}
+
+	// if we updated our own password, remove the password-reset scope from our access key.
+	if accessKey := rCtx.Authenticated.AccessKey; accessKey != nil {
+		for i, v := range accessKey.Scopes {
+			if v == models.ScopePasswordReset {
+				accessKey.Scopes = append(accessKey.Scopes[:i], accessKey.Scopes[i+1:]...)
+				break
+			}
+		}
+
+		if err := data.UpdateAccessKey(tx, accessKey); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func updateCredential(c *gin.Context, user *models.Identity, newPassword string, isSelf bool) error {
-	rCtx := GetRequestContext(c)
-	db := rCtx.DBTxn
-
-	if err := checkPasswordRequirements(db, newPassword); err != nil {
-		return err
-	}
-
-	if err := checkBadPasswords(newPassword); err != nil {
-		return err
-	}
-
-	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+func updateCredential(tx *data.Transaction, credential *models.Credential, password string) error {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		return fmt.Errorf("hash: %w", err)
+		return fmt.Errorf("generate from password: %w", err)
 	}
 
-	userCredential, err := data.GetCredentialByUserID(db, user.ID)
-	if err != nil {
-		if errors.Is(err, internal.ErrNotFound) && !isSelf {
-			if err := data.CreateCredential(db, &models.Credential{
-				IdentityID:      user.ID,
-				PasswordHash:    hash,
-				OneTimePassword: true,
-			}); err != nil {
-				return fmt.Errorf("creating credentials: %w", err)
-			}
-			return nil
-		}
-		return fmt.Errorf("existing credential: %w", err)
+	credential.PasswordHash = hash
+
+	if err := data.UpdateCredential(tx, credential); err != nil {
+		return fmt.Errorf("update credential: %w", err)
 	}
 
-	userCredential.PasswordHash = hash
-	userCredential.OneTimePassword = !isSelf
-
-	if err := data.UpdateCredential(db, userCredential); err != nil {
-		return fmt.Errorf("saving credentials: %w", err)
-	}
-
-	if isSelf {
-		// if we updated our own password, remove the password-reset scope from our access key.
-		if accessKey := rCtx.Authenticated.AccessKey; accessKey != nil {
-			accessKey.Scopes = sliceWithoutElement(accessKey.Scopes, models.ScopePasswordReset)
-			if err = data.UpdateAccessKey(db, accessKey); err != nil {
-				return fmt.Errorf("updating access key: %w", err)
-			}
-		}
-	}
 	return nil
-}
-
-func sliceWithoutElement(s []string, without string) []string {
-	result := []string{}
-	for _, v := range s {
-		if v != without {
-			result = append(result, v)
-		}
-	}
-	return result
 }
 
 func GetRequestContext(c *gin.Context) RequestContext {
@@ -226,6 +223,10 @@ func checkPasswordRequirements(db data.ReadTxn, password string) error {
 
 	if !valid {
 		return validate.Error{"password": requirementError}
+	}
+
+	if err := checkBadPasswords(password); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -1,11 +1,8 @@
 package access
 
 import (
-	"fmt"
-
 	"github.com/gin-gonic/gin"
 
-	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
@@ -53,15 +50,6 @@ func CreateIdentity(c *gin.Context, identity *models.Identity) error {
 }
 
 func DeleteIdentity(c *gin.Context, id uid.ID) error {
-	rCtx := GetRequestContext(c)
-	if isIdentitySelf(rCtx, data.GetIdentityOptions{ByID: id}) {
-		return fmt.Errorf("cannot delete self: %w", internal.ErrBadRequest)
-	}
-
-	if data.InfraConnectorIdentity(rCtx.DBTxn).ID == id {
-		return fmt.Errorf("%w: the connector user can not be deleted", internal.ErrBadRequest)
-	}
-
 	db, err := RequireInfraRole(c, models.InfraAdminRole)
 	if err != nil {
 		return HandleAuthErr(err, "user", "delete", models.InfraAdminRole)
@@ -71,6 +59,7 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 		ByProviderID: data.InfraProvider(db).ID,
 		ByID:         id,
 	}
+
 	return data.DeleteIdentities(db, opts)
 }
 

--- a/internal/server/email/sendgrid.go
+++ b/internal/server/email/sendgrid.go
@@ -55,7 +55,7 @@ var (
 	SendgridAPIKey     = os.Getenv("SENDGRID_API_KEY")
 	SMTPServer         = "smtp.sendgrid.net:465"
 	TestMode           = false
-	TestDataSent       = []any{}
+	TestData           = []any{}
 	ErrUnknownTemplate = errors.New("unknown template")
 	ErrNotConfigured   = errors.New("email sending not configured")
 )
@@ -112,7 +112,7 @@ func SendTemplate(name, address string, template EmailTemplate, data any, bypass
 		logging.Debugf("sent email to %q: %+v\n", address, data)
 		logging.Debugf("plain: %s", string(msg.PlainBody))
 		logging.Debugf("html: %s", string(msg.HTMLBody))
-		TestDataSent = append(TestDataSent, data)
+		TestData = append(TestData, data)
 		return nil // quietly return
 	}
 

--- a/internal/server/passwordreset.go
+++ b/internal/server/passwordreset.go
@@ -45,6 +45,7 @@ func (a *API) RequestPasswordReset(c *gin.Context, r *api.PasswordResetRequest) 
 	err = email.SendPasswordResetEmail("", r.Email, email.PasswordResetData{
 		Link: wrapLinkWithVerification(fmt.Sprintf("https://%s/password-reset?token=%s", org.Domain, token), org.Domain, user.VerificationToken),
 	})
+
 	return nil, err
 }
 

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -694,7 +694,7 @@ func TestAPI_CreateUserAndUpdatePassword(t *testing.T) {
 						OldPassword: "whatever",
 						Password:    "1234567890987654321a!",
 					})
-					assert.Error(t, err, "existing credential: record not found")
+					assert.Error(t, err, "get credential: record not found")
 				})
 			})
 			t.Run("with an existing infra user", func(t *testing.T) {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

`UpdateUser` is actually just `UpdateCredential` since no other user field is currently modifiable. There are two modes for `UpdateCredential`: 

1. Update the caller’s user credential. This does not require special authorization.
2. Update another user’s credential. This requires admin authorization.

To support these modes, there are 6 `isSelf` checks between `access.UpdateCredential` and its helper `access.updateCredential`. This makes it very difficult to trace the code. 

In total there are 3 use cases where update credential is needed:

1. A user wants to change their own password. The current password must be provided and verified against the database
1. A user wants to reset their password out-of-band through email verification. The current password is unknown so it cannot be verified
1. An admin wants to reset another users password. The current password is unknown. The only way to do this currently is through the CLI which generates a password and sends it in the request

There's a fourth use case where a user is invited by email. To create their account, the user claims invite and sets a password. This reuses the password reset flow so it's omitted from this list.

The third use case raises red flags. The CLI generates a random 12-character password which it sends in the `UpdateUser` request. If the password policy requires greater than 12 characters, this action will never succeed. Even if the policy requires ≤ 12 characters but has other requirements like numbers or symbols, the password generate may fail even with retries. Even if the CLI generates a valid value, allowing the admin to decide a user’s new password feels like a bad pattern. While this PR makes changes relevant to this issue, for compatibility reasons this will be addressed in a follow up.

This PR focuses on streamlining the `UpdateUser` flow. There's a single check to determine if the request is intended for the caller's user `UpdateCredential` or another user `ResetCredential`.

This PR also adds `UpdateUserResponse` which is `User` with an extra field `OneTimePassword`. If the `UpdateUser` request is for resetting a user's password and a password is not specified, a password will be generated and returned in this new field. If a password is specified in the request, it will return that value. This should be compatible with older clients.