### PR TITLE
Remove kin-openapi

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getkin/kin-openapi/openapi3"
-
+	"github.com/infrahq/infra/internal/openapi3"
 	"github.com/infrahq/infra/internal/validate"
 	"github.com/infrahq/infra/uid"
 )

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/coreos/go-oidc/v3 v3.5.0
 	github.com/creack/pty v1.1.18
-	github.com/getkin/kin-openapi v0.112.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-redis/redis_rate/v9 v9.1.2
 	github.com/google/go-cmp v0.5.9
@@ -55,8 +54,6 @@ require (
 	gotest.tools/v3 v3.4.0
 )
 
-require github.com/invopop/yaml v0.1.0 // indirect
-
 require (
 	cloud.google.com/go/compute v1.14.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
@@ -75,7 +72,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdk
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell v1.1.4 h1:6Bubmk3vZvnL9umQ9qTV2kwNQnjaZ4HLAbxR+xR3ATg=
 github.com/gdamore/tcell v1.1.4/go.mod h1:Hjvr+Ofd+gLglo7RYKxxnzCBmev3BzsS67MebKS4zMM=
-github.com/getkin/kin-openapi v0.112.0 h1:lnLXx3bAG53EJVI4E/w0N8i1Y/vUZUEsnrXkgnfn7/Y=
-github.com/getkin/kin-openapi v0.112.0/go.mod h1:QtwUNt0PAAgIIBEvFWYfB7dfngxtAaqCX1zYHMZDeK8=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -251,7 +249,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.7.0 h1:IcsPKeInNvYi7eqSaDjiZqDDKu5rsmunY0Y1YupQSSQ=
 github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57QpBWsYpwqHJx8=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/goware/urlx v0.3.2 h1:gdoo4kBHlkqZNaf6XlQ12LGtQOmpKJrR04Rc3RnpJEo=
 github.com/goware/urlx v0.3.2/go.mod h1:h8uwbJy68o+tQXCGZNa9D73WN8n0r9OBae5bUnLcgjw=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -268,8 +265,6 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/infrahq/gin v1.7.2-0.20220120203023-0eaa562f3a8a h1:0IuR5ELjJz636UzenPRDT5NY1qNOOtQnuiFxRAt+v7Q=
 github.com/infrahq/gin v1.7.2-0.20220120203023-0eaa562f3a8a/go.mod h1:DBqzoPGrzHYPk0x6KcX6JiOjgFMOztPfWkVwlUDYV88=
-github.com/invopop/yaml v0.1.0 h1:YW3WGUoJEXYfzWBjn00zIlrw7brGVD0fUKRYDPAPhrc=
-github.com/invopop/yaml v0.1.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -409,8 +404,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
-github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/muesli/termenv v0.13.0 h1:wK20DRpJdDX8b7Ek2QfhvqhRQFZ237RGRO0RQ/Iqdy0=
 github.com/muesli/termenv v0.13.0/go.mod h1:sP1+uffeLaEYpyOTb8pLCUctGcGLnoFjSn4YJK5e2bc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -938,7 +931,6 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=

--- a/internal/openapi3/openapi3.go
+++ b/internal/openapi3/openapi3.go
@@ -68,28 +68,47 @@ type RequestBody struct {
 // MediaType is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-type-object
 type MediaType struct {
-	Schema   *openapi3.SchemaRef           `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Example  interface{}                   `json:"example,omitempty" yaml:"example,omitempty"`
-	Examples map[string]*openapi3.Example  `json:"examples,omitempty" yaml:"examples,omitempty"`
-	Encoding map[string]*openapi3.Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
+	Schema   *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Example  interface{}         `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples map[string]Example  `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Encoding map[string]Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
 }
 
 // Parameter is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object
 type Parameter struct {
-	AllowEmptyValue bool                `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
-	AllowReserved   bool                `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
-	Deprecated      bool                `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-	Description     string              `json:"description,omitempty" yaml:"description,omitempty"`
-	Example         interface{}         `json:"example,omitempty" yaml:"example,omitempty"`
-	Examples        openapi3.Examples   `json:"examples,omitempty" yaml:"examples,omitempty"`
-	Explode         *bool               `json:"explode,omitempty" yaml:"explode,omitempty"`
-	In              string              `json:"in,omitempty" yaml:"in,omitempty"`
-	Name            string              `json:"name,omitempty" yaml:"name,omitempty"`
-	Required        bool                `json:"required,omitempty" yaml:"required,omitempty"`
-	Schema          *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Style           string              `json:"style,omitempty" yaml:"style,omitempty"`
-	Content         openapi3.Content    `json:"content,omitempty" yaml:"content,omitempty"`
+	AllowEmptyValue bool                  `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	AllowReserved   bool                  `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
+	Deprecated      bool                  `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Description     string                `json:"description,omitempty" yaml:"description,omitempty"`
+	Example         interface{}           `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples        map[string]Example    `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Explode         *bool                 `json:"explode,omitempty" yaml:"explode,omitempty"`
+	In              string                `json:"in,omitempty" yaml:"in,omitempty"`
+	Name            string                `json:"name,omitempty" yaml:"name,omitempty"`
+	Required        bool                  `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema          *openapi3.SchemaRef   `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Style           string                `json:"style,omitempty" yaml:"style,omitempty"`
+	Content         map[string]*MediaType `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+// Example is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#example-object
+type Example struct {
+	Summary       string      `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description   string      `json:"description,omitempty" yaml:"description,omitempty"`
+	Value         interface{} `json:"value,omitempty" yaml:"value,omitempty"`
+	ExternalValue string      `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
+}
+
+// Encoding is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#encoding-object
+type Encoding struct {
+	ContentType   string                `json:"contentType,omitempty" yaml:"contentType,omitempty"`
+	Headers       map[string]*Parameter `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Style         string                `json:"style,omitempty" yaml:"style,omitempty"`
+	Explode       *bool                 `json:"explode,omitempty" yaml:"explode,omitempty"`
+	AllowReserved bool                  `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
 }
 
 // Response is specified by OpenAPI/Swagger 3.0 standard.

--- a/internal/openapi3/openapi3.go
+++ b/internal/openapi3/openapi3.go
@@ -5,12 +5,62 @@ import "github.com/getkin/kin-openapi/openapi3"
 // Doc is the root of an OpenAPI v3 document
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#openapi-object
 type Doc struct {
-	OpenAPI      string                        `json:"openapi" yaml:"openapi"` // Required
-	Components   openapi3.Components           `json:"components,omitempty" yaml:"components,omitempty"`
-	Info         *openapi3.Info                `json:"info" yaml:"info"`   // Required
-	Paths        openapi3.Paths                `json:"paths" yaml:"paths"` // Required
-	Security     openapi3.SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
-	Servers      openapi3.Servers              `json:"servers,omitempty" yaml:"servers,omitempty"`
-	Tags         openapi3.Tags                 `json:"tags,omitempty" yaml:"tags,omitempty"`
-	ExternalDocs *openapi3.ExternalDocs        `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	OpenAPI    string                `json:"openapi" yaml:"openapi"` // Required
+	Components openapi3.Components   `json:"components,omitempty" yaml:"components,omitempty"`
+	Info       *Info                 `json:"info" yaml:"info"`   // Required
+	Paths      openapi3.Paths        `json:"paths" yaml:"paths"` // Required
+	Security   []SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
+	Servers    []Server              `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Tags       []Tag                 `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+// Info is specified by OpenAPI/Swagger standard version 3.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#info-object
+type Info struct {
+	Description    string   `json:"description,omitempty" yaml:"description,omitempty"`
+	TermsOfService string   `json:"termsOfService,omitempty" yaml:"termsOfService,omitempty"`
+	Contact        *Contact `json:"contact,omitempty" yaml:"contact,omitempty"`
+	License        *License `json:"license,omitempty" yaml:"license,omitempty"`
+	Title          string   `json:"title" yaml:"title"`     // Required
+	Version        string   `json:"version" yaml:"version"` // Required
+}
+
+// Contact is specified by OpenAPI/Swagger standard version 3.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#contact-object
+type Contact struct {
+	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL   string `json:"url,omitempty" yaml:"url,omitempty"`
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
+}
+
+// License is specified by OpenAPI/Swagger standard version 3.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#license-object
+type License struct {
+	Name string `json:"name" yaml:"name"` // Required
+	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
+// SecurityRequirement is specified by OpenAPI/Swagger standard version 3.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-requirement-object
+type SecurityRequirement map[string][]string
+
+// Server is specified by OpenAPI/Swagger standard version 3.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-object
+type Server struct {
+	URL         string                     `json:"url" yaml:"url"`
+	Description string                     `json:"description,omitempty" yaml:"description,omitempty"`
+	Variables   map[string]*ServerVariable `json:"variables,omitempty" yaml:"variables,omitempty"`
+}
+
+// ServerVariable is specified by OpenAPI/Swagger standard version 3.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object
+type ServerVariable struct {
+	Enum        []string `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Default     string   `json:"default,omitempty" yaml:"default,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+type Tag struct {
+	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }

--- a/internal/openapi3/openapi3.go
+++ b/internal/openapi3/openapi3.go
@@ -42,8 +42,8 @@ type Operation struct {
 	OperationID string                `json:"operationId,omitempty" yaml:"operationId,omitempty"`
 	Parameters  []*Parameter          `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	RequestBody *RequestBody          `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
-	Responses   openapi3.Responses    `json:"responses" yaml:"responses"` // Required
-	Callbacks   openapi3.Callbacks    `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
+	Responses   map[string]Response   `json:"responses" yaml:"responses"` // Required
+	Callbacks   map[string]Callback   `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
 	Deprecated  bool                  `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	Security    []SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
 	Servers     []Server              `json:"servers,omitempty" yaml:"servers,omitempty"`
@@ -54,6 +54,8 @@ type Operation struct {
 func (o *Operation) AddParameter(p *Parameter) {
 	o.Parameters = append(o.Parameters, p)
 }
+
+type Callback map[string]*PathItem
 
 // RequestBody is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#request-body-object
@@ -88,6 +90,15 @@ type Parameter struct {
 	Schema          *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Style           string              `json:"style,omitempty" yaml:"style,omitempty"`
 	Content         openapi3.Content    `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+// Response is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#response-object
+type Response struct {
+	Content     map[string]*MediaType `json:"content,omitempty" yaml:"content,omitempty"`
+	Description string                `json:"description,omitempty" yaml:"description,omitempty"`
+	Headers     map[string]*Parameter `json:"headers,omitempty" yaml:"headers,omitempty"`
+	// Links are not used yet
 }
 
 // Info is specified by OpenAPI/Swagger standard version 3.

--- a/internal/openapi3/openapi3.go
+++ b/internal/openapi3/openapi3.go
@@ -1,19 +1,26 @@
 package openapi3
 
-import (
-	"github.com/getkin/kin-openapi/openapi3"
-)
-
 // Doc is the root of an OpenAPI v3 document
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#openapi-object
 type Doc struct {
 	OpenAPI    string                `json:"openapi" yaml:"openapi"` // Required
-	Components openapi3.Components   `json:"components,omitempty" yaml:"components,omitempty"`
+	Components Components            `json:"components,omitempty" yaml:"components,omitempty"`
 	Info       *Info                 `json:"info" yaml:"info"`   // Required
 	Paths      map[string]*PathItem  `json:"paths" yaml:"paths"` // Required
 	Security   []SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
 	Servers    []Server              `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Tags       []Tag                 `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+// Components is specified by OpenAPI/Swagger standard version 3.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#components-object
+type Components struct {
+	Schemas    map[string]*SchemaRef `json:"schemas,omitempty" yaml:"schemas,omitempty"`
+	Parameters map[string]*Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Headers    map[string]*Parameter `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Responses  map[string]Response   `json:"responses,omitempty" yaml:"responses,omitempty"`
+	Examples   map[string]Example    `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Callbacks  map[string]Callback   `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
 }
 
 // PathItem is specified by OpenAPI/Swagger standard version 3.
@@ -68,7 +75,7 @@ type RequestBody struct {
 // MediaType is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-type-object
 type MediaType struct {
-	Schema   *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Schema   *SchemaRef          `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Example  interface{}         `json:"example,omitempty" yaml:"example,omitempty"`
 	Examples map[string]Example  `json:"examples,omitempty" yaml:"examples,omitempty"`
 	Encoding map[string]Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
@@ -87,9 +94,55 @@ type Parameter struct {
 	In              string                `json:"in,omitempty" yaml:"in,omitempty"`
 	Name            string                `json:"name,omitempty" yaml:"name,omitempty"`
 	Required        bool                  `json:"required,omitempty" yaml:"required,omitempty"`
-	Schema          *openapi3.SchemaRef   `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Schema          *SchemaRef            `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Style           string                `json:"style,omitempty" yaml:"style,omitempty"`
 	Content         map[string]*MediaType `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+// SchemaRef represents either a Schema or a $ref to a Schema.
+// When serializing and both fields are set, Ref is preferred over Value.
+type SchemaRef struct {
+	Ref     string `json:"$ref,omitempty"`
+	*Schema `json:",inline,omitempty"`
+}
+
+// Schema is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schema-object
+type Schema struct {
+	AdditionalProperties        *SchemaRef            `multijson:"additionalProperties,omitempty" json:"-" yaml:"-"`
+	AdditionalPropertiesAllowed *bool                 `multijson:"additionalProperties,omitempty" json:"-" yaml:"-"`
+	AllOf                       []*SchemaRef          `json:"allOf,omitempty" yaml:"allOf,omitempty"`
+	AllowEmptyValue             bool                  `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	AnyOf                       []*SchemaRef          `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
+	Default                     interface{}           `json:"default,omitempty" yaml:"default,omitempty"`
+	Deprecated                  bool                  `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Description                 string                `json:"description,omitempty" yaml:"description,omitempty"`
+	Enum                        []interface{}         `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Example                     interface{}           `json:"example,omitempty" yaml:"example,omitempty"`
+	ExclusiveMax                bool                  `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	ExclusiveMin                bool                  `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	Format                      string                `json:"format,omitempty" yaml:"format,omitempty"`
+	Items                       *SchemaRef            `json:"items,omitempty" yaml:"items,omitempty"`
+	Max                         *float64              `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	MaxItems                    *uint64               `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	MaxLength                   *uint64               `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MaxProps                    *uint64               `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
+	Min                         *float64              `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	MinItems                    uint64                `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	MinLength                   uint64                `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	MinProps                    uint64                `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	MultipleOf                  *float64              `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Not                         *SchemaRef            `json:"not,omitempty" yaml:"not,omitempty"`
+	Nullable                    bool                  `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	OneOf                       []*SchemaRef          `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+	Pattern                     string                `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Properties                  map[string]*SchemaRef `json:"properties,omitempty" yaml:"properties,omitempty"`
+	ReadOnly                    bool                  `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
+	Required                    []string              `json:"required,omitempty" yaml:"required,omitempty"`
+	Title                       string                `json:"title,omitempty" yaml:"title,omitempty"`
+	Type                        string                `json:"type,omitempty" yaml:"type,omitempty"`
+	UniqueItems                 bool                  `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	WriteOnly                   bool                  `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"`
 }
 
 // Example is specified by OpenAPI/Swagger 3.0 standard.

--- a/internal/openapi3/openapi3.go
+++ b/internal/openapi3/openapi3.go
@@ -1,6 +1,8 @@
 package openapi3
 
-import "github.com/getkin/kin-openapi/openapi3"
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+)
 
 // Doc is the root of an OpenAPI v3 document
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#openapi-object
@@ -8,10 +10,67 @@ type Doc struct {
 	OpenAPI    string                `json:"openapi" yaml:"openapi"` // Required
 	Components openapi3.Components   `json:"components,omitempty" yaml:"components,omitempty"`
 	Info       *Info                 `json:"info" yaml:"info"`   // Required
-	Paths      openapi3.Paths        `json:"paths" yaml:"paths"` // Required
+	Paths      map[string]*PathItem  `json:"paths" yaml:"paths"` // Required
 	Security   []SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
 	Servers    []Server              `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Tags       []Tag                 `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+// PathItem is specified by OpenAPI/Swagger standard version 3.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#path-item-object
+type PathItem struct {
+	Ref         string       `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	Summary     string       `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string       `json:"description,omitempty" yaml:"description,omitempty"`
+	Connect     *Operation   `json:"connect,omitempty" yaml:"connect,omitempty"`
+	Delete      *Operation   `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Get         *Operation   `json:"get,omitempty" yaml:"get,omitempty"`
+	Head        *Operation   `json:"head,omitempty" yaml:"head,omitempty"`
+	Options     *Operation   `json:"options,omitempty" yaml:"options,omitempty"`
+	Patch       *Operation   `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Post        *Operation   `json:"post,omitempty" yaml:"post,omitempty"`
+	Put         *Operation   `json:"put,omitempty" yaml:"put,omitempty"`
+	Trace       *Operation   `json:"trace,omitempty" yaml:"trace,omitempty"`
+	Servers     []Server     `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Parameters  []*Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+}
+
+// Operation represents "operation" specified by" OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object
+type Operation struct {
+	Description string                   `json:"description,omitempty" yaml:"description,omitempty"`
+	OperationID string                   `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Parameters  []*Parameter             `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	RequestBody *openapi3.RequestBodyRef `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Responses   openapi3.Responses       `json:"responses" yaml:"responses"` // Required
+	Callbacks   openapi3.Callbacks       `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
+	Deprecated  bool                     `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Security    []SecurityRequirement    `json:"security,omitempty" yaml:"security,omitempty"`
+	Servers     []Server                 `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Summary     string                   `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Tags        []string                 `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+func (o *Operation) AddParameter(p *Parameter) {
+	o.Parameters = append(o.Parameters, p)
+}
+
+// Parameter is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object
+type Parameter struct {
+	AllowEmptyValue bool                `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	AllowReserved   bool                `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
+	Deprecated      bool                `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Description     string              `json:"description,omitempty" yaml:"description,omitempty"`
+	Example         interface{}         `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples        openapi3.Examples   `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Explode         *bool               `json:"explode,omitempty" yaml:"explode,omitempty"`
+	In              string              `json:"in,omitempty" yaml:"in,omitempty"`
+	Name            string              `json:"name,omitempty" yaml:"name,omitempty"`
+	Required        bool                `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema          *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Style           string              `json:"style,omitempty" yaml:"style,omitempty"`
+	Content         openapi3.Content    `json:"content,omitempty" yaml:"content,omitempty"`
 }
 
 // Info is specified by OpenAPI/Swagger standard version 3.

--- a/internal/openapi3/openapi3.go
+++ b/internal/openapi3/openapi3.go
@@ -1,0 +1,16 @@
+package openapi3
+
+import "github.com/getkin/kin-openapi/openapi3"
+
+// Doc is the root of an OpenAPI v3 document
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#openapi-object
+type Doc struct {
+	OpenAPI      string                        `json:"openapi" yaml:"openapi"` // Required
+	Components   openapi3.Components           `json:"components,omitempty" yaml:"components,omitempty"`
+	Info         *openapi3.Info                `json:"info" yaml:"info"`   // Required
+	Paths        openapi3.Paths                `json:"paths" yaml:"paths"` // Required
+	Security     openapi3.SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
+	Servers      openapi3.Servers              `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Tags         openapi3.Tags                 `json:"tags,omitempty" yaml:"tags,omitempty"`
+	ExternalDocs *openapi3.ExternalDocs        `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+}

--- a/internal/openapi3/openapi3.go
+++ b/internal/openapi3/openapi3.go
@@ -38,21 +38,38 @@ type PathItem struct {
 // Operation represents "operation" specified by" OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object
 type Operation struct {
-	Description string                   `json:"description,omitempty" yaml:"description,omitempty"`
-	OperationID string                   `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-	Parameters  []*Parameter             `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	RequestBody *openapi3.RequestBodyRef `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
-	Responses   openapi3.Responses       `json:"responses" yaml:"responses"` // Required
-	Callbacks   openapi3.Callbacks       `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
-	Deprecated  bool                     `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-	Security    []SecurityRequirement    `json:"security,omitempty" yaml:"security,omitempty"`
-	Servers     []Server                 `json:"servers,omitempty" yaml:"servers,omitempty"`
-	Summary     string                   `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Tags        []string                 `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Description string                `json:"description,omitempty" yaml:"description,omitempty"`
+	OperationID string                `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Parameters  []*Parameter          `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	RequestBody *RequestBody          `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Responses   openapi3.Responses    `json:"responses" yaml:"responses"` // Required
+	Callbacks   openapi3.Callbacks    `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
+	Deprecated  bool                  `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Security    []SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
+	Servers     []Server              `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Summary     string                `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Tags        []string              `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 func (o *Operation) AddParameter(p *Parameter) {
 	o.Parameters = append(o.Parameters, p)
+}
+
+// RequestBody is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#request-body-object
+type RequestBody struct {
+	Description string                `json:"description,omitempty" yaml:"description,omitempty"`
+	Required    bool                  `json:"required,omitempty" yaml:"required,omitempty"`
+	Content     map[string]*MediaType `json:"content" yaml:"content"`
+}
+
+// MediaType is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-type-object
+type MediaType struct {
+	Schema   *openapi3.SchemaRef           `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Example  interface{}                   `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples map[string]*openapi3.Example  `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Encoding map[string]*openapi3.Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
 }
 
 // Parameter is specified by OpenAPI/Swagger 3.0 standard.

--- a/internal/openapigen/main.go
+++ b/internal/openapigen/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server"
 )
 
@@ -22,5 +21,5 @@ func run(args []string) error {
 	filename := args[0]
 
 	doc := server.GenerateOpenAPIDoc()
-	return server.WriteOpenAPIDocToFile(doc, internal.FullVersion(), filename)
+	return server.WriteOpenAPIDocToFile(doc, filename)
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -11,11 +11,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"gopkg.in/square/go-jose.v2"
 
-	openapi3b "github.com/infrahq/infra/internal/openapi3"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
+	openapi3b "github.com/infrahq/infra/internal/openapi3"
 	"github.com/infrahq/infra/internal/server/authn"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
-	openapi3b "github.com/infrahq/infra/internal/openapi3"
+	"github.com/infrahq/infra/internal/openapi3"
 	"github.com/infrahq/infra/internal/server/authn"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -24,7 +24,7 @@ import (
 type API struct {
 	t          *Telemetry
 	server     *Server
-	openAPIDoc openapi3b.Doc
+	openAPIDoc openapi3.Doc
 	versions   map[routeIdentifier][]routeVersion
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin"
 	"gopkg.in/square/go-jose.v2"
+
+	openapi3b "github.com/infrahq/infra/internal/openapi3"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
@@ -24,7 +25,7 @@ import (
 type API struct {
 	t          *Telemetry
 	server     *Server
-	openAPIDoc openapi3.T
+	openAPIDoc openapi3b.Doc
 	versions   map[routeIdentifier][]routeVersion
 }
 

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -218,19 +218,22 @@ func buildProperty(f reflect.StructField, t, parent reflect.Type, parentSchema *
 func newOpenAPIDoc(version string) openapi3b.Doc {
 	doc := openapi3b.Doc{}
 	doc.OpenAPI = "3.0.0"
-	doc.Info = &openapi3.Info{
+	doc.Info = &openapi3b.Info{
 		Title:       "Infra API",
 		Version:     version,
 		Description: "Infra API",
-		License:     &openapi3.License{Name: "Elastic License v2.0", URL: "https://www.elastic.co/licensing/elastic-license"},
+		License: &openapi3b.License{
+			Name: "Elastic License v2.0",
+			URL:  "https://www.elastic.co/licensing/elastic-license",
+		},
 	}
-	doc.Servers = []*openapi3.Server{
+	doc.Servers = []openapi3b.Server{
 		{URL: "https://api.infrahq.com"},
 	}
 	return doc
 }
 
-func writeOpenAPISpec(spec openapi3b.Doc, out io.Writer) error {
+func writeOpenAPIDoc(spec openapi3b.Doc, out io.Writer) error {
 	encoder := json.NewEncoder(out)
 	encoder.SetIndent("", "  ")
 
@@ -246,10 +249,7 @@ func WriteOpenAPIDocToFile(openAPIDoc openapi3b.Doc, filename string) error {
 		return err
 	}
 	defer fh.Close()
-	if err := writeOpenAPISpec(openAPIDoc, fh); err != nil {
-		return err
-	}
-	return nil
+	return writeOpenAPIDoc(openAPIDoc, fh)
 }
 
 func updateSchemaFromStructTags(field reflect.StructField, schema *openapi3.Schema) {

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -214,17 +214,22 @@ func buildProperty(f reflect.StructField, t, parent reflect.Type, parentSchema *
 	return &openapi3.SchemaRef{Value: s}
 }
 
-func writeOpenAPISpec(spec openapi3.T, version string, out io.Writer) error {
-	spec.OpenAPI = "3.0.0"
-	spec.Info = &openapi3.Info{
+func newOpenAPIDoc(version string) openapi3.T {
+	doc := openapi3.T{}
+	doc.OpenAPI = "3.0.0"
+	doc.Info = &openapi3.Info{
 		Title:       "Infra API",
 		Version:     version,
 		Description: "Infra API",
 		License:     &openapi3.License{Name: "Elastic License v2.0", URL: "https://www.elastic.co/licensing/elastic-license"},
 	}
-	spec.Servers = []*openapi3.Server{
+	doc.Servers = []*openapi3.Server{
 		{URL: "https://api.infrahq.com"},
 	}
+	return doc
+}
+
+func writeOpenAPISpec(spec openapi3.T, out io.Writer) error {
 	encoder := json.NewEncoder(out)
 	encoder.SetIndent("", "  ")
 
@@ -234,13 +239,13 @@ func writeOpenAPISpec(spec openapi3.T, version string, out io.Writer) error {
 	return nil
 }
 
-func WriteOpenAPIDocToFile(openAPIDoc openapi3.T, version string, filename string) error {
+func WriteOpenAPIDocToFile(openAPIDoc openapi3.T, filename string) error {
 	fh, err := os.Create(filename)
 	if err != nil {
 		return err
 	}
 	defer fh.Close()
-	if err := writeOpenAPISpec(openAPIDoc, version, fh); err != nil {
+	if err := writeOpenAPISpec(openAPIDoc, fh); err != nil {
 		return err
 	}
 	return nil

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -512,14 +512,10 @@ func buildRequest(r reflect.Type, op *openapi3b.Operation, method string, requir
 	switch method {
 	// These methods accept arguments from a request body
 	case http.MethodPut, http.MethodPost, http.MethodPatch:
-		op.RequestBody = &openapi3.RequestBodyRef{
-			Value: &openapi3.RequestBody{
-				Content: openapi3.Content{
-					"application/json": &openapi3.MediaType{
-						Schema: &openapi3.SchemaRef{
-							Value: schema,
-						},
-					},
+		op.RequestBody = &openapi3b.RequestBody{
+			Content: map[string]*openapi3b.MediaType{
+				"application/json": {
+					Schema: &openapi3.SchemaRef{Value: schema},
 				},
 			},
 		}

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -316,11 +316,7 @@ func setTypeInfo(t reflect.Type, schema *openapi3.Schema) {
 	}
 }
 
-func pstr(s string) *string {
-	return &s
-}
-
-func buildResponse(schemas openapi3.Schemas, rst reflect.Type) openapi3.Responses {
+func buildResponse(schemas openapi3.Schemas, rst reflect.Type) map[string]openapi3b.Response {
 	schema := &openapi3.SchemaRef{
 		Value: &openapi3.Schema{Type: "object"},
 	}
@@ -329,57 +325,40 @@ func buildResponse(schemas openapi3.Schemas, rst reflect.Type) openapi3.Response
 		schema = createComponent(schemas, rst)
 	}
 
-	resp := openapi3.NewResponses()
-	resp["default"] = &openapi3.ResponseRef{
-		Value: &openapi3.Response{
-			Description: pstr("Success"),
-			Content: openapi3.Content{
-				"application/json": &openapi3.MediaType{
-					Schema: schema,
-				},
+	content := map[string]*openapi3b.MediaType{
+		"application/json": {
+			Schema: createComponent(schemas, reflect.TypeOf(api.Error{})),
+		},
+	}
+
+	resp := map[string]openapi3b.Response{
+		"default": {
+			Description: "Success",
+			Content: map[string]*openapi3b.MediaType{
+				"application/json": {Schema: schema},
 			},
 		},
-	}
-
-	content := openapi3.Content{"application/json": &openapi3.MediaType{
-		Schema: createComponent(schemas, reflect.TypeOf(api.Error{})),
-	}}
-
-	resp["400"] = &openapi3.ResponseRef{
-		Value: &openapi3.Response{
-			Description: pstr("Bad Request"),
+		"400": {
+			Description: "Bad Request",
+			Content:     content,
+		},
+		"401": {
+			Description: "Unauthorized: Requestor is not authenticated",
+			Content:     content,
+		},
+		"403": {
+			Description: "Forbidden: Requestor does not have the right permissions",
+			Content:     content,
+		},
+		"409": {
+			Description: "Duplicate Record",
+			Content:     content,
+		},
+		"404": {
+			Description: "Not Found",
 			Content:     content,
 		},
 	}
-
-	resp["401"] = &openapi3.ResponseRef{
-		Value: &openapi3.Response{
-			Description: pstr("Unauthorized: Requestor is not authenticated"),
-			Content:     content,
-		},
-	}
-
-	resp["403"] = &openapi3.ResponseRef{
-		Value: &openapi3.Response{
-			Description: pstr("Forbidden: Requestor does not have the right permissions"),
-			Content:     content,
-		},
-	}
-
-	resp["409"] = &openapi3.ResponseRef{ // also used for Conflict
-		Value: &openapi3.Response{
-			Description: pstr("Duplicate Record"),
-			Content:     content,
-		},
-	}
-
-	resp["404"] = &openapi3.ResponseRef{
-		Value: &openapi3.Response{
-			Description: pstr("Not Found"),
-			Content:     content,
-		},
-	}
-
 	return resp
 }
 

--- a/internal/server/openapi.go
+++ b/internal/server/openapi.go
@@ -17,10 +17,11 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
+	openapi3b "github.com/infrahq/infra/internal/openapi3"
 	"github.com/infrahq/infra/internal/validate"
 )
 
-func GenerateOpenAPIDoc() openapi3.T {
+func GenerateOpenAPIDoc() openapi3b.Doc {
 	srv := newServer(Options{})
 	srv.metricsRegistry = prometheus.NewRegistry()
 	return srv.GenerateRoutes().OpenAPIDocument
@@ -214,8 +215,8 @@ func buildProperty(f reflect.StructField, t, parent reflect.Type, parentSchema *
 	return &openapi3.SchemaRef{Value: s}
 }
 
-func newOpenAPIDoc(version string) openapi3.T {
-	doc := openapi3.T{}
+func newOpenAPIDoc(version string) openapi3b.Doc {
+	doc := openapi3b.Doc{}
 	doc.OpenAPI = "3.0.0"
 	doc.Info = &openapi3.Info{
 		Title:       "Infra API",
@@ -229,7 +230,7 @@ func newOpenAPIDoc(version string) openapi3.T {
 	return doc
 }
 
-func writeOpenAPISpec(spec openapi3.T, out io.Writer) error {
+func writeOpenAPISpec(spec openapi3b.Doc, out io.Writer) error {
 	encoder := json.NewEncoder(out)
 	encoder.SetIndent("", "  ")
 
@@ -239,7 +240,7 @@ func writeOpenAPISpec(spec openapi3.T, out io.Writer) error {
 	return nil
 }
 
-func WriteOpenAPIDocToFile(openAPIDoc openapi3.T, filename string) error {
+func WriteOpenAPIDocToFile(openAPIDoc openapi3b.Doc, filename string) error {
 	fh, err := os.Create(filename)
 	if err != nil {
 		return err

--- a/internal/server/openapi_test.go
+++ b/internal/server/openapi_test.go
@@ -38,5 +38,4 @@ func patchProductVersion(t *testing.T, version string) {
 	t.Cleanup(func() {
 		productVersion = orig
 	})
-
 }

--- a/internal/server/openapi_test.go
+++ b/internal/server/openapi_test.go
@@ -22,7 +22,7 @@ func TestWriteOpenAPIDocToFile(t *testing.T) {
 	routes := s.GenerateRoutes()
 
 	filename := filepath.Join(t.TempDir(), "openapi3.json")
-	err := WriteOpenAPIDocToFile(routes.OpenAPIDocument, "0.0.0", filename)
+	err := WriteOpenAPIDocToFile(routes.OpenAPIDocument, filename)
 	assert.NilError(t, err)
 
 	actual, err := os.ReadFile(filename)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -18,7 +18,7 @@ import (
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
-	openapi3b "github.com/infrahq/infra/internal/openapi3"
+	"github.com/infrahq/infra/internal/openapi3"
 	"github.com/infrahq/infra/internal/validate"
 	"github.com/infrahq/infra/metrics"
 )
@@ -26,7 +26,7 @@ import (
 // Routes is the return value of GenerateRoutes.
 type Routes struct {
 	http.Handler
-	OpenAPIDocument openapi3b.Doc
+	OpenAPIDocument openapi3.Doc
 	api             *API
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -14,12 +14,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 
-	openapi3b "github.com/infrahq/infra/internal/openapi3"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
+	openapi3b "github.com/infrahq/infra/internal/openapi3"
 	"github.com/infrahq/infra/internal/validate"
 	"github.com/infrahq/infra/metrics"
 )

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -11,9 +11,10 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
+
+	openapi3b "github.com/infrahq/infra/internal/openapi3"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
@@ -26,7 +27,7 @@ import (
 // Routes is the return value of GenerateRoutes.
 type Routes struct {
 	http.Handler
-	OpenAPIDocument openapi3.T
+	OpenAPIDocument openapi3b.Doc
 	api             *API
 }
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -40,7 +40,7 @@ type Routes struct {
 // with all the middleware that will apply to the route when the
 // Router.{GET,POST,etc} method is called.
 func (s *Server) GenerateRoutes() Routes {
-	a := &API{t: s.tel, server: s}
+	a := &API{t: s.tel, server: s, openAPIDoc: newOpenAPIDoc(productVersion())}
 
 	router := gin.New()
 	router.NoRoute(a.notFoundHandler)

--- a/internal/validate/date.go
+++ b/internal/validate/date.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 type DateRule struct {

--- a/internal/validate/email.go
+++ b/internal/validate/email.go
@@ -5,7 +5,7 @@ import (
 	"net/mail"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 // Email validates a field that should contain an email address.

--- a/internal/validate/email_test.go
+++ b/internal/validate/email_test.go
@@ -97,7 +97,7 @@ func TestEmail_DescribeSchema(t *testing.T) {
 	e.DescribeSchema(&schema)
 	expected := openapi3.Schema{
 		Properties: map[string]*openapi3.SchemaRef{
-			"addrField": &openapi3.SchemaRef{
+			"addrField": {
 				Schema: &openapi3.Schema{Format: "email"},
 			},
 		},

--- a/internal/validate/email_test.go
+++ b/internal/validate/email_test.go
@@ -3,8 +3,9 @@ package validate
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
 	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 type EmailExample struct {
@@ -95,9 +96,9 @@ func TestEmail_DescribeSchema(t *testing.T) {
 	var schema openapi3.Schema
 	e.DescribeSchema(&schema)
 	expected := openapi3.Schema{
-		Properties: openapi3.Schemas{
+		Properties: map[string]*openapi3.SchemaRef{
 			"addrField": &openapi3.SchemaRef{
-				Value: &openapi3.Schema{Format: "email"},
+				Schema: &openapi3.Schema{Format: "email"},
 			},
 		},
 	}

--- a/internal/validate/numbers.go
+++ b/internal/validate/numbers.go
@@ -3,7 +3,7 @@ package validate
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 type IntRule struct {

--- a/internal/validate/numbers_test.go
+++ b/internal/validate/numbers_test.go
@@ -69,7 +69,7 @@ func TestIntRule_DescribeSchema(t *testing.T) {
 
 	expected := openapi3.Schema{
 		Properties: map[string]*openapi3.SchemaRef{
-			"count": &openapi3.SchemaRef{
+			"count": {
 				Schema: &openapi3.Schema{
 					Min: float64Ptr(3),
 					Max: float64Ptr(5),

--- a/internal/validate/numbers_test.go
+++ b/internal/validate/numbers_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
 	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 type IntExample struct {
@@ -67,9 +68,9 @@ func TestIntRule_DescribeSchema(t *testing.T) {
 	i.DescribeSchema(&schema)
 
 	expected := openapi3.Schema{
-		Properties: openapi3.Schemas{
+		Properties: map[string]*openapi3.SchemaRef{
 			"count": &openapi3.SchemaRef{
-				Value: &openapi3.Schema{
+				Schema: &openapi3.Schema{
 					Min: float64Ptr(3),
 					Max: float64Ptr(5),
 				},

--- a/internal/validate/slice.go
+++ b/internal/validate/slice.go
@@ -3,7 +3,7 @@ package validate
 import (
 	"fmt"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 type SliceRule struct {

--- a/internal/validate/string.go
+++ b/internal/validate/string.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 type StringRule struct {

--- a/internal/validate/string_test.go
+++ b/internal/validate/string_test.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 type StringExample struct {
@@ -118,9 +119,9 @@ func TestStringRule_DescribeSchema(t *testing.T) {
 
 	var max uint64 = 10
 	expected := openapi3.Schema{
-		Properties: openapi3.Schemas{
-			"street": &openapi3.SchemaRef{
-				Value: &openapi3.Schema{
+		Properties: map[string]*openapi3.SchemaRef{
+			"street": {
+				Schema: &openapi3.Schema{
 					MinLength: 2,
 					MaxLength: &max,
 					Format:    `[A-Z.\-]`,
@@ -178,9 +179,9 @@ func TestEnum_DescribeSchema(t *testing.T) {
 	e.DescribeSchema(&schema)
 
 	expected := openapi3.Schema{
-		Properties: openapi3.Schemas{
-			"kind": &openapi3.SchemaRef{
-				Value: &openapi3.Schema{
+		Properties: map[string]*openapi3.SchemaRef{
+			"kind": {
+				Schema: &openapi3.Schema{
 					Enum: []interface{}{"car", "truck", "bus"},
 				},
 			},

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 // Validate that the values in the Request struct are valid according to the
@@ -211,7 +211,7 @@ func (m requireAnyOf) Validate() *Failure {
 func (m requireAnyOf) DescribeSchema(schema *openapi3.Schema) {
 	for _, f := range m {
 		schema.AnyOf = append(schema.AnyOf, &openapi3.SchemaRef{
-			Value: &openapi3.Schema{Required: []string{f.Name}},
+			Schema: &openapi3.Schema{Required: []string{f.Name}},
 		})
 	}
 }
@@ -247,19 +247,19 @@ func (m requireOneOf) Validate() *Failure {
 func (m requireOneOf) DescribeSchema(schema *openapi3.Schema) {
 	for _, f := range m {
 		schema.OneOf = append(schema.OneOf, &openapi3.SchemaRef{
-			Value: &openapi3.Schema{Required: []string{f.Name}},
+			Schema: &openapi3.Schema{Required: []string{f.Name}},
 		})
 	}
 }
 
 func schemaForProperty(parent *openapi3.Schema, prop string) *openapi3.Schema {
 	if parent.Properties == nil {
-		parent.Properties = make(openapi3.Schemas)
+		parent.Properties = make(map[string]*openapi3.SchemaRef)
 	}
 	if parent.Properties[prop] == nil {
-		parent.Properties[prop] = &openapi3.SchemaRef{Value: &openapi3.Schema{}}
+		parent.Properties[prop] = &openapi3.SchemaRef{Schema: &openapi3.Schema{}}
 	}
-	return parent.Properties[prop].Value
+	return parent.Properties[prop].Schema
 }
 
 func fieldName(f reflect.StructField) string {

--- a/uid/snowid.go
+++ b/uid/snowid.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/infrahq/infra/internal/openapi3"
 )
 
 var (


### PR DESCRIPTION
## Summary

We only used this library for the struct definitions to mirror the openapi 3 specification. In #4061 dependabot failed to update this dependency because of new unexported fields on those structures.

The commit history here is a bit messy, just saving progress as I go. Probably best viewed as a single diff, and I may remove the intermediate history when I merge.

We don't need much of the complexity in the internal structure (custom json encoding, external references, etc), and we don't use any of the other code in this library.

This PR removes the dependency, and replaces it with a few struct definitions. I omitted a few of the fringe fields that we don't use and are unlikely to ever use. There are still plenty of fields we could trim, but we could also keep them since it's more likely we use them in the future.

In a bunch of places I removed the types that aliased slices and maps, to make it easier to construct the document. I also removed the `Ref` types in a few places where we don't use them.

I also sorted the fields on the struct so that our JSON document did not change. `kin-openapi` was relying on custom json encoding to make that work.

This change only removes a couple dependencies so far, because some of the dependencies are shared by `gin`. When we remove `gin` I think we'll see a lot more of them removed.

The `TestWriteOpenAPIDocToFile` test shows that our JSON document has not changed, and that's the only place where we use these types, so we should be confident that this change hasn't accidentally modified our docs.