### PR TITLE
fix: delay creating provider user

### DIFF
--- a/internal/server/passwordreset_test.go
+++ b/internal/server/passwordreset_test.go
@@ -16,17 +16,20 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func patchEmailTestMode(t *testing.T) {
+func patchEmailTestMode(t *testing.T, testKey string) {
 	t.Helper()
+	originalSendgridAPIKey := email.SendgridAPIKey
+	email.SendgridAPIKey = testKey
 	email.TestMode = true
 	t.Cleanup(func() {
 		email.TestMode = false
 		email.TestData = make([]any, 0)
+		email.SendgridAPIKey = originalSendgridAPIKey
 	})
 }
 
 func TestPasswordResetFlow(t *testing.T) {
-	patchEmailTestMode(t)
+	patchEmailTestMode(t, "fakekey")
 
 	s := setupServer(t)
 	routes := s.GenerateRoutes()

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -346,7 +346,8 @@ export default function Users() {
               // can only delete users that exist within Infra which are not the currently logged in user
               if (
                 info.row.original.id === user?.id ||
-                !info.row.original.providerNames?.includes('infra')
+                (info.row.original.providerNames !== undefined &&
+                  !info.row.original.providerNames?.includes('infra'))
               ) {
                 return null
               }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Right now when an admin creates a user by email invite, the provider user and credential are created immediately even though a user may not accept the invitation. With this change, only create the provider user and credential when the end user accepts the invite.

Note: this is only applicable when a SMTP server is configured.

Update the UI to allow removing a user that's been invited but hasn't accepted the invite. 

![image](https://user-images.githubusercontent.com/2372640/212771054-e8bff759-5841-4643-bb21-43da8bd6de3c.png)

1. Current user - user cannot be deleted
2. Okta user - user cannot be deleted
3. Invited user, accepted - user can be delete
4. Invited user, not accepted - user can be deleted

### TODO
- [x] More tests

Resolves #3908 