### PR TITLE
Keys remove command improved error message and connector flag

### DIFF
--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -208,8 +209,12 @@ func newKeysRemoveCmd(cli *CLI) *cobra.Command {
 			}
 
 			if len(keys) == 0 {
+				errMsg := fmt.Sprintf("No access key named '%s' for the current user, another user can be specified with the '--user' flag", keyName)
+				if options.UserName != "" {
+					errMsg = fmt.Sprintf("No access key named '%s' for the user '%s'", keyName, options.UserName)
+				}
 				return Error{
-					Message: "No access key named: " + keyName,
+					Message: errMsg,
 				}
 			}
 

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -162,8 +162,9 @@ $ MY_ACCESS_KEY=$(infra keys add -q --name my-key)
 }
 
 type keyRemoveOptions struct {
-	Force    bool
-	UserName string
+	Force     bool
+	UserName  string
+	Connector bool
 }
 
 func newKeysRemoveCmd(cli *CLI) *cobra.Command {
@@ -188,6 +189,11 @@ func newKeysRemoveCmd(cli *CLI) *cobra.Command {
 
 			keyName := args[0]
 			userID := config.UserID
+
+			// override the user setting if the user wants to delete a connector access key
+			if options.Connector {
+				options.UserName = "connector"
+			}
 
 			if options.UserName != "" {
 				user, err := getUserByNameOrID(client, options.UserName)
@@ -237,6 +243,7 @@ func newKeysRemoveCmd(cli *CLI) *cobra.Command {
 
 	cmd.Flags().BoolVar(&options.Force, "force", false, "Exit successfully even if access key does not exist")
 	cmd.Flags().StringVar(&options.UserName, "user", "", "The name of the user who owns the key")
+	cmd.Flags().BoolVar(&options.Connector, "connector", false, "Remove a key for the connector")
 
 	return cmd
 }

--- a/internal/cmd/keys.go
+++ b/internal/cmd/keys.go
@@ -215,9 +215,15 @@ func newKeysRemoveCmd(cli *CLI) *cobra.Command {
 			}
 
 			if len(keys) == 0 {
-				errMsg := fmt.Sprintf("No access key named '%s' for the current user, another user can be specified with the '--user' flag", keyName)
-				if options.UserName != "" {
-					errMsg = fmt.Sprintf("No access key named '%s' for the user '%s'", keyName, options.UserName)
+				// the username for the user this is being run against is used in the error
+				username := options.UserName
+				if username == "" {
+					username = config.Name
+				}
+				errMsg := fmt.Sprintf("Access key %q for user %q does not exist", keyName, username)
+				if username == config.Name {
+					// give a suggestion on how to use a different key if running the command on yourself
+					errMsg = fmt.Sprintf("%s\nUse the '--user' flag to remove an access key for a different user", errMsg)
 				}
 				return Error{
 					Message: errMsg,


### PR DESCRIPTION
## Summary
Add a suggestion in the `infra keys remove ...` command to suggest using the username flag when no access key is found for a name.

Add a `--connector` flag to match the format of `infra keys add --connector`.

```
 $ infra keys remove test 
No access key named 'test' for the current user, another user can be specified with the '--user' flag

$ infra keys remove test --user another@example.com
No access key named 'test' for the user 'another@example.com'

$ infra keys remove --help
Delete an access key

Usage:
  infra keys remove KEY [flags]

Aliases:
  remove, rm

Flags:
      --connector     Remove a key for the connector
      --force         Exit successfully even if access key does not exist
      --user string   The name of the user who owns the key

Global Flags:
      --help                 Display help
      --log-level string     Show logs when running the command [error, warn, info, debug] (default "info")
      --skip-version-check   Skip checking if the CLI is ahead of the server version

$ infra keys remove connector-jLzw17NtqU --connector
Removed access key "connector-jLzw17NtqU"
```

## Checklist

- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged