### PR TITLE
Add API endpoint to support SSH group grants

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -387,6 +387,13 @@ func (c Client) ListDestinations(ctx context.Context, req ListDestinationsReques
 	})
 }
 
+func (c Client) ListDestinationAccess(ctx context.Context, req ListDestinationAccessRequest) (*ListDestinationAccessResponse, error) {
+	path := fmt.Sprintf("/api/destinations/%s/user-access", req.Name)
+	return get[ListDestinationAccessResponse](ctx, c, path, Query{
+		"lastUpdateIndex": {strconv.FormatInt(req.LastUpdateIndex, 10)},
+	})
+}
+
 func (c Client) CreateDestination(ctx context.Context, req *CreateDestinationRequest) (*Destination, error) {
 	return post[Destination](ctx, c, "/api/destinations", req)
 }

--- a/api/destination.go
+++ b/api/destination.go
@@ -109,3 +109,20 @@ func validateDestinationName(value string) validate.StringRule {
 	}
 	return rule
 }
+
+type ListDestinationAccessRequest struct {
+	Name string `uri:"id"` // TODO: change to ID when grants stores destinationID
+	BlockingRequest
+}
+
+type ListDestinationAccessResponse struct {
+	Items           []DestinationAccess `json:"items"`
+	LastUpdateIndex `json:"-"`
+}
+
+type DestinationAccess struct {
+	UserID           uid.ID `json:"userID"`
+	UserSSHLoginName string `json:"userSSHLoginName"`
+	Privilege        string `json:"privilege"`
+	Resource         string `json:"resource"`
+}

--- a/api/types.go
+++ b/api/types.go
@@ -141,12 +141,6 @@ type ListResponse[T any] struct {
 	LastUpdateIndex `json:"-"`
 }
 
