### PR TITLE
fix: minor ui issues with allowed domains

### DIFF
--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -765,12 +765,12 @@ function Authentication() {
             </div>
           </header>
           <form
-            className='group form-input flex w-full rounded border-gray-300 py-2 px-3 leading-tight focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500'
+            className='group form-input flex flex-wrap w-full rounded border-gray-300 py-2 px-3 leading-tight focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500'
             onSubmit={addDomain}
           >
             {allowedDomains.map(d => (
               <span
-                className='mr-1 inline-block rounded-md bg-gray-200 py-1 px-2 pl-2.5 pr-1 text-xs font-medium'
+                className='mr-1 mt-1 inline-block rounded-md bg-gray-200 py-1 px-2 pl-2.5 pr-1 text-xs font-medium'
                 key={d}
               >
                 {d}
@@ -785,7 +785,7 @@ function Authentication() {
               </span>
             ))}
             <input
-              className='peer grow bg-transparent focus:outline-none'
+              className='peer mt-1 grow bg-transparent focus:outline-none'
               value={newDomain}
               onChange={e => {
                 setNewDomain(e.target.value)

--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -785,8 +785,9 @@ function Authentication() {
               </span>
             ))}
             <input
-              className='peer mt-1 grow bg-transparent focus:outline-none'
+              className='peer mt-1 text-sm grow bg-transparent focus:outline-none'
               value={newDomain}
+              placeholder={'enter a domain...'}
               onChange={e => {
                 setNewDomain(e.target.value)
               }}

--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -765,12 +765,12 @@ function Authentication() {
             </div>
           </header>
           <form
-            className='group form-input flex flex-wrap w-full rounded border-gray-300 py-2 px-3 leading-tight focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500'
+            className='group form-input flex w-full flex-wrap rounded border-gray-300 py-2 px-3 leading-tight focus-within:border-blue-500 focus-within:ring-1 focus-within:ring-blue-500'
             onSubmit={addDomain}
           >
             {allowedDomains.map(d => (
               <span
-                className='mr-1 my-1 inline-block rounded-md bg-gray-200 py-1 pl-2.5 pr-1 text-xs font-medium'
+                className='my-1 mr-1 inline-block rounded-md bg-gray-200 py-1 pl-2.5 pr-1 text-xs font-medium'
                 key={d}
               >
                 {d}
@@ -785,7 +785,7 @@ function Authentication() {
               </span>
             ))}
             <input
-              className='peer mt-1 py-1 text-sm grow bg-transparent focus:outline-none'
+              className='peer mt-1 grow bg-transparent py-1 text-sm focus:outline-none'
               value={newDomain}
               placeholder={'enter a domain...'}
               onChange={e => {

--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -718,7 +718,7 @@ function Authentication() {
     }
     if (!allowedDomains.includes(cleanedInput)) {
       const newAllowedDomains = [...allowedDomains, cleanedInput]
-      updateAllowedDomains(newAllowedDomains)
+      await updateAllowedDomains(newAllowedDomains)
     }
     setNewDomain('')
   }
@@ -770,7 +770,7 @@ function Authentication() {
           >
             {allowedDomains.map(d => (
               <span
-                className='mr-1 mt-1 inline-block rounded-md bg-gray-200 py-1 px-2 pl-2.5 pr-1 text-xs font-medium'
+                className='mr-1 my-1 inline-block rounded-md bg-gray-200 py-1 pl-2.5 pr-1 text-xs font-medium'
                 key={d}
               >
                 {d}
@@ -785,7 +785,7 @@ function Authentication() {
               </span>
             ))}
             <input
-              className='peer mt-1 text-sm grow bg-transparent focus:outline-none'
+              className='peer mt-1 py-1 text-sm grow bg-transparent focus:outline-none'
               value={newDomain}
               placeholder={'enter a domain...'}
               onChange={e => {


### PR DESCRIPTION
## Summary
- Add placeholder text before input
- Adding first domain does not change this size of the input box
- Adding many domains wraps to a new line rather than squishing the domain tag
- No flash of domain disappearing after hitting enter

📸 
<img width="1149" alt="Screen Shot 2023-01-12 at 12 40 30 PM" src="https://user-images.githubusercontent.com/5853428/212176899-56e54254-4baf-41c3-93d1-ae81245deec8.png">


## Checklist

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

Resolves #3968 
