### PR TITLE
Reduce the use of `gin.Context` in `server` package

### DIFF
--- a/internal/access/request.go
+++ b/internal/access/request.go
@@ -25,7 +25,7 @@ type RequestContext struct {
 
 	// Response is a mutable field. It can be modified by API handlers to add
 	// new response metadata.
-	Response *ResponseMetadata
+	Response *Response
 }
 
 // Authenticated stores data about the authenticated user. If the AccessKey or
@@ -36,22 +36,29 @@ type Authenticated struct {
 	Organization *models.Organization
 }
 
-// ResponseMetadata is accumulated by API endpoints and used for logging and
+// Response is accumulated by API endpoints and used for logging and
 // reporting.
-type ResponseMetadata struct {
+type Response struct {
+	// HTTPWriter is the http.ResponseWriter that will be used to write the response.
+	// In most cases the HTTPWriter should only be used to write response headers
+	// or cookies using Header().
+	// It is only safe to call Write and WriteHeader if the API handler returns
+	// an empty response and no error.
+	HTTPWriter http.ResponseWriter
+
 	// logFields is a slice of function that can add fields to the API
 	// request log entry.
 	logFields []func(event *zerolog.Event)
 }
 
-func (r *ResponseMetadata) AddLogFields(fn func(event *zerolog.Event)) {
+func (r *Response) AddLogFields(fn func(event *zerolog.Event)) {
 	if r == nil {
 		return
 	}
 	r.logFields = append(r.logFields, fn)
 }
 
-func (r *ResponseMetadata) ApplyLogFields(event *zerolog.Event) {
+func (r *Response) ApplyLogFields(event *zerolog.Event) {
 	if r == nil {
 		return
 	}

--- a/internal/access/request.go
+++ b/internal/access/request.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 const RequestContextKey = "requestContext"
@@ -45,6 +46,14 @@ type Response struct {
 	// It is only safe to call Write and WriteHeader if the API handler returns
 	// an empty response and no error.
 	HTTPWriter http.ResponseWriter
+
+	// LoginUserID stores the user ID for login, and signup type endpoints so that
+	// the ID can be included in the API request log entry.
+	LoginUserID uid.ID
+
+	// SignupOrgID stores the organization ID for a new signup so that the ID
+	// can be included in the API request log entry.
+	SignupOrgID uid.ID
 
 	// logFields is a slice of function that can add fields to the API
 	// request log entry.

--- a/internal/server/debug.go
+++ b/internal/server/debug.go
@@ -40,12 +40,12 @@ func pprofHandler(c *gin.Context, _ *pprofRequest) (*api.EmptyResponse, error) {
 
 	switch c.Param("profile") {
 	case "/trace":
-		pprof.Trace(c.Writer, c.Request)
+		pprof.Trace(rCtx.Response.HTTPWriter, c.Request)
 	case "/profile":
-		pprof.Profile(c.Writer, c.Request)
+		pprof.Profile(rCtx.Response.HTTPWriter, c.Request)
 	default:
 		// All other types of profiles are served from Index
-		http.StripPrefix("/api", http.HandlerFunc(pprof.Index)).ServeHTTP(c.Writer, c.Request)
+		http.StripPrefix("/api", http.HandlerFunc(pprof.Index)).ServeHTTP(rCtx.Response.HTTPWriter, c.Request)
 	}
 	return nil, nil
 }

--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -122,7 +122,7 @@ func (a *API) GetDeviceFlowStatus(c *gin.Context, req *api.DeviceFlowStatusReque
 
 	// Update the request context so that logging middleware can include the userID
 	rctx.Authenticated.User = user
-	c.Set(access.RequestContextKey, rctx)
+	rctx.Response.LoginUserID = user.ID
 
 	org, err := data.GetOrganization(rctx.DBTxn, data.GetOrganizationOptions{ByID: accessKey.OrganizationID})
 	if err != nil {

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/api"
@@ -139,15 +138,13 @@ func TestSendAPIError(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.err.Error(), func(t *testing.T) {
 			resp := httptest.NewRecorder()
-			c, _ := gin.CreateTestContext(resp)
-			c.Request = &http.Request{
+			req := &http.Request{
 				Method:     http.MethodPost,
 				URL:        &url.URL{Path: "/api/path"},
 				RemoteAddr: "10.10.10.10:34124",
 			}
 
-			sendAPIError(c, test.err)
-
+			sendAPIError(resp, req, test.err)
 			assert.Equal(t, test.result.Code, int32(resp.Result().StatusCode))
 
 			if test.emptyResponseBody {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -46,7 +46,7 @@ func addVersionHandler[Req, Res any](a *API, method, path, version string, route
 		handler: func(c *gin.Context) {
 			wrapped := wrapRoute(a, key, routeDef)
 			if err := wrapped(c); err != nil {
-				sendAPIError(c, err)
+				sendAPIError(c.Writer, c.Request, err)
 			}
 		},
 	})

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -218,7 +218,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 
 	// Update the request context so that logging middleware can include the userID
 	rCtx.Authenticated.User = result.User
-	c.Set(access.RequestContextKey, rCtx)
+	rCtx.Response.LoginUserID = result.User.ID
 
 	return &api.LoginResponse{
 		UserID:                 key.IssuedFor,

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -206,7 +206,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 		Domain:  rCtx.Request.Host,
 		Expires: result.AccessKey.ExpiresAt,
 	}
-	setCookie(rCtx.Request, c.Writer, cookie)
+	setCookie(rCtx.Request, rCtx.Response.HTTPWriter, cookie)
 
 	key := result.AccessKey
 	a.t.User(key.IssuedFor.String(), result.User.Name)
@@ -239,7 +239,7 @@ func (a *API) Logout(c *gin.Context, _ *api.EmptyRequest) (*api.EmptyResponse, e
 		return nil, err
 	}
 
-	deleteCookie(c.Request, c.Writer, cookieAuthorizationName, c.Request.Host)
+	deleteCookie(c.Request, rCtx.Response.HTTPWriter, cookieAuthorizationName, c.Request.Host)
 	return nil, nil
 }
 

--- a/internal/server/logging.go
+++ b/internal/server/logging.go
@@ -67,10 +67,16 @@ func loggingMiddleware(enableSampling bool) gin.HandlerFunc {
 		rCtx := getRequestContext(c)
 		if user := rCtx.Authenticated.User; user != nil {
 			event = event.Str("userID", user.ID.String())
+		} else if rCtx.Response != nil && rCtx.Response.LoginUserID != 0 {
+			event = event.Str("userID", rCtx.Response.LoginUserID.String())
 		}
+
 		if org := rCtx.Authenticated.Organization; org != nil {
 			event = event.Str("orgID", org.ID.String())
+		} else if rCtx.Response != nil && rCtx.Response.SignupOrgID != 0 {
+			event = event.Str("orgID", rCtx.Response.SignupOrgID.String())
 		}
+
 		rCtx.Response.ApplyLogFields(event)
 
 		event.Dur("elapsed", time.Since(begin)).

--- a/internal/server/logging_test.go
+++ b/internal/server/logging_test.go
@@ -25,16 +25,23 @@ func TestLoggingMiddleware(t *testing.T) {
 		router := gin.New()
 		router.Use(loggingMiddleware(true))
 
-		router.GET("/good/:id", func(c *gin.Context) {})
-		router.POST("/good/:id", func(c *gin.Context) {})
-		router.GET("/gooder/", func(c *gin.Context) {})
+		setRequestContext := func(c *gin.Context) {
+			c.Set(access.RequestContextKey, access.RequestContext{
+				Response: &access.Response{},
+			})
+		}
+
+		router.GET("/good/:id", setRequestContext)
+		router.POST("/good/:id", setRequestContext)
+		router.GET("/gooder/", setRequestContext)
 		router.GET("/bad/:id", func(c *gin.Context) {
+			setRequestContext(c)
 			c.Status(http.StatusBadRequest)
 		})
 		router.GET("/broken", func(c *gin.Context) {
+			setRequestContext(c)
 			c.Status(http.StatusInternalServerError)
 		})
-
 		router.GET("/authned", func(c *gin.Context) {
 			// simulate authenticateRequest
 			c.Set(access.RequestContextKey, access.RequestContext{

--- a/internal/server/logging_test.go
+++ b/internal/server/logging_test.go
@@ -42,7 +42,7 @@ func TestLoggingMiddleware(t *testing.T) {
 					User:         &models.Identity{Model: models.Model{ID: 12345}},
 					Organization: &models.Organization{Model: models.Model{ID: 2323}},
 				},
-				Response: &access.ResponseMetadata{},
+				Response: &access.Response{},
 			})
 		})
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -194,7 +194,7 @@ func add[Req, Res any](a *API, group *routeGroup, method, urlPath string, route 
 	handler := func(c *gin.Context) {
 		reqVer, err := requestVersion(c.Request)
 		if err != nil && !route.infraVersionHeaderOptional {
-			sendAPIError(c, err)
+			sendAPIError(c.Writer, c.Request, err)
 			return
 		}
 
@@ -205,7 +205,8 @@ func add[Req, Res any](a *API, group *routeGroup, method, urlPath string, route 
 		}
 
 		if err := wrapRoute(a, routeID, route)(c); err != nil {
-			sendAPIError(c, err)
+			sendAPIError(c.Writer, c.Request, err)
+			return
 		}
 	}
 	group.RouterGroup.Handle(routeID.method, routeID.path, handler)
@@ -437,7 +438,7 @@ func healthHandler(c *gin.Context) {
 func (a *API) notFoundHandler(c *gin.Context) {
 	accept := c.Request.Header.Get("Accept")
 	if strings.HasPrefix(accept, "application/json") {
-		sendAPIError(c, internal.ErrNotFound)
+		sendAPIError(c.Writer, c.Request, internal.ErrNotFound)
 		return
 	}
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -256,7 +256,7 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 			DBTxn:         tx,
 			Authenticated: authned,
 			DataDB:        a.server.db,
-			Response:      &access.ResponseMetadata{},
+			Response:      &access.Response{HTTPWriter: c.Writer},
 		}
 		c.Set(access.RequestContextKey, rCtx)
 
@@ -280,7 +280,7 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 
 		// TODO: extract all response header/status/body writing to another function
 		if respHeaders, ok := any(resp).(hasResponseHeaders); ok {
-			respHeaders.SetHeaders(c.Writer.Header())
+			respHeaders.SetHeaders(rCtx.Response.HTTPWriter.Header())
 		}
 		if r, ok := any(resp).(isRedirect); ok {
 			c.Redirect(http.StatusPermanentRedirect, r.RedirectURL())

--- a/internal/server/signup.go
+++ b/internal/server/signup.go
@@ -227,7 +227,7 @@ func createOrgAndUserForSignup(c *gin.Context, keyExpiresAt time.Time, baseDomai
 	db = db.WithOrgID(details.Org.ID)
 	rCtx.DBTxn = db
 	rCtx.Authenticated.Organization = details.Org
-	c.Set(access.RequestContextKey, rCtx)
+	rCtx.Response.SignupOrgID = details.Org.ID
 
 	var identity *models.Identity
 	bearer := ""
@@ -242,7 +242,7 @@ func createOrgAndUserForSignup(c *gin.Context, keyExpiresAt time.Time, baseDomai
 		}
 
 		var err error
-		identity, bearer, err = signupUser(c, keyExpiresAt, user)
+		identity, bearer, err = signupUser(rCtx, keyExpiresAt, user)
 		if err != nil {
 			return nil, err
 		}
@@ -274,7 +274,7 @@ func createOrgAndUserForSignup(c *gin.Context, keyExpiresAt time.Time, baseDomai
 		}
 
 		var err error
-		identity, bearer, err = signupUser(c, keyExpiresAt, user)
+		identity, bearer, err = signupUser(rCtx, keyExpiresAt, user)
 		if err != nil {
 			return nil, err
 		}
@@ -291,8 +291,7 @@ func createOrgAndUserForSignup(c *gin.Context, keyExpiresAt time.Time, baseDomai
 }
 
 // signupUser creates the user identity and grants for a new org
-func signupUser(c *gin.Context, keyExpiresAt time.Time, user *models.ProviderUser) (*models.Identity, string, error) {
-	rCtx := getRequestContext(c)
+func signupUser(rCtx access.RequestContext, keyExpiresAt time.Time, user *models.ProviderUser) (*models.Identity, string, error) {
 	tx := rCtx.DBTxn
 
 	identity := &models.Identity{
@@ -334,8 +333,7 @@ func signupUser(c *gin.Context, keyExpiresAt time.Time, user *models.ProviderUse
 	}
 
 	// Update the request context so that logging middleware can include the userID
-	rCtx.Authenticated.User = identity
-	c.Set(access.RequestContextKey, rCtx)
+	rCtx.Response.LoginUserID = identity.ID
 
 	return identity, bearer, nil
 }

--- a/internal/server/signup.go
+++ b/internal/server/signup.go
@@ -106,7 +106,7 @@ func (a *API) Signup(c *gin.Context, r *api.SignupRequest) (*api.SignupResponse,
 		Domain:  a.server.options.BaseDomain,
 		Expires: time.Now().Add(1 * time.Minute),
 	}
-	setCookie(c.Request, c.Writer, cookie)
+	setCookie(c.Request, rCtx.Response.HTTPWriter, cookie)
 
 	a.t.User(created.Identity.ID.String(), created.Identity.Name)
 	a.t.Org(created.Organization.ID.String(), created.Identity.ID.String(), created.Organization.Name, created.Organization.Domain)


### PR DESCRIPTION
## Summary

Removes the use of `gin.Context` from a few places in the `server` package:
* accessing the `http.Request`
* using the `http.ResponseWriter` directly
* for log context


## Related Issues

Related to https://github.com/infrahq/infra/issues/2796, and https://github.com/infrahq/internal/issues/19