### PR TITLE
Remove gin Recovery middleware

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -44,8 +44,6 @@ func (s *Server) GenerateRoutes() Routes {
 
 	router := gin.New()
 	router.NoRoute(a.notFoundHandler)
-
-	router.Use(gin.Recovery())
 	router.GET("/healthz", healthHandler)
 
 	// This group of middleware will apply to everything, including the UI


### PR DESCRIPTION
We noticed some panic logs in dev. After investigation we learned that the panic was an `http.ErrAbortHandler`.

See: https://github.com/golang/go/blob/f07910bd577f73b81e4f7117c7cfdf9cf7579028/src/net/http/server.go#L1822-L1826

The http.Server knows to ignore this panic, but `gin.Recovery` does not.

`http.Server` already handles panics so, as far as I can tell, there's no benefit to using `gin.Recovery`.

By removing gin.Recovery we get 2 benefits:

1. these panics in logs go away, the `http.Server` will ignore them
2. other panics in the logs from `http.Server` get sent to zerolog (along with everything else), where as `gin.Recovery` just writes them to stderr (without any of the contextual information like log level.
