### PR TITLE
Combine api.Client hooks so that we can remove one

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -107,7 +107,11 @@ func NewAPIClient(opts *APIClientOpts) (*api.Client, error) {
 		},
 	}
 	if !opts.SkipLogoutOnUnauthorized {
-		client.OnUnauthorized = logoutCurrent
+		client.ObserveFunc = func(_ time.Time, _ *http.Request, resp *http.Response, _ error) {
+			if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+				logoutCurrent()
+			}
+		}
 	}
 	return client, nil
 }


### PR DESCRIPTION
## Summary

I noticed we had two hooks in the `api.Client`,  `ObserveFunc` and `OnUnauthorized`. Both of these hooks are called at about the same place, so I think we may be able to combine these and use only `ObserveFunc`.

I haven't done much testing on this, and I suspect we don't have much automated test coverage.

Suggestions for what needs to be tested manually?
