### PR TITLE
fix: sanity check kubeconfig

### DIFF
--- a/.github/workflows/cd-containers.yaml
+++ b/.github/workflows/cd-containers.yaml
@@ -111,10 +111,13 @@ jobs:
             argocd-image-updater
       - run: |
           for TRY in $(seq $MAX_TRIES); do
-            argocd-image-updater run --once --match-application-label=ci.infrahq.com/component=${{ matrix.component.name }} && exit 0
+            # argocd-image-updater exits 0 so need to consult the logs to determine if there's a failure
+            argocd-image-updater run --once --match-application-label=ci.infrahq.com/component=${{ matrix.component.name }} 2>&1 \
+              | tee /dev/stderr \
+              | grep level=error \
+              || exit 0
             sleep $(( 3 ** $TRY ))
           done
-
           # all attempts to sync image have failed
           exit 1
         env:


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

argocd-image-updater exits 0 even if the image update fails. This is likely due to its intended role as a service. In order to determine if the service has had an error, consult the log output. 

Note: log format changes if it's being piped and errors are printed to `stderr`

```
$ argocd-image-updater run --once --match-application-label=ci.infrahq.com/component=core; echo $?
INFO[0000] argocd-image-updater v0.12.1+16cff2e starting [loglevel:INFO, interval:once, healthport:off]
WARN[0000] commit message template at /app/config/commit.template does not exist, using default
WARN[0000] Registry configuration at /app/config/registries.conf could not be read: stat /app/config/registries.conf: no such file or directory -- using default configuration
INFO[0000] ArgoCD configuration: [apiKind=kubernetes, server=argocd-server.argocd, auth_token=false, insecure=false, grpc_web=false, plaintext=false]
INFO[0000] Starting metrics server on TCP port=8081
INFO[0000] Warming up image cache
ERRO[0000] error while communicating with ArgoCD         argocd_server=argocd-server.argocd grpc_web=false grpc_webroot= insecure=false plaintext=false
ERRO[0000] error while communicating with ArgoCD         argocd_server=argocd-server.argocd grpc_web=false grpc_webroot= insecure=false plaintext=false
ERRO[0000] Error: stream error when reading response body, may be caused by closed connection. Please retry. Original error: stream error: stream ID 3; INTERNAL_ERROR; received from peer
INFO[0000] Finished.
0
```