-func (r ListResponse[T]) SetHeaders(h http.Header) {
-	if r.LastUpdateIndex.Index > 0 {
-		h.Set("Last-Update-Index", strconv.FormatInt(r.LastUpdateIndex.Index, 10))
-	}
-}
-
 func NewListResponse[T, M any](items []M, pr PaginationResponse, fn func(item M) T) *ListResponse[T] {
 	result := &ListResponse[T]{
 		Items:              make([]T, 0, len(items)),
@@ -172,6 +166,12 @@ func (l *LastUpdateIndex) setValuesFromHeader(header http.Header) error {
 		return err
 	}
 	return nil
+}
+
+func (l LastUpdateIndex) SetHeaders(h http.Header) {
+	if l.Index > 0 {
+		h.Set("Last-Update-Index", strconv.FormatInt(l.Index, 10))
+	}
 }
 
 // CopyListResponse makes a copy of old, and translates the items from old type

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -104,6 +104,7 @@ type connector struct {
 
 type apiClient interface {
 	ListGrants(ctx context.Context, req api.ListGrantsRequest) (*api.ListResponse[api.Grant], error)
+	ListDestinationAccess(ctx context.Context, req api.ListDestinationAccessRequest) (*api.ListDestinationAccessResponse, error)
 	ListDestinations(ctx context.Context, req api.ListDestinationsRequest) (*api.ListResponse[api.Destination], error)
 	CreateDestination(ctx context.Context, req *api.CreateDestinationRequest) (*api.Destination, error)
 	UpdateDestination(ctx context.Context, req api.UpdateDestinationRequest) (*api.Destination, error)

--- a/internal/connector/ssh_test.go
+++ b/internal/connector/ssh_test.go
@@ -1,7 +1,6 @@
 package connector
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/infrahq/infra/api"
 	data "github.com/infrahq/infra/internal/linux"
-	"github.com/infrahq/infra/uid"
 )
 
 func TestUpdateLocalUsers(t *testing.T) {
@@ -27,20 +25,13 @@ func TestUpdateLocalUsers(t *testing.T) {
 		etcPasswdFilename = "/etc/passwd"
 	})
 
-	ctx := context.Background()
-	fakeClient := &fakeAPIClient{
-		users: map[uid.ID]api.User{
-			1111: {ID: 1111, Name: "one@example.com", SSHLoginName: "one111"},
-			2222: {ID: 2222, Name: "two@example.com", SSHLoginName: "two222"},
-		},
-	}
-	grants := []api.Grant{
-		{ID: 123, User: 1111, Privilege: "connect"},
-		{ID: 124, User: 2222, Privilege: "connect"},
+	grants := []api.DestinationAccess{
+		{UserID: 1111, UserSSHLoginName: "one111", Privilege: "connect"},
+		{UserID: 2222, UserSSHLoginName: "two222", Privilege: "connect"},
 	}
 
 	opts := SSHOptions{Group: "infra-users"}
-	err := updateLocalUsers(ctx, fakeClient, opts, grants)
+	err := updateLocalUsers(opts, grants)
 	assert.NilError(t, err)
 
 	actual, err := os.ReadFile(logFile)
@@ -68,20 +59,13 @@ func TestUpdateLocalUsers_RemoveFailed(t *testing.T) {
 		etcPasswdFilename = "/etc/passwd"
 	})
 
-	ctx := context.Background()
-	fakeClient := &fakeAPIClient{
-		users: map[uid.ID]api.User{
-			1111: {ID: 1111, Name: "one@example.com", SSHLoginName: "one111"},
-			2222: {ID: 2222, Name: "two@example.com", SSHLoginName: "two222"},
-		},
-	}
-	grants := []api.Grant{
-		{ID: 123, User: 1111, Privilege: "connect"},
-		{ID: 124, User: 2222, Privilege: "connect"},
+	grants := []api.DestinationAccess{
+		{UserID: 1111, UserSSHLoginName: "one111", Privilege: "connect"},
+		{UserID: 2222, UserSSHLoginName: "two222", Privilege: "connect"},
 	}
 
 	opts := SSHOptions{Group: "infra-users"}
-	err := updateLocalUsers(ctx, fakeClient, opts, grants)
+	err := updateLocalUsers(opts, grants)
 	assert.ErrorContains(t, err, "remove user failremove: userdel: exit status 8")
 
 	actual, err := os.ReadFile(logFile)

--- a/internal/linux/users.go
+++ b/internal/linux/users.go
@@ -63,10 +63,10 @@ func isRuneComma(r rune) bool {
 	return r == ','
 }
 
-func AddUser(user *api.User, group string) error {
+func AddUser(user api.DestinationAccess, group string) error {
 	args := []string{
-		"--comment", fmt.Sprintf("%v,%v", user.ID, sentinelManagedByInfra),
-		"-m", "-p", "*", "-g", group, user.SSHLoginName,
+		"--comment", fmt.Sprintf("%v,%v", user.UserID, sentinelManagedByInfra),
+		"-m", "-p", "*", "-g", group, user.UserSSHLoginName,
 	}
 	cmd := exec.Command("useradd", args...)
 	cmd.Stdout = logging.L

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -231,6 +231,7 @@ type DestinationAccess struct {
 }
 
 func ListDestinationAccess(tx ReadTxn, destination string) ([]DestinationAccess, error) {
+	// IMPORTANT: changes to this query likely also need to be applied to DestinationAccessMaxUpdateIndex
 	query := querybuilder.New("SELECT")
 	query.B("identities.id, identities.ssh_login_name, grants.privilege, grants.resource")
 	query.B("FROM grants")
@@ -269,4 +270,35 @@ func ListDestinationAccess(tx ReadTxn, destination string) ([]DestinationAccess,
 		return userAccess[i].UserID < userAccess[j].UserID
 	})
 	return userAccess, nil
+}
+
+// DestinationAccessMaxUpdateIndex returns the maximum update_index from all
+// the grants and groups that match the query.
+// This MUST include soft-deleted rows as well.
+//
+// Returns 1 if no records match the query, so that the caller can block until
+// a record exists.
+//
+// TODO: any way to assert this tx has the right isolation level?
+func DestinationAccessMaxUpdateIndex(tx ReadTxn, destination string) (int64, error) {
+	// IMPORTANT: changes to this query likely also need to be applied to ListDestinationAccess
+	query := querybuilder.New("SELECT max(idx) FROM (")
+	query.B("SELECT max(grants.update_index) as idx FROM grants")
+	query.B("WHERE grants.organization_id = ?", tx.OrganizationID())
+	grantsByDestination(query, destination)
+	query.B("UNION ALL SELECT")
+	query.B("max(groups.membership_update_index) as idx")
+	query.B("FROM grants")
+	query.B("JOIN groups ON grants.subject_id = groups.id")
+	query.B("AND grants.subject_kind = ?", models.SubjectKindGroup)
+	query.B("AND grants.organization_id = ?", tx.OrganizationID())
+	grantsByDestination(query, destination)
+	query.B(") as subq")
+
+	var result *int64
+	err := tx.QueryRow(query.String(), query.Args...).Scan(&result)
+	if err != nil || result == nil {
+		return 1, err
+	}
+	return *result, err
 }

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -230,8 +230,20 @@ type DestinationAccess struct {
 	Resource         string
 }
 
-func ListDestinationAccess(tx ReadTxn, destination string) ([]DestinationAccess, error) {
-	// IMPORTANT: changes to this query likely also need to be applied to DestinationAccessMaxUpdateIndex
+type ListDestinationAccessResult struct {
+	// Items is the list of items that match the query, excluding soft-deleted rows.
+	Items []DestinationAccess
+
+	// MaxUpdateIndex is the maximum update_index from all the grants and groups
+	// that match the query. This MUST include soft-deleted rows as well.
+	// The value will be 1 if no records match the query, so that the caller can
+	// block until a record exists.
+	MaxUpdateIndex int64
+}
+
+func ListDestinationAccess(tx ReadTxn, destination string) (*ListDestinationAccessResult, error) {
+	// IMPORTANT: changes to this query likely also need to be applied to
+	// destinationAccessMaxUpdateIndex.
 	query := querybuilder.New("SELECT")
 	query.B("identities.id, identities.ssh_login_name, grants.privilege, grants.resource")
 	query.B("FROM grants")
@@ -262,6 +274,11 @@ func ListDestinationAccess(tx ReadTxn, destination string) ([]DestinationAccess,
 		return nil, err
 	}
 
+	maxUpdateIndex, err := destinationAccessMaxUpdateIndex(tx, destination)
+	if err != nil {
+		return nil, err
+	}
+
 	// Sort after the query to avoid creating a temporary DB table
 	sort.Slice(userAccess, func(i, j int) bool {
 		if userAccess[i].UserID == userAccess[j].UserID {
@@ -269,10 +286,13 @@ func ListDestinationAccess(tx ReadTxn, destination string) ([]DestinationAccess,
 		}
 		return userAccess[i].UserID < userAccess[j].UserID
 	})
-	return userAccess, nil
+	return &ListDestinationAccessResult{
+		Items:          userAccess,
+		MaxUpdateIndex: maxUpdateIndex,
+	}, nil
 }
 
-// DestinationAccessMaxUpdateIndex returns the maximum update_index from all
+// destinationAccessMaxUpdateIndex returns the maximum update_index from all
 // the grants and groups that match the query.
 // This MUST include soft-deleted rows as well.
 //
@@ -280,7 +300,7 @@ func ListDestinationAccess(tx ReadTxn, destination string) ([]DestinationAccess,
 // a record exists.
 //
 // TODO: any way to assert this tx has the right isolation level?
-func DestinationAccessMaxUpdateIndex(tx ReadTxn, destination string) (int64, error) {
+func destinationAccessMaxUpdateIndex(tx ReadTxn, destination string) (int64, error) {
 	// IMPORTANT: changes to this query likely also need to be applied to ListDestinationAccess
 	query := querybuilder.New("SELECT max(idx) FROM (")
 	query.B("SELECT max(grants.update_index) as idx FROM grants")

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -497,7 +497,7 @@ func TestListDestinationAccess(t *testing.T) {
 				Resource:         "destination1",
 			},
 		}
-		assert.DeepEqual(t, actual, expected)
+		assert.DeepEqual(t, actual.Items, expected)
 	})
 }
 
@@ -526,9 +526,9 @@ func TestDestinationAccessMaxUpdateIndex(t *testing.T) {
 		run := func(t *testing.T, tc testStep) {
 			tc.setup(t)
 
-			actual, err := DestinationAccessMaxUpdateIndex(tx, dest.Name)
+			actual, err := ListDestinationAccess(tx, dest.Name)
 			assert.NilError(t, err)
-			assert.Equal(t, actual, tc.expected)
+			assert.Equal(t, actual.MaxUpdateIndex, tc.expected)
 		}
 
 		var startIndex int64 = 10001

--- a/internal/server/destinations.go
+++ b/internal/server/destinations.go
@@ -112,20 +112,20 @@ func (a *API) DeleteDestination(c *gin.Context, r *api.Resource) (*api.EmptyResp
 
 // TODO: move types to api package
 type ListDestinationAccessRequest struct {
-	Name string `uri:"name"` // TODO: change to ID when grants stores destinationID
+	Name string `uri:"id"` // TODO: change to ID when grants stores destinationID
 	api.BlockingRequest
 }
 
 type ListDestinationAccessResponse struct {
-	Items               []DestinationAccess
+	Items               []DestinationAccess `json:"items"`
 	api.LastUpdateIndex `json:"-"`
 }
 
 type DestinationAccess struct {
-	UserID           uid.ID
-	UserSSHLoginName string
-	Privilege        string
-	Resource         string
+	UserID           uid.ID `json:"userID"`
+	UserSSHLoginName string `json:"userSSHLoginName"`
+	Privilege        string `json:"privilege"`
+	Resource         string `json:"resource"`
 }
 
 func ListDestinationAccess(c *gin.Context, r *ListDestinationAccessRequest) (*ListDestinationAccessResponse, error) {

--- a/internal/server/destinations.go
+++ b/internal/server/destinations.go
@@ -1,15 +1,18 @@
 package server
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func (a *API) ListDestinations(c *gin.Context, r *api.ListDestinationsRequest) (*api.ListResponse[api.Destination], error) {
@@ -105,4 +108,139 @@ func (a *API) UpdateDestination(c *gin.Context, r *api.UpdateDestinationRequest)
 
 func (a *API) DeleteDestination(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
 	return nil, access.DeleteDestination(getRequestContext(c), r.ID)
+}
+
+// TODO: move types to api package
+type ListDestinationAccessRequest struct {
+	Name string `uri:"name"` // TODO: change to ID when grants stores destinationID
+	api.BlockingRequest
+}
+
+type ListDestinationAccessResponse struct {
+	Items               []DestinationAccess
+	api.LastUpdateIndex `json:"-"`
+}
+
+type DestinationAccess struct {
+	UserID           uid.ID
+	UserSSHLoginName string
+	Privilege        string
+	Resource         string
+}
+
+func ListDestinationAccess(c *gin.Context, r *ListDestinationAccessRequest) (*ListDestinationAccessResponse, error) {
+	rCtx := getRequestContext(c)
+	rCtx.Response.AddLogFields(func(event *zerolog.Event) {
+		event.Int64("lastUpdateIndex", r.LastUpdateIndex)
+	})
+
+	roles := []string{models.InfraAdminRole, models.InfraViewRole, models.InfraConnectorRole}
+	if err := access.IsAuthorized(rCtx, roles...); err != nil {
+		return nil, access.HandleAuthErr(err, "grants", "list", roles...)
+	}
+
+	if r.LastUpdateIndex == 0 {
+		result, err := data.ListDestinationAccess(rCtx.DBTxn, r.Name)
+		if err != nil {
+			return nil, err
+		}
+		return &api.ListDestinationAccessResponse{
+			Items: destinationAccessToAPI(result.Items),
+		}, nil
+	}
+
+	dest, err := data.GetDestination(rCtx.DBTxn, data.GetDestinationOptions{ByName: r.Name})
+	if err != nil {
+		return nil, err
+	}
+
+	grants, err := data.ListGrants(rCtx.DBTxn, data.ListGrantsOptions{ByDestination: r.Name})
+	if err != nil {
+		return nil, err
+	}
+
+	// Close the request scoped txn to avoid long-running transactions.
+	if err := rCtx.DBTxn.Rollback(); err != nil {
+		return nil, err
+	}
+
+	channels := []data.ListenChannelDescriptor{
+		data.ListenChannelGrantsByDestination{
+			OrgID:         rCtx.DBTxn.OrganizationID(),
+			DestinationID: dest.ID,
+		},
+	}
+	for _, grant := range grants {
+		if grant.Subject.Kind == models.SubjectKindGroup {
+			channels = append(channels, data.ListenChannelGroupMembership{
+				OrgID:   rCtx.DBTxn.OrganizationID(),
+				GroupID: grant.Subject.ID,
+			})
+		}
+	}
+	query := &destinationAccessQuery{
+		previousUpdateIndex: r.LastUpdateIndex,
+		do: func() (*data.ListDestinationAccessResult, error) {
+			return listDestinationAccessWithMaxUpdateIndex(rCtx, r.Name)
+		},
+	}
+	if err = access.RunBlockingRequest(rCtx, query, channels...); err != nil {
+		return nil, err
+	}
+
+	rCtx.Response.AddLogFields(func(event *zerolog.Event) {
+		event.Int("numItems", len(query.result.Items))
+	})
+
+	return &api.ListDestinationAccessResponse{
+		Items:           destinationAccessToAPI(query.result.Items),
+		LastUpdateIndex: api.LastUpdateIndex{Index: query.result.MaxUpdateIndex},
+	}, nil
+
+}
+
+type destinationAccessQuery struct {
+	previousUpdateIndex int64
+	do                  func() (*data.ListDestinationAccessResult, error)
+	result              *data.ListDestinationAccessResult
+}
+
+func (q *destinationAccessQuery) Do() error {
+	var err error
+	q.result, err = q.do()
+	return err
+}
+
+func (q *destinationAccessQuery) IsDone() bool {
+	if q.result == nil {
+		return false
+	}
+	return q.result.MaxUpdateIndex > q.previousUpdateIndex
+}
+
+func destinationAccessToAPI(a []data.DestinationAccess) []DestinationAccess {
+	result := make([]DestinationAccess, 0, len(a))
+	for _, item := range a {
+		result = append(result, DestinationAccess{
+			UserID:           item.UserID,
+			UserSSHLoginName: item.UserSSHLoginName,
+			Privilege:        item.Privilege,
+			Resource:         item.Resource,
+		})
+	}
+	return result
+}
+
+func listDestinationAccessWithMaxUpdateIndex(rCtx access.RequestContext, name string) (*data.ListDestinationAccessResult, error) {
+	tx, err := rCtx.DataDB.Begin(rCtx.Request.Context(), &sql.TxOptions{
+		ReadOnly:  true,
+		Isolation: sql.LevelRepeatableRead,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer logError(tx.Rollback, "failed to rollback transaction")
+	tx = tx.WithOrgID(rCtx.DBTxn.OrganizationID())
+
+	return data.ListDestinationAccess(tx, name)
 }

--- a/internal/server/destinations.go
+++ b/internal/server/destinations.go
@@ -12,7 +12,6 @@ import (
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
-	"github.com/infrahq/infra/uid"
 )
 
 func (a *API) ListDestinations(c *gin.Context, r *api.ListDestinationsRequest) (*api.ListResponse[api.Destination], error) {
@@ -110,25 +109,7 @@ func (a *API) DeleteDestination(c *gin.Context, r *api.Resource) (*api.EmptyResp
 	return nil, access.DeleteDestination(getRequestContext(c), r.ID)
 }
 
-// TODO: move types to api package
-type ListDestinationAccessRequest struct {
-	Name string `uri:"id"` // TODO: change to ID when grants stores destinationID
-	api.BlockingRequest
-}
-
-type ListDestinationAccessResponse struct {
-	Items               []DestinationAccess `json:"items"`
-	api.LastUpdateIndex `json:"-"`
-}
-
-type DestinationAccess struct {
-	UserID           uid.ID `json:"userID"`
-	UserSSHLoginName string `json:"userSSHLoginName"`
-	Privilege        string `json:"privilege"`
-	Resource         string `json:"resource"`
-}
-
-func ListDestinationAccess(c *gin.Context, r *ListDestinationAccessRequest) (*ListDestinationAccessResponse, error) {
+func ListDestinationAccess(c *gin.Context, r *api.ListDestinationAccessRequest) (*api.ListDestinationAccessResponse, error) {
 	rCtx := getRequestContext(c)
 	rCtx.Response.AddLogFields(func(event *zerolog.Event) {
 		event.Int64("lastUpdateIndex", r.LastUpdateIndex)
@@ -218,10 +199,10 @@ func (q *destinationAccessQuery) IsDone() bool {
 	return q.result.MaxUpdateIndex > q.previousUpdateIndex
 }
 
-func destinationAccessToAPI(a []data.DestinationAccess) []DestinationAccess {
-	result := make([]DestinationAccess, 0, len(a))
+func destinationAccessToAPI(a []data.DestinationAccess) []api.DestinationAccess {
+	result := make([]api.DestinationAccess, 0, len(a))
 	for _, item := range a {
-		result = append(result, DestinationAccess{
+		result = append(result, api.DestinationAccess{
 			UserID:           item.UserID,
 			UserSSHLoginName: item.UserSSHLoginName,
 			Privilege:        item.Privilege,

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -95,6 +95,7 @@ func (s *Server) GenerateRoutes() Routes {
 	post(a, authn, "/api/destinations", a.CreateDestination)
 	put(a, authn, "/api/destinations/:id", a.UpdateDestination)
 	del(a, authn, "/api/destinations/:id", a.DeleteDestination)
+	get(a, authn, "/api/destinations/:id/user-access", ListDestinationAccess)
 
 	add(a, authn, http.MethodPost, "/api/tokens", createTokenRoute)
 	post(a, authn, "/api/logout", a.Logout)


### PR DESCRIPTION
## Summary

Branched from #4087

Add API endpoint to return destination access. Use that new API endpoint from the SSH connector.

TODO:
* [ ] API endpoint test coverage


## Related Issues

Resolves #3761
