### PR TITLE
Improve schema names used for testing

### DIFF
--- a/internal/access/access_test.go
+++ b/internal/access/access_test.go
@@ -19,7 +19,7 @@ import (
 func setupDB(t *testing.T) *data.DB {
 	t.Helper()
 	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_access").DSN})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "access").DSN})
 	assert.NilError(t, err)
 	return db
 }

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -220,7 +220,7 @@ func setupServerOptions(t *testing.T, opts *server.Options) {
 	assert.NilError(t, err)
 	opts.TLS.Certificate = types.StringOrFile(cert)
 
-	pgDriver := database.PostgresDriver(t, "_cmd")
+	pgDriver := database.PostgresDriver(t, "cmd")
 	opts.DBConnectionString = pgDriver.DSN
 }
 

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -327,7 +327,7 @@ api:
 }
 
 func TestServerCmd_WithSecretsConfig(t *testing.T) {
-	pgDriver := database.PostgresDriver(t, "_cmd")
+	pgDriver := database.PostgresDriver(t, "cmd")
 
 	var actual server.Options
 	patchRunServer(t, func(ctx context.Context, s *server.Server) error {

--- a/internal/server/authn/authn_method_test.go
+++ b/internal/server/authn/authn_method_test.go
@@ -18,7 +18,7 @@ import (
 func setupDB(t *testing.T) *data.Transaction {
 	t.Helper()
 	patch.ModelsSymmetricKey(t)
-	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_authn").DSN})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "authn").DSN})
 	assert.NilError(t, err)
 	return txnForTestCase(t, db, db.DefaultOrg.ID)
 }

--- a/internal/server/data/data_test.go
+++ b/internal/server/data/data_test.go
@@ -20,7 +20,7 @@ func setupDB(t *testing.T) *DB {
 	t.Helper()
 	patch.ModelsSymmetricKey(t)
 
-	db, err := NewDB(NewDBOptions{DSN: database.PostgresDriver(t, "_data").DSN})
+	db, err := NewDB(NewDBOptions{DSN: database.PostgresDriver(t, "data").DSN})
 	assert.NilError(t, err)
 
 	logging.PatchLogger(t, zerolog.NewTestWriter(t))

--- a/internal/server/data/migrator/migrator_test.go
+++ b/internal/server/data/migrator/migrator_test.go
@@ -355,7 +355,7 @@ func migrationCount(t *testing.T, db DB) (count int64) {
 func runDBTests(t *testing.T, fn func(t *testing.T, db DB)) {
 	databases := []dbDriver{}
 
-	if pg := database.PostgresDriver(t, "_migrator"); pg != nil {
+	if pg := database.PostgresDriver(t, "migrator"); pg != nil {
 		databases = append(databases, dbDriver{dialect: "postgres", dsn: pg.DSN})
 	}
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -30,7 +30,7 @@ func setupDB(t *testing.T) *data.DB {
 	t.Helper()
 	tpatch.ModelsSymmetricKey(t)
 
-	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_server").DSN})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "server").DSN})
 	assert.NilError(t, err)
 	t.Cleanup(func() {
 		assert.NilError(t, db.Close())

--- a/internal/server/models/encryption_test.go
+++ b/internal/server/models/encryption_test.go
@@ -28,7 +28,7 @@ CREATE TABLE struct_for_testings (
 func TestEncryptedAtRest(t *testing.T) {
 	patch.ModelsSymmetricKey(t)
 
-	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_models").DSN})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "models").DSN})
 	assert.NilError(t, err)
 
 	_, err = db.Exec(StructForTesting{}.Schema())
@@ -61,7 +61,7 @@ func TestEncryptedAtRest(t *testing.T) {
 func TestEncryptedAtRest_WithBytes(t *testing.T) {
 	patch.ModelsSymmetricKey(t)
 
-	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "_models").DSN})
+	db, err := data.NewDB(data.NewDBOptions{DSN: database.PostgresDriver(t, "models").DSN})
 	assert.NilError(t, err)
 
 	settings, err := data.GetSettings(db)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -117,7 +117,7 @@ func TestServer_Run(t *testing.T) {
 		API: APIOptions{RequestTimeout: time.Minute},
 	}
 
-	driver := database.PostgresDriver(t, "_server_run")
+	driver := database.PostgresDriver(t, "server")
 	opts.DBConnectionString = driver.DSN
 
 	srv, err := New(opts)
@@ -216,7 +216,7 @@ func TestServer_Run_UIProxy(t *testing.T) {
 	}
 	assert.NilError(t, opts.UI.ProxyURL.Set(uiSrv.URL))
 
-	driver := database.PostgresDriver(t, "_server_run")
+	driver := database.PostgresDriver(t, "server")
 	opts.DBConnectionString = driver.DSN
 
 	srv, err := New(opts)

--- a/internal/testing/database/postgres.go
+++ b/internal/testing/database/postgres.go
@@ -43,8 +43,12 @@ func PostgresDriver(t TestingT, schemaSuffix string) *Driver {
 	suffix := strings.NewReplacer("--", "", ";", "", "/", "").Replace(schemaSuffix)
 	name := "testing"
 	if schemaSuffix != "" {
-		name = fmt.Sprintf("testing_%v_%v", suffix, generate.MathRandom(5, generate.CharsetNumbers))
+		name = fmt.Sprintf("test_%v_%v", suffix, generate.MathRandom(3, generate.CharsetNumbers))
 	}
+	if len(schemaSuffix) >= 24 {
+		t.Fatal("schema suffix", schemaSuffix, "must be less than 24 characters")
+	}
+
 	db, err := sql.Open("pgx", pgConn)
 	assert.NilError(t, err, "connect to postgresql")
 	t.Cleanup(func() {


### PR DESCRIPTION
To ensure that tests don't fail because of a schema name that is too long.

Remove a redundant underscore.
Reduce the length of the longest ones.
Add a check to prevent accidentally using one that is too long.
