### PR TITLE
use latest api version unless testing a previous version

### DIFF
--- a/internal/server/authn_test.go
+++ b/internal/server/authn_test.go
@@ -30,7 +30,7 @@ func TestServerLimitsAccessWithTemporaryPassword(t *testing.T) {
 		// nolint:noctx
 		req := httptest.NewRequest(http.MethodGet, "/api/users/"+loginResp.UserID.String(), nil)
 		req.Header.Add("Authorization", "Bearer "+key)
-		req.Header.Add("Infra-Version", "0.14")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		resp1 := httptest.NewRecorder()
 		routes.ServeHTTP(resp1, req)
@@ -60,7 +60,7 @@ func changePassword(t *testing.T, routes Routes, accessKey string, id uid.ID, ol
 	// nolint:noctx
 	req := httptest.NewRequest(http.MethodPut, "/api/users/"+id.String(), bytes.NewReader(body))
 	req.Header.Add("Authorization", "Bearer "+accessKey)
-	req.Header.Add("Infra-Version", "0.14")
+	req.Header.Add("Infra-Version", apiVersionLatest)
 
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
@@ -79,7 +79,7 @@ func login(t *testing.T, routes Routes, name, pass string) *api.LoginResponse {
 	loginReq := api.LoginRequest{PasswordCredentials: &api.LoginRequestPasswordCredentials{Name: name, Password: pass}}
 	body := jsonBody(t, loginReq)
 	req := httptest.NewRequest(http.MethodPost, "/api/login", body)
-	req.Header.Add("Infra-Version", "0.14.0")
+	req.Header.Add("Infra-Version", apiVersionLatest)
 
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -29,7 +29,7 @@ func TestAPI_PProfHandler(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		// nolint:noctx
 		req := httptest.NewRequest(http.MethodGet, "/api/debug/pprof/heap?debug=1", nil)
-		req.Header.Add("Infra-Version", "0.12.3")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setupRequest != nil {
 			tc.setupRequest(t, req)

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -36,7 +36,7 @@ func TestAPI_ListGrants(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodPost, "/api/users", &buf)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
-		req.Header.Add("Infra-Version", "0.12.3")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		resp := httptest.NewRecorder()
 		routes.ServeHTTP(resp, req)
@@ -61,7 +61,7 @@ func TestAPI_ListGrants(t *testing.T) {
 		// nolint:noctx
 		req := httptest.NewRequest(http.MethodPost, "/api/grants", &buf)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
-		req.Header.Add("Infra-Version", "0.12.3")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		resp := httptest.NewRecorder()
 		routes.ServeHTTP(resp, req)
@@ -114,7 +114,7 @@ func TestAPI_ListGrants(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
-		req.Header.Add("Infra-Version", "0.18.2")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)
@@ -339,7 +339,7 @@ func TestAPI_ListGrants(t *testing.T) {
 			urlPath: "/api/grants?resource=res1",
 			setup: func(t *testing.T, req *http.Request) {
 				req.Header.Set("Authorization", "Bearer "+adminAccessKey(srv))
-				req.Header.Add("Infra-Version", "0.12.3")
+				req.Header.Add("Infra-Version", apiVersionLatest)
 			},
 			expected: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, resp.Code, http.StatusOK, resp.Body.String())
@@ -559,7 +559,7 @@ func TestAPI_ListGrants_InheritedGrants(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodPost, "/api/users", &buf)
 		req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
-		req.Header.Add("Infra-Version", "0.12.3")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		resp := httptest.NewRecorder()
 		routes.ServeHTTP(resp, req)
@@ -625,7 +625,7 @@ func TestAPI_ListGrants_InheritedGrants(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
-		req.Header.Add("Infra-Version", "0.12.3")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)
@@ -988,7 +988,7 @@ func TestAPI_CreateGrant(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		body := jsonBody(t, tc.body)
 		req := httptest.NewRequest(http.MethodPost, "/api/grants", body)
-		req.Header.Add("Infra-Version", "0.18.2")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)

--- a/internal/server/groups_test.go
+++ b/internal/server/groups_test.go
@@ -61,7 +61,7 @@ func TestAPI_ListGroups(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
-		req.Header.Add("Infra-Version", "0.13.0")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)
@@ -200,7 +200,7 @@ func TestAPI_CreateGroup(t *testing.T) {
 		// nolint:noctx
 		req := httptest.NewRequest(http.MethodPost, "/api/groups", body)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
-		req.Header.Add("Infra-Version", "0.13.0")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)
@@ -288,7 +288,7 @@ func TestAPI_DeleteGroup(t *testing.T) {
 		// nolint:noctx
 		req := httptest.NewRequest(http.MethodDelete, tc.urlPath, nil)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
-		req.Header.Add("Infra-Version", "0.13.0")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)
@@ -364,7 +364,7 @@ func TestAPI_UpdateUsersInGroup(t *testing.T) {
 		// nolint:noctx
 		req := httptest.NewRequest(http.MethodPatch, tc.urlPath, body)
 		req.Header.Set("Authorization", "Bearer "+accessKey)
-		req.Header.Add("Infra-Version", "0.13.0")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -157,7 +157,7 @@ func createUser(t *testing.T, srv *Server, routes Routes, email string) *api.Cre
 	// nolint:noctx
 	req := httptest.NewRequest(http.MethodPost, "/api/users", bytes.NewReader(body))
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
-	req.Header.Add("Infra-Version", "0.14")
+	req.Header.Add("Infra-Version", apiVersionLatest)
 
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)

--- a/internal/server/login_test.go
+++ b/internal/server/login_test.go
@@ -42,7 +42,7 @@ func TestAPI_Login(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		body := jsonBody(t, tc.setup(t))
 		req := httptest.NewRequest(http.MethodPost, "/api/login", body)
-		req.Header.Add("Infra-Version", "0.13.3")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		resp := httptest.NewRecorder()
 		routes.ServeHTTP(resp, req)

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -75,7 +75,7 @@ func TestAPI_GetOrganization(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
-		req.Header.Add("Infra-Version", "0.15.2")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)
@@ -203,7 +203,7 @@ func TestAPI_ListOrganizations(t *testing.T) {
 
 	run := func(t *testing.T, tc testCase) {
 		req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
-		req.Header.Add("Infra-Version", "0.14.1")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)
@@ -276,7 +276,7 @@ func TestAPI_CreateOrganization(t *testing.T) {
 		body := jsonBody(t, tc.body)
 		// nolint:noctx
 		req := httptest.NewRequest(http.MethodPost, "/api/organizations", body)
-		req.Header.Add("Infra-Version", "0.14.1")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 		ctx := providers.WithOIDCClient(req.Context(), &fakeOIDCImplementation{})
 		*req = *req.WithContext(ctx)
 
@@ -354,7 +354,7 @@ func TestAPI_DeleteOrganization(t *testing.T) {
 	run := func(t *testing.T, tc testCase) {
 		// nolint:noctx
 		req := httptest.NewRequest(http.MethodDelete, tc.urlPath, nil)
-		req.Header.Add("Infra-Version", "0.14.1")
+		req.Header.Add("Infra-Version", apiVersionLatest)
 
 		if tc.setup != nil {
 			tc.setup(t, req)

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -155,7 +155,7 @@ func TestTrimWhitespace(t *testing.T) {
 		Resource:  " kubernetes.production.*",
 	}))
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
-	req.Header.Add("Infra-Version", "0.13.1")
+	req.Header.Add("Infra-Version", apiVersionLatest)
 
 	resp := httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
@@ -164,7 +164,7 @@ func TestTrimWhitespace(t *testing.T) {
 	// nolint:noctx
 	req = httptest.NewRequest(http.MethodGet, "/api/grants?privilege=%20admin%20&userID="+userID.String(), nil)
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
-	req.Header.Add("Infra-Version", "0.13.1")
+	req.Header.Add("Infra-Version", apiVersionLatest)
 
 	resp = httptest.NewRecorder()
 	routes.ServeHTTP(resp, req)
@@ -306,7 +306,7 @@ func TestRequestTimeout(t *testing.T) {
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/sleep", nil)
-	req.Header.Add("Infra-Version", "0.13.1")
+	req.Header.Add("Infra-Version", apiVersionLatest)
 
 	resp := httptest.NewRecorder()
 	started := time.Now()


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Use `apiVersionLatest` consistently in tests unless explicitly testing a previous version since using non-latest versions can produces unexpected failures when changing the API.