### PR TITLE
maintain: allow removing any users for an org

### DIFF
--- a/internal/access/identity.go
+++ b/internal/access/identity.go
@@ -55,12 +55,7 @@ func DeleteIdentity(c *gin.Context, id uid.ID) error {
 		return HandleAuthErr(err, "user", "delete", models.InfraAdminRole)
 	}
 
-	opts := data.DeleteIdentitiesOptions{
-		ByProviderID: data.InfraProvider(db).ID,
-		ByID:         id,
-	}
-
-	return data.DeleteIdentities(db, opts)
+	return data.DeleteIdentities(db, data.DeleteIdentitiesOptions{ByID: id})
 }
 
 func ListIdentities(c *gin.Context, opts data.ListIdentityOptions) ([]models.Identity, error) {

--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -252,9 +252,6 @@ func DeleteAccessKeys(tx WriteTxn, opts DeleteAccessKeysOptions) error {
 	if opts.ByID == 0 && opts.ByIssuedForID == 0 && opts.ByProviderID == 0 {
 		return fmt.Errorf("DeleteAccessKeys requires an ID, IssuedForID, or ProviderID")
 	}
-	if opts.ByIssuedForID != 0 && opts.ByProviderID == 0 {
-		return fmt.Errorf("DeleteAccessKeys by IssuedForID requires ProviderID")
-	}
 	query := querybuilder.New("UPDATE access_keys")
 	query.B("SET deleted_at = ?", time.Now())
 	query.B("WHERE organization_id = ?", tx.OrganizationID())

--- a/internal/server/data/access_key_test.go
+++ b/internal/server/data/access_key_test.go
@@ -232,13 +232,6 @@ func TestDeleteAccessKeys(t *testing.T) {
 			assert.DeepEqual(t, remaining, expected, cmpModelByID)
 		})
 
-		t.Run("by user id requires provider id", func(t *testing.T) {
-			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
-
-			err := DeleteAccessKeys(tx, DeleteAccessKeysOptions{ByIssuedForID: uid.New()})
-			assert.ErrorContains(t, err, "DeleteAccessKeys by IssuedForID requires ProviderID")
-		})
-
 		t.Run("by provider id", func(t *testing.T) {
 			tx := txnForTestCase(t, db, db.DefaultOrg.ID)
 			key1 := &models.AccessKey{IssuedFor: user.ID, ProviderID: provider.ID}

--- a/internal/server/data/provideruser.go
+++ b/internal/server/data/provideruser.go
@@ -240,13 +240,16 @@ type DeleteProviderUsersOptions struct {
 }
 
 func DeleteProviderUsers(tx WriteTxn, opts DeleteProviderUsersOptions) error {
-	if opts.ByProviderID == 0 {
-		return fmt.Errorf("DeleteProviderUsers must supply a provider_id")
+	if opts.ByIdentityID == 0 && opts.ByProviderID == 0 {
+		return fmt.Errorf("DeleteProviderUsers must supply an identity_id or provider_id")
 	}
 	query := querybuilder.New("DELETE FROM provider_users")
-	query.B("WHERE provider_id = ?", opts.ByProviderID)
+	query.B("WHERE 1=1") // this is always true, used to make the logic of adding clauses simpler by always appending them with an AND
 	if opts.ByIdentityID != 0 {
 		query.B("AND identity_id = ?", opts.ByIdentityID)
+	}
+	if opts.ByProviderID != 0 {
+		query.B("AND provider_id = ?", opts.ByProviderID)
 	}
 
 	_, err := tx.Exec(query.String(), query.Args...)

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -344,9 +344,7 @@ export default function Users() {
               )
 
               // cannot delete the currently logged in user
-              if (
-                info.row.original.id === user?.id
-              ) {
+              if (info.row.original.id === user?.id) {
                 return null
               }
 

--- a/ui/pages/users/index.js
+++ b/ui/pages/users/index.js
@@ -343,11 +343,9 @@ export default function Users() {
                 }
               )
 
-              // can only delete users that exist within Infra which are not the currently logged in user
+              // cannot delete the currently logged in user
               if (
-                info.row.original.id === user?.id ||
-                (info.row.original.providerNames !== undefined &&
-                  !info.row.original.providerNames?.includes('infra'))
+                info.row.original.id === user?.id
               ) {
                 return null
               }
@@ -387,7 +385,7 @@ export default function Users() {
                                     onClick={() => setOpen(true)}
                                   >
                                     <XMarkIcon className='mr-1 mt-px h-3.5 w-3.5' />{' '}
-                                    Remove Infra user
+                                    Remove user
                                   </button>
                                 )}
                               </Menu.Item>


### PR DESCRIPTION
- allow removing users from your org regardless of where they have logged in from
- remove some previously enforced key deletion requirements which are not needed
- simplify delete identity references

## Summary
Allow removing users completely from Infra (right now you can only remove the Infra user). This is needed because if you invite someone and they sign in through Google, then you can’t actually remove the user from your Infra org without going and finding all their grants to remove.

## Checklist
- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues
Part of #4033
