### PR TITLE
remove unused wasCreated field value from grants response

### DIFF
--- a/api/grant.go
+++ b/api/grant.go
@@ -24,7 +24,7 @@ type Grant struct {
 
 type CreateGrantResponse struct {
 	*Grant     `json:",inline"`
-	WasCreated bool `json:"wasCreated" note:"Indicates that grant was successfully created, false it already existed beforehand" example:"true"`
+	WasCreated bool `json:"-" note:"Indicates that grant was successfully created, false it already existed beforehand" example:"true"`
 }
 
 func (r *CreateGrantResponse) StatusCode() int {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -99,11 +99,6 @@
             "format": "uid",
             "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
             "type": "string"
-          },
-          "wasCreated": {
-            "description": "Indicates that grant was successfully created, false it already existed beforehand",
-            "example": "true",
-            "type": "boolean"
           }
         }
       },

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -1055,8 +1055,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"resource": "some-cluster",
 					"user": "%[3]v",
 					"created": "%[4]v",
-					"updated": "%[4]v",
-					"wasCreated": true
+					"updated": "%[4]v"
 				}`,
 					accessKey.IssuedFor,
 					models.InfraAdminRole,
@@ -1087,8 +1086,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"resource": "some-big-cluster",
 					"user": "%[3]v",
 					"created": "%[4]v",
-					"updated": "%[4]v",
-					"wasCreated": true
+					"updated": "%[4]v"
 				}`,
 					accessKey.IssuedFor,
 					models.InfraAdminRole,
@@ -1140,8 +1138,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"resource": "some-resource",
 					"group": "%[3]v",
 					"created": "%[4]v",
-					"updated": "%[4]v",
-					"wasCreated": true
+					"updated": "%[4]v"
 				}`,
 					accessKey.IssuedFor,
 					models.InfraViewRole,
@@ -1206,8 +1203,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"resource": "infra",
 					"user": "%[3]v",
 					"created": "%[4]v",
-					"updated": "%[4]v",
-					"wasCreated": true
+					"updated": "%[4]v"
 				}`,
 					supportAdmin.ID,
 					models.InfraSupportAdminRole,


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

This value as a JSON field in the response is unnecessary since the HTTP status code can be used to determine if the request was effective or not. The only place where this may be useful is in the bulk request where each grant is tagged with `wasCreated`. Removing `wasCreated` from this response makes it harder to determine if a particular grant has been created but since nothing is checking that value right now, it doesn't seem very important.