### PR TITLE
maintain: rename access key issued_for

### DIFF
--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -31,10 +31,13 @@
             "format": "date-time",
             "type": "string"
           },
-          "issuedFor": {
+          "issuedForID": {
             "example": "4yJ3n3D8E2",
             "format": "uid",
             "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+            "type": "string"
+          },
+          "issuedForKind": {
             "type": "string"
           },
           "name": {
@@ -456,11 +459,16 @@
                   "format": "date-time",
                   "type": "string"
                 },
-                "issuedFor": {
-                  "description": "ID of the user the key was issued to",
+                "issuedForID": {
+                  "description": "ID of the entity the key was issued to",
                   "example": "4yJ3n3D8E2",
                   "format": "uid",
                   "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+                  "type": "string"
+                },
+                "issuedForKind": {
+                  "description": "the kind entity the key was issued for (eg: user, organization, or provider)",
+                  "example": "user",
                   "type": "string"
                 },
                 "issuedForName": {
@@ -1861,21 +1869,30 @@
                     "format": "duration",
                     "type": "string"
                   },
+                  "issuedForID": {
+                    "example": "4yJ3n3D8E2",
+                    "format": "uid",
+                    "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
+                    "type": "string"
+                  },
+                  "issuedForKind": {
+                    "enum": [
+                      "user",
+                      "provider",
+                      "organization"
+                    ],
+                    "type": "string"
+                  },
                   "name": {
                     "format": "[a-zA-Z0-9\\-_.]",
                     "maxLength": 256,
                     "minLength": 2,
                     "type": "string"
-                  },
-                  "userID": {
-                    "example": "4yJ3n3D8E2",
-                    "format": "uid",
-                    "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
-                    "type": "string"
                   }
                 },
                 "required": [
-                  "userID",
+                  "issuedForID",
+                  "issuedForKind",
                   "expiry",
                   "inactivityTimeout"
                 ],

--- a/internal/access/access_key.go
+++ b/internal/access/access_key.go
@@ -30,14 +30,14 @@ func ListAccessKeys(rCtx RequestContext, identityID uid.ID, name string, showExp
 
 func CreateAccessKey(rCtx RequestContext, accessKey *models.AccessKey) (string, error) {
 	if rCtx.Authenticated.AccessKey != nil && !rCtx.Authenticated.AccessKey.Scopes.Includes(models.ScopeAllowCreateAccessKey) {
-		if connector := data.InfraConnectorIdentity(rCtx.DBTxn); connector.ID != accessKey.IssuedFor {
+		if connector := data.InfraConnectorIdentity(rCtx.DBTxn); connector.ID != accessKey.IssuedForID {
 			// non-login access keys can not currently create non-connector access keys.
 			return "", fmt.Errorf("%w: cannot use an access key to create other access keys", internal.ErrBadRequest)
 		}
 	}
 
 	err := IsAuthorized(rCtx, models.InfraAdminRole)
-	if err != nil && accessKey.IssuedFor != rCtx.Authenticated.User.ID {
+	if err != nil && accessKey.IssuedForID != rCtx.Authenticated.User.ID {
 		return "", HandleAuthErr(err, "access key", "create", models.InfraAdminRole)
 	}
 
@@ -76,7 +76,7 @@ func DeleteAccessKey(rCtx RequestContext, id uid.ID, name string) error {
 		}
 	}
 
-	if key.IssuedFor == rCtx.Authenticated.User.ID {
+	if key.IssuedForID == rCtx.Authenticated.User.ID {
 		// users can delete their own keys
 	} else {
 		if err := IsAuthorized(rCtx, models.InfraAdminRole); err != nil {

--- a/internal/access/access_key_test.go
+++ b/internal/access/access_key_test.go
@@ -32,7 +32,7 @@ func TestAccessKeys_SelfManagement(t *testing.T) {
 		key := &models.AccessKey{
 			Name:               "foo key",
 			OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
-			IssuedFor:          user.ID,
+			IssuedForID:        user.ID,
 			ExpiresAt:          time.Now().Add(1 * time.Minute),
 		}
 		_, err = CreateAccessKey(rCtx, key)
@@ -53,7 +53,7 @@ func TestAccessKeys_SelfManagement(t *testing.T) {
 		key := &models.AccessKey{
 			Name:               "foo2 key",
 			OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
-			IssuedFor:          user.ID,
+			IssuedForID:        user.ID,
 			ExpiresAt:          time.Now().Add(1 * time.Minute),
 		}
 		_, err = CreateAccessKey(rCtx, key)
@@ -84,8 +84,8 @@ func TestAccessKeys_AccessKeyAuthn(t *testing.T) {
 		err = data.CreateGrant(db, &models.Grant{Subject: models.NewSubjectForUser(user.ID), Privilege: "admin", Resource: "infra", OrganizationMember: orgMember})
 		assert.NilError(t, err)
 
-		key := &models.AccessKey{Name: "admin key", IssuedFor: user.ID, ExpiresAt: time.Now().Add(1 * time.Minute), OrganizationMember: orgMember}
-		_, err = data.CreateAccessKey(db, key)
+		key := &models.AccessKey{Name: "admin key", IssuedForID: user.ID, ExpiresAt: time.Now().Add(1 * time.Minute), OrganizationMember: orgMember}
+		_, err = data.CreateAccessKey(tx, key)
 		assert.NilError(t, err)
 
 		rCtx := RequestContext{
@@ -97,7 +97,7 @@ func TestAccessKeys_AccessKeyAuthn(t *testing.T) {
 			key := &models.AccessKey{
 				Name:               "a key",
 				OrganizationMember: orgMember,
-				IssuedFor:          user.ID,
+				IssuedForID:        user.ID,
 				ExpiresAt:          time.Now().Add(1 * time.Minute),
 			}
 			_, err := CreateAccessKey(rCtx, key)
@@ -112,7 +112,7 @@ func TestAccessKeys_AccessKeyAuthn(t *testing.T) {
 			key := &models.AccessKey{
 				Name:               "b key",
 				OrganizationMember: orgMember,
-				IssuedFor:          user.ID,
+				IssuedForID:        user.ID,
 				ExpiresAt:          time.Now().Add(1 * time.Minute),
 			}
 			_, err := CreateAccessKey(rCtx, key)
@@ -124,7 +124,7 @@ func TestAccessKeys_AccessKeyAuthn(t *testing.T) {
 			key := &models.AccessKey{
 				Name:               "c key",
 				OrganizationMember: orgMember,
-				IssuedFor:          connector.ID,
+				IssuedForID:        connector.ID,
 				ExpiresAt:          time.Now().Add(1 * time.Minute),
 			}
 
@@ -138,8 +138,8 @@ func TestAccessKeys_AccessKeyAuthn(t *testing.T) {
 		err = data.CreateIdentity(db, user)
 		assert.NilError(t, err)
 
-		key := &models.AccessKey{Name: "user key", IssuedFor: user.ID, ExpiresAt: time.Now().Add(1 * time.Minute), OrganizationMember: orgMember}
-		_, err = data.CreateAccessKey(db, key)
+		key := &models.AccessKey{Name: "user key", IssuedForID: user.ID, ExpiresAt: time.Now().Add(1 * time.Minute), OrganizationMember: orgMember}
+		_, err = data.CreateAccessKey(tx, key)
 		assert.NilError(t, err)
 
 		rCtx := RequestContext{
@@ -151,7 +151,7 @@ func TestAccessKeys_AccessKeyAuthn(t *testing.T) {
 			key := &models.AccessKey{
 				Name:               "d key",
 				OrganizationMember: orgMember,
-				IssuedFor:          user.ID,
+				IssuedForID:        user.ID,
 				ExpiresAt:          time.Now().Add(1 * time.Minute),
 			}
 

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -61,7 +61,7 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	// create some resources for this identity
 
 	keyID := generate.MathRandom(models.AccessKeyKeyLength, generate.CharsetAlphaNumeric)
-	_, err = data.CreateAccessKey(db, &models.AccessKey{KeyID: keyID, IssuedFor: identity.ID, ProviderID: infraProvider.ID})
+	_, err = data.CreateAccessKey(db, &models.AccessKey{KeyID: keyID, IssuedForID: identity.ID, ProviderID: infraProvider.ID})
 	assert.NilError(t, err)
 
 	creds := &models.Credential{

--- a/internal/access/scim.go
+++ b/internal/access/scim.go
@@ -17,7 +17,7 @@ func GetProviderUser(rCtx RequestContext, id uid.ID) (*models.ProviderUser, erro
 	if err := checkKeyIdentityProvider(rCtx); err != nil {
 		return nil, err
 	}
-	user, err := data.GetProviderUser(rCtx.DBTxn, rCtx.Authenticated.AccessKey.IssuedFor, id)
+	user, err := data.GetProviderUser(rCtx.DBTxn, rCtx.Authenticated.AccessKey.IssuedForID, id)
 	if err != nil {
 		return nil, fmt.Errorf("get provider users: %w", err)
 	}
@@ -30,7 +30,7 @@ func ListProviderUsers(rCtx RequestContext, p *data.SCIMParameters) ([]models.Pr
 		return []models.ProviderUser{}, err
 	}
 	opts := data.ListProviderUsersOptions{
-		ByProviderID:   rCtx.Authenticated.AccessKey.IssuedFor,
+		ByProviderID:   rCtx.Authenticated.AccessKey.IssuedForID,
 		SCIMParameters: p,
 	}
 	users, err := data.ListProviderUsers(rCtx.DBTxn, opts)
@@ -45,7 +45,7 @@ func CreateProviderUser(rCtx RequestContext, u *models.ProviderUser) error {
 	if err := checkKeyIdentityProvider(rCtx); err != nil {
 		return err
 	}
-	u.ProviderID = rCtx.Authenticated.AccessKey.IssuedFor
+	u.ProviderID = rCtx.Authenticated.AccessKey.IssuedForID
 	err := data.ProvisionProviderUser(rCtx.DBTxn, u)
 	if err != nil {
 		return fmt.Errorf("provision provider user: %w", err)
@@ -58,7 +58,7 @@ func UpdateProviderUser(rCtx RequestContext, u *models.ProviderUser) error {
 	if err := checkKeyIdentityProvider(rCtx); err != nil {
 		return err
 	}
-	u.ProviderID = rCtx.Authenticated.AccessKey.IssuedFor
+	u.ProviderID = rCtx.Authenticated.AccessKey.IssuedForID
 	err := data.UpdateProviderUser(rCtx.DBTxn, u)
 	if err != nil {
 		if errors.Is(err, data.ErrSourceOfTruthConflict) {
@@ -74,7 +74,7 @@ func PatchProviderUser(rCtx RequestContext, u *models.ProviderUser) (*models.Pro
 	if err := checkKeyIdentityProvider(rCtx); err != nil {
 		return nil, err
 	}
-	u.ProviderID = rCtx.Authenticated.AccessKey.IssuedFor
+	u.ProviderID = rCtx.Authenticated.AccessKey.IssuedForID
 	updated, err := data.PatchProviderUserActiveStatus(rCtx.DBTxn, u)
 	if err != nil {
 		return nil, fmt.Errorf("patch provider user: %w", err)
@@ -87,7 +87,7 @@ func DeleteProviderUser(rCtx RequestContext, userID uid.ID) error {
 	if err := checkKeyIdentityProvider(rCtx); err != nil {
 		return err
 	}
-	providerID := rCtx.Authenticated.AccessKey.IssuedFor
+	providerID := rCtx.Authenticated.AccessKey.IssuedForID
 	// delete the provider user, and if its the last reference to the user, remove their identity also
 	opts := data.DeleteIdentitiesOptions{
 		ByProviderID: providerID,
@@ -101,7 +101,7 @@ func DeleteProviderUser(rCtx RequestContext, userID uid.ID) error {
 
 func checkKeyIdentityProvider(rCtx RequestContext) error {
 	_, err := data.GetProvider(rCtx.DBTxn,
-		data.GetProviderOptions{ByID: rCtx.Authenticated.AccessKey.IssuedFor})
+		data.GetProviderOptions{ByID: rCtx.Authenticated.AccessKey.IssuedForID})
 	if err != nil {
 		if errors.Is(err, internal.ErrNotFound) {
 			return internal.ErrUnauthorized

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -80,9 +80,11 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
 			}
 
 			userID := config.UserID
+			kind := api.KeyIssuedForKindUser
 
 			// override the user setting if the user wants to create a connector access key
 			if options.Connector {
+				kind = api.KeyIssuedForKindOrganization
 				options.UserName = "connector"
 			}
 
@@ -102,7 +104,8 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
 
 			logging.Debugf("call server: create access key named %q", options.Name)
 			resp, err := client.CreateAccessKey(ctx, &api.CreateAccessKeyRequest{
-				UserID:            userID,
+				IssuedForID:       userID,
+				IssuedForKind:     kind,
 				Name:              options.Name,
 				Expiry:            api.Duration(options.Expiry),
 				InactivityTimeout: api.Duration(options.InactivityTimeout),
@@ -324,7 +327,7 @@ func newKeysListCmd(cli *CLI) *cobra.Command {
 
 			var rows []row
 			for _, k := range keys {
-				name := k.IssuedFor.String()
+				name := k.IssuedForID.String()
 				if k.IssuedForName != "" {
 					name = k.IssuedForName
 				}

--- a/internal/cmd/keys_test.go
+++ b/internal/cmd/keys_test.go
@@ -79,7 +79,8 @@ func TestKeysAddCmd(t *testing.T) {
 
 		req := <-ch
 		expected := api.CreateAccessKeyRequest{
-			UserID:            uid.ID(12345678),
+			IssuedForID:       uid.ID(12345678),
+			IssuedForKind:     "user",
 			Name:              "the-name",
 			Expiry:            api.Duration(400 * time.Hour),
 			InactivityTimeout: api.Duration(5 * time.Hour),
@@ -165,7 +166,7 @@ func TestKeysListCmd(t *testing.T) {
 					Items: []api.AccessKey{
 						{
 							Name:          "user-key",
-							IssuedFor:     uid.ID(12345678),
+							IssuedForID:   uid.ID(12345678),
 							IssuedForName: "my-user",
 							Created:       api.Time(base.Add(5 * time.Minute)),
 							Expires:       api.Time(base.Add(30 * time.Hour)),
@@ -180,13 +181,13 @@ func TestKeysListCmd(t *testing.T) {
 				Items: []api.AccessKey{
 					{
 						Name:          "front-door",
-						IssuedFor:     uid.ID(12345),
+						IssuedForID:   uid.ID(12345),
 						IssuedForName: "admin",
 						Created:       api.Time(base.Add(time.Minute)),
 					},
 					{
 						Name:              "side-door",
-						IssuedFor:         uid.ID(12345),
+						IssuedForID:       uid.ID(12345),
 						IssuedForName:     "admin",
 						Created:           api.Time(base.Add(time.Minute)),
 						Expires:           api.Time(base.Add(30 * time.Hour)),
@@ -194,7 +195,7 @@ func TestKeysListCmd(t *testing.T) {
 					},
 					{
 						Name:          "storage",
-						IssuedFor:     uid.ID(12349),
+						IssuedForID:   uid.ID(12349),
 						IssuedForName: "clerk",
 						Created:       api.Time(base.Add(4 * time.Hour)),
 						Expires:       api.Time(base.Add(30 * time.Hour)),

--- a/internal/cmd/providers.go
+++ b/internal/cmd/providers.go
@@ -260,7 +260,7 @@ $ infra providers add google --url accounts.google.com --client-id 0oa3sz06o6do0
 
 			if opts.SCIM {
 				key, err := client.CreateAccessKey(ctx, &api.CreateAccessKeyRequest{
-					UserID:            provider.ID,
+					IssuedForID:       provider.ID,
 					Name:              fmt.Sprintf("%s-SCIM", args[0]),
 					Expiry:            api.Duration(time.Hour * 87600), // 10 years
 					InactivityTimeout: api.Duration(time.Hour * 87600), // 10 years
@@ -325,7 +325,7 @@ func updateProvider(cli *CLI, name string, opts providerEditOptions) error {
 			err = nil
 		}
 		key, err := client.CreateAccessKey(ctx, &api.CreateAccessKeyRequest{
-			UserID:            provider.ID,
+			IssuedForID:       provider.ID,
 			Name:              keyName,
 			Expiry:            api.Duration(time.Hour * 87600), // 10 years
 			InactivityTimeout: api.Duration(time.Hour * 87600), // 10 years

--- a/internal/cmd/providers_test.go
+++ b/internal/cmd/providers_test.go
@@ -129,7 +129,7 @@ func TestProvidersAddCmd(t *testing.T) {
 		createKeyRequest := <-keyCh
 
 		expectedKey := api.CreateAccessKeyRequest{
-			UserID:            0,
+			IssuedForID:       0,
 			Name:              "okta-SCIM",
 			Expiry:            api.Duration(time.Hour * 87600),
 			InactivityTimeout: api.Duration(time.Hour * 87600),
@@ -366,7 +366,7 @@ func TestProvidersEditCmd(t *testing.T) {
 		req := <-ch
 
 		expected := api.CreateAccessKeyRequest{
-			UserID:            0,
+			IssuedForID:       0,
 			Name:              "okta-SCIM",
 			Expiry:            api.Duration(time.Hour * 87600),
 			InactivityTimeout: api.Duration(time.Hour * 87600),

--- a/internal/server/access_keys.go
+++ b/internal/server/access_keys.go
@@ -139,16 +139,17 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 			handler: func(c *gin.Context, reqOld *createAccessKeysRequestV0_18_0) (*createAccessKeyResponseV0_18_0, error) {
 				req := &api.CreateAccessKeyRequest{
 					IssuedForID:       reqOld.UserID,
+					IssuedForKind:     models.IssuedForKindUser.String(),
 					Name:              reqOld.Name,
 					Expiry:            reqOld.TTL,
 					InactivityTimeout: reqOld.ExtensionDeadline,
 				}
-				if err := validate.Validate(req); err != nil {
-					return nil, err
-				}
 				// check if this is an access key being issued for identity provider scim
 				if strings.HasSuffix(req.Name, "-scim") {
 					req.IssuedForKind = api.KeyIssuedForKindProvider
+				}
+				if err := validate.Validate(req); err != nil {
+					return nil, err
 				}
 				resp, err := a.CreateAccessKey(c, req)
 				if err != nil {

--- a/internal/server/access_keys.go
+++ b/internal/server/access_keys.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -41,7 +42,8 @@ func (a *API) DeleteAccessKeys(c *gin.Context, r *api.DeleteAccessKeyRequest) (*
 func (a *API) CreateAccessKey(c *gin.Context, r *api.CreateAccessKeyRequest) (*api.CreateAccessKeyResponse, error) {
 	rCtx := getRequestContext(c)
 	accessKey := &models.AccessKey{
-		IssuedFor:           r.UserID,
+		IssuedForID:         r.IssuedForID,
+		IssuedForKind:       models.IssuedKind(r.IssuedForKind),
 		Name:                r.Name,
 		ExpiresAt:           time.Now().UTC().Add(time.Duration(r.Expiry)),
 		InactivityExtension: time.Duration(r.InactivityTimeout),
@@ -57,7 +59,8 @@ func (a *API) CreateAccessKey(c *gin.Context, r *api.CreateAccessKeyRequest) (*a
 		ID:                accessKey.ID,
 		Created:           api.Time(accessKey.CreatedAt),
 		Name:              accessKey.Name,
-		IssuedFor:         accessKey.IssuedFor,
+		IssuedForID:       accessKey.IssuedForID,
+		IssuedForKind:     accessKey.IssuedForKind.String(),
 		Expires:           api.Time(accessKey.ExpiresAt),
 		InactivityTimeout: api.Time(accessKey.InactivityTimeout),
 		AccessKey:         raw,
@@ -90,7 +93,7 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 			LastUsed:          latest.LastUsed,
 			Name:              latest.Name,
 			IssuedForName:     latest.IssuedForName,
-			IssuedFor:         latest.IssuedFor,
+			IssuedFor:         latest.IssuedForID,
 			ProviderID:        latest.ProviderID,
 			Expires:           latest.Expires,
 			ExtensionDeadline: latest.InactivityTimeout,
@@ -135,13 +138,17 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 		route[createAccessKeysRequestV0_18_0, *createAccessKeyResponseV0_18_0]{
 			handler: func(c *gin.Context, reqOld *createAccessKeysRequestV0_18_0) (*createAccessKeyResponseV0_18_0, error) {
 				req := &api.CreateAccessKeyRequest{
-					UserID:            reqOld.UserID,
+					IssuedForID:       reqOld.UserID,
 					Name:              reqOld.Name,
 					Expiry:            reqOld.TTL,
 					InactivityTimeout: reqOld.ExtensionDeadline,
 				}
 				if err := validate.Validate(req); err != nil {
 					return nil, err
+				}
+				// check if this is an access key being issued for identity provider scim
+				if strings.HasSuffix(req.Name, "-scim") {
+					req.IssuedForKind = api.KeyIssuedForKindProvider
 				}
 				resp, err := a.CreateAccessKey(c, req)
 				if err != nil {
@@ -151,7 +158,7 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 					ID:                resp.ID,
 					Created:           resp.Created,
 					Name:              resp.Name,
-					IssuedFor:         resp.IssuedFor,
+					IssuedFor:         resp.IssuedForID,
 					ProviderID:        resp.ProviderID,
 					Expires:           resp.Expires,
 					ExtensionDeadline: resp.InactivityTimeout,
@@ -165,6 +172,97 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 			handler: func(c *gin.Context, req *api.ListAccessKeysRequest) (*api.ListResponse[accessKeyV0_18_0], error) {
 				resp, err := a.ListAccessKeys(c, req)
 				return api.CopyListResponse(resp, newAccessKeyV0_18_0FromLatest), err
+			},
+		})
+
+	type createAccessKeyRequestV0_20_0 struct {
+		UserID            uid.ID       `json:"userID"`
+		IssuedForID       uid.ID       `json:"issuedForID"`
+		Name              string       `json:"name"`
+		Expiry            api.Duration `json:"expiry" note:"maximum time valid"`
+		InactivityTimeout api.Duration `json:"inactivityTimeout" note:"key must be used within this duration to remain valid"`
+	}
+	type createAccessKeyResponseV0_20_0 struct {
+		ID                uid.ID   `json:"id"`
+		Created           api.Time `json:"created"`
+		Name              string   `json:"name"`
+		IssuedFor         uid.ID   `json:"issuedFor"`
+		ProviderID        uid.ID   `json:"providerID"`
+		Expires           api.Time `json:"expires" note:"after this deadline the key is no longer valid"`
+		InactivityTimeout api.Time `json:"inactivityTimeout" note:"the key must be used by this time to remain valid"`
+		AccessKey         string   `json:"accessKey"`
+	}
+	addVersionHandler(a,
+		http.MethodPost, "/api/access-keys", "0.20.0",
+		route[createAccessKeyRequestV0_20_0, *createAccessKeyResponseV0_20_0]{
+			handler: func(c *gin.Context, reqOld *createAccessKeyRequestV0_20_0) (*createAccessKeyResponseV0_20_0, error) {
+				iss := reqOld.UserID
+				if iss == 0 {
+					// try setting this from the new field
+					iss = reqOld.IssuedForID
+				}
+				req := &api.CreateAccessKeyRequest{
+					IssuedForID:       iss,
+					IssuedForKind:     api.KeyIssuedForKindUser,
+					Name:              reqOld.Name,
+					Expiry:            reqOld.Expiry,
+					InactivityTimeout: reqOld.InactivityTimeout,
+				}
+				// check if this is an access key being issued for identity provider scim
+				if strings.HasSuffix(req.Name, "-scim") {
+					req.IssuedForKind = api.KeyIssuedForKindProvider
+				}
+
+				resp, err := a.CreateAccessKey(c, req)
+				if err != nil {
+					return nil, err
+				}
+
+				return &createAccessKeyResponseV0_20_0{
+					ID:                resp.ID,
+					Created:           resp.Created,
+					Name:              resp.Name,
+					IssuedFor:         resp.IssuedForID,
+					ProviderID:        resp.ProviderID,
+					Expires:           resp.Expires,
+					InactivityTimeout: resp.InactivityTimeout,
+					AccessKey:         resp.AccessKey,
+				}, nil
+			},
+		})
+
+	type accessKeyV0_20_0 struct {
+		ID                uid.ID   `json:"id"`
+		Created           api.Time `json:"created"`
+		LastUsed          api.Time `json:"lastUsed"`
+		Name              string   `json:"name"`
+		IssuedForUser     string   `json:"issuedForUser"`
+		IssuedFor         uid.ID   `json:"issuedFor"`
+		ProviderID        uid.ID   `json:"providerID"`
+		Expires           api.Time `json:"expires"`
+		InactivityTimeout api.Time `json:"inactivityTimeout"`
+		Scopes            []string `json:"scopes"`
+	}
+	newAccessKeyV0_20_0FromLatest := func(latest api.AccessKey) accessKeyV0_20_0 {
+		return accessKeyV0_20_0{
+			ID:                latest.ID,
+			Created:           latest.Created,
+			LastUsed:          latest.LastUsed,
+			Name:              latest.Name,
+			IssuedForUser:     latest.IssuedForName,
+			IssuedFor:         latest.IssuedForID,
+			ProviderID:        latest.ProviderID,
+			Expires:           latest.Expires,
+			InactivityTimeout: latest.InactivityTimeout,
+			Scopes:            latest.Scopes,
+		}
+	}
+	addVersionHandler(a,
+		http.MethodGet, "/api/access-keys", "0.20.0",
+		route[api.ListAccessKeysRequest, *api.ListResponse[accessKeyV0_20_0]]{
+			handler: func(c *gin.Context, req *api.ListAccessKeysRequest) (*api.ListResponse[accessKeyV0_20_0], error) {
+				resp, err := a.ListAccessKeys(c, req)
+				return api.CopyListResponse(resp, newAccessKeyV0_20_0FromLatest), err
 			},
 		})
 }

--- a/internal/server/authn/authn_method.go
+++ b/internal/server/authn/authn_method.go
@@ -52,7 +52,8 @@ func Login(
 	// login authentication was successful, create an access key for the user
 
 	accessKey := &models.AccessKey{
-		IssuedFor:           authenticated.Identity.ID,
+		IssuedForID:         authenticated.Identity.ID,
+		IssuedForKind:       models.IssuedForKindUser,
 		IssuedForName:       authenticated.Identity.Name,
 		ProviderID:          authenticated.Provider.ID,
 		ExpiresAt:           authenticated.SessionExpiry,

--- a/internal/server/authn/key_exchange.go
+++ b/internal/server/authn/key_exchange.go
@@ -33,7 +33,7 @@ func (a *keyExchangeAuthn) Authenticate(_ context.Context, db *data.Transaction,
 		sessionExpiry = validatedRequestKey.ExpiresAt
 	}
 
-	identity, err := data.GetIdentity(db, data.GetIdentityOptions{ByID: validatedRequestKey.IssuedFor})
+	identity, err := data.GetIdentity(db, data.GetIdentityOptions{ByID: validatedRequestKey.IssuedForID})
 	if err != nil {
 		return AuthenticatedIdentity{}, fmt.Errorf("user is not valid: %w", err) // the user was probably deleted
 	}

--- a/internal/server/authn/password_credentials_test.go
+++ b/internal/server/authn/password_credentials_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPasswordCredentialAuthentication(t *testing.T) {
-	db := setupDB(t)
+	tx := setupDB(t)
 
 	type testCase struct {
 		setup       func(t *testing.T, db *data.Transaction) LoginMethod
@@ -180,9 +180,9 @@ func TestPasswordCredentialAuthentication(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			credentialLogin := tc.setup(t, db)
+			credentialLogin := tc.setup(t, tx)
 
-			authnIdentity, err := credentialLogin.Authenticate(context.Background(), db, time.Now().Add(1*time.Minute))
+			authnIdentity, err := credentialLogin.Authenticate(context.Background(), tx, time.Now().Add(1*time.Minute))
 			if tc.expectedErr != "" {
 				assert.ErrorContains(t, err, tc.expectedErr)
 				return

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -226,12 +226,12 @@ func (s Server) loadAccessKey(db data.WriteTxn, identity *models.Identity, key S
 		provider := data.InfraProvider(db)
 
 		accessKey := &models.AccessKey{
-			IssuedFor:  identity.ID,
-			ExpiresAt:  time.Now().AddDate(10, 0, 0),
-			KeyID:      keyID,
-			Secret:     secret,
-			ProviderID: provider.ID,
-			Scopes:     models.CommaSeparatedStrings{models.ScopeAllowCreateAccessKey}, // allows user to create access keys
+			IssuedForID: identity.ID,
+			ExpiresAt:   time.Now().AddDate(10, 0, 0),
+			KeyID:       keyID,
+			Secret:      secret,
+			ProviderID:  provider.ID,
+			Scopes:      models.CommaSeparatedStrings{models.ScopeAllowCreateAccessKey}, // allows user to create access keys
 		}
 
 		if _, err := data.CreateAccessKey(db, accessKey); err != nil {
@@ -245,7 +245,7 @@ func (s Server) loadAccessKey(db data.WriteTxn, identity *models.Identity, key S
 		return nil
 	}
 
-	if accessKey.IssuedFor != identity.ID {
+	if accessKey.IssuedForID != identity.ID {
 		return fmt.Errorf("access key assigned to %q is already assigned to another user, a user's access key must have a unique ID", identity.Name)
 	}
 

--- a/internal/server/data/provider_test.go
+++ b/internal/server/data/provider_test.go
@@ -359,10 +359,10 @@ func TestDeleteProviders(t *testing.T) {
 			tx := setup(t)
 
 			key := &models.AccessKey{
-				Name:       "test key",
-				IssuedFor:  user.ID,
-				ProviderID: providerDevelop.ID,
-				ExpiresAt:  time.Now().Add(5 * time.Minute),
+				Name:        "test key",
+				IssuedForID: user.ID,
+				ProviderID:  providerDevelop.ID,
+				ExpiresAt:   time.Now().Add(5 * time.Minute),
 			}
 
 			_, err := CreateAccessKey(tx, key)
@@ -382,10 +382,10 @@ func TestDeleteProviders(t *testing.T) {
 			assert.NilError(t, err)
 
 			key := &models.AccessKey{
-				Name:       "test key",
-				IssuedFor:  user.ID,
-				ProviderID: providerProduction.ID,
-				ExpiresAt:  time.Now().Add(5 * time.Minute),
+				Name:        "test key",
+				IssuedForID: user.ID,
+				ProviderID:  providerProduction.ID,
+				ExpiresAt:   time.Now().Add(5 * time.Minute),
 			}
 
 			_, err = CreateAccessKey(tx, key)

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -113,7 +113,7 @@ CREATE TABLE access_keys (
     updated_at timestamp with time zone,
     deleted_at timestamp with time zone,
     name text,
-    issued_for bigint,
+    issued_for_id bigint,
     provider_id bigint,
     expires_at timestamp with time zone,
     inactivity_extension bigint,
@@ -121,7 +121,8 @@ CREATE TABLE access_keys (
     key_id text,
     secret_checksum bytea,
     scopes text,
-    organization_id bigint
+    organization_id bigint,
+    issued_for_kind smallint DEFAULT 1
 );
 
 CREATE TABLE credentials (
@@ -349,7 +350,7 @@ ALTER TABLE ONLY user_public_keys
 
 CREATE INDEX idx_access_keys_expires_at ON access_keys USING btree (expires_at);
 
-CREATE UNIQUE INDEX idx_access_keys_issued_for_name ON access_keys USING btree (organization_id, issued_for, name) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_access_keys_issued_for ON access_keys USING btree (organization_id, issued_for_id, name) WHERE (deleted_at IS NULL);
 
 CREATE UNIQUE INDEX idx_access_keys_key_id ON access_keys USING btree (key_id) WHERE (deleted_at IS NULL);
 

--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -95,7 +95,8 @@ func (a *API) GetDeviceFlowStatus(c *gin.Context, req *api.DeviceFlowStatusReque
 	}
 
 	accessKey := &models.AccessKey{
-		IssuedFor:     user.ID,
+		IssuedForID:   user.ID,
+		IssuedForKind: models.IssuedForKindUser,
 		IssuedForName: user.Name,
 
 		// Share the same provider ID that was used to approve
@@ -116,9 +117,9 @@ func (a *API) GetDeviceFlowStatus(c *gin.Context, req *api.DeviceFlowStatusReque
 		return nil, fmt.Errorf("%w: update user last seen: %v", internal.ErrUnauthorized, err)
 	}
 
-	a.t.User(accessKey.IssuedFor.String(), user.Name)
-	a.t.OrgMembership(accessKey.OrganizationID.String(), accessKey.IssuedFor.String())
-	a.t.Event("login", accessKey.IssuedFor.String(), accessKey.OrganizationID.String(), Properties{"method": "deviceflow"})
+	a.t.User(accessKey.IssuedForID.String(), user.Name)
+	a.t.OrgMembership(accessKey.OrganizationID.String(), accessKey.IssuedForID.String())
+	a.t.Event("login", accessKey.IssuedForID.String(), accessKey.OrganizationID.String(), Properties{"method": "deviceflow"})
 
 	// Update the request context so that logging middleware can include the userID
 	rctx.Authenticated.User = user
@@ -139,7 +140,7 @@ func (a *API) GetDeviceFlowStatus(c *gin.Context, req *api.DeviceFlowStatusReque
 		Status:     api.DeviceFlowStatusConfirmed,
 		DeviceCode: dfar.DeviceCode,
 		LoginResponse: &api.LoginResponse{
-			UserID:           accessKey.IssuedFor,
+			UserID:           accessKey.IssuedForID,
 			Name:             accessKey.IssuedForName,
 			AccessKey:        string(bearer),
 			Expires:          api.Time(accessKey.ExpiresAt),

--- a/internal/server/deviceflow_test.go
+++ b/internal/server/deviceflow_test.go
@@ -46,7 +46,7 @@ func TestDeviceFlow(t *testing.T) {
 	scoped := &models.AccessKey{
 		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 		Name:               "Scoped",
-		IssuedFor:          user.ID,
+		IssuedForID:        user.ID,
 		IssuedForName:      user.Name,
 		ProviderID:         data.InfraProvider(tx).ID,
 		ExpiresAt:          expires,
@@ -56,7 +56,7 @@ func TestDeviceFlow(t *testing.T) {
 	notscoped := &models.AccessKey{
 		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 		Name:               "Not scoped",
-		IssuedFor:          user.ID,
+		IssuedForID:        user.ID,
 		IssuedForName:      user.Name,
 		ProviderID:         data.InfraProvider(tx).ID,
 		ExpiresAt:          expires,

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -92,9 +92,9 @@ func TestAPI_ListGrants(t *testing.T) {
 	otherGroup := createGroup(t, "others", idOther)
 
 	token := &models.AccessKey{
-		IssuedFor:  idInGroup,
-		ProviderID: data.InfraProvider(srv.DB()).ID,
-		ExpiresAt:  time.Now().Add(10 * time.Minute),
+		IssuedForID: idInGroup,
+		ProviderID:  data.InfraProvider(srv.DB()).ID,
+		ExpiresAt:   time.Now().Add(10 * time.Minute),
 	}
 
 	accessKey, err := data.CreateAccessKey(srv.DB(), token)
@@ -591,9 +591,9 @@ func TestAPI_ListGrants_InheritedGrants(t *testing.T) {
 	loginAs := func(t *testing.T, userID uid.ID, req *http.Request) {
 		t.Helper()
 		token := &models.AccessKey{
-			IssuedFor:  userID,
-			ProviderID: data.InfraProvider(srv.DB()).ID,
-			ExpiresAt:  time.Now().Add(10 * time.Minute),
+			IssuedForID: userID,
+			ProviderID:  data.InfraProvider(srv.DB()).ID,
+			ExpiresAt:   time.Now().Add(10 * time.Minute),
 		}
 
 		var err error
@@ -969,9 +969,9 @@ func TestAPI_CreateGrant(t *testing.T) {
 	assert.NilError(t, err)
 
 	token := &models.AccessKey{
-		IssuedFor:  supportAdmin.ID,
-		ProviderID: data.InfraProvider(srv.DB()).ID,
-		ExpiresAt:  time.Now().Add(10 * time.Second),
+		IssuedForID: supportAdmin.ID,
+		ProviderID:  data.InfraProvider(srv.DB()).ID,
+		ExpiresAt:   time.Now().Add(10 * time.Second),
 	}
 
 	supportAccessKeyStr, err := data.CreateAccessKey(srv.DB(), token)
@@ -1058,7 +1058,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"updated": "%[4]v",
 					"wasCreated": true
 				}`,
-					accessKey.IssuedFor,
+					accessKey.IssuedForID,
 					models.InfraAdminRole,
 					someUser.ID.String(),
 					time.Now().UTC().Format(time.RFC3339),
@@ -1090,7 +1090,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"updated": "%[4]v",
 					"wasCreated": true
 				}`,
-					accessKey.IssuedFor,
+					accessKey.IssuedForID,
 					models.InfraAdminRole,
 					someUser.ID.String(),
 					time.Now().UTC().Format(time.RFC3339),
@@ -1143,7 +1143,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"updated": "%[4]v",
 					"wasCreated": true
 				}`,
-					accessKey.IssuedFor,
+					accessKey.IssuedForID,
 					models.InfraViewRole,
 					someGroup.String(),
 					time.Now().UTC().Format(time.RFC3339),
@@ -1242,7 +1242,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"updated": "%[4]v",
 					"wasCreated": true
 				}`,
-					accessKey.IssuedFor,
+					accessKey.IssuedForID,
 					models.InfraAdminRole,
 					someUser.ID.String(),
 					time.Now().UTC().Format(time.RFC3339),
@@ -1740,5 +1740,4 @@ func TestAPI_UpdateGrants(t *testing.T) {
 			run(t, tc)
 		})
 	}
-
 }

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -44,9 +44,9 @@ func TestAPI_ListGroups(t *testing.T) {
 	createIdentities(t, srv.DB(), &idInGroup, &idOther)
 
 	token := &models.AccessKey{
-		IssuedFor:  idInGroup.ID,
-		ProviderID: data.InfraProvider(srv.DB()).ID,
-		ExpiresAt:  time.Now().Add(10 * time.Second),
+		IssuedForID: idInGroup.ID,
+		ProviderID:  data.InfraProvider(srv.DB()).ID,
+		ExpiresAt:   time.Now().Add(10 * time.Second),
 	}
 
 	accessKey, err := data.CreateAccessKey(srv.DB(), token)
@@ -187,9 +187,9 @@ func TestAPI_CreateGroup(t *testing.T) {
 	createIdentities(t, srv.DB(), &meUser)
 
 	token := &models.AccessKey{
-		IssuedFor:  meUser.ID,
-		ProviderID: data.InfraProvider(srv.DB()).ID,
-		ExpiresAt:  time.Now().Add(10 * time.Second),
+		IssuedForID: meUser.ID,
+		ProviderID:  data.InfraProvider(srv.DB()).ID,
+		ExpiresAt:   time.Now().Add(10 * time.Second),
 	}
 
 	accessKey, err := data.CreateAccessKey(srv.DB(), token)
@@ -276,9 +276,9 @@ func TestAPI_DeleteGroup(t *testing.T) {
 	}
 
 	token := &models.AccessKey{
-		IssuedFor:  inGroup.ID,
-		ProviderID: data.InfraProvider(srv.DB()).ID,
-		ExpiresAt:  time.Now().Add(10 * time.Second),
+		IssuedForID: inGroup.ID,
+		ProviderID:  data.InfraProvider(srv.DB()).ID,
+		ExpiresAt:   time.Now().Add(10 * time.Second),
 	}
 
 	accessKey, err := data.CreateAccessKey(srv.DB(), token)
@@ -351,9 +351,9 @@ func TestAPI_UpdateUsersInGroup(t *testing.T) {
 	}
 
 	token := &models.AccessKey{
-		IssuedFor:  first.ID,
-		ProviderID: data.InfraProvider(srv.DB()).ID,
-		ExpiresAt:  time.Now().Add(10 * time.Second),
+		IssuedForID: first.ID,
+		ProviderID:  data.InfraProvider(srv.DB()).ID,
+		ExpiresAt:   time.Now().Add(10 * time.Second),
 	}
 
 	accessKey, err := data.CreateAccessKey(srv.DB(), token)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -208,9 +208,9 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 	setCookie(rCtx.Request, rCtx.Response.HTTPWriter, cookie)
 
 	key := result.AccessKey
-	a.t.User(key.IssuedFor.String(), result.User.Name)
-	a.t.OrgMembership(key.OrganizationID.String(), key.IssuedFor.String())
-	a.t.Event("login", key.IssuedFor.String(), key.OrganizationID.String(), Properties{
+	a.t.User(key.IssuedForID.String(), result.User.Name)
+	a.t.OrgMembership(key.OrganizationID.String(), key.IssuedForID.String())
+	a.t.Event("login", key.IssuedForID.String(), key.OrganizationID.String(), Properties{
 		"method": loginMethod.Name(),
 		"email":  result.User.Name,
 	})
@@ -220,7 +220,7 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 	rCtx.Response.LoginUserID = result.User.ID
 
 	return &api.LoginResponse{
-		UserID:                 key.IssuedFor,
+		UserID:                 key.IssuedForID,
 		Name:                   key.IssuedForName,
 		AccessKey:              result.Bearer,
 		Expires:                api.Time(key.ExpiresAt),

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -45,9 +45,9 @@ func TestWellKnownJWKs(t *testing.T) {
 
 	connector := data.InfraConnectorIdentity(otherOrgTx)
 	accessKey, err := data.CreateAccessKey(otherOrgTx, &models.AccessKey{
-		IssuedFor:  connector.ID,
-		ExpiresAt:  time.Now().Add(20 * time.Second),
-		ProviderID: data.InfraProvider(otherOrgTx).ID,
+		IssuedForID: connector.ID,
+		ExpiresAt:   time.Now().Add(20 * time.Second),
+		ProviderID:  data.InfraProvider(otherOrgTx).ID,
 	})
 	assert.NilError(t, err)
 

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -40,9 +40,9 @@ func createOtherOrg(t *testing.T, db *data.DB) organizationData {
 	admin := createAdmin(t, tx)
 
 	token := &models.AccessKey{
-		IssuedFor:  admin.ID,
-		ProviderID: data.InfraProvider(tx).ID,
-		ExpiresAt:  time.Now().Add(1000 * time.Second),
+		IssuedForID: admin.ID,
+		ProviderID:  data.InfraProvider(tx).ID,
+		ExpiresAt:   time.Now().Add(1000 * time.Second),
 	}
 
 	accessKey, err := data.CreateAccessKey(tx, token)
@@ -115,9 +115,9 @@ func createAccessKey(t *testing.T, db data.WriteTxn, email string) (string, *mod
 	provider := data.InfraProvider(db)
 
 	token := &models.AccessKey{
-		IssuedFor:  user.ID,
-		ProviderID: provider.ID,
-		ExpiresAt:  time.Now().Add(10 * time.Second),
+		IssuedForID: user.ID,
+		ProviderID:  provider.ID,
+		ExpiresAt:   time.Now().Add(10 * time.Second),
 	}
 
 	body, err := data.CreateAccessKey(db, token)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -194,7 +194,7 @@ func requireAccessKey(c *gin.Context, db data.WriteTxn, srv *Server) (access.Aut
 
 	if accessKey.Scopes.Includes(models.ScopePasswordReset) {
 		// PUT /api/users/:id only
-		if c.Request.URL.Path != "/api/users/"+accessKey.IssuedFor.String() || c.Request.Method != http.MethodPut {
+		if c.Request.URL.Path != "/api/users/"+accessKey.IssuedForID.String() || c.Request.Method != http.MethodPut {
 			return u, fmt.Errorf("%w: temporary passwords can only be used to set new passwords", access.ErrNotAuthorized)
 		}
 	}
@@ -204,11 +204,11 @@ func requireAccessKey(c *gin.Context, db data.WriteTxn, srv *Server) (access.Aut
 		return u, fmt.Errorf("access key org lookup: %w", err)
 	}
 
-	// either this access key was issued for a user or for an identity provider to do SCIM
-	if accessKey.IssuedFor == accessKey.ProviderID {
+	// either this access key was issued for a user, connector, or for an identity provider to do SCIM
+	if accessKey.IssuedForKind == models.IssuedForKindProvider {
 		// this access key was issued for SCIM for an identity provider, validate the provider still exists
 		_, err := data.GetProvider(db, data.GetProviderOptions{
-			ByID:             accessKey.IssuedFor,
+			ByID:             accessKey.IssuedForID,
 			FromOrganization: accessKey.OrganizationID,
 		})
 		if err != nil {
@@ -217,7 +217,7 @@ func requireAccessKey(c *gin.Context, db data.WriteTxn, srv *Server) (access.Aut
 	} else {
 		// the typical case, this is an access key for a user, validate the user still exists
 		identity, err := data.GetIdentity(db, data.GetIdentityOptions{
-			ByID:             accessKey.IssuedFor,
+			ByID:             accessKey.IssuedForID,
 			FromOrganization: accessKey.OrganizationID,
 		})
 		if err != nil {

--- a/internal/server/providers_test.go
+++ b/internal/server/providers_test.go
@@ -47,9 +47,9 @@ func TestAPI_ListProviders(t *testing.T) {
 		assert.NilError(t, err)
 
 		key := &models.AccessKey{
-			IssuedFor:  user.ID,
-			ProviderID: testProvider.ID,
-			ExpiresAt:  time.Now().Add(-1 * time.Minute),
+			IssuedForID: user.ID,
+			ProviderID:  testProvider.ID,
+			ExpiresAt:   time.Now().Add(-1 * time.Minute),
 		}
 		bearer, err := data.CreateAccessKey(s.DB(), key)
 		assert.NilError(t, err)
@@ -141,9 +141,9 @@ func TestAPI_GetProvider(t *testing.T) {
 		assert.NilError(t, err)
 
 		key := &models.AccessKey{
-			IssuedFor:  user.ID,
-			ProviderID: testProvider.ID,
-			ExpiresAt:  time.Now().Add(-1 * time.Minute),
+			IssuedForID: user.ID,
+			ProviderID:  testProvider.ID,
+			ExpiresAt:   time.Now().Add(-1 * time.Minute),
 		}
 		bearer, err := data.CreateAccessKey(s.DB(), key)
 		assert.NilError(t, err)

--- a/internal/server/scim_test.go
+++ b/internal/server/scim_test.go
@@ -81,7 +81,7 @@ func TestAPI_GetProviderUser(t *testing.T) {
 
 				key := &models.AccessKey{
 					OrganizationMember: models.OrganizationMember{OrganizationID: s.db.DefaultOrg.ID},
-					IssuedFor:          users[1].IdentityID,
+					IssuedForID:        users[1].IdentityID,
 					IssuedForName:      user.UserName,
 					Name:               fmt.Sprintf("%s-123", user.UserName),
 					ProviderID:         1234,
@@ -156,7 +156,7 @@ func TestAPI_ListProviderUsers(t *testing.T) {
 				_, users, routes := createTestSCIMProvider(t, s, "another")
 				key := &models.AccessKey{
 					OrganizationMember: models.OrganizationMember{OrganizationID: s.db.DefaultOrg.ID},
-					IssuedFor:          users[0].IdentityID,
+					IssuedForID:        users[0].IdentityID,
 					IssuedForName:      "another",
 					Name:               fmt.Sprintf("%s-123", "another"),
 					ProviderID:         data.InfraProvider(s.DB()).ID,
@@ -431,7 +431,7 @@ func TestAPI_CreateProviderUser(t *testing.T) {
 				user := *(users[1]).ToAPI()
 				key := &models.AccessKey{
 					OrganizationMember: models.OrganizationMember{OrganizationID: s.db.DefaultOrg.ID},
-					IssuedFor:          users[1].IdentityID,
+					IssuedForID:        users[1].IdentityID,
 					IssuedForName:      user.UserName,
 					Name:               fmt.Sprintf("%s-123", user.UserName),
 					ProviderID:         1234,
@@ -634,7 +634,7 @@ func TestAPI_UpdateProviderUser(t *testing.T) {
 
 				key := &models.AccessKey{
 					OrganizationMember: models.OrganizationMember{OrganizationID: s.db.DefaultOrg.ID},
-					IssuedFor:          user.IdentityID,
+					IssuedForID:        user.IdentityID,
 					IssuedForName:      user.Email,
 					Name:               fmt.Sprintf("%s-123", user.Email),
 					ProviderID:         1234,
@@ -744,7 +744,7 @@ func TestAPI_PatchProviderUser(t *testing.T) {
 				user := users[0]
 				key := &models.AccessKey{
 					OrganizationMember: models.OrganizationMember{OrganizationID: s.db.DefaultOrg.ID},
-					IssuedFor:          user.IdentityID,
+					IssuedForID:        user.IdentityID,
 					IssuedForName:      user.Email,
 					Name:               fmt.Sprintf("%s-123", user.Email),
 					ProviderID:         1234,
@@ -814,7 +814,7 @@ func TestAPI_DeleteProviderUser(t *testing.T) {
 				user := users[0]
 				key := &models.AccessKey{
 					OrganizationMember: models.OrganizationMember{OrganizationID: s.db.DefaultOrg.ID},
-					IssuedFor:          user.IdentityID,
+					IssuedForID:        user.IdentityID,
 					IssuedForName:      user.Email,
 					Name:               fmt.Sprintf("%s-123", user.Email),
 					ProviderID:         1234,
@@ -872,7 +872,7 @@ func createTestSCIMProvider(t *testing.T, s *Server, extraUserNames ...string) (
 
 	key := &models.AccessKey{
 		OrganizationMember: models.OrganizationMember{OrganizationID: s.db.DefaultOrg.ID},
-		IssuedFor:          testProvider.ID,
+		IssuedForID:        testProvider.ID,
 		IssuedForName:      testProvider.Name,
 		Name:               fmt.Sprintf("%s-123", testProvider.Name),
 		ProviderID:         testProvider.ID,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -455,14 +455,14 @@ func TestSyncIdentityInfo(t *testing.T) {
 		ctx := providers.WithOIDCClient(context.Background(), &fakeOIDCImplementation{UserInfoRevoked: true})
 
 		toBeRevoked := &models.AccessKey{
-			IssuedFor:  identity.ID,
-			ProviderID: provider.ID,
+			IssuedForID: identity.ID,
+			ProviderID:  provider.ID,
 		}
 		_, err = data.CreateAccessKey(db, toBeRevoked)
 		assert.NilError(t, err)
 		shouldStayValid := &models.AccessKey{
-			IssuedFor:  identity.ID,
-			ProviderID: infraProvider.ID,
+			IssuedForID: identity.ID,
+			ProviderID:  infraProvider.ID,
 		}
 		_, err = data.CreateAccessKey(db, shouldStayValid)
 		assert.NilError(t, err)
@@ -491,14 +491,14 @@ func TestSyncIdentityInfo(t *testing.T) {
 		ctx := providers.WithOIDCClient(context.Background(), &fakeOIDCImplementation{UserInfoRevoked: true})
 
 		toBeRevoked := &models.AccessKey{
-			IssuedFor:  identity.ID,
-			ProviderID: google.ID,
+			IssuedForID: identity.ID,
+			ProviderID:  google.ID,
 		}
 		_, err = data.CreateAccessKey(db, toBeRevoked)
 		assert.NilError(t, err)
 		shouldStayValid := &models.AccessKey{
-			IssuedFor:  identity.ID,
-			ProviderID: infraProvider.ID,
+			IssuedForID: identity.ID,
+			ProviderID:  infraProvider.ID,
 		}
 		_, err = data.CreateAccessKey(db, shouldStayValid)
 		assert.NilError(t, err)
@@ -527,8 +527,8 @@ func TestSyncIdentityInfo(t *testing.T) {
 		ctx := providers.WithOIDCClient(context.Background(), &fakeOIDCImplementation{})
 
 		key := &models.AccessKey{
-			IssuedFor:  identity.ID,
-			ProviderID: provider.ID,
+			IssuedForID: identity.ID,
+			ProviderID:  provider.ID,
 		}
 		_, err = data.CreateAccessKey(db, key)
 		assert.NilError(t, err)

--- a/internal/server/signup.go
+++ b/internal/server/signup.go
@@ -323,7 +323,8 @@ func signupUser(rCtx access.RequestContext, keyExpiresAt time.Time, user *models
 
 	// grant the user a session on initial sign-up
 	accessKey := &models.AccessKey{
-		IssuedFor:     identity.ID,
+		IssuedForID:   identity.ID,
+		IssuedForKind: models.IssuedForKindUser,
 		IssuedForName: identity.Name,
 		ProviderID:    user.ProviderID,
 		ExpiresAt:     keyExpiresAt,

--- a/internal/server/tokens_test.go
+++ b/internal/server/tokens_test.go
@@ -55,9 +55,9 @@ func TestAPI_CreateToken(t *testing.T) {
 				assert.NilError(t, err)
 
 				key := &models.AccessKey{
-					IssuedFor:  user.ID,
-					ProviderID: data.InfraProvider(srv.DB()).ID,
-					ExpiresAt:  time.Now().Add(10 * time.Second),
+					IssuedForID: user.ID,
+					ProviderID:  data.InfraProvider(srv.DB()).ID,
+					ExpiresAt:   time.Now().Add(10 * time.Second),
 				}
 				accessKey, err := data.CreateAccessKey(srv.DB(), key)
 				assert.NilError(t, err)

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -55,9 +55,9 @@ func TestAPI_GetUser(t *testing.T) {
 	idHal := createID(t, "HAL@example.com")
 
 	token := &models.AccessKey{
-		IssuedFor:  idMe,
-		ProviderID: data.InfraProvider(srv.DB()).ID,
-		ExpiresAt:  time.Now().Add(10 * time.Second),
+		IssuedForID: idMe,
+		ProviderID:  data.InfraProvider(srv.DB()).ID,
+		ExpiresAt:   time.Now().Add(10 * time.Second),
 	}
 
 	accessKeyMe, err := data.CreateAccessKey(srv.DB(), token)
@@ -133,9 +133,9 @@ func TestAPI_GetUser(t *testing.T) {
 			urlPath: "/api/users/self",
 			setup: func(t *testing.T, req *http.Request) {
 				token := &models.AccessKey{
-					IssuedFor:  idMe,
-					ProviderID: data.InfraProvider(srv.DB()).ID,
-					ExpiresAt:  time.Now().Add(10 * time.Second),
+					IssuedForID: idMe,
+					ProviderID:  data.InfraProvider(srv.DB()).ID,
+					ExpiresAt:   time.Now().Add(10 * time.Second),
 				}
 
 				key, err := data.CreateAccessKey(srv.DB(), token)
@@ -987,7 +987,7 @@ func TestAPI_UpdateUser(t *testing.T) {
 		err := data.CreateIdentity(srv.DB(), user)
 		assert.NilError(t, err)
 
-		accessKey := &models.AccessKey{IssuedFor: user.ID, ProviderID: data.InfraProvider(srv.DB()).ID}
+		accessKey := &models.AccessKey{IssuedForID: user.ID, ProviderID: data.InfraProvider(srv.DB()).ID}
 		accessKeySecret, err := data.CreateAccessKey(srv.DB(), accessKey)
 		assert.NilError(t, err)
 
@@ -1061,9 +1061,9 @@ func TestAPI_UpdateUser(t *testing.T) {
 
 		t.Run("changing own password unsets password reset scope", func(t *testing.T) {
 			accessKey := &models.AccessKey{
-				IssuedFor:  user.ID,
-				ProviderID: data.InfraProvider(srv.DB()).ID,
-				Scopes:     models.CommaSeparatedStrings{models.ScopePasswordReset},
+				IssuedForID: user.ID,
+				ProviderID:  data.InfraProvider(srv.DB()).ID,
+				Scopes:      models.CommaSeparatedStrings{models.ScopePasswordReset},
 			}
 
 			accessKeySecret, err := data.CreateAccessKey(srv.DB(), accessKey)


### PR DESCRIPTION
- rename access key issued_for to issued_for_id and add issued_for_kind
- specifically check for scim access keys

## Summary
Update access key `IssuedFor` to `IssuedForID` and add `IssuedForKind`.

## Checklist

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Updated associated configuration where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades

Resolves #3830 