### PR TITLE
Filter infra grants

### DIFF
--- a/api/grant.go
+++ b/api/grant.go
@@ -35,13 +35,14 @@ func (r *CreateGrantResponse) StatusCode() int {
 }
 
 type ListGrantsRequest struct {
-	User          uid.ID `form:"user" note:"ID of user granted access" example:"6TjWTAgYYu"`
-	Group         uid.ID `form:"group" note:"ID of group granted access" example:"6k3Eqcqu6B"`
-	Resource      string `form:"resource" example:"production.namespace" note:"a resource name"`
-	Destination   string `form:"destination" example:"production" note:"name of the destination where a connector is installed"`
-	Privilege     string `form:"privilege" example:"view" note:"a role or permission"`
-	ShowInherited bool   `form:"showInherited" note:"if true, this field includes grants that the user inherits through groups" example:"true"`
-	ShowSystem    bool   `form:"showSystem" note:"if true, this shows the connector and other internal grants" example:"false"`
+	User             uid.ID `form:"user" note:"ID of user granted access" example:"6TjWTAgYYu"`
+	Group            uid.ID `form:"group" note:"ID of group granted access" example:"6k3Eqcqu6B"`
+	Resource         string `form:"resource" example:"production.namespace" note:"a resource name"`
+	Destination      string `form:"destination" example:"production" note:"name of the destination where a connector is installed"`
+	Privilege        string `form:"privilege" example:"view" note:"a role or permission"`
+	ShowInherited    bool   `form:"showInherited" note:"if true, this field includes grants that the user inherits through groups" example:"true"`
+	ExcludeConnector bool   `form:"-"`
+	ShowSystem       bool   `form:"showSystem" note:"if true, this shows the connector and other internal grants" example:"false"`
 	BlockingRequest
 	PaginationRequest
 }

