### PR TITLE
Add data support for SSH group grants 

### DIFF
--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -9,10 +9,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 
-	"github.com/infrahq/infra/uid"
-
 	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/uid"
 )
 
 func TestCreateDestination(t *testing.T) {

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -497,7 +497,7 @@ func TestListDestinationAccess(t *testing.T) {
 				Resource:         "destination1",
 			},
 		}
-		assert.DeepEqual(t, actual, expected)
+		assert.DeepEqual(t, actual.Items, expected)
 	})
 }
 
@@ -526,9 +526,9 @@ func TestDestinationAccessMaxUpdateIndex(t *testing.T) {
 		run := func(t *testing.T, tc testStep) {
 			tc.setup(t)
 
-			actual, err := DestinationAccessMaxUpdateIndex(tx, dest.Name)
+			actual, err := ListDestinationAccess(tx, dest.Name)
 			assert.NilError(t, err)
-			assert.Equal(t, actual, tc.expected)
+			assert.Equal(t, actual.MaxUpdateIndex, tc.expected)
 		}
 
 		var startIndex int64 = 10001

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -87,6 +87,7 @@ func migrations() []*migrator.Migration {
 		addUserPublicKeyUserIDIndex(),
 		addGrantsSubjectID(),
 		removeSettingsPasswordPolicy(),
+		addUpdateIndexToGroups(),
 		// next one here, then run `go test -run TestMigrations ./internal/server/data -update`
 	}
 }
@@ -1255,6 +1256,21 @@ func removeSettingsPasswordPolicy() *migrator.Migration {
 					DROP COLUMN IF EXISTS number_min,
 					DROP COLUMN IF EXISTS symbol_min;`)
 			return err
+		},
+	}
+}
+
+func addUpdateIndexToGroups() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2023-01-17T13:17",
+		Migrate: func(tx migrator.DB) error {
+			stmt := `ALTER TABLE groups ADD COLUMN IF NOT EXISTS membership_update_index bigint NOT NULL default 2`
+			_, err := tx.Exec(stmt)
+			if err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 }

--- a/internal/server/data/migrations_test.go
+++ b/internal/server/data/migrations_test.go
@@ -1058,6 +1058,12 @@ INSERT INTO providers(id, name) VALUES (12345, 'okta');
 				// schema changes are tested with schema comparison
 			},
 		},
+		{
+			label: testCaseLine("2023-01-17T13:17"),
+			expected: func(t *testing.T, tx WriteTxn) {
+				// schema changes are tested with schema comparison
+			},
+		},
 	}
 
 	ids := make(map[string]struct{}, len(testCases))

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -210,7 +210,8 @@ CREATE TABLE groups (
     name text,
     created_by bigint,
     created_by_provider bigint,
-    organization_id bigint
+    organization_id bigint,
+    membership_update_index bigint DEFAULT 2 NOT NULL
 );
 
 CREATE TABLE identities (


### PR DESCRIPTION
## Summary

Branched from #4086, extracted from #4039

This PR adds the database query and listen/notify support for SSH group grants.

Related to #3761 

TODO:
* [x] combine MaxUpdateIndex query into ListDestinationAccess
* [ ] test cases for listen