### PR TITLE
fix: invite when user exists

### DIFF
--- a/internal/server/passwordreset_test.go
+++ b/internal/server/passwordreset_test.go
@@ -26,6 +26,8 @@ func patchEmailTestMode(t *testing.T, testKey string) {
 		email.TestData = make([]any, 0)
 		email.SendgridAPIKey = originalSendgridAPIKey
 	})
+
+	assert.Assert(t, email.IsConfigured())
 }
 
 func TestPasswordResetFlow(t *testing.T) {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Email invite can be sent to a user who already has a password setup. This regression introduced in #4012 which changed when a user credential was created. Previously creating a user unconditionally creates the user credential which would fix any duplicates when saving to the database. 

Since the linked changed, credentials are created for the invited user only when they accept the email invite. The missing piece is checking for duplicate credentials _before_ sending the invite.

This change does not affect re-sending an invite before the target user has accepted.

The behaviour for non-email user creation is unaffected.

Resolves #4079
