### PR TITLE
Completely clear cache on login and logout

### DIFF
--- a/ui/components/layouts/dashboard.js
+++ b/ui/components/layouts/dashboard.js
@@ -78,15 +78,19 @@ function SidebarNav({ children, open, setOpen }) {
 export default function Dashboard({ children }) {
   const router = useRouter()
 
-  const { user, loading, isAdmin, org, logout } = useUser({
-    redirectTo:
-      router.asPath === '/'
-        ? '/login'
-        : `/login?next=${encodeURIComponent(router.asPath)}`,
-  })
+  const { user, loading, isAdmin, org, logout } = useUser()
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   if (loading) {
+    return null
+  }
+
+  if (!user) {
+    router.replace(
+      router.asPath === '/'
+        ? '/login'
+        : `/login?next=${encodeURIComponent(router.asPath)}`
+    )
     return null
   }
 
@@ -181,7 +185,10 @@ export default function Dashboard({ children }) {
           </div>
           <button
             type='button'
-            onClick={() => logout()}
+            onClick={async () => {
+              await logout()
+              router.replace('/login')
+            }}
             className='flex w-full cursor-pointer items-center text-[12px] font-medium text-gray-500/75 hover:text-gray-500'
           >
             <ArrowLeftOnRectangleIcon

--- a/ui/components/layouts/login.js
+++ b/ui/components/layouts/login.js
@@ -5,12 +5,14 @@ export default function Login({ children }) {
   const router = useRouter()
   const { next } = router.query
 
-  const { loading } = useUser({
-    redirectTo: next ? decodeURIComponent(next) : '/',
-    redirectIfFound: true,
-  })
+  const { loading, user } = useUser()
 
   if (loading) {
+    return null
+  }
+
+  if (user) {
+    router.replace(next ? decodeURIComponent(next) : '/')
     return null
   }
 


### PR DESCRIPTION
Fixes #3985 

While https://github.com/infrahq/infra/pull/4014 cleared some data, errors would still be cached causing flashes of content on logout and in some remaining cases, on login.

This PR simplifies the redirect logic as well: components can now choose where to redirect users, instead of it automatically happening in `useUser` hook.