### PR TITLE
fix: remove non-secure cookies on logout

### DIFF
--- a/internal/server/cookie.go
+++ b/internal/server/cookie.go
@@ -47,13 +47,19 @@ func setCookie(req *http.Request, resp http.ResponseWriter, config cookieConfig)
 	})
 }
 
-func deleteCookie(resp http.ResponseWriter, name, domain string) {
+func deleteCookie(req *http.Request, resp http.ResponseWriter, name, domain string) {
+	secure := true
+	if req.TLS == nil {
+		// if the request came over HTTP, then the cookie will need to be sent unsecured
+		secure = false
+	}
+
 	http.SetCookie(resp, &http.Cookie{
 		Name:     name,
 		MaxAge:   cookieMaxAgeDeleteImmediately,
 		Path:     cookiePath,
 		Domain:   domain,
-		Secure:   true, // only over https
+		Secure:   secure,
 		HttpOnly: true, // not accessible by javascript
 	})
 }
@@ -79,7 +85,7 @@ func exchangeSignupCookieForSession(
 		Expires: exp,
 	}
 	setCookie(req, resp, conf)
-	deleteCookie(resp, cookieSignupName, opts.BaseDomain)
+	deleteCookie(req, resp, cookieSignupName, opts.BaseDomain)
 
 	return signupCookie
 }

--- a/internal/server/cookie_test.go
+++ b/internal/server/cookie_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ func TestResendAuthCookie(t *testing.T) {
 	req := &http.Request{
 		Host:   fmt.Sprintf("dev.%s", baseDomain),
 		Header: make(http.Header),
+		TLS:    &tls.ConnectionState{}, // if this isnt nil the request is considered secure
 	}
 	maxAge := int(time.Until(time.Now().Add(5 * time.Second)).Seconds())
 	req.AddCookie(&http.Cookie{
@@ -39,10 +41,32 @@ func TestResendAuthCookie(t *testing.T) {
 	cookies := resp.Header()["Set-Cookie"]
 
 	matched, err := regexp.MatchString(
-		"auth=aaa; Path=/; Domain=dev.example.com; Max-Age=\\d\\d; HttpOnly; SameSite=Strict",
+		"auth=aaa; Path=/; Domain=dev.example.com; Max-Age=\\d\\d; HttpOnly; Secure; SameSite=Strict",
 		cookies[0])
 	assert.NilError(t, err)
 	assert.Assert(t, matched)
 
 	assert.Equal(t, "signup=; Path=/; Domain=example.com; Max-Age=0; HttpOnly; Secure", cookies[1])
+}
+
+func TestCookieSecureFlagIsSetForTLS(t *testing.T) {
+	baseDomain := "example.com"
+	req := &http.Request{
+		Host:   fmt.Sprintf("dev.%s", baseDomain),
+		Header: make(http.Header),
+		TLS:    &tls.ConnectionState{}, // if this isnt nil the request is considered secure
+	}
+
+	resp := httptest.NewRecorder()
+	setCookie(
+		req,
+		resp,
+		cookieConfig{
+			Name:  "tls-cookie-test",
+			Value: "1234",
+		})
+	assert.Equal(t, len(resp.Header()["Set-Cookie"]), 1)
+	cookies := resp.Header()["Set-Cookie"]
+
+	assert.Equal(t, "tls-cookie-test=1234; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Strict", cookies[0])
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -225,7 +225,7 @@ func (a *API) Logout(c *gin.Context, _ *api.EmptyRequest) (*api.EmptyResponse, e
 		return nil, err
 	}
 
-	deleteCookie(c.Writer, cookieAuthorizationName, c.Request.Host)
+	deleteCookie(c.Request, c.Writer, cookieAuthorizationName, c.Request.Host)
 	return nil, nil
 }
 

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -131,7 +131,7 @@ func authenticateRequest(c *gin.Context, route routeSettings, srv *Server) (acce
 		tx = tx.WithOrgID(authned.Organization.ID)
 		// sync the identity info here to keep the UI session in sync with IDP session validity
 		if err := srv.syncIdentityInfo(context.Background(), tx, authned.User, authned.AccessKey.ProviderID); err != nil {
-			deleteCookie(c.Writer, cookieAuthorizationName, c.Request.Host)
+			deleteCookie(c.Request, c.Writer, cookieAuthorizationName, c.Request.Host)
 			if errors.Is(err, ErrSyncFailed) {
 				logging.L.Debug().Err(err)
 			} else {


### PR DESCRIPTION
## Summary
When logging out on an `http` connection the cookie is not cleared, check if the incoming request is secure to clear this cookie.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #4003
