### PR TITLE
Remove gin.Context from API handlers

### DIFF
--- a/internal/server/access_keys.go
+++ b/internal/server/access_keys.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/models"
@@ -14,8 +12,8 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api.ListResponse[api.AccessKey], error) {
-	rCtx := getRequestContext(c)
+func (a *API) ListAccessKeys(rCtx access.RequestContext, r *api.ListAccessKeysRequest) (*api.ListResponse[api.AccessKey], error) {
+	
 	p := PaginationFromRequest(r.PaginationRequest)
 	accessKeys, err := access.ListAccessKeys(rCtx, r.UserID, r.Name, r.ShowExpired, &p)
 	if err != nil {
@@ -30,17 +28,17 @@ func (a *API) ListAccessKeys(c *gin.Context, r *api.ListAccessKeysRequest) (*api
 }
 
 // DeleteAccessKey deletes an access key by id
-func (a *API) DeleteAccessKey(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
+func (a *API) DeleteAccessKey(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
 	return nil, access.DeleteAccessKey(getRequestContext(c), r.ID, "")
 }
 
 // DeleteAccessKeys deletes 0 or more access keys by any attribute
-func (a *API) DeleteAccessKeys(c *gin.Context, r *api.DeleteAccessKeyRequest) (*api.EmptyResponse, error) {
+func (a *API) DeleteAccessKeys(rCtx access.RequestContext, r *api.DeleteAccessKeyRequest) (*api.EmptyResponse, error) {
 	return nil, access.DeleteAccessKey(getRequestContext(c), 0, r.Name)
 }
 
-func (a *API) CreateAccessKey(c *gin.Context, r *api.CreateAccessKeyRequest) (*api.CreateAccessKeyResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) CreateAccessKey(rCtx access.RequestContext, r *api.CreateAccessKeyRequest) (*api.CreateAccessKeyResponse, error) {
+	
 	accessKey := &models.AccessKey{
 		IssuedForID:         r.IssuedForID,
 		IssuedForKind:       models.IssuedKind(r.IssuedForKind),
@@ -103,7 +101,7 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 	addVersionHandler(a, http.MethodGet, "/api/access-keys", "0.16.1",
 		route[listAccessKeysRequestV0_16_1, *api.ListResponse[accessKeyV0_18_0]]{
 			routeSettings: defaultRouteSettingsGet,
-			handler: func(c *gin.Context, reqOld *listAccessKeysRequestV0_16_1) (*api.ListResponse[accessKeyV0_18_0], error) {
+			handler: func(rCtx access.RequestContext, reqOld *listAccessKeysRequestV0_16_1) (*api.ListResponse[accessKeyV0_18_0], error) {
 				req := &api.ListAccessKeysRequest{
 					UserID:            reqOld.UserID,
 					Name:              reqOld.Name,
@@ -136,7 +134,7 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 	}
 	addVersionHandler(a, http.MethodPost, "/api/access-keys", "0.18.0",
 		route[createAccessKeysRequestV0_18_0, *createAccessKeyResponseV0_18_0]{
-			handler: func(c *gin.Context, reqOld *createAccessKeysRequestV0_18_0) (*createAccessKeyResponseV0_18_0, error) {
+			handler: func(rCtx access.RequestContext, reqOld *createAccessKeysRequestV0_18_0) (*createAccessKeyResponseV0_18_0, error) {
 				req := &api.CreateAccessKeyRequest{
 					IssuedForID:       reqOld.UserID,
 					IssuedForKind:     models.IssuedForKindUser.String(),
@@ -170,7 +168,7 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 
 	addVersionHandler(a, http.MethodGet, "/api/access-keys", "0.18.0",
 		route[api.ListAccessKeysRequest, *api.ListResponse[accessKeyV0_18_0]]{
-			handler: func(c *gin.Context, req *api.ListAccessKeysRequest) (*api.ListResponse[accessKeyV0_18_0], error) {
+			handler: func(rCtx access.RequestContext, req *api.ListAccessKeysRequest) (*api.ListResponse[accessKeyV0_18_0], error) {
 				resp, err := a.ListAccessKeys(c, req)
 				return api.CopyListResponse(resp, newAccessKeyV0_18_0FromLatest), err
 			},

--- a/internal/server/configuration.go
+++ b/internal/server/configuration.go
@@ -3,13 +3,12 @@ package server
 import (
 	"fmt"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/email"
 )
 
-func (a *API) GetServerConfiguration(c *gin.Context, _ *api.EmptyRequest) (*api.ServerConfiguration, error) {
+func (a *API) GetServerConfiguration(rCtx access.RequestContext, _ *api.EmptyRequest) (*api.ServerConfiguration, error) {
 	config := &api.ServerConfiguration{
 		IsEmailConfigured: email.IsConfigured(),
 		BaseDomain:        a.server.options.BaseDomain,

--- a/internal/server/configuration.go
+++ b/internal/server/configuration.go
@@ -8,7 +8,7 @@ import (
 	"github.com/infrahq/infra/internal/server/email"
 )
 
-func (a *API) GetServerConfiguration(rCtx access.RequestContext, _ *api.EmptyRequest) (*api.ServerConfiguration, error) {
+func (a *API) GetServerConfiguration(_ access.RequestContext, _ *api.EmptyRequest) (*api.ServerConfiguration, error) {
 	config := &api.ServerConfiguration{
 		IsEmailConfigured: email.IsConfigured(),
 		BaseDomain:        a.server.options.BaseDomain,

--- a/internal/server/debug.go
+++ b/internal/server/debug.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"net/http/pprof"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/models"
@@ -28,8 +26,8 @@ func (pprofRequest) IsBlockingRequest() bool {
 	return true
 }
 
-func pprofHandler(c *gin.Context, _ *pprofRequest) (*api.EmptyResponse, error) {
-	rCtx := getRequestContext(c)
+func pprofHandler(rCtx access.RequestContext, _ *pprofRequest) (*api.EmptyResponse, error) {
+	
 	if err := access.IsAuthorized(rCtx, models.InfraSupportAdminRole); err != nil {
 		return nil, access.HandleAuthErr(err, "debug", "run", models.InfraSupportAdminRole)
 	}

--- a/internal/server/destinations.go
+++ b/internal/server/destinations.go
@@ -11,7 +11,6 @@ import (
 )
 
 func (a *API) ListDestinations(rCtx access.RequestContext, r *api.ListDestinationsRequest) (*api.ListResponse[api.Destination], error) {
-	
 	p := PaginationFromRequest(r.PaginationRequest)
 
 	opts := data.ListDestinationsOptions{
@@ -34,7 +33,6 @@ func (a *API) ListDestinations(rCtx access.RequestContext, r *api.ListDestinatio
 
 func (a *API) GetDestination(rCtx access.RequestContext, r *api.Resource) (*api.Destination, error) {
 	// No authorization required to view a destination
-	
 	destination, err := data.GetDestination(rCtx.DBTxn, data.GetDestinationOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
@@ -44,7 +42,6 @@ func (a *API) GetDestination(rCtx access.RequestContext, r *api.Resource) (*api.
 }
 
 func (a *API) CreateDestination(rCtx access.RequestContext, r *api.CreateDestinationRequest) (*api.Destination, error) {
-	
 	destination := &models.Destination{
 		Name:          r.Name,
 		UniqueID:      r.UniqueID,
@@ -78,8 +75,6 @@ func (a *API) CreateDestination(rCtx access.RequestContext, r *api.CreateDestina
 }
 
 func (a *API) UpdateDestination(rCtx access.RequestContext, r *api.UpdateDestinationRequest) (*api.Destination, error) {
-	
-
 	// Start with the existing value, so that non-update fields are not set to zero.
 	destination, err := data.GetDestination(rCtx.DBTxn, data.GetDestinationOptions{ByID: r.ID})
 	if err != nil {
@@ -102,5 +97,5 @@ func (a *API) UpdateDestination(rCtx access.RequestContext, r *api.UpdateDestina
 }
 
 func (a *API) DeleteDestination(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
-	return nil, access.DeleteDestination(getRequestContext(c), r.ID)
+	return nil, access.DeleteDestination(rCtx, r.ID)
 }

--- a/internal/server/destinations.go
+++ b/internal/server/destinations.go
@@ -4,16 +4,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func (a *API) ListDestinations(c *gin.Context, r *api.ListDestinationsRequest) (*api.ListResponse[api.Destination], error) {
-	rCtx := getRequestContext(c)
+func (a *API) ListDestinations(rCtx access.RequestContext, r *api.ListDestinationsRequest) (*api.ListResponse[api.Destination], error) {
+	
 	p := PaginationFromRequest(r.PaginationRequest)
 
 	opts := data.ListDestinationsOptions{
@@ -34,9 +32,9 @@ func (a *API) ListDestinations(c *gin.Context, r *api.ListDestinationsRequest) (
 	return result, nil
 }
 
-func (a *API) GetDestination(c *gin.Context, r *api.Resource) (*api.Destination, error) {
+func (a *API) GetDestination(rCtx access.RequestContext, r *api.Resource) (*api.Destination, error) {
 	// No authorization required to view a destination
-	rCtx := getRequestContext(c)
+	
 	destination, err := data.GetDestination(rCtx.DBTxn, data.GetDestinationOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
@@ -45,8 +43,8 @@ func (a *API) GetDestination(c *gin.Context, r *api.Resource) (*api.Destination,
 	return destination.ToAPI(), nil
 }
 
-func (a *API) CreateDestination(c *gin.Context, r *api.CreateDestinationRequest) (*api.Destination, error) {
-	rCtx := getRequestContext(c)
+func (a *API) CreateDestination(rCtx access.RequestContext, r *api.CreateDestinationRequest) (*api.Destination, error) {
+	
 	destination := &models.Destination{
 		Name:          r.Name,
 		UniqueID:      r.UniqueID,
@@ -79,8 +77,8 @@ func (a *API) CreateDestination(c *gin.Context, r *api.CreateDestinationRequest)
 	return destination.ToAPI(), nil
 }
 
-func (a *API) UpdateDestination(c *gin.Context, r *api.UpdateDestinationRequest) (*api.Destination, error) {
-	rCtx := getRequestContext(c)
+func (a *API) UpdateDestination(rCtx access.RequestContext, r *api.UpdateDestinationRequest) (*api.Destination, error) {
+	
 
 	// Start with the existing value, so that non-update fields are not set to zero.
 	destination, err := data.GetDestination(rCtx.DBTxn, data.GetDestinationOptions{ByID: r.ID})
@@ -103,6 +101,6 @@ func (a *API) UpdateDestination(c *gin.Context, r *api.UpdateDestinationRequest)
 	return destination.ToAPI(), nil
 }
 
-func (a *API) DeleteDestination(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
+func (a *API) DeleteDestination(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
 	return nil, access.DeleteDestination(getRequestContext(c), r.ID)
 }

--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
@@ -20,8 +18,8 @@ const DeviceCodeExpirySeconds = 600
 
 const CharsetDeviceFlowUserCode = "BCDFGHJKLMNPQRSTVWXZ" // no vowels to avoid spelling words
 
-func (a *API) StartDeviceFlow(c *gin.Context, req *api.EmptyRequest) (*api.DeviceFlowResponse, error) {
-	rctx := getRequestContext(c)
+func (a *API) StartDeviceFlow(rCtx access.RequestContext, req *api.EmptyRequest) (*api.DeviceFlowResponse, error) {
+
 	tries := 0
 retry:
 	tries++
@@ -67,8 +65,7 @@ retry:
 
 // GetDeviceFlowStatus is an API handler for checking the status of a device
 // flow login. The response status can be pending, expired, or confirmed.
-func (a *API) GetDeviceFlowStatus(c *gin.Context, req *api.DeviceFlowStatusRequest) (*api.DeviceFlowStatusResponse, error) {
-	rctx := getRequestContext(c)
+func (a *API) GetDeviceFlowStatus(rCtx access.RequestContext, req *api.DeviceFlowStatusRequest) (*api.DeviceFlowStatusResponse, error) {
 
 	dfar, err := data.GetDeviceFlowAuthRequest(rctx.DBTxn, data.GetDeviceFlowAuthRequestOptions{ByDeviceCode: req.DeviceCode})
 	if err != nil {
@@ -149,8 +146,7 @@ func (a *API) GetDeviceFlowStatus(c *gin.Context, req *api.DeviceFlowStatusReque
 	}, nil
 }
 
-func (a *API) ApproveDeviceFlow(c *gin.Context, req *api.ApproveDeviceFlowRequest) (*api.EmptyResponse, error) {
-	rctx := getRequestContext(c)
+func (a *API) ApproveDeviceFlow(rCtx access.RequestContext, req *api.ApproveDeviceFlowRequest) (*api.EmptyResponse, error) {
 
 	if !rctx.Authenticated.AccessKey.Scopes.Includes(models.ScopeAllowCreateAccessKey) {
 		return nil, fmt.Errorf("%w: access key missing scope '%s'", access.ErrNotAuthorized, models.ScopeAllowCreateAccessKey)

--- a/internal/server/deviceflow.go
+++ b/internal/server/deviceflow.go
@@ -19,7 +19,6 @@ const DeviceCodeExpirySeconds = 600
 const CharsetDeviceFlowUserCode = "BCDFGHJKLMNPQRSTVWXZ" // no vowels to avoid spelling words
 
 func (a *API) StartDeviceFlow(rCtx access.RequestContext, req *api.EmptyRequest) (*api.DeviceFlowResponse, error) {
-
 	tries := 0
 retry:
 	tries++
@@ -33,7 +32,7 @@ retry:
 		return nil, err
 	}
 
-	err = data.CreateDeviceFlowAuthRequest(rctx.DBTxn, &models.DeviceFlowAuthRequest{
+	err = data.CreateDeviceFlowAuthRequest(rCtx.DBTxn, &models.DeviceFlowAuthRequest{
 		UserCode:   userCode,
 		DeviceCode: deviceCode,
 		ExpiresAt:  time.Now().Add(DeviceCodeExpirySeconds * time.Second),
@@ -46,12 +45,12 @@ retry:
 	}
 
 	var host string
-	if rctx.Authenticated.Organization != nil {
-		host = rctx.Authenticated.Organization.Domain
+	if rCtx.Authenticated.Organization != nil {
+		host = rCtx.Authenticated.Organization.Domain
 	}
 
 	if host == "" {
-		host = rctx.Request.Host
+		host = rCtx.Request.Host
 	}
 
 	return &api.DeviceFlowResponse{
@@ -66,8 +65,7 @@ retry:
 // GetDeviceFlowStatus is an API handler for checking the status of a device
 // flow login. The response status can be pending, expired, or confirmed.
 func (a *API) GetDeviceFlowStatus(rCtx access.RequestContext, req *api.DeviceFlowStatusRequest) (*api.DeviceFlowStatusResponse, error) {
-
-	dfar, err := data.GetDeviceFlowAuthRequest(rctx.DBTxn, data.GetDeviceFlowAuthRequestOptions{ByDeviceCode: req.DeviceCode})
+	dfar, err := data.GetDeviceFlowAuthRequest(rCtx.DBTxn, data.GetDeviceFlowAuthRequestOptions{ByDeviceCode: req.DeviceCode})
 	if err != nil {
 		return nil, fmt.Errorf("%w: error retrieving device flow auth request: %v", internal.ErrUnauthorized, err)
 	}
@@ -86,7 +84,7 @@ func (a *API) GetDeviceFlowStatus(rCtx access.RequestContext, req *api.DeviceFlo
 		}, nil
 	}
 
-	user, err := data.GetIdentity(rctx.DBTxn, data.GetIdentityOptions{ByID: dfar.UserID})
+	user, err := data.GetIdentity(rCtx.DBTxn, data.GetIdentityOptions{ByID: dfar.UserID})
 	if err != nil {
 		return nil, fmt.Errorf("%w: retrieving approval user: %v", internal.ErrUnauthorized, err)
 	}
@@ -104,13 +102,13 @@ func (a *API) GetDeviceFlowStatus(rCtx access.RequestContext, req *api.DeviceFlo
 		Scopes:              models.CommaSeparatedStrings{models.ScopeAllowCreateAccessKey},
 	}
 
-	bearer, err := data.CreateAccessKey(rctx.DBTxn, accessKey)
+	bearer, err := data.CreateAccessKey(rCtx.DBTxn, accessKey)
 	if err != nil {
 		return nil, fmt.Errorf("%w: creating new access key: %v", internal.ErrUnauthorized, err)
 	}
 
 	user.LastSeenAt = time.Now().UTC()
-	if err := data.UpdateIdentity(rctx.DBTxn, user); err != nil {
+	if err := data.UpdateIdentity(rCtx.DBTxn, user); err != nil {
 		return nil, fmt.Errorf("%w: update user last seen: %v", internal.ErrUnauthorized, err)
 	}
 
@@ -119,16 +117,16 @@ func (a *API) GetDeviceFlowStatus(rCtx access.RequestContext, req *api.DeviceFlo
 	a.t.Event("login", accessKey.IssuedForID.String(), accessKey.OrganizationID.String(), Properties{"method": "deviceflow"})
 
 	// Update the request context so that logging middleware can include the userID
-	rctx.Authenticated.User = user
-	rctx.Response.LoginUserID = user.ID
+	rCtx.Authenticated.User = user
+	rCtx.Response.LoginUserID = user.ID
 
-	org, err := data.GetOrganization(rctx.DBTxn, data.GetOrganizationOptions{ByID: accessKey.OrganizationID})
+	org, err := data.GetOrganization(rCtx.DBTxn, data.GetOrganizationOptions{ByID: accessKey.OrganizationID})
 	if err != nil {
 		return nil, fmt.Errorf("%w: device flow get organization for user: %v", internal.ErrUnauthorized, err)
 	}
 
 	// Delete the request so it can't be claimed twice
-	err = data.DeleteDeviceFlowAuthRequest(rctx.DBTxn, dfar.ID)
+	err = data.DeleteDeviceFlowAuthRequest(rCtx.DBTxn, dfar.ID)
 	if err != nil {
 		return nil, fmt.Errorf("%w: device flow delete auth request: %v", internal.ErrUnauthorized, err)
 	}
@@ -147,12 +145,11 @@ func (a *API) GetDeviceFlowStatus(rCtx access.RequestContext, req *api.DeviceFlo
 }
 
 func (a *API) ApproveDeviceFlow(rCtx access.RequestContext, req *api.ApproveDeviceFlowRequest) (*api.EmptyResponse, error) {
-
-	if !rctx.Authenticated.AccessKey.Scopes.Includes(models.ScopeAllowCreateAccessKey) {
+	if !rCtx.Authenticated.AccessKey.Scopes.Includes(models.ScopeAllowCreateAccessKey) {
 		return nil, fmt.Errorf("%w: access key missing scope '%s'", access.ErrNotAuthorized, models.ScopeAllowCreateAccessKey)
 	}
 
-	dfar, err := data.GetDeviceFlowAuthRequest(rctx.DBTxn, data.GetDeviceFlowAuthRequestOptions{ByUserCode: strings.Replace(req.UserCode, "-", "", 1)})
+	dfar, err := data.GetDeviceFlowAuthRequest(rCtx.DBTxn, data.GetDeviceFlowAuthRequestOptions{ByUserCode: strings.Replace(req.UserCode, "-", "", 1)})
 	if err != nil {
 		return nil, fmt.Errorf("%w: invalid code", internal.ErrNotFound)
 	}
@@ -165,5 +162,5 @@ func (a *API) ApproveDeviceFlow(rCtx access.RequestContext, req *api.ApproveDevi
 		return nil, nil
 	}
 
-	return nil, data.ApproveDeviceFlowAuthRequest(rctx.DBTxn, dfar.ID, rctx.Authenticated.User.ID, rctx.Authenticated.AccessKey.ProviderID)
+	return nil, data.ApproveDeviceFlowAuthRequest(rCtx.DBTxn, dfar.ID, rCtx.Authenticated.User.ID, rCtx.Authenticated.AccessKey.ProviderID)
 }

--- a/internal/server/forgotdomain.go
+++ b/internal/server/forgotdomain.go
@@ -9,8 +9,6 @@ import (
 )
 
 func (a *API) RequestForgotDomains(rCtx access.RequestContext, r *api.ForgotDomainRequest) (*api.EmptyResponse, error) {
-	
-
 	if err := redis.NewLimiter(a.server.redis).RateOK(r.Email, 10); err != nil {
 		return nil, err
 	}

--- a/internal/server/forgotdomain.go
+++ b/internal/server/forgotdomain.go
@@ -1,16 +1,15 @@
 package server
 
 import (
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/email"
 	"github.com/infrahq/infra/internal/server/redis"
 )
 
-func (a *API) RequestForgotDomains(c *gin.Context, r *api.ForgotDomainRequest) (*api.EmptyResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) RequestForgotDomains(rCtx access.RequestContext, r *api.ForgotDomainRequest) (*api.EmptyResponse, error) {
+	
 
 	if err := redis.NewLimiter(a.server.redis).RateOK(r.Email, 10); err != nil {
 		return nil, err

--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -16,8 +16,6 @@ import (
 )
 
 func (a *API) ListGrants(rCtx access.RequestContext, r *api.ListGrantsRequest) (*api.ListResponse[api.Grant], error) {
-	
-
 	rCtx.Response.AddLogFields(func(event *zerolog.Event) {
 		event.Int64("lastUpdateIndex", r.LastUpdateIndex)
 	})
@@ -64,7 +62,6 @@ func (a *API) ListGrants(rCtx access.RequestContext, r *api.ListGrantsRequest) (
 }
 
 func (a *API) GetGrant(rCtx access.RequestContext, r *api.Resource) (*api.Grant, error) {
-	
 	grant, err := access.GetGrant(rCtx, r.ID)
 	if err != nil {
 		return nil, err
@@ -74,7 +71,6 @@ func (a *API) GetGrant(rCtx access.RequestContext, r *api.Resource) (*api.Grant,
 }
 
 func (a *API) CreateGrant(rCtx access.RequestContext, r *api.GrantRequest) (*api.CreateGrantResponse, error) {
-	
 	grant, err := getGrantFromGrantRequest(rCtx, *r)
 	if err != nil {
 		return nil, err
@@ -111,7 +107,6 @@ func (a *API) CreateGrant(rCtx access.RequestContext, r *api.GrantRequest) (*api
 }
 
 func (a *API) DeleteGrant(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
-	
 	grant, err := access.GetGrant(rCtx, r.ID)
 	if err != nil {
 		return nil, err
@@ -136,7 +131,6 @@ func (a *API) DeleteGrant(rCtx access.RequestContext, r *api.Resource) (*api.Emp
 }
 
 func (a *API) UpdateGrants(rCtx access.RequestContext, r *api.UpdateGrantsRequest) (*api.EmptyResponse, error) {
-	
 	iden := rCtx.Authenticated.User
 	var addGrants []*models.Grant
 	for _, g := range r.GrantsToAdd {
@@ -238,7 +232,7 @@ func (a *API) addPreviousVersionHandlersGrants() {
 		route[api.ListGrantsRequest, *api.ListResponse[grantV0_18_1]]{
 			routeSettings: defaultRouteSettingsGet,
 			handler: func(rCtx access.RequestContext, req *api.ListGrantsRequest) (*api.ListResponse[grantV0_18_1], error) {
-				resp, err := a.ListGrants(c, req)
+				resp, err := a.ListGrants(rCtx, req)
 				return api.CopyListResponse(resp, func(item api.Grant) grantV0_18_1 {
 					return *newGrantsV0_18_1FromLatest(&item)
 				}), err
@@ -249,7 +243,7 @@ func (a *API) addPreviousVersionHandlersGrants() {
 		route[api.Resource, *grantV0_18_1]{
 			routeSettings: defaultRouteSettingsGet,
 			handler: func(rCtx access.RequestContext, req *api.Resource) (*grantV0_18_1, error) {
-				resp, err := a.GetGrant(c, req)
+				resp, err := a.GetGrant(rCtx, req)
 				return newGrantsV0_18_1FromLatest(resp), err
 			},
 		})
@@ -261,7 +255,7 @@ func (a *API) addPreviousVersionHandlersGrants() {
 	addVersionHandler(a, http.MethodPost, "/api/grants", "0.18.1",
 		route[api.GrantRequest, *createGrantResponseV0_18_1]{
 			handler: func(rCtx access.RequestContext, req *api.GrantRequest) (*createGrantResponseV0_18_1, error) {
-				resp, err := a.CreateGrant(c, req)
+				resp, err := a.CreateGrant(rCtx, req)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/server/grants.go
+++ b/internal/server/grants.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 
 	"github.com/infrahq/infra/api"
@@ -16,8 +15,8 @@ import (
 	"github.com/infrahq/infra/uid"
 )
 
-func (a *API) ListGrants(c *gin.Context, r *api.ListGrantsRequest) (*api.ListResponse[api.Grant], error) {
-	rCtx := getRequestContext(c)
+func (a *API) ListGrants(rCtx access.RequestContext, r *api.ListGrantsRequest) (*api.ListResponse[api.Grant], error) {
+	
 
 	rCtx.Response.AddLogFields(func(event *zerolog.Event) {
 		event.Int64("lastUpdateIndex", r.LastUpdateIndex)
@@ -64,8 +63,8 @@ func (a *API) ListGrants(c *gin.Context, r *api.ListGrantsRequest) (*api.ListRes
 	return result, nil
 }
 
-func (a *API) GetGrant(c *gin.Context, r *api.Resource) (*api.Grant, error) {
-	rCtx := getRequestContext(c)
+func (a *API) GetGrant(rCtx access.RequestContext, r *api.Resource) (*api.Grant, error) {
+	
 	grant, err := access.GetGrant(rCtx, r.ID)
 	if err != nil {
 		return nil, err
@@ -74,8 +73,8 @@ func (a *API) GetGrant(c *gin.Context, r *api.Resource) (*api.Grant, error) {
 	return grant.ToAPI(), nil
 }
 
-func (a *API) CreateGrant(c *gin.Context, r *api.GrantRequest) (*api.CreateGrantResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) CreateGrant(rCtx access.RequestContext, r *api.GrantRequest) (*api.CreateGrantResponse, error) {
+	
 	grant, err := getGrantFromGrantRequest(rCtx, *r)
 	if err != nil {
 		return nil, err
@@ -111,8 +110,8 @@ func (a *API) CreateGrant(c *gin.Context, r *api.GrantRequest) (*api.CreateGrant
 
 }
 
-func (a *API) DeleteGrant(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) DeleteGrant(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
+	
 	grant, err := access.GetGrant(rCtx, r.ID)
 	if err != nil {
 		return nil, err
@@ -136,8 +135,8 @@ func (a *API) DeleteGrant(c *gin.Context, r *api.Resource) (*api.EmptyResponse, 
 	return nil, access.DeleteGrant(rCtx, r.ID)
 }
 
-func (a *API) UpdateGrants(c *gin.Context, r *api.UpdateGrantsRequest) (*api.EmptyResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) UpdateGrants(rCtx access.RequestContext, r *api.UpdateGrantsRequest) (*api.EmptyResponse, error) {
+	
 	iden := rCtx.Authenticated.User
 	var addGrants []*models.Grant
 	for _, g := range r.GrantsToAdd {
@@ -238,7 +237,7 @@ func (a *API) addPreviousVersionHandlersGrants() {
 	addVersionHandler(a, http.MethodGet, "/api/grants", "0.18.1",
 		route[api.ListGrantsRequest, *api.ListResponse[grantV0_18_1]]{
 			routeSettings: defaultRouteSettingsGet,
-			handler: func(c *gin.Context, req *api.ListGrantsRequest) (*api.ListResponse[grantV0_18_1], error) {
+			handler: func(rCtx access.RequestContext, req *api.ListGrantsRequest) (*api.ListResponse[grantV0_18_1], error) {
 				resp, err := a.ListGrants(c, req)
 				return api.CopyListResponse(resp, func(item api.Grant) grantV0_18_1 {
 					return *newGrantsV0_18_1FromLatest(&item)
@@ -249,7 +248,7 @@ func (a *API) addPreviousVersionHandlersGrants() {
 	addVersionHandler(a, http.MethodGet, "/api/grants/:id", "0.18.1",
 		route[api.Resource, *grantV0_18_1]{
 			routeSettings: defaultRouteSettingsGet,
-			handler: func(c *gin.Context, req *api.Resource) (*grantV0_18_1, error) {
+			handler: func(rCtx access.RequestContext, req *api.Resource) (*grantV0_18_1, error) {
 				resp, err := a.GetGrant(c, req)
 				return newGrantsV0_18_1FromLatest(resp), err
 			},
@@ -261,7 +260,7 @@ func (a *API) addPreviousVersionHandlersGrants() {
 	}
 	addVersionHandler(a, http.MethodPost, "/api/grants", "0.18.1",
 		route[api.GrantRequest, *createGrantResponseV0_18_1]{
-			handler: func(c *gin.Context, req *api.GrantRequest) (*createGrantResponseV0_18_1, error) {
+			handler: func(rCtx access.RequestContext, req *api.GrantRequest) (*createGrantResponseV0_18_1, error) {
 				resp, err := a.CreateGrant(c, req)
 				if err != nil {
 					return nil, err

--- a/internal/server/groups.go
+++ b/internal/server/groups.go
@@ -8,7 +8,6 @@ import (
 )
 
 func (a *API) ListGroups(rCtx access.RequestContext, r *api.ListGroupsRequest) (*api.ListResponse[api.Group], error) {
-	
 	p := PaginationFromRequest(r.PaginationRequest)
 	groups, err := access.ListGroups(rCtx, r.Name, r.UserID, &p)
 	if err != nil {
@@ -23,7 +22,6 @@ func (a *API) ListGroups(rCtx access.RequestContext, r *api.ListGroupsRequest) (
 }
 
 func (a *API) GetGroup(rCtx access.RequestContext, r *api.Resource) (*api.Group, error) {
-	
 	group, err := access.GetGroup(rCtx, data.GetGroupOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
@@ -33,10 +31,9 @@ func (a *API) GetGroup(rCtx access.RequestContext, r *api.Resource) (*api.Group,
 }
 
 func (a *API) CreateGroup(rCtx access.RequestContext, r *api.CreateGroupRequest) (*api.Group, error) {
-	
 	group := &models.Group{Name: r.Name}
 
-	authIdent := getRequestContext(c).Authenticated.User
+	authIdent := rCtx.Authenticated.User
 	if authIdent != nil {
 		group.CreatedBy = authIdent.ID
 	}
@@ -50,11 +47,9 @@ func (a *API) CreateGroup(rCtx access.RequestContext, r *api.CreateGroupRequest)
 }
 
 func (a *API) DeleteGroup(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
-	
 	return nil, access.DeleteGroup(rCtx, r.ID)
 }
 
 func (a *API) UpdateUsersInGroup(rCtx access.RequestContext, r *api.UpdateUsersInGroupRequest) (*api.EmptyResponse, error) {
-	
 	return nil, access.UpdateUsersInGroup(rCtx, r.GroupID, r.UserIDsToAdd, r.UserIDsToRemove)
 }

--- a/internal/server/groups.go
+++ b/internal/server/groups.go
@@ -1,16 +1,14 @@
 package server
 
 import (
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func (a *API) ListGroups(c *gin.Context, r *api.ListGroupsRequest) (*api.ListResponse[api.Group], error) {
-	rCtx := getRequestContext(c)
+func (a *API) ListGroups(rCtx access.RequestContext, r *api.ListGroupsRequest) (*api.ListResponse[api.Group], error) {
+	
 	p := PaginationFromRequest(r.PaginationRequest)
 	groups, err := access.ListGroups(rCtx, r.Name, r.UserID, &p)
 	if err != nil {
@@ -24,8 +22,8 @@ func (a *API) ListGroups(c *gin.Context, r *api.ListGroupsRequest) (*api.ListRes
 	return result, nil
 }
 
-func (a *API) GetGroup(c *gin.Context, r *api.Resource) (*api.Group, error) {
-	rCtx := getRequestContext(c)
+func (a *API) GetGroup(rCtx access.RequestContext, r *api.Resource) (*api.Group, error) {
+	
 	group, err := access.GetGroup(rCtx, data.GetGroupOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
@@ -34,8 +32,8 @@ func (a *API) GetGroup(c *gin.Context, r *api.Resource) (*api.Group, error) {
 	return group.ToAPI(), nil
 }
 
-func (a *API) CreateGroup(c *gin.Context, r *api.CreateGroupRequest) (*api.Group, error) {
-	rCtx := getRequestContext(c)
+func (a *API) CreateGroup(rCtx access.RequestContext, r *api.CreateGroupRequest) (*api.Group, error) {
+	
 	group := &models.Group{Name: r.Name}
 
 	authIdent := getRequestContext(c).Authenticated.User
@@ -51,12 +49,12 @@ func (a *API) CreateGroup(c *gin.Context, r *api.CreateGroupRequest) (*api.Group
 	return group.ToAPI(), nil
 }
 
-func (a *API) DeleteGroup(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) DeleteGroup(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
+	
 	return nil, access.DeleteGroup(rCtx, r.ID)
 }
 
-func (a *API) UpdateUsersInGroup(c *gin.Context, r *api.UpdateUsersInGroupRequest) (*api.EmptyResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) UpdateUsersInGroup(rCtx access.RequestContext, r *api.UpdateUsersInGroupRequest) (*api.EmptyResponse, error) {
+	
 	return nil, access.UpdateUsersInGroup(rCtx, r.GroupID, r.UserIDsToAdd, r.UserIDsToRemove)
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -57,8 +57,8 @@ var createTokenRoute = route[api.EmptyRequest, *api.CreateTokenResponse]{
 	handler:       CreateToken,
 }
 
-func CreateToken(c *gin.Context, r *api.EmptyRequest) (*api.CreateTokenResponse, error) {
-	rCtx := getRequestContext(c)
+func CreateToken(rCtx access.RequestContext, r *api.EmptyRequest) (*api.CreateTokenResponse, error) {
+	
 
 	if rCtx.Authenticated.User == nil {
 		return nil, fmt.Errorf("no authenticated user")
@@ -81,8 +81,8 @@ var wellKnownJWKsRoute = route[api.EmptyRequest, WellKnownJWKResponse]{
 	},
 }
 
-func wellKnownJWKsHandler(c *gin.Context, _ *api.EmptyRequest) (WellKnownJWKResponse, error) {
-	rCtx := getRequestContext(c)
+func wellKnownJWKsHandler(rCtx access.RequestContext, _ *api.EmptyRequest) (WellKnownJWKResponse, error) {
+	
 	keys, err := getPublicJWK(rCtx)
 	if err != nil {
 		return WellKnownJWKResponse{}, err
@@ -113,8 +113,8 @@ func wrapLinkWithVerification(link, domain, verificationToken string) string {
 	return fmt.Sprintf("https://%s/link?vt=%s&r=%s", domain, verificationToken, link)
 }
 
-func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) Login(rCtx access.RequestContext, r *api.LoginRequest) (*api.LoginResponse, error) {
+	
 
 	var onSuccess, onFailure func()
 
@@ -229,9 +229,9 @@ func (a *API) Login(c *gin.Context, r *api.LoginRequest) (*api.LoginResponse, er
 	}, nil
 }
 
-func (a *API) Logout(c *gin.Context, _ *api.EmptyRequest) (*api.EmptyResponse, error) {
+func (a *API) Logout(rCtx access.RequestContext, _ *api.EmptyRequest) (*api.EmptyResponse, error) {
 	// does not need authorization check, this action is limited to the calling key
-	rCtx := getRequestContext(c)
+	
 	id := rCtx.Authenticated.AccessKey.ID
 	err := data.DeleteAccessKeys(rCtx.DBTxn, data.DeleteAccessKeysOptions{ByID: id})
 	if err != nil {
@@ -242,6 +242,6 @@ func (a *API) Logout(c *gin.Context, _ *api.EmptyRequest) (*api.EmptyResponse, e
 	return nil, nil
 }
 
-func (a *API) Version(c *gin.Context, r *api.EmptyRequest) (*api.Version, error) {
+func (a *API) Version(rCtx access.RequestContext, r *api.EmptyRequest) (*api.Version, error) {
 	return &api.Version{Version: internal.FullVersion()}, nil
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -58,8 +58,6 @@ var createTokenRoute = route[api.EmptyRequest, *api.CreateTokenResponse]{
 }
 
 func CreateToken(rCtx access.RequestContext, r *api.EmptyRequest) (*api.CreateTokenResponse, error) {
-	
-
 	if rCtx.Authenticated.User == nil {
 		return nil, fmt.Errorf("no authenticated user")
 	}
@@ -82,7 +80,6 @@ var wellKnownJWKsRoute = route[api.EmptyRequest, WellKnownJWKResponse]{
 }
 
 func wellKnownJWKsHandler(rCtx access.RequestContext, _ *api.EmptyRequest) (WellKnownJWKResponse, error) {
-	
 	keys, err := getPublicJWK(rCtx)
 	if err != nil {
 		return WellKnownJWKResponse{}, err
@@ -114,8 +111,6 @@ func wrapLinkWithVerification(link, domain, verificationToken string) string {
 }
 
 func (a *API) Login(rCtx access.RequestContext, r *api.LoginRequest) (*api.LoginResponse, error) {
-	
-
 	var onSuccess, onFailure func()
 
 	var loginMethod authn.LoginMethod
@@ -231,17 +226,16 @@ func (a *API) Login(rCtx access.RequestContext, r *api.LoginRequest) (*api.Login
 
 func (a *API) Logout(rCtx access.RequestContext, _ *api.EmptyRequest) (*api.EmptyResponse, error) {
 	// does not need authorization check, this action is limited to the calling key
-	
 	id := rCtx.Authenticated.AccessKey.ID
 	err := data.DeleteAccessKeys(rCtx.DBTxn, data.DeleteAccessKeysOptions{ByID: id})
 	if err != nil {
 		return nil, err
 	}
 
-	deleteCookie(c.Request, rCtx.Response.HTTPWriter, cookieAuthorizationName, c.Request.Host)
+	deleteCookie(rCtx.Request, rCtx.Response.HTTPWriter, cookieAuthorizationName, rCtx.Request.Host)
 	return nil, nil
 }
 
-func (a *API) Version(rCtx access.RequestContext, r *api.EmptyRequest) (*api.Version, error) {
+func (a *API) Version(_ access.RequestContext, _ *api.EmptyRequest) (*api.Version, error) {
 	return &api.Version{Version: internal.FullVersion()}, nil
 }

--- a/internal/server/logging.go
+++ b/internal/server/logging.go
@@ -64,7 +64,6 @@ func loggingMiddleware(enableSampling bool) gin.HandlerFunc {
 			event = event.Int64("contentLength", c.Request.ContentLength)
 		}
 
-		rCtx := getRequestContext(c)
 		if user := rCtx.Authenticated.User; user != nil {
 			event = event.Str("userID", user.ID.String())
 		} else if rCtx.Response != nil && rCtx.Response.LoginUserID != 0 {

--- a/internal/server/logging.go
+++ b/internal/server/logging.go
@@ -64,6 +64,7 @@ func loggingMiddleware(enableSampling bool) gin.HandlerFunc {
 			event = event.Int64("contentLength", c.Request.ContentLength)
 		}
 
+		rCtx := getRequestContext(c)
 		if user := rCtx.Authenticated.User; user != nil {
 			event = event.Str("userID", user.ID.String())
 		} else if rCtx.Response != nil && rCtx.Response.LoginUserID != 0 {

--- a/internal/server/organizations.go
+++ b/internal/server/organizations.go
@@ -3,15 +3,13 @@ package server
 import (
 	"fmt"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-func (a *API) ListOrganizations(c *gin.Context, r *api.ListOrganizationsRequest) (*api.ListResponse[api.Organization], error) {
-	rCtx := getRequestContext(c)
+func (a *API) ListOrganizations(rCtx access.RequestContext, r *api.ListOrganizationsRequest) (*api.ListResponse[api.Organization], error) {
+	
 	p := PaginationFromRequest(r.PaginationRequest)
 	orgs, err := access.ListOrganizations(rCtx, r.Name, &p)
 	if err != nil {
@@ -25,8 +23,8 @@ func (a *API) ListOrganizations(c *gin.Context, r *api.ListOrganizationsRequest)
 	return result, nil
 }
 
-func (a *API) GetOrganization(c *gin.Context, r *api.GetOrganizationRequest) (*api.Organization, error) {
-	rCtx := getRequestContext(c)
+func (a *API) GetOrganization(rCtx access.RequestContext, r *api.GetOrganizationRequest) (*api.Organization, error) {
+	
 	if r.ID.IsSelf {
 		iden := rCtx.Authenticated.Organization
 		if iden == nil {
@@ -42,8 +40,8 @@ func (a *API) GetOrganization(c *gin.Context, r *api.GetOrganizationRequest) (*a
 	return org.ToAPI(), nil
 }
 
-func (a *API) CreateOrganization(c *gin.Context, r *api.CreateOrganizationRequest) (*api.Organization, error) {
-	rCtx := getRequestContext(c)
+func (a *API) CreateOrganization(rCtx access.RequestContext, r *api.CreateOrganizationRequest) (*api.Organization, error) {
+	
 	org := &models.Organization{
 		Name:      r.Name,
 		Domain:    r.Domain,
@@ -65,12 +63,12 @@ func (a *API) CreateOrganization(c *gin.Context, r *api.CreateOrganizationReques
 	return org.ToAPI(), nil
 }
 
-func (a *API) DeleteOrganization(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
+func (a *API) DeleteOrganization(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
 	return nil, access.DeleteOrganization(getRequestContext(c), r.ID)
 }
 
-func (a *API) UpdateOrganization(c *gin.Context, r *api.UpdateOrganizationRequest) (*api.Organization, error) {
-	rCtx := getRequestContext(c)
+func (a *API) UpdateOrganization(rCtx access.RequestContext, r *api.UpdateOrganizationRequest) (*api.Organization, error) {
+	
 	org, err := access.GetOrganization(rCtx, r.ID)
 	if err != nil {
 		return nil, err

--- a/internal/server/organizations.go
+++ b/internal/server/organizations.go
@@ -9,7 +9,6 @@ import (
 )
 
 func (a *API) ListOrganizations(rCtx access.RequestContext, r *api.ListOrganizationsRequest) (*api.ListResponse[api.Organization], error) {
-	
 	p := PaginationFromRequest(r.PaginationRequest)
 	orgs, err := access.ListOrganizations(rCtx, r.Name, &p)
 	if err != nil {
@@ -24,7 +23,6 @@ func (a *API) ListOrganizations(rCtx access.RequestContext, r *api.ListOrganizat
 }
 
 func (a *API) GetOrganization(rCtx access.RequestContext, r *api.GetOrganizationRequest) (*api.Organization, error) {
-	
 	if r.ID.IsSelf {
 		iden := rCtx.Authenticated.Organization
 		if iden == nil {
@@ -41,7 +39,6 @@ func (a *API) GetOrganization(rCtx access.RequestContext, r *api.GetOrganization
 }
 
 func (a *API) CreateOrganization(rCtx access.RequestContext, r *api.CreateOrganizationRequest) (*api.Organization, error) {
-	
 	org := &models.Organization{
 		Name:      r.Name,
 		Domain:    r.Domain,
@@ -64,11 +61,10 @@ func (a *API) CreateOrganization(rCtx access.RequestContext, r *api.CreateOrgani
 }
 
 func (a *API) DeleteOrganization(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
-	return nil, access.DeleteOrganization(getRequestContext(c), r.ID)
+	return nil, access.DeleteOrganization(rCtx, r.ID)
 }
 
 func (a *API) UpdateOrganization(rCtx access.RequestContext, r *api.UpdateOrganizationRequest) (*api.Organization, error) {
-	
 	org, err := access.GetOrganization(rCtx, r.ID)
 	if err != nil {
 		return nil, err

--- a/internal/server/passwordreset.go
+++ b/internal/server/passwordreset.go
@@ -14,7 +14,6 @@ import (
 )
 
 func (a *API) RequestPasswordReset(rCtx access.RequestContext, r *api.PasswordResetRequest) (*api.EmptyResponse, error) {
-	
 	// no authorization required
 	if err := redis.NewLimiter(a.server.redis).RateOK(r.Email, 10); err != nil {
 		return nil, err
@@ -48,13 +47,12 @@ func (a *API) RequestPasswordReset(rCtx access.RequestContext, r *api.PasswordRe
 }
 
 func (a *API) VerifiedPasswordReset(rCtx access.RequestContext, r *api.VerifiedResetPasswordRequest) (*api.LoginResponse, error) {
-	
 	user, err := access.VerifiedPasswordReset(rCtx, r.Token, r.Password)
 	if err != nil {
 		return nil, err
 	}
 
-	return a.Login(c, &api.LoginRequest{
+	return a.Login(rCtx, &api.LoginRequest{
 		PasswordCredentials: &api.LoginRequestPasswordCredentials{
 			Name:     user.Name,
 			Password: r.Password,

--- a/internal/server/passwordreset.go
+++ b/internal/server/passwordreset.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
@@ -15,8 +13,8 @@ import (
 	"github.com/infrahq/infra/internal/server/redis"
 )
 
-func (a *API) RequestPasswordReset(c *gin.Context, r *api.PasswordResetRequest) (*api.EmptyResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) RequestPasswordReset(rCtx access.RequestContext, r *api.PasswordResetRequest) (*api.EmptyResponse, error) {
+	
 	// no authorization required
 	if err := redis.NewLimiter(a.server.redis).RateOK(r.Email, 10); err != nil {
 		return nil, err
@@ -49,8 +47,8 @@ func (a *API) RequestPasswordReset(c *gin.Context, r *api.PasswordResetRequest) 
 	return nil, err
 }
 
-func (a *API) VerifiedPasswordReset(c *gin.Context, r *api.VerifiedResetPasswordRequest) (*api.LoginResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) VerifiedPasswordReset(rCtx access.RequestContext, r *api.VerifiedResetPasswordRequest) (*api.LoginResponse, error) {
+	
 	user, err := access.VerifiedPasswordReset(rCtx, r.Token, r.Password)
 	if err != nil {
 		return nil, err

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -17,7 +17,6 @@ import (
 
 // caution: this endpoint is unauthenticated, do not return sensitive info
 func (a *API) ListProviders(rCtx access.RequestContext, r *api.ListProvidersRequest) (*api.ListResponse[api.Provider], error) {
-	
 	p := PaginationFromRequest(r.PaginationRequest)
 	opts := data.ListProvidersOptions{
 		ByName:               r.Name,
@@ -43,7 +42,6 @@ func (a *API) ListProviders(rCtx access.RequestContext, r *api.ListProvidersRequ
 
 // caution: this endpoint is unauthenticated, do not return sensitive info
 func (a *API) GetProvider(rCtx access.RequestContext, r *api.Resource) (*api.Provider, error) {
-	
 	provider, err := data.GetProvider(rCtx.DBTxn, data.GetProviderOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
@@ -66,7 +64,6 @@ func cleanupURL(url string) string {
 }
 
 func (a *API) CreateProvider(rCtx access.RequestContext, r *api.CreateProviderRequest) (*api.Provider, error) {
-	
 	provider := &models.Provider{
 		Name:         r.Name,
 		URL:          cleanupURL(r.URL),
@@ -120,7 +117,6 @@ func (a *API) CreateProvider(rCtx access.RequestContext, r *api.CreateProviderRe
 }
 
 func (a *API) PatchProvider(rCtx access.RequestContext, r *api.PatchProviderRequest) (*api.Provider, error) {
-	
 	provider, err := data.GetProvider(rCtx.DBTxn, data.GetProviderOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
@@ -138,7 +134,6 @@ func (a *API) PatchProvider(rCtx access.RequestContext, r *api.PatchProviderRequ
 }
 
 func (a *API) UpdateProvider(rCtx access.RequestContext, r *api.UpdateProviderRequest) (*api.Provider, error) {
-	
 	provider := &models.Provider{
 		Model: models.Model{
 			ID: r.ID,
@@ -162,7 +157,7 @@ func (a *API) UpdateProvider(rCtx access.RequestContext, r *api.UpdateProviderRe
 	}
 	provider.Kind = kind
 
-	if err := a.setProviderInfoFromServer(c.Request.Context(), provider); err != nil {
+	if err := a.setProviderInfoFromServer(rCtx.Request.Context(), provider); err != nil {
 		return nil, err
 	}
 
@@ -174,7 +169,7 @@ func (a *API) UpdateProvider(rCtx access.RequestContext, r *api.UpdateProviderRe
 }
 
 func (a *API) DeleteProvider(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
-	return nil, access.DeleteProvider(getRequestContext(c), r.ID)
+	return nil, access.DeleteProvider(rCtx, r.ID)
 }
 
 // setProviderInfoFromServer checks information provided by an OIDC server

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
@@ -18,8 +16,8 @@ import (
 )
 
 // caution: this endpoint is unauthenticated, do not return sensitive info
-func (a *API) ListProviders(c *gin.Context, r *api.ListProvidersRequest) (*api.ListResponse[api.Provider], error) {
-	rCtx := getRequestContext(c)
+func (a *API) ListProviders(rCtx access.RequestContext, r *api.ListProvidersRequest) (*api.ListResponse[api.Provider], error) {
+	
 	p := PaginationFromRequest(r.PaginationRequest)
 	opts := data.ListProvidersOptions{
 		ByName:               r.Name,
@@ -44,8 +42,8 @@ func (a *API) ListProviders(c *gin.Context, r *api.ListProvidersRequest) (*api.L
 }
 
 // caution: this endpoint is unauthenticated, do not return sensitive info
-func (a *API) GetProvider(c *gin.Context, r *api.Resource) (*api.Provider, error) {
-	rCtx := getRequestContext(c)
+func (a *API) GetProvider(rCtx access.RequestContext, r *api.Resource) (*api.Provider, error) {
+	
 	provider, err := data.GetProvider(rCtx.DBTxn, data.GetProviderOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
@@ -67,8 +65,8 @@ func cleanupURL(url string) string {
 	return url
 }
 
-func (a *API) CreateProvider(c *gin.Context, r *api.CreateProviderRequest) (*api.Provider, error) {
-	rCtx := getRequestContext(c)
+func (a *API) CreateProvider(rCtx access.RequestContext, r *api.CreateProviderRequest) (*api.Provider, error) {
+	
 	provider := &models.Provider{
 		Name:         r.Name,
 		URL:          cleanupURL(r.URL),
@@ -121,8 +119,8 @@ func (a *API) CreateProvider(c *gin.Context, r *api.CreateProviderRequest) (*api
 	return provider.ToAPI(), nil
 }
 
-func (a *API) PatchProvider(c *gin.Context, r *api.PatchProviderRequest) (*api.Provider, error) {
-	rCtx := getRequestContext(c)
+func (a *API) PatchProvider(rCtx access.RequestContext, r *api.PatchProviderRequest) (*api.Provider, error) {
+	
 	provider, err := data.GetProvider(rCtx.DBTxn, data.GetProviderOptions{ByID: r.ID})
 	if err != nil {
 		return nil, err
@@ -139,8 +137,8 @@ func (a *API) PatchProvider(c *gin.Context, r *api.PatchProviderRequest) (*api.P
 	return provider.ToAPI(), nil
 }
 
-func (a *API) UpdateProvider(c *gin.Context, r *api.UpdateProviderRequest) (*api.Provider, error) {
-	rCtx := getRequestContext(c)
+func (a *API) UpdateProvider(rCtx access.RequestContext, r *api.UpdateProviderRequest) (*api.Provider, error) {
+	
 	provider := &models.Provider{
 		Model: models.Model{
 			ID: r.ID,
@@ -175,7 +173,7 @@ func (a *API) UpdateProvider(c *gin.Context, r *api.UpdateProviderRequest) (*api
 	return provider.ToAPI(), nil
 }
 
-func (a *API) DeleteProvider(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
+func (a *API) DeleteProvider(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
 	return nil, access.DeleteProvider(getRequestContext(c), r.ID)
 }
 

--- a/internal/server/redirect.go
+++ b/internal/server/redirect.go
@@ -4,8 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/gin-gonic/gin"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
@@ -20,9 +18,9 @@ var verifyAndRedirectRoute = route[api.VerifyAndRedirectRequest, *api.RedirectRe
 	},
 }
 
-func VerifyAndRedirect(c *gin.Context, r *api.VerifyAndRedirectRequest) (*api.RedirectResponse, error) {
+func VerifyAndRedirect(rCtx access.RequestContext, r *api.VerifyAndRedirectRequest) (*api.RedirectResponse, error) {
 	// No authorization required
-	rCtx := getRequestContext(c)
+	
 	if err := data.SetIdentityVerified(rCtx.DBTxn, r.VerificationToken); err != nil {
 		logging.L.Error().Msg("VerifyUserByToken: " + err.Error())
 	}

--- a/internal/server/redirect.go
+++ b/internal/server/redirect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/infrahq/infra/api"
+	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 )
@@ -20,7 +21,6 @@ var verifyAndRedirectRoute = route[api.VerifyAndRedirectRequest, *api.RedirectRe
 
 func VerifyAndRedirect(rCtx access.RequestContext, r *api.VerifyAndRedirectRequest) (*api.RedirectResponse, error) {
 	// No authorization required
-	
 	if err := data.SetIdentityVerified(rCtx.DBTxn, r.VerificationToken); err != nil {
 		logging.L.Error().Msg("VerifyUserByToken: " + err.Error())
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -261,7 +261,7 @@ func wrapRoute[Req, Res any](a *API, routeID routeIdentifier, route route[Req, R
 		}
 		c.Set(access.RequestContextKey, rCtx)
 
-		resp, err := route.handler(c, req)
+		resp, err := route.handler(rCtx, req)
 		if err != nil {
 			return err
 		}
@@ -394,7 +394,7 @@ func del[Req any, Res any](a *API, r *routeGroup, path string, handler HandlerFu
 	add(a, r, http.MethodDelete, path, route[Req, Res]{handler: handler})
 }
 
-func readRequest(rCtx access.RequestContext, req interface{}) error {
+func readRequest(c *gin.Context, req interface{}) error {
 	if len(c.Params) > 0 {
 		params := make(map[string][]string)
 		for _, v := range c.Params {

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -148,7 +148,7 @@ func (s *Server) GenerateRoutes() Routes {
 	return Routes{Handler: router, OpenAPIDocument: a.openAPIDoc, api: a}
 }
 
-type HandlerFunc[Req, Res any] func(c *gin.Context, req *Req) (Res, error)
+type HandlerFunc[Req, Res any] func(rCtx access.RequestContext, req *Req) (Res, error)
 
 type route[Req, Res any] struct {
 	routeSettings
@@ -394,7 +394,7 @@ func del[Req any, Res any](a *API, r *routeGroup, path string, handler HandlerFu
 	add(a, r, http.MethodDelete, path, route[Req, Res]{handler: handler})
 }
 
-func readRequest(c *gin.Context, req interface{}) error {
+func readRequest(rCtx access.RequestContext, req interface{}) error {
 	if len(c.Params) > 0 {
 		params := make(map[string][]string)
 		for _, v := range c.Params {
@@ -457,7 +457,7 @@ func (a *API) deprecatedRoutes(noAuthnNoOrg *routeGroup) {
 	}
 
 	add(a, noAuthnNoOrg, http.MethodGet, "/api/signup", route[api.EmptyRequest, *SignupEnabledResponse]{
-		handler: func(c *gin.Context, _ *api.EmptyRequest) (*SignupEnabledResponse, error) {
+		handler: func(rCtx access.RequestContext, _ *api.EmptyRequest) (*SignupEnabledResponse, error) {
 			return &SignupEnabledResponse{Enabled: false}, nil
 		},
 		routeSettings: routeSettings{

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -188,8 +188,8 @@ func TestWrapRoute_TxnRollbackOnError(t *testing.T) {
 	router := gin.New()
 
 	r := route[api.EmptyRequest, *api.EmptyResponse]{
-		handler: func(c *gin.Context, request *api.EmptyRequest) (*api.EmptyResponse, error) {
-			rCtx := getRequestContext(c)
+		handler: func(rCtx access.RequestContext, request *api.EmptyRequest) (*api.EmptyResponse, error) {
+			
 
 			user := &models.Identity{
 				Model:              models.Model{ID: 1555},
@@ -228,8 +228,8 @@ func TestWrapRoute_HandleErrorOnCommit(t *testing.T) {
 	router := gin.New()
 
 	r := route[api.EmptyRequest, *api.EmptyResponse]{
-		handler: func(c *gin.Context, request *api.EmptyRequest) (*api.EmptyResponse, error) {
-			rCtx := getRequestContext(c)
+		handler: func(rCtx access.RequestContext, request *api.EmptyRequest) (*api.EmptyResponse, error) {
+			
 
 			// Commit the transaction so that the call in wrapRoute returns an error
 			err := rCtx.DBTxn.Commit()
@@ -292,7 +292,7 @@ func TestRequestTimeout(t *testing.T) {
 
 	group := &routeGroup{RouterGroup: router.Group("/"), authenticationOptional: true, organizationOptional: true}
 	add(a, group, http.MethodGet, "/sleep", route[api.EmptyRequest, *api.EmptyResponse]{
-		handler: func(c *gin.Context, req *api.EmptyRequest) (*api.EmptyResponse, error) {
+		handler: func(rCtx access.RequestContext, req *api.EmptyRequest) (*api.EmptyResponse, error) {
 			ctx := getRequestContext(c)
 
 			_, exist := ctx.Request.Context().Deadline()

--- a/internal/server/scim.go
+++ b/internal/server/scim.go
@@ -3,7 +3,6 @@ package server
 import (
 	"fmt"
 
-	"github.com/gin-gonic/gin"
 	"github.com/scim2/filter-parser/v2"
 
 	"github.com/infrahq/infra/api"
@@ -67,7 +66,7 @@ var deleteProviderUserRoute = route[api.Resource, *api.EmptyResponse]{
 	},
 }
 
-func GetProviderUser(c *gin.Context, r *api.Resource) (*api.SCIMUser, error) {
+func GetProviderUser(rCtx access.RequestContext, r *api.Resource) (*api.SCIMUser, error) {
 	user, err := access.GetProviderUser(getRequestContext(c), r.ID)
 	if err != nil {
 		return nil, err
@@ -75,8 +74,8 @@ func GetProviderUser(c *gin.Context, r *api.Resource) (*api.SCIMUser, error) {
 	return user.ToAPI(), nil
 }
 
-func ListProviderUsers(c *gin.Context, r *api.SCIMParametersRequest) (*api.ListProviderUsersResponse, error) {
-	rCtx := getRequestContext(c)
+func ListProviderUsers(rCtx access.RequestContext, r *api.SCIMParametersRequest) (*api.ListProviderUsersResponse, error) {
+	
 	p := data.SCIMParameters{
 		StartIndex: r.StartIndex,
 		Count:      r.Count,
@@ -104,8 +103,8 @@ func ListProviderUsers(c *gin.Context, r *api.SCIMParametersRequest) (*api.ListP
 	return result, nil
 }
 
-func CreateProviderUser(c *gin.Context, r *api.SCIMUserCreateRequest) (*api.SCIMUser, error) {
-	rCtx := getRequestContext(c)
+func CreateProviderUser(rCtx access.RequestContext, r *api.SCIMUserCreateRequest) (*api.SCIMUser, error) {
+	
 	user := &models.ProviderUser{
 		GivenName:  r.Name.GivenName,
 		FamilyName: r.Name.FamilyName,
@@ -126,8 +125,8 @@ func CreateProviderUser(c *gin.Context, r *api.SCIMUserCreateRequest) (*api.SCIM
 	return user.ToAPI(), nil
 }
 
-func UpdateProviderUser(c *gin.Context, r *api.SCIMUserUpdateRequest) (*api.SCIMUser, error) {
-	rCtx := getRequestContext(c)
+func UpdateProviderUser(rCtx access.RequestContext, r *api.SCIMUserUpdateRequest) (*api.SCIMUser, error) {
+	
 	user := &models.ProviderUser{
 		IdentityID: r.ID,
 		GivenName:  r.Name.GivenName,
@@ -149,8 +148,8 @@ func UpdateProviderUser(c *gin.Context, r *api.SCIMUserUpdateRequest) (*api.SCIM
 	return user.ToAPI(), nil
 }
 
-func PatchProviderUser(c *gin.Context, r *api.SCIMUserPatchRequest) (*api.SCIMUser, error) {
-	rCtx := getRequestContext(c)
+func PatchProviderUser(rCtx access.RequestContext, r *api.SCIMUserPatchRequest) (*api.SCIMUser, error) {
+	
 	// we only support active status patching, so there can only be one operation
 	if len(r.Operations) != 1 || r.Operations[0].Op != "replace" {
 		return nil, internal.ErrBadRequest
@@ -167,6 +166,6 @@ func PatchProviderUser(c *gin.Context, r *api.SCIMUserPatchRequest) (*api.SCIMUs
 	return result.ToAPI(), nil
 }
 
-func DeleteProviderUser(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
+func DeleteProviderUser(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
 	return nil, access.DeleteProviderUser(getRequestContext(c), r.ID)
 }

--- a/internal/server/scim.go
+++ b/internal/server/scim.go
@@ -67,7 +67,7 @@ var deleteProviderUserRoute = route[api.Resource, *api.EmptyResponse]{
 }
 
 func GetProviderUser(rCtx access.RequestContext, r *api.Resource) (*api.SCIMUser, error) {
-	user, err := access.GetProviderUser(getRequestContext(c), r.ID)
+	user, err := access.GetProviderUser(rCtx, r.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,6 @@ func GetProviderUser(rCtx access.RequestContext, r *api.Resource) (*api.SCIMUser
 }
 
 func ListProviderUsers(rCtx access.RequestContext, r *api.SCIMParametersRequest) (*api.ListProviderUsersResponse, error) {
-	
 	p := data.SCIMParameters{
 		StartIndex: r.StartIndex,
 		Count:      r.Count,
@@ -104,7 +103,6 @@ func ListProviderUsers(rCtx access.RequestContext, r *api.SCIMParametersRequest)
 }
 
 func CreateProviderUser(rCtx access.RequestContext, r *api.SCIMUserCreateRequest) (*api.SCIMUser, error) {
-	
 	user := &models.ProviderUser{
 		GivenName:  r.Name.GivenName,
 		FamilyName: r.Name.FamilyName,
@@ -126,7 +124,6 @@ func CreateProviderUser(rCtx access.RequestContext, r *api.SCIMUserCreateRequest
 }
 
 func UpdateProviderUser(rCtx access.RequestContext, r *api.SCIMUserUpdateRequest) (*api.SCIMUser, error) {
-	
 	user := &models.ProviderUser{
 		IdentityID: r.ID,
 		GivenName:  r.Name.GivenName,
@@ -149,7 +146,6 @@ func UpdateProviderUser(rCtx access.RequestContext, r *api.SCIMUserUpdateRequest
 }
 
 func PatchProviderUser(rCtx access.RequestContext, r *api.SCIMUserPatchRequest) (*api.SCIMUser, error) {
-	
 	// we only support active status patching, so there can only be one operation
 	if len(r.Operations) != 1 || r.Operations[0].Op != "replace" {
 		return nil, internal.ErrBadRequest
@@ -167,5 +163,5 @@ func PatchProviderUser(rCtx access.RequestContext, r *api.SCIMUserPatchRequest) 
 }
 
 func DeleteProviderUser(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
-	return nil, access.DeleteProviderUser(getRequestContext(c), r.ID)
+	return nil, access.DeleteProviderUser(rCtx, r.ID)
 }

--- a/internal/server/signup.go
+++ b/internal/server/signup.go
@@ -30,7 +30,6 @@ func (a *API) SignupRoute() route[api.SignupRequest, *api.SignupResponse] {
 }
 
 func (a *API) Signup(rCtx access.RequestContext, r *api.SignupRequest) (*api.SignupResponse, error) {
-
 	if !a.server.options.EnableSignup {
 		return nil, fmt.Errorf("%w: signup is disabled", internal.ErrBadRequest)
 	}
@@ -55,7 +54,7 @@ func (a *API) Signup(rCtx access.RequestContext, r *api.SignupRequest) (*api.Sig
 			RedirectURL: r.Social.RedirectURL,
 			Code:        r.Social.Code,
 		}
-		idpAuth, err := a.socialSignupUserAuth(c, provider, auth)
+		idpAuth, err := a.socialSignupUserAuth(rCtx, provider, auth)
 		if err != nil {
 			return nil, err // make sure to return this error directly for an unauthorized response
 		}
@@ -68,7 +67,7 @@ func (a *API) Signup(rCtx access.RequestContext, r *api.SignupRequest) (*api.Sig
 			Org:       &models.Organization{Name: r.OrgName},
 			SubDomain: r.Subdomain,
 		}
-		created, err = createOrgAndUserForSignup(c, keyExpires, a.server.options.BaseDomain, details)
+		created, err = createOrgAndUserForSignup(rCtx, keyExpires, a.server.options.BaseDomain, details)
 		if err != nil {
 			return nil, handleSignupError(err)
 		}
@@ -82,7 +81,7 @@ func (a *API) Signup(rCtx access.RequestContext, r *api.SignupRequest) (*api.Sig
 			SubDomain: r.Subdomain,
 		}
 		var err error
-		created, err = createOrgAndUserForSignup(c, keyExpires, a.server.options.BaseDomain, details)
+		created, err = createOrgAndUserForSignup(rCtx, keyExpires, a.server.options.BaseDomain, details)
 		if err != nil {
 			return nil, handleSignupError(err)
 		}
@@ -104,7 +103,7 @@ func (a *API) Signup(rCtx access.RequestContext, r *api.SignupRequest) (*api.Sig
 		Domain:  a.server.options.BaseDomain,
 		Expires: time.Now().Add(1 * time.Minute),
 	}
-	setCookie(c.Request, rCtx.Response.HTTPWriter, cookie)
+	setCookie(rCtx.Request, rCtx.Response.HTTPWriter, cookie)
 
 	a.t.User(created.Identity.ID.String(), created.Identity.Name)
 	a.t.Org(created.Organization.ID.String(), created.Identity.ID.String(), created.Organization.Name, created.Organization.Domain)
@@ -143,14 +142,14 @@ func handleSignupError(err error) error {
 }
 
 func (a *API) socialSignupUserAuth(rCtx access.RequestContext, provider *models.Provider, auth *authn.OIDCAuthn) (*providers.IdentityProviderAuth, error) {
-	providerClient, err := a.server.providerClient(c.Request.Context(), provider, auth.RedirectURL)
+	providerClient, err := a.server.providerClient(rCtx.Request.Context(), provider, auth.RedirectURL)
 	if err != nil {
 		return nil, fmt.Errorf("sign-up provider client: %w", err)
 	}
 	auth.OIDCProviderClient = providerClient
 
 	// exchange code for tokens from identity provider (these tokens are for the IDP, not Infra)
-	result, err := auth.OIDCProviderClient.ExchangeAuthCodeForProviderTokens(c, auth.Code)
+	result, err := auth.OIDCProviderClient.ExchangeAuthCodeForProviderTokens(rCtx.Request.Context(), auth.Code)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, fmt.Errorf("%w: %s", internal.ErrBadGateway, err.Error())
@@ -366,10 +365,12 @@ func (a *API) addPreviousVersionHandlersSignup() {
 					OrgName:   reqOld.Org.Name,
 					Subdomain: reqOld.Org.Subdomain,
 				}
+
 				if err := validate.Validate(req); err != nil {
 					return nil, err
 				}
-				return a.Signup(c, req)
+
+				return a.Signup(rCtx, req)
 			},
 		},
 	)

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/infrahq/infra/api"
@@ -20,8 +19,8 @@ import (
 	"github.com/infrahq/infra/internal/validate"
 )
 
-func (a *API) ListUsers(c *gin.Context, r *api.ListUsersRequest) (*api.ListResponse[api.User], error) {
-	rCtx := getRequestContext(c)
+func (a *API) ListUsers(rCtx access.RequestContext, r *api.ListUsersRequest) (*api.ListResponse[api.User], error) {
+
 	p := PaginationFromRequest(r.PaginationRequest)
 
 	opts := data.ListIdentityOptions{
@@ -59,8 +58,8 @@ var getUserRoute = route[api.GetUserRequest, *api.User]{
 	handler: GetUser,
 }
 
-func GetUser(c *gin.Context, r *api.GetUserRequest) (*api.User, error) {
-	rCtx := getRequestContext(c)
+func GetUser(rCtx access.RequestContext, r *api.GetUserRequest) (*api.User, error) {
+
 	if r.ID.IsSelf {
 		iden := rCtx.Authenticated.User
 		if iden == nil {
@@ -81,8 +80,9 @@ func GetUser(c *gin.Context, r *api.GetUserRequest) (*api.User, error) {
 }
 
 // CreateUser creates a user with the Infra provider
-func (a *API) CreateUser(c *gin.Context, r *api.CreateUserRequest) (*api.CreateUserResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) CreateUser(rCtx access.RequestContext, r *api.CreateUserRequest) (*api.CreateUserResponse, error) {
+
+	user := &models.Identity{Name: r.Name}
 
 	user, err := access.GetIdentity(rCtx, data.GetIdentityOptions{ByName: r.Name, LoadProviders: true})
 	switch {
@@ -140,8 +140,7 @@ func (a *API) CreateUser(c *gin.Context, r *api.CreateUserRequest) (*api.CreateU
 	return resp, nil
 }
 
-func (a *API) UpdateUser(c *gin.Context, r *api.UpdateUserRequest) (*api.UpdateUserResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) UpdateUser(rCtx access.RequestContext, r *api.UpdateUserRequest) (*api.UpdateUserResponse, error) {
 
 	if rCtx.Authenticated.User.ID == r.ID {
 		if err := access.UpdateCredential(rCtx, rCtx.Authenticated.User, r.OldPassword, r.Password); err != nil {
@@ -169,8 +168,8 @@ func (a *API) UpdateUser(c *gin.Context, r *api.UpdateUserRequest) (*api.UpdateU
 	}, nil
 }
 
-func (a *API) DeleteUser(c *gin.Context, r *api.Resource) (*api.EmptyResponse, error) {
-	rCtx := getRequestContext(c)
+func (a *API) DeleteUser(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
+
 	if rCtx.Authenticated.User.ID == r.ID {
 		return nil, fmt.Errorf("%w: cannot delete own user", internal.ErrBadRequest)
 	}
@@ -182,8 +181,7 @@ func (a *API) DeleteUser(c *gin.Context, r *api.Resource) (*api.EmptyResponse, e
 	return nil, access.DeleteIdentity(rCtx, r.ID)
 }
 
-func AddUserPublicKey(c *gin.Context, r *api.AddUserPublicKeyRequest) (*api.UserPublicKey, error) {
-	rCtx := getRequestContext(c)
+func AddUserPublicKey(rCtx access.RequestContext, r *api.AddUserPublicKeyRequest) (*api.UserPublicKey, error) {
 
 	// no authz required, because the userID comes from authenticated User.ID
 	if rCtx.Authenticated.User == nil {

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -20,7 +20,6 @@ import (
 )
 
 func (a *API) ListUsers(rCtx access.RequestContext, r *api.ListUsersRequest) (*api.ListResponse[api.User], error) {
-
 	p := PaginationFromRequest(r.PaginationRequest)
 
 	opts := data.ListIdentityOptions{
@@ -59,7 +58,6 @@ var getUserRoute = route[api.GetUserRequest, *api.User]{
 }
 
 func GetUser(rCtx access.RequestContext, r *api.GetUserRequest) (*api.User, error) {
-
 	if r.ID.IsSelf {
 		iden := rCtx.Authenticated.User
 		if iden == nil {
@@ -81,9 +79,6 @@ func GetUser(rCtx access.RequestContext, r *api.GetUserRequest) (*api.User, erro
 
 // CreateUser creates a user with the Infra provider
 func (a *API) CreateUser(rCtx access.RequestContext, r *api.CreateUserRequest) (*api.CreateUserResponse, error) {
-
-	user := &models.Identity{Name: r.Name}
-
 	user, err := access.GetIdentity(rCtx, data.GetIdentityOptions{ByName: r.Name, LoadProviders: true})
 	switch {
 	case errors.Is(err, internal.ErrNotFound):
@@ -141,7 +136,6 @@ func (a *API) CreateUser(rCtx access.RequestContext, r *api.CreateUserRequest) (
 }
 
 func (a *API) UpdateUser(rCtx access.RequestContext, r *api.UpdateUserRequest) (*api.UpdateUserResponse, error) {
-
 	if rCtx.Authenticated.User.ID == r.ID {
 		if err := access.UpdateCredential(rCtx, rCtx.Authenticated.User, r.OldPassword, r.Password); err != nil {
 			return nil, err
@@ -169,7 +163,6 @@ func (a *API) UpdateUser(rCtx access.RequestContext, r *api.UpdateUserRequest) (
 }
 
 func (a *API) DeleteUser(rCtx access.RequestContext, r *api.Resource) (*api.EmptyResponse, error) {
-
 	if rCtx.Authenticated.User.ID == r.ID {
 		return nil, fmt.Errorf("%w: cannot delete own user", internal.ErrBadRequest)
 	}
@@ -182,7 +175,6 @@ func (a *API) DeleteUser(rCtx access.RequestContext, r *api.Resource) (*api.Empt
 }
 
 func AddUserPublicKey(rCtx access.RequestContext, r *api.AddUserPublicKeyRequest) (*api.UserPublicKey, error) {
-
 	// no authz required, because the userID comes from authenticated User.ID
 	if rCtx.Authenticated.User == nil {
 		return nil, fmt.Errorf("missing authentication")


### PR DESCRIPTION
## Summary

Replace `gin.Context` with `RequestContxt` in API handlers. 

After this change, the only place we're using `gin.Context` is in the middleware for logging/metrics, the router, and binding.

Resolves #2796 