### PR TITLE
fix: save new org to visited orgs on google signup

### DIFF
--- a/ui/pages/signup/callback.js
+++ b/ui/pages/signup/callback.js
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/router'
 
 import { useServerConfig } from '../../lib/serverconfig'
+import { saveToVisitedOrgs } from '../../lib/login'
 import LoginLayout from '../../components/layouts/login'
 import OrgSignup from '../../components/org-signup'
 
@@ -55,6 +56,7 @@ export default function Callback() {
 
       // redirect to the new org subdomain
       let created = await jsonBody(res)
+      saveToVisitedOrgs(`${created?.organization?.domain}`, orgName)
 
       window.location = `${window.location.protocol}//${created?.organization?.domain}`
     } catch (e) {


### PR DESCRIPTION
## Summary
Update the "visited orgs" cookie when a new org signs up using Google.

## Checklist
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

Resolves #4077
