### PR TITLE
Move pg_notify to the server

### DIFF
--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -60,9 +60,9 @@ func ListGrants(rCtx RequestContext, opts data.ListGrantsOptions, lastUpdateInde
 		return ListGrantsResponse{}, err
 	}
 
-	listenOpts := data.ListenForNotifyOptions{
-		GrantsByDestination: opts.ByDestination,
-		OrgID:               rCtx.DBTxn.OrganizationID(),
+	listenOpts := data.ListenChannelGrantsByDestination{
+		Destination: opts.ByDestination,
+		OrgID:       rCtx.DBTxn.OrganizationID(),
 	}
 	listener, err := data.ListenForNotify(rCtx.Request.Context(), rCtx.DataDB, listenOpts)
 	if err != nil {

--- a/internal/server/data/credentialrequest_test.go
+++ b/internal/server/data/credentialrequest_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
+// TODO: move to test case in TestListenForNotify
 func TestCreateDestinationCredentialPgNotifyRequest(t *testing.T) {
 	db := setupDB(t)
 
@@ -73,6 +74,7 @@ func TestCreateDestinationCredentialPgNotifyRequest(t *testing.T) {
 	}
 }
 
+// TODO: move to test case in TestListenForNotify
 func TestAnswerDestinationCredentialPgNotifyResponse(t *testing.T) {
 	db := setupDB(t)
 

--- a/internal/server/data/credentialrequest_test.go
+++ b/internal/server/data/credentialrequest_test.go
@@ -28,9 +28,9 @@ func TestCreateDestinationCredentialPgNotifyRequest(t *testing.T) {
 	wg.Add(2)
 
 	go func() {
-		listener, err := ListenForNotify(context.Background(), db, ListenForNotifyOptions{
-			OrgID:                                 orgID,
-			DestinationCredentialsByDestinationID: destID,
+		listener, err := ListenForNotify(context.Background(), db, ListenChannelDestinationCredentialsByDestinationID{
+			OrgID:         orgID,
+			DestinationID: destID,
 		})
 		assert.NilError(t, err)
 
@@ -97,9 +97,9 @@ func TestAnswerDestinationCredentialPgNotifyResponse(t *testing.T) {
 	wg.Add(2)
 
 	go func() {
-		listener, err := ListenForNotify(context.Background(), db, ListenForNotifyOptions{
-			OrgID:                      orgID,
-			DestinationCredentialsByID: dcID,
+		listener, err := ListenForNotify(context.Background(), db, ListenChannelDestinationCredentialsByID{
+			OrgID:                    orgID,
+			DestinationCredentialsID: dcID,
 		})
 		assert.NilError(t, err)
 

--- a/internal/server/data/destinationcredential.go
+++ b/internal/server/data/destinationcredential.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/infrahq/infra/internal/server/data/querybuilder"
@@ -33,7 +34,9 @@ func CreateDestinationCredential(tx WriteTxn, cr *models.DestinationCredential) 
 		return handleError(err)
 	}
 
-	return nil
+	stmt := `SELECT pg_notify(current_schema() || '.destCredReq.' || ?, '')`
+	_, err = tx.Exec(stmt, fmt.Sprintf("%v.%v", tx.OrganizationID(), cr.DestinationID))
+	return err
 }
 
 func AnswerDestinationCredential(tx WriteTxn, cr *models.DestinationCredential) error {
@@ -50,7 +53,9 @@ func AnswerDestinationCredential(tx WriteTxn, cr *models.DestinationCredential) 
 		return handleError(err)
 	}
 
-	return nil
+	stmt := `SELECT pg_notify(current_schema() || '.destCredResp.' || ?, '')`
+	_, err = tx.Exec(stmt, fmt.Sprintf("%v.%v", tx.OrganizationID(), cr.ID))
+	return err
 }
 
 func ListDestinationCredentials(tx ReadTxn, destinationID uid.ID) ([]models.DestinationCredential, error) {

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -83,9 +83,9 @@ func TestCreateGrant(t *testing.T) {
 		})
 		t.Run("notify", func(t *testing.T) {
 			ctx := context.Background()
-			listener, err := ListenForNotify(ctx, db, ListenForNotifyOptions{
-				GrantsByDestination: "match",
-				OrgID:               defaultOrganizationID,
+			listener, err := ListenForNotify(ctx, db, ListenChannelGrantsByDestination{
+				Destination: "match",
+				OrgID:       defaultOrganizationID,
 			})
 			assert.NilError(t, err)
 			t.Cleanup(func() {
@@ -210,9 +210,9 @@ func TestDeleteGrants(t *testing.T) {
 			assert.NilError(t, CreateGrant(db, &g))
 
 			ctx := context.Background()
-			listener, err := ListenForNotify(ctx, db, ListenForNotifyOptions{
-				GrantsByDestination: "match",
-				OrgID:               defaultOrganizationID,
+			listener, err := ListenForNotify(ctx, db, ListenChannelGrantsByDestination{
+				Destination: "match",
+				OrgID:       defaultOrganizationID,
 			})
 			assert.NilError(t, err)
 			t.Cleanup(func() {
@@ -695,7 +695,7 @@ func TestListenForGrantsNotify(t *testing.T) {
 	}
 	type testCase struct {
 		name string
-		opts ListenForNotifyOptions
+		opts ListenChannelGrantsByDestination
 		ops  []operation
 	}
 
@@ -756,9 +756,9 @@ func TestListenForGrantsNotify(t *testing.T) {
 		testcases := []testCase{
 			{
 				name: "by destination",
-				opts: ListenForNotifyOptions{
-					GrantsByDestination: "mydest",
-					OrgID:               mainOrg.ID,
+				opts: ListenChannelGrantsByDestination{
+					Destination: "mydest",
+					OrgID:       mainOrg.ID,
 				},
 				ops: []operation{
 					{

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -730,7 +730,7 @@ func TestGrantsMaxUpdateIndex(t *testing.T) {
 	})
 }
 
-func TestListenForGrantsNotify(t *testing.T) {
+func TestListenForNotify(t *testing.T) {
 	type operation struct {
 		name        string
 		run         func(t *testing.T, tx WriteTxn)
@@ -805,7 +805,7 @@ func TestListenForGrantsNotify(t *testing.T) {
 
 		testcases := []testCase{
 			{
-				name: "by destination",
+				name: "grants by destination",
 				opts: ListenChannelGrantsByDestination{
 					DestinationID: dest.ID,
 					OrgID:         mainOrg.ID,

--- a/internal/server/data/notify.go
+++ b/internal/server/data/notify.go
@@ -101,7 +101,7 @@ type ListenChannelDestinationCredentialsByDestinationID struct {
 }
 
 func (l ListenChannelDestinationCredentialsByDestinationID) Channel() string {
-	return fmt.Sprintf("credreq_%v_%v", l.OrgID, l.DestinationID)
+	return fmt.Sprintf("destCredReq.%v.%v", l.OrgID, l.DestinationID)
 }
 
 type ListenChannelDestinationCredentialsByID struct {
@@ -110,7 +110,7 @@ type ListenChannelDestinationCredentialsByID struct {
 }
 
 func (l ListenChannelDestinationCredentialsByID) Channel() string {
-	return fmt.Sprintf("credans_%v_%v", l.OrgID, l.DestinationCredentialsID)
+	return fmt.Sprintf("destCredResp.%v.%v", l.OrgID, l.DestinationCredentialsID)
 }
 
 type ListenChannelGroupMembership struct {

--- a/internal/server/data/notify.go
+++ b/internal/server/data/notify.go
@@ -65,11 +65,22 @@ func (l *Listener) Release(ctx context.Context) error {
 	return nil
 }
 
-type ListenForNotifyOptions struct {
-	OrgID                                 uid.ID
-	GrantsByDestination                   string
-	DestinationCredentialsByDestinationID uid.ID
-	DestinationCredentialsByID            uid.ID
+// ListenChannelDescriptor provides a channel name that ListenForNotify uses
+// to listen for notifications.
+type ListenChannelDescriptor interface {
+	// Channel returns the name of the channel to listen on. The channel
+	// name is limited by the size of a postgres identifier. It should
+	// be no more than 40 characters, because 23 characters are reserved
+	// for the schema name that we need to prepend.
+	//
+	// The channel name should use camel case, and follow the convention of
+	//
+	//   <channel type>.<encoded orgID>.<encoded entity ID>
+	//
+	// The encoded ids use internal/uid base58 encoding. Encoded IDs are up to
+	// 11 characters long, so the channel type should be no more than 16
+	// characters.
+	Channel() string
 }
 
 // ListenForNotify starts listening for notification on one or more
@@ -79,11 +90,7 @@ type ListenForNotifyOptions struct {
 //
 // If error is nil the caller must call Listener.Release to return the database
 // connection to the pool.
-func ListenForNotify(ctx context.Context, db *DB, opts ListenForNotifyOptions) (*Listener, error) {
-	if opts.OrgID == 0 {
-		return nil, fmt.Errorf("OrgID is required")
-	}
-
+func ListenForNotify(ctx context.Context, db *DB, descriptors ...ListenChannelDescriptor) (*Listener, error) {
 	sqlDB := db.SQLdb()
 	pgxConn, err := pgxstdlib.AcquireConn(sqlDB)
 	if err != nil {
@@ -92,39 +99,70 @@ func ListenForNotify(ctx context.Context, db *DB, opts ListenForNotifyOptions) (
 
 	listener := &Listener{sqlDB: sqlDB, pgxConn: pgxConn}
 
-	var channel string
-	switch {
-	case opts.GrantsByDestination != "":
-		channel = fmt.Sprintf("grants_%d", opts.OrgID)
-	case opts.DestinationCredentialsByDestinationID != 0:
-		channel = fmt.Sprintf("credreq_%s_%s", opts.OrgID.String(), opts.DestinationCredentialsByDestinationID.String())
-	case opts.DestinationCredentialsByID != 0:
-		channel = fmt.Sprintf("credans_%s_%s", opts.OrgID.String(), opts.DestinationCredentialsByID.String())
-	}
-
-	logging.Debugf("listing for notify on %s", channel)
-	_, err = pgxConn.Exec(ctx, "SELECT listen_on_chan($1)", channel)
-	if err != nil {
-		if err := pgxstdlib.ReleaseConn(sqlDB, pgxConn); err != nil {
-			logging.L.Warn().Err(err).Msgf("release pgx conn")
+	for _, descriptor := range descriptors {
+		_, err = pgxConn.Exec(ctx, "SELECT listen_on_chan($1)", descriptor.Channel())
+		if err != nil {
+			if err := pgxstdlib.ReleaseConn(sqlDB, pgxConn); err != nil {
+				logging.L.Warn().Err(err).Msgf("release pgx conn")
+			}
+			return nil, err
 		}
-		return nil, err
-	}
 
-	switch {
-	case opts.GrantsByDestination != "":
-		listener.isMatchingNotify = func(payload string) error {
-			var grant grantJSON
-			err := json.Unmarshal([]byte(payload), &grant)
-			if err != nil {
-				return err
-			}
-			destination, _, _ := strings.Cut(grant.Resource, ".")
-			if destination != opts.GrantsByDestination {
-				return errNotificationNoMatch
-			}
-			return nil
+		// FIXME: this won't work now that we support multiple channels
+		if matcher, ok := descriptor.(interface {
+			Match(payload string) error
+		}); ok {
+			listener.isMatchingNotify = matcher.Match
 		}
 	}
 	return listener, nil
+}
+
+type ListenChannelGrantsByDestination struct {
+	OrgID       uid.ID
+	Destination string
+}
+
+func (l ListenChannelGrantsByDestination) Channel() string {
+	return fmt.Sprintf("grants_%d", l.OrgID)
+}
+
+func (l ListenChannelGrantsByDestination) Match(payload string) error {
+	var grant grantJSON
+	err := json.Unmarshal([]byte(payload), &grant)
+	if err != nil {
+		return err
+	}
+	destination, _, _ := strings.Cut(grant.Resource, ".")
+	if destination != l.Destination {
+		return errNotificationNoMatch
+	}
+	return nil
+}
+
+type ListenChannelDestinationCredentialsByDestinationID struct {
+	OrgID         uid.ID
+	DestinationID uid.ID
+}
+
+func (l ListenChannelDestinationCredentialsByDestinationID) Channel() string {
+	return fmt.Sprintf("credreq_%v_%v", l.OrgID, l.DestinationID)
+}
+
+type ListenChannelDestinationCredentialsByID struct {
+	OrgID                    uid.ID
+	DestinationCredentialsID uid.ID
+}
+
+func (l ListenChannelDestinationCredentialsByID) Channel() string {
+	return fmt.Sprintf("credans_%v_%v", l.OrgID, l.DestinationCredentialsID)
+}
+
+type ListenChannelGroupMembership struct {
+	OrgID   uid.ID
+	GroupID uid.ID
+}
+
+func (l ListenChannelGroupMembership) Channel() string {
+	return fmt.Sprintf("groupMembers.%v.%v", l.OrgID, l.GroupID)
 }


### PR DESCRIPTION
## Summary

Related to #4039. Best viewed by individual commit.

This PR changes how we send notifications, and adds support for listening for multiple notifications.

1. We need to listen on multiple channels for #4039, so this PR starts by refactoring `ListenForNotify` to accept a list of channels. The previous "does notify match" becomes a lot more complicated with multiple listens, so this required a few other changes to remove the match function.
2. The channel for "grants by destination" had to use a match function because we don't have access to the destination ID from the trigger that was sending the notification. To address this I moved all the `pg_notify` into the application. I think this makes them easier to manage, but does require us to send the notification from every place a change is made. This happens to be the same places that we have to set the `update_index`, so it ends up being not so bad to send the notify from the server.
3. We can't use the destination name in the channel name (destination name is too long), so we have to look up the destination ID from the name before we do a notify or listen.

#4043 removes the triggers and functions as a follow up PR. We should deploy them to production separately so that we don't break any active blocking requests.