### PR TITLE
Add level to HTTP error logs

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -17,6 +16,7 @@ import (
 	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/goware/urlx"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 	rbacv1 "k8s.io/api/rbac/v1"
 
@@ -257,7 +257,7 @@ func runKubernetesConnector(ctx context.Context, options Options) error {
 		MinVersion: tls.VersionTLS12,
 	}
 
-	httpErrorLog := log.New(logging.L, "", 0)
+	httpErrorLog := logging.HTTPErrorLog(zerolog.WarnLevel)
 
 	proxy := httputil.NewSingleHostReverseProxy(kubeAPIAddr)
 	proxy.Transport = proxyTransport

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/infrahq/infra/internal"
@@ -319,7 +320,7 @@ func (s *Server) listen() error {
 	ginutil.SetMode()
 	router := s.GenerateRoutes()
 
-	httpErrorLog := log.New(logging.L, "", 0)
+	httpErrorLog := logging.HTTPErrorLog(zerolog.WarnLevel)
 	metricsServer := &http.Server{
 		ReadHeaderTimeout: 30 * time.Second,
 		ReadTimeout:       60 * time.Second,


### PR DESCRIPTION
Previously they were output with a nil level, this change outputs the logs at warning level.

Warning seems appropriate because we get a lot of noise in these logs for bad TLS requests. 

In the future we could add some logic to inspect the messages and use `Error` for panics, but for now I'm hoping a warning level is better than no level.

https://github.com/rs/zerolog/issues/508 is an issue to add this support to `zerolog`, but it ended up being easy enough to do from our code.

I tested this manually by curling the HTTP server without trusting the CA certificate. I saw a log message with level=WARN.