### PR TITLE
Call validate in versioned handlers

### DIFF
--- a/docs/dev/api-versioned-handlers.md
+++ b/docs/dev/api-versioned-handlers.md
@@ -21,9 +21,13 @@ endpoint.
    as a field in other `api` types will require a versioned handler for all of the
    API endpoints that use the struct. Any existing versioned handlers that reference
    the api struct directly also need to be updated to use the new versioned struct.
-4. Once all the existing handlers have been updated, it's time to create the new
+4. Any handlers that have their request struct changed to a versioned struct also
+   need to now call `validate.Validate` to apply the request validation rules on
+   the struct.
+5. Once all the existing handlers have been updated, it's time to create the new
    versioned handler. Use `addVersionHandler` to register the handler. The version argument to
    `addVersionHandler` must be the current API version (in other words, the last version
-   of the API that used the old types).
-5. Finally, now that the old behaviour of all API endpoints have been preserved by
+   of the API that used the old types). Once again, make sure to call `validate.Validate`
+   if a request struct is being constructed in the versioned handler.
+6. Finally, now that the old behaviour of all API endpoints have been preserved by
    versioned handlers you are free to modify the `api` types and API endpoint behaviour.

--- a/internal/server/access_keys.go
+++ b/internal/server/access_keys.go
@@ -9,6 +9,7 @@ import (
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/models"
+	"github.com/infrahq/infra/internal/validate"
 	"github.com/infrahq/infra/uid"
 )
 
@@ -96,8 +97,7 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 		}
 	}
 
-	addVersionHandler(a,
-		http.MethodGet, "/api/access-keys", "0.16.1",
+	addVersionHandler(a, http.MethodGet, "/api/access-keys", "0.16.1",
 		route[listAccessKeysRequestV0_16_1, *api.ListResponse[accessKeyV0_18_0]]{
 			routeSettings: defaultRouteSettingsGet,
 			handler: func(c *gin.Context, reqOld *listAccessKeysRequestV0_16_1) (*api.ListResponse[accessKeyV0_18_0], error) {
@@ -106,6 +106,9 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 					Name:              reqOld.Name,
 					ShowExpired:       reqOld.ShowExpired,
 					PaginationRequest: reqOld.PaginationRequest,
+				}
+				if err := validate.Validate(req); err != nil {
+					return nil, err
 				}
 				resp, err := a.ListAccessKeys(c, req)
 				return api.CopyListResponse(resp, newAccessKeyV0_18_0FromLatest), err
@@ -128,8 +131,7 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 		ExtensionDeadline api.Time `json:"extensionDeadline"`
 		AccessKey         string   `json:"accessKey"`
 	}
-	addVersionHandler(a,
-		http.MethodPost, "/api/access-keys", "0.18.0",
+	addVersionHandler(a, http.MethodPost, "/api/access-keys", "0.18.0",
 		route[createAccessKeysRequestV0_18_0, *createAccessKeyResponseV0_18_0]{
 			handler: func(c *gin.Context, reqOld *createAccessKeysRequestV0_18_0) (*createAccessKeyResponseV0_18_0, error) {
 				req := &api.CreateAccessKeyRequest{
@@ -137,6 +139,9 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 					Name:              reqOld.Name,
 					Expiry:            reqOld.TTL,
 					InactivityTimeout: reqOld.ExtensionDeadline,
+				}
+				if err := validate.Validate(req); err != nil {
+					return nil, err
 				}
 				resp, err := a.CreateAccessKey(c, req)
 				if err != nil {
@@ -155,8 +160,7 @@ func (a *API) addPreviousVersionHandlersAccessKey() {
 			},
 		})
 
-	addVersionHandler(a,
-		http.MethodGet, "/api/access-keys", "0.18.0",
+	addVersionHandler(a, http.MethodGet, "/api/access-keys", "0.18.0",
 		route[api.ListAccessKeysRequest, *api.ListResponse[accessKeyV0_18_0]]{
 			handler: func(c *gin.Context, req *api.ListAccessKeysRequest) (*api.ListResponse[accessKeyV0_18_0], error) {
 				resp, err := a.ListAccessKeys(c, req)

--- a/internal/server/signup.go
+++ b/internal/server/signup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/infrahq/infra/internal/server/email"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/server/providers"
+	"github.com/infrahq/infra/internal/validate"
 )
 
 func (a *API) SignupRoute() route[api.SignupRequest, *api.SignupResponse] {
@@ -356,8 +357,7 @@ func (a *API) addPreviousVersionHandlersSignup() {
 		Org      signupOrgV0_19_0 `json:"org"`
 	}
 
-	addVersionHandler(a,
-		http.MethodPost, "/api/signup", "0.19.0",
+	addVersionHandler(a, http.MethodPost, "/api/signup", "0.19.0",
 		route[signupRequestV0_19_0, *api.SignupResponse]{
 			handler: func(c *gin.Context, reqOld *signupRequestV0_19_0) (*api.SignupResponse, error) {
 				req := &api.SignupRequest{
@@ -367,6 +367,9 @@ func (a *API) addPreviousVersionHandlersSignup() {
 					},
 					OrgName:   reqOld.Org.Name,
 					Subdomain: reqOld.Org.Subdomain,
+				}
+				if err := validate.Validate(req); err != nil {
+					return nil, err
 				}
 				return a.Signup(c, req)
 			},


### PR DESCRIPTION
## Summary

@BruceMacD noticed that in cases where we create a versioned API request struct we were not applying validation rules, because the versioned structs did have any rules.

To ensure that we apply the right request validation this PR adds the missing calls to `validate.Validate`,  and updates the docs so that we don't forget in the future.



## Related Issues


Resolves https://github.com/infrahq/internal/issues/41
