### PR TITLE
Reduce the use of gin.Context - part 1

### DIFF
--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -269,7 +269,7 @@ func provisionSSHKey(ctx context.Context, opts provisionSSHKeyOptions) (string, 
 
 		// key doesn't exist in the API
 		fmt.Fprintf(opts.cli.Stderr,
-			"Removing %v because it was expired or deleted from Infra", filename)
+			"Removing %v because it was expired or deleted from Infra\n", filename)
 		if err := os.Remove(filename); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return "", fmt.Errorf("removing deleted key %w", err)
 		}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -145,7 +145,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 			}
 		}
 
-		providerClient, err := a.server.providerClient(c, provider, r.OIDC.RedirectURL)
+		providerClient, err := a.server.providerClient(rCtx.Request.Context(), provider, r.OIDC.RedirectURL)
 		if err != nil {
 			return nil, fmt.Errorf("login provider client: %w", err)
 		}

--- a/internal/server/signup.go
+++ b/internal/server/signup.go
@@ -145,7 +145,7 @@ func handleSignupError(err error) error {
 }
 
 func (a *API) socialSignupUserAuth(c *gin.Context, provider *models.Provider, auth *authn.OIDCAuthn) (*providers.IdentityProviderAuth, error) {
-	providerClient, err := a.server.providerClient(c, provider, auth.RedirectURL)
+	providerClient, err := a.server.providerClient(c.Request.Context(), provider, auth.RedirectURL)
 	if err != nil {
 		return nil, fmt.Errorf("sign-up provider client: %w", err)
 	}


### PR DESCRIPTION
## Summary

We are currently using a fork of `gin` to support decoding of types that implement `encoding.TextUnmarshaler`.

This PR takes a few small steps to reduce our use of `gin.Context`, and to replace our fork with upstream `gin`.

Full details in the commit messages, but in summary:
1. use `context.Context` directly from the `http.Request.Context()` instead of using `gin.Context` (which implements `context.Context`). `gin.Context`'s implementation of `context.Context` is error prone, and doesn't actually provide the correct context value in some cases (which I didn't bother to debug, because there's really no reason to be using `gin.Context` as a `context.Context`).
2. remove the unnecessary indirection in `readRequest`. `ShouldBind` is replaced with the methods that were called eventually after 2 unnecessary other calls that do nothing but indirect
3. Small bug fix, adding a missing newline


## Related Issues

Related to https://github.com/infrahq/infra/issues/2796, and https://github.com/infrahq/internal/issues/19