### PR TITLE
use latest version in api/client.go

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -15,11 +15,10 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
+	"github.com/infrahq/infra/internal"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/uid"
 )
-
-var apiVersion = "0.18.1"
 
 var (
 	ErrTimeout            = errors.New("client timed out waiting for response from server")
@@ -104,8 +103,8 @@ func (c *Client) buildRequest(
 	req.Header.Add("Authorization", "Bearer "+c.AccessKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Infra-Version", apiVersion)
-	req.Header.Set("User-Agent", fmt.Sprintf("Infra/%v (%s %v; %v/%v)", apiVersion, clientName, clientVersion, runtime.GOOS, runtime.GOARCH))
+	req.Header.Set("Infra-Version", internal.FullVersion())
+	req.Header.Set("User-Agent", fmt.Sprintf("Infra/%v (%s %v; %v/%v)", internal.FullVersion(), clientName, clientVersion, runtime.GOOS, runtime.GOARCH))
 
 	for k, v := range c.Headers {
 		req.Header[k] = v

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/infrahq/infra/internal"
 )
 
 func TestErrorStatusCode(t *testing.T) {
@@ -94,8 +96,8 @@ func TestGet(t *testing.T) {
 		"Authorization":   []string{"Bearer the-access-key"},
 		"Content-Type":    []string{"application/json"},
 		"Accept":          []string{"application/json"},
-		"Infra-Version":   []string{apiVersion},
-		"User-Agent":      []string{fmt.Sprintf("Infra/%v (testing version; %v/%v)", apiVersion, runtime.GOOS, runtime.GOARCH)},
+		"Infra-Version":   []string{internal.FullVersion()},
+		"User-Agent":      []string{fmt.Sprintf("Infra/%v (testing version; %v/%v)", internal.FullVersion(), runtime.GOOS, runtime.GOARCH)},
 	}
 
 	ctx := context.Background()
@@ -150,8 +152,8 @@ func TestDelete(t *testing.T) {
 		"Authorization":   {"Bearer access-key"},
 		"Content-Type":    {"application/json"},
 		"Accept":          {"application/json"},
-		"Infra-Version":   {apiVersion},
-		"User-Agent":      {fmt.Sprintf("Infra/%v (testing version; %v/%v)", apiVersion, runtime.GOOS, runtime.GOARCH)},
+		"Infra-Version":   {internal.FullVersion()},
+		"User-Agent":      {fmt.Sprintf("Infra/%v (testing version; %v/%v)", internal.FullVersion(), runtime.GOOS, runtime.GOARCH)},
 	}
 
 	t.Run("headers", func(t *testing.T) {


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Infra API is tightly coupled with the API client since its structs are used in the API handlers and also used to generate API docs. This means any changes to the API requires changing the API client so it doesn't make sense to pin the JSON format to anything other than the version implemented by the server.

Note: this version gets set to git tag when building a release so released builds won't see any change.