### PR TITLE
fix: remove signup redirect cookie after sign-up finishes

### DIFF
--- a/ui/pages/signup/callback.js
+++ b/ui/pages/signup/callback.js
@@ -56,6 +56,7 @@ export default function Callback() {
       // redirect to the new org subdomain
       let created = await jsonBody(res)
 
+      window.localStorage.removeItem('redirectURL')
       window.location = `${window.location.protocol}//${created?.organization?.domain}`
     } catch (e) {
       setError(e.message)


### PR DESCRIPTION
## Summary
In some rare cases (signing up across different environments) not removing the "redirectURL" cookie after sign-up would cause the redirect to take the user to whatever org they signed up with previously. Removing the "redirectURL" cookie after sign-up ensures that the user is always redirected to the org they just created.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
