### PR TITLE
Fix panic in infra ssh command

### DIFF
--- a/internal/cmd/ssh_keys.go
+++ b/internal/cmd/ssh_keys.go
@@ -54,20 +54,12 @@ func writeKeysConfig(infraSSHDir string, cfg *keysConfig) error {
 	return fh.Close()
 }
 
-// matchingPublicKeys looks for any keys in cfg that match the hostCfg and OrgID,
-// and returns the list of matching keys. Returns nil if none match.
-func matchingPublicKeys(cfg *keysConfig, hostCfg *ClientHostConfig, orgID uid.ID) []localPublicKey {
-	var result []localPublicKey
-	for _, publicKey := range cfg.Keys {
-		if publicKey.Server != hostCfg.Host || publicKey.UserID != hostCfg.UserID.String() {
-			continue
-		}
-		if publicKey.OrganizationID != orgID.String() {
-			continue
-		}
-		result = append(result, publicKey)
-	}
-	return result
+// publicKeyMatches matches localKey against hostCfg and OrgID. Returns true
+// when the localKey matches the host, user and org.
+func publicKeyMatches(localKey localPublicKey, hostCfg *ClientHostConfig, orgID uid.ID) bool {
+	return localKey.Server == hostCfg.Host &&
+		localKey.UserID == hostCfg.UserID.String() &&
+		localKey.OrganizationID == orgID.String()
 }
 
 func userPublicKeyContains(keys []api.UserPublicKey, id string) bool {


### PR DESCRIPTION
## Summary

Fixes #4048

There were two bugs in the same place that could cause the wrong files to be deleted, or in the worst case a panic.

The first bug was the `for` loop was iterating over the `existingKeys` slice, but deleting from a different slice using the loop index variable. This meant that in some cases the wrong local key file (one for a different server, or different org) would be deleted.
This bug is fixed by no longer creating a separate slice. Iterate over the main slice, and skip entries as necessary.

The second bug was that we kept deleting using that index variable, even after having deleted previous entries. If there were at least 2 deletes then our index would be out of range and cause the panic.
This bug is fixed by only incrementing the index variable when we skip entries. When we delete the current entry the index variable will be pointing at the next item already (ex: we delete index 2, variable is still at 2, next item was previously at index 3 but now is at index 2), so we don't need to increment it.