### PR TITLE
fix: check password policy for username/password signup

### DIFF
--- a/api/signup.go
+++ b/api/signup.go
@@ -42,13 +42,6 @@ func (r SignupUser) ValidationRules() []validate.ValidationRule {
 		validate.Required("username", r.UserName),
 		validate.Email("username", r.UserName),
 		validate.Required("password", r.Password),
-		// check the admin user's password requirements against our basic password requirements
-		validate.StringRule{
-			Name:      "password",
-			Value:     r.Password,
-			MinLength: 8,
-			MaxLength: 253,
-		},
 	}
 }
 

--- a/internal/access/credential_test.go
+++ b/internal/access/credential_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"testing"
 
+	"golang.org/x/crypto/bcrypt"
 	"gotest.tools/v3/assert"
 
 	"github.com/infrahq/infra/internal/server/data"
@@ -99,13 +100,15 @@ func TestResetCredentials(t *testing.T) {
 	})
 }
 
-func TestCheckPasswordRequirements(t *testing.T) {
-	rCtx := setupAccessTestContext(t)
+func TestGenerateFromPassword(t *testing.T) {
 	t.Run("default password requirements", func(t *testing.T) {
-		err := checkPasswordRequirements(rCtx.DBTxn, "password")
+		hash, err := GenerateFromPassword("password")
 		assert.NilError(t, err)
 
-		err = checkPasswordRequirements(rCtx.DBTxn, "passwor")
+		err = bcrypt.CompareHashAndPassword(hash, []byte("password"))
+		assert.NilError(t, err)
+
+		_, err = GenerateFromPassword("passwor")
 		assert.DeepEqual(t, err, validate.Error{
 			"password": []string{"8 characters"},
 		})

--- a/internal/server/signup.go
+++ b/internal/server/signup.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
@@ -247,7 +246,7 @@ func createOrgAndUserForSignup(c *gin.Context, keyExpiresAt time.Time, baseDomai
 			return nil, err
 		}
 
-		hash, err := bcrypt.GenerateFromPassword([]byte(details.User.Password), bcrypt.DefaultCost)
+		hash, err := access.GenerateFromPassword(details.User.Password)
 		if err != nil {
 			return nil, fmt.Errorf("hash password on sign-up: %w", err)
 		}


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Check password policy when signing up with username and password. The signup endpoint previously was not using the same password policy checker as every other similar endpoints. This means when the bad passwords checking was added in #3963, signup was missed.

Resolves #4076 
