### PR TITLE
Fix HTTP metric in connector proxy

### DIFF
--- a/internal/connector/proxy.go
+++ b/internal/connector/proxy.go
@@ -27,10 +27,11 @@ func proxyMiddleware(
 		status := http.StatusOK
 		defer func() {
 			metrics.RequestDuration.With(prometheus.Labels{
-				"host":   req.Host,
-				"method": req.Method,
-				"path":   "proxy",
-				"status": strconv.Itoa(status),
+				"host":     req.Host,
+				"method":   req.Method,
+				"path":     "proxy",
+				"status":   strconv.Itoa(status),
+				"blocking": "false",
 			}).Observe(time.Since(start).Seconds())
 		}()
 


### PR DESCRIPTION
## Summary

I missed a label in the metric, which caused a panic:

```
http2: panic serving 127.0.0.1:35828: inconsistent label cardinality: expected 5 label values but got 4 in prometheus.Labels
```

I would have liked to add test coverage for this change, but unfortunately we don't have any way of getting the dynamically allocated port from `:0` in the connector. The server is setup to do this, so we'll have to use that approach in the connector to support testing the proxy.

I tested this manually with a local setup. There is no longer a panic after this change.