### PR TITLE
Fix configs that used file: prefix

### DIFF
--- a/dev/server.yaml
+++ b/dev/server.yaml
@@ -3,7 +3,7 @@ ui:
 
 tls:
   ca: internal/server/testdata/pki/ca.crt
-  caPrivateKey: file:internal/server/testdata/pki/ca.key
+  caPrivateKey: internal/server/testdata/pki/ca.key
 
 dbHost: localhost
 dbName: postgres

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     image: alpine:latest
     environment:
       - INFRA_SERVER_TLS_CA=/work/internal/server/testdata/pki/ca.crt
-      - INFRA_SERVER_TLS_CA_PRIVATE_KEY=file:/work/internal/server/testdata/pki/ca.key
+      - INFRA_SERVER_TLS_CA_PRIVATE_KEY=/work/internal/server/testdata/pki/ca.key
       - INFRA_SERVER_DB_CONNECTION_STRING=host=db port=5432 user=postgres dbname=postgres password=postgres
       - INFRA_SERVER_DB_ENCRYPTION_KEY=/work/test/root.key
     command: /work/dist/infra_linux_amd64_v1/infra server --config-file /work/test/dockerfiles/server.yaml


### PR DESCRIPTION
The config used by `test_acceptance` and `dev/server.yaml` had `file:` prefix for the TLS CA private key, which need to be updated for the changes from #3951