--- a/api/grant.go
+++ b/api/grant.go
@@ -80,7 +80,7 @@ func (r ListGrantsRequest) validateLastUpdateIndex() *validate.Failure {
 	// query parameters can be set
 	switch {
 	case r.Destination != "":
-		if fields := r.fieldsWithValues("destination", "lastUpdateIndex"); len(fields) > 0 {
+		if fields := r.fieldsWithValues("showSystem", "destination", "lastUpdateIndex"); len(fields) > 0 {
 			return validate.Fail("lastUpdateIndex",
 				fmt.Sprintf("can not be used with %v parameter(s)", strings.Join(fields, ",")))
 		}

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -131,8 +131,13 @@ type ListGrantsOptions struct {
 	IncludeInheritedFromGroups bool
 
 	// ExcludeConnectorGrant instructs ListGrants to exclude grants where
-	// privilege=connector and resource=infra.
+	// privilege=connector and resource=infra. Note that this is only used
+	// for legacy API calls.
 	ExcludeConnectorGrant bool
+
+	// ExcludeInfraGrants instructs ListGrants to exclude grants which
+	// have their resource set to infra
+	ExcludeInfraGrants bool
 
 	Pagination *Pagination
 }
@@ -185,6 +190,9 @@ func ListGrants(tx ReadTxn, opts ListGrantsOptions) ([]models.Grant, error) {
 	}
 	if opts.ExcludeConnectorGrant {
 		query.B("AND NOT (privilege = 'connector' AND resource = 'infra')")
+	}
+	if opts.ExcludeInfraGrants {
+		query.B("AND NOT resource = 'infra'")
 	}
 
 	query.B("ORDER BY id ASC")

--- a/internal/server/data/grant_test.go
+++ b/internal/server/data/grant_test.go
@@ -622,15 +622,14 @@ func TestListGrants(t *testing.T) {
 			expected := []models.Grant{*grant1, *grant3, *grant4, *gGrant1, *gGrant2}
 			assert.DeepEqual(t, actual, expected, cmpModelByID)
 		})
-		t.Run("exclude connector grant", func(t *testing.T) {
-			actual, err := ListGrants(tx, ListGrantsOptions{ExcludeConnectorGrant: true})
+		t.Run("exclude infra grants", func(t *testing.T) {
+			actual, err := ListGrants(tx, ListGrantsOptions{ExcludeInfraGrants: true})
 			assert.NilError(t, err)
 
 			expected := []models.Grant{
 				*grant1,
 				*grant2,
 				*grant3,
-				*grant4,
 				*grant5,
 				*gGrant1,
 				*gGrant2,

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -852,7 +852,7 @@ func TestAPI_ListGrants_BlockingRequest_BlocksUntilUpdate(t *testing.T) {
 	g := errgroup.Group{}
 	respCh := make(chan *httptest.ResponseRecorder)
 	g.Go(func() error {
-		urlPath := "/api/grants?destination=infra&lastUpdateIndex=10001"
+		urlPath := "/api/grants?showSystem=true&destination=infra&lastUpdateIndex=10001"
 		req := httptest.NewRequest(http.MethodGet, urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
 		req.Header.Add("Infra-Version", apiVersionLatest)

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -534,6 +534,9 @@ func removeString(seq []string, name string) []string {
 
 func getFieldName(f reflect.StructField, parent reflect.Type) string {
 	if name, ok := f.Tag.Lookup("form"); ok {
+		if name == "-" {
+			return ""
+		}
 		validateFieldName(name)
 		return name
 	}
@@ -561,6 +564,8 @@ func validateFieldName(name string) {
 	// temporary allow list
 	switch name {
 	case "unique_id":
+		return
+	case "-":
 		return
 	}
 

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -164,7 +164,7 @@ func TestTrimWhitespace(t *testing.T) {
 	// nolint:noctx
 	req = httptest.NewRequest(http.MethodGet, "/api/grants?privilege=%20admin%20&userID="+userID.String(), nil)
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
-	req.Header.Add("Infra-Version", "0.13.1")
+	req.Header.Add("Infra-Version", "0.21.0")
 
 	resp = httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
@@ -174,13 +174,13 @@ func TestTrimWhitespace(t *testing.T) {
 	err := json.Unmarshal(resp.Body.Bytes(), rb)
 	assert.NilError(t, err)
 
-	assert.Equal(t, len(rb.Items), 2, rb.Items)
+	assert.Equal(t, len(rb.Items), 1, rb.Items)
 	expected := api.Grant{
 		User:      userID,
 		Privilege: "admin",
 		Resource:  "kubernetes.production.*",
 	}
-	assert.DeepEqual(t, rb.Items[1], expected, cmpAPIGrantShallow)
+	assert.DeepEqual(t, rb.Items[0], expected, cmpAPIGrantShallow)
 }
 
 func TestWrapRoute_TxnRollbackOnError(t *testing.T) {

--- a/ui/lib/fetch.js
+++ b/ui/lib/fetch.js
@@ -1,6 +1,6 @@
 const fetch = global.fetch
 
-const base = '0.19.1'
+const base = '0.21.0'
 
 // Patch the global fetch to include our base API
 // version for requests to the same domain

--- a/ui/lib/hooks.js
+++ b/ui/lib/hooks.js
@@ -8,7 +8,7 @@ export function useUser() {
   const { data: org } = useSWR(() => (user ? '/api/organizations/self' : null))
   const { data: { items: grants } = {}, grantsError } = useSWR(() =>
     user
-      ? `/api/grants?user=${user?.id}&showInherited=1&resource=infra&limit=1000`
+      ? `/api/grants?user=${user?.id}&showInherited=1&resource=infra&limit=1000&showSystem=true`
       : null
   )
 

--- a/ui/pages/groups/[id].js
+++ b/ui/pages/groups/[id].js
@@ -104,7 +104,7 @@ export default function GroupDetails() {
   } = useSWR(`/api/users?group=${group?.id}&limit=${limit}&p=${page}`)
   const { data: { items: allUsers } = {} } = useSWR(`/api/users?limit=1000`)
   const { data: { items: infraAdmins } = {} } = useSWR(
-    '/api/grants?resource=infra&privilege=admin&limit=1000'
+    '/api/grants?resource=infra&privilege=admin&limit=1000&showSystem=true'
   )
   const [addUser, setAddUser] = useState('')
   const [selectedDeleteIds, setSelectedDeleteIds] = useState([])

--- a/ui/pages/settings/index.js
+++ b/ui/pages/settings/index.js
@@ -547,7 +547,7 @@ function Admins() {
   const { data: { items: users } = {} } = useSWR('/api/users?limit=1000')
   const { data: { items: groups } = {} } = useSWR('/api/groups?limit=1000')
   const { data: { items: grants } = {}, mutate } = useSWR(
-    '/api/grants?resource=infra&privilege=admin&limit=1000'
+    '/api/grants?resource=infra&privilege=admin&limit=1000&showSystem=true'
   )
   const { data: { items: selfGroups } = {} } = useSWR(
     () => `/api/groups?userID=${user?.id}&limit=1000`


### PR DESCRIPTION
## Summary

This PR changes the `/api/grants` to filter both connector grants, and infra admin grants from the default grants listing. To display the infra and connector grants, you can append the `showSystem=true` argument to the query. This behaviour is different than how `showSystem` previously worked, which only filtered out the results for the connector grants. The API maintains backwards compatibility via the `Infra-Version` header.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [ ] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

Resolves #3800 
