### PR TITLE
refactor grants data model

### DIFF
--- a/internal/access/access.go
+++ b/internal/access/access.go
@@ -9,8 +9,6 @@ import (
 	"github.com/infrahq/infra/internal/server/models"
 )
 
-const ResourceInfraAPI = "infra"
-
 var ErrNotAuthorized = errors.New("not authorized")
 
 // AuthorizationError indicates that the user who performed the operation does
@@ -71,7 +69,7 @@ func IsAuthorized(rCtx RequestContext, requiredRole ...string) error {
 		Pagination:                 &data.Pagination{Limit: 1},
 		BySubject:                  models.NewSubjectForUser(user.ID),
 		ByPrivileges:               requiredRole,
-		ByResource:                 ResourceInfraAPI,
+		ByDestinationName:          models.GrantDestinationInfra,
 		IncludeInheritedFromGroups: true,
 	})
 	if err != nil {

--- a/internal/access/access_key_test.go
+++ b/internal/access/access_key_test.go
@@ -81,7 +81,7 @@ func TestAccessKeys_AccessKeyAuthn(t *testing.T) {
 		err = data.CreateIdentity(db, user)
 		assert.NilError(t, err)
 
-		err = data.CreateGrant(db, &models.Grant{Subject: models.NewSubjectForUser(user.ID), Privilege: "admin", Resource: "infra", OrganizationMember: orgMember})
+		err = data.CreateGrant(db, &models.Grant{Subject: models.NewSubjectForUser(user.ID), Privilege: "admin", DestinationName: models.GrantDestinationInfra, OrganizationMember: orgMember})
 		assert.NilError(t, err)
 
 		key := &models.AccessKey{Name: "admin key", IssuedForID: user.ID, ExpiresAt: time.Now().Add(1 * time.Minute), OrganizationMember: orgMember}

--- a/internal/access/grant.go
+++ b/internal/access/grant.go
@@ -61,8 +61,8 @@ func ListGrants(rCtx RequestContext, opts data.ListGrantsOptions, lastUpdateInde
 	}
 
 	listenOpts := data.ListenForNotifyOptions{
-		GrantsByDestination: opts.ByDestination,
-		OrgID:               rCtx.DBTxn.OrganizationID(),
+		GrantsByDestinationName: opts.ByDestinationName,
+		OrgID:                   rCtx.DBTxn.OrganizationID(),
 	}
 	listener, err := data.ListenForNotify(rCtx.Request.Context(), rCtx.DataDB, listenOpts)
 	if err != nil {
@@ -124,7 +124,8 @@ func listGrantsWithMaxUpdateIndex(rCtx RequestContext, opts data.ListGrantsOptio
 	}
 
 	maxUpdateIndex, err := data.GrantsMaxUpdateIndex(tx, data.GrantsMaxUpdateIndexOptions{
-		ByDestination: opts.ByDestination,
+		ByDestinationName:     opts.ByDestinationName,
+		ByDestinationResource: opts.ByDestinationResource,
 	})
 	return ListGrantsResponse{Grants: result, MaxUpdateIndex: maxUpdateIndex}, err
 }
@@ -187,7 +188,7 @@ func UpdateGrants(rCtx RequestContext, addGrants, rmGrants []*models.Grant) erro
 
 func requiredInfraRoleForGrantOperation(grants ...*models.Grant) string {
 	for _, grant := range grants {
-		if grant.Privilege == models.InfraSupportAdminRole && grant.Resource == ResourceInfraAPI {
+		if grant.Privilege == models.InfraSupportAdminRole && grant.DestinationName == models.GrantDestinationInfra {
 			return models.InfraSupportAdminRole
 		}
 	}

--- a/internal/access/identity_test.go
+++ b/internal/access/identity_test.go
@@ -72,17 +72,17 @@ func TestDeleteIdentityCleansUpResources(t *testing.T) {
 	assert.NilError(t, err)
 
 	grantInfra := &models.Grant{
-		Subject:   models.NewSubjectForUser(identity.ID),
-		Resource:  "infra",
-		Privilege: "admin",
+		Subject:         models.NewSubjectForUser(identity.ID),
+		DestinationName: models.GrantDestinationInfra,
+		Privilege:       "admin",
 	}
 	err = data.CreateGrant(db, grantInfra)
 	assert.NilError(t, err)
 
 	grantDestination := &models.Grant{
-		Subject:   models.NewSubjectForUser(identity.ID),
-		Resource:  "example",
-		Privilege: "cluster-admin",
+		Subject:         models.NewSubjectForUser(identity.ID),
+		DestinationName: "example",
+		Privilege:       "cluster-admin",
 	}
 	err = data.CreateGrant(db, grantDestination)
 	assert.NilError(t, err)

--- a/internal/cmd/grants.go
+++ b/internal/cmd/grants.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal/logging"
-	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/uid"
 )
+
+const BasePermissionConnect = "connect"
 
 type grantsCmdOptions struct {
 	UserName    string
@@ -350,7 +351,7 @@ $ infra grants add johndoe@example.com infra --role admin
 	}
 
 	cmd.Flags().BoolVarP(&isGroup, "group", "g", false, "When set, creates a grant for a group instead of a user")
-	cmd.Flags().StringVar(&options.Role, "role", models.BasePermissionConnect, "Type of access that the user or group will be given")
+	cmd.Flags().StringVar(&options.Role, "role", BasePermissionConnect, "Type of access that the user or group will be given")
 	cmd.Flags().BoolVar(&options.Force, "force", false, "Create grant even if requested user, destination, or role are unknown")
 	return cmd
 }

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -29,10 +30,12 @@ func createGrants(t *testing.T, tx data.WriteTxn, grants ...api.GrantRequest) {
 			subject = models.NewSubjectForGroup(group.ID)
 		}
 
+		destinationName, destinationResource, _ := strings.Cut(g.Resource, ".")
 		err := data.CreateGrant(tx, &models.Grant{
-			Subject:   subject,
-			Resource:  g.Resource,
-			Privilege: g.Privilege,
+			Subject:             subject,
+			DestinationName:     destinationName,
+			DestinationResource: destinationResource,
+			Privilege:           g.Privilege,
 		})
 		assert.NilError(t, err, "grant %v", i)
 	}

--- a/internal/server/access_keys_test.go
+++ b/internal/server/access_keys_test.go
@@ -417,9 +417,9 @@ func TestAPI_ListAccessKeys(t *testing.T) {
 	assert.NilError(t, err)
 	provider := data.InfraProvider(db)
 	err = data.CreateGrant(db, &models.Grant{
-		Subject:   models.NewSubjectForUser(user.ID),
-		Privilege: "admin",
-		Resource:  "infra",
+		Subject:         models.NewSubjectForUser(user.ID),
+		Privilege:       "admin",
+		DestinationName: models.GrantDestinationInfra,
 	})
 	assert.NilError(t, err)
 
@@ -650,9 +650,9 @@ func TestAPI_DeleteAccessKey(t *testing.T) {
 	assert.NilError(t, err)
 	provider := data.InfraProvider(db)
 	err = data.CreateGrant(db, &models.Grant{
-		Subject:   models.NewSubjectForUser(user.ID),
-		Privilege: "admin",
-		Resource:  "infra",
+		Subject:         models.NewSubjectForUser(user.ID),
+		Privilege:       "admin",
+		DestinationName: models.GrantDestinationInfra,
 	})
 	assert.NilError(t, err)
 

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/infrahq/infra/internal"
-	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/logging"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
@@ -109,19 +108,19 @@ func loadGrant(tx data.WriteTxn, userID uid.ID, role string) error {
 		return nil
 	}
 	_, err := data.GetGrant(tx, data.GetGrantOptions{
-		BySubject:   models.NewSubjectForUser(userID),
-		ByResource:  access.ResourceInfraAPI,
-		ByPrivilege: role,
+		BySubject:         models.NewSubjectForUser(userID),
+		ByDestinationName: models.GrantDestinationInfra,
+		ByPrivilege:       role,
 	})
 	if err == nil || !errors.Is(err, internal.ErrNotFound) {
 		return err
 	}
 
 	grant := &models.Grant{
-		Subject:   models.NewSubjectForUser(userID),
-		Resource:  access.ResourceInfraAPI,
-		Privilege: role,
-		CreatedBy: models.CreatedBySystem,
+		Subject:         models.NewSubjectForUser(userID),
+		DestinationName: models.GrantDestinationInfra,
+		Privilege:       role,
+		CreatedBy:       models.CreatedBySystem,
 	}
 	return data.CreateGrant(tx, grant)
 }

--- a/internal/server/data/destination.go
+++ b/internal/server/data/destination.go
@@ -181,7 +181,7 @@ func DeleteDestination(tx WriteTxn, id uid.ID) error {
 		return handleError(err)
 	}
 
-	err = DeleteGrants(tx, DeleteGrantsOptions{ByDestination: dest.Name})
+	err = DeleteGrants(tx, DeleteGrantsOptions{ByDestinationName: dest.Name})
 	if err != nil {
 		return handleError(err)
 	}

--- a/internal/server/data/destination_test.go
+++ b/internal/server/data/destination_test.go
@@ -335,19 +335,20 @@ func TestDeleteDestination(t *testing.T) {
 
 		pileOGrants := []*models.Grant{
 			{
-				Subject:   models.NewSubjectForUser(1234567),
-				Privilege: "view",
-				Resource:  "kube",
+				Subject:         models.NewSubjectForUser(1234567),
+				Privilege:       "view",
+				DestinationName: "kube",
 			},
 			{
-				Subject:   models.NewSubjectForUser(1234567),
-				Privilege: "view",
-				Resource:  "kube.namespace",
+				Subject:             models.NewSubjectForUser(1234567),
+				Privilege:           "view",
+				DestinationName:     "kube",
+				DestinationResource: "namespace",
 			},
 			{
-				Subject:   models.NewSubjectForUser(1234567),
-				Privilege: "view",
-				Resource:  "somethingelse",
+				Subject:         models.NewSubjectForUser(1234567),
+				Privilege:       "view",
+				DestinationName: "somethingelse",
 			},
 		}
 
@@ -369,7 +370,7 @@ func TestDeleteDestination(t *testing.T) {
 		actual, err = ListGrants(tx, ListGrantsOptions{BySubject: models.NewSubjectForUser(1234567)})
 		assert.NilError(t, err)
 		assert.Equal(t, len(actual), 1)
-		assert.Equal(t, actual[0].Resource, "somethingelse")
+		assert.Equal(t, actual[0].DestinationName, "somethingelse")
 	})
 }
 

--- a/internal/server/data/group_test.go
+++ b/internal/server/data/group_test.go
@@ -239,9 +239,9 @@ func TestDeleteGroup(t *testing.T) {
 		createIdentities(t, tx, someone)
 
 		groupGrant := &models.Grant{
-			Subject:   models.NewSubjectForGroup(everyone.ID),
-			Privilege: "admin",
-			Resource:  "any",
+			Subject:         models.NewSubjectForGroup(everyone.ID),
+			Privilege:       "admin",
+			DestinationName: "any",
 		}
 		createGrants(t, tx, groupGrant)
 

--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -504,7 +504,7 @@ func TestDeleteIdentities(t *testing.T) {
 				err = AddUsersToGroup(tx, group.ID, []uid.ID{bond.ID})
 				assert.NilError(t, err)
 
-				err = CreateGrant(tx, &models.Grant{Subject: models.NewSubjectForUser(bond.ID), Privilege: "admin", Resource: "infra"})
+				err = CreateGrant(tx, &models.Grant{Subject: models.NewSubjectForUser(bond.ID), Privilege: "admin", DestinationName: "infra"})
 				assert.NilError(t, err)
 
 				return DeleteIdentitiesOptions{

--- a/internal/server/data/organization.go
+++ b/internal/server/data/organization.go
@@ -102,7 +102,7 @@ func CreateOrganization(tx WriteTxn, org *models.Organization) error {
 	err := CreateGrant(tx, &models.Grant{
 		Subject:            models.NewSubjectForUser(connector.ID),
 		Privilege:          models.InfraConnectorRole,
-		Resource:           "infra",
+		DestinationName:    models.GrantDestinationInfra,
 		CreatedBy:          models.CreatedBySystem,
 		OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 	})

--- a/internal/server/data/organization_test.go
+++ b/internal/server/data/organization_test.go
@@ -76,9 +76,9 @@ func TestCreateOrganization(t *testing.T) {
 		assert.DeepEqual(t, connector, expectedConnector, anyValidToken)
 
 		connectorGrant, err := GetGrant(tx, GetGrantOptions{
-			BySubject:   models.NewSubjectForUser(connector.ID),
-			ByPrivilege: models.InfraConnectorRole,
-			ByResource:  "infra",
+			BySubject:         models.NewSubjectForUser(connector.ID),
+			ByPrivilege:       models.InfraConnectorRole,
+			ByDestinationName: models.GrantDestinationInfra,
 		})
 		assert.NilError(t, err)
 		expectedConnectorGrant := &models.Grant{
@@ -86,7 +86,7 @@ func TestCreateOrganization(t *testing.T) {
 			OrganizationMember: models.OrganizationMember{OrganizationID: org.ID},
 			Subject:            models.NewSubjectForUser(connector.ID),
 			Privilege:          models.InfraConnectorRole,
-			Resource:           "infra",
+			DestinationName:    models.GrantDestinationInfra,
 			CreatedBy:          models.CreatedBySystem,
 			UpdateIndex:        10001,
 		}

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -195,12 +195,13 @@ CREATE TABLE grants (
     updated_at timestamp with time zone,
     deleted_at timestamp with time zone,
     privilege text,
-    resource text,
     created_by bigint,
     organization_id bigint,
     update_index bigint,
     subject_id bigint NOT NULL,
-    subject_kind smallint NOT NULL
+    subject_kind smallint NOT NULL,
+		destination_name text,
+		destination_resource text
 );
 
 CREATE TABLE groups (
@@ -370,7 +371,7 @@ CREATE UNIQUE INDEX idx_emails_providers_identities ON provider_users USING btre
 
 CREATE UNIQUE INDEX idx_encryption_keys_key_id ON encryption_keys USING btree (key_id);
 
-CREATE UNIQUE INDEX idx_grants_subject_privilege_resource ON grants USING btree (organization_id, subject_id, privilege, resource) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_grants_subject_privilege_destination_resource ON grants USING btree (organization_id, subject_id, privilege, destination_name, destination_resource) WHERE (deleted_at IS NULL);
 
 CREATE INDEX idx_grants_update_index ON grants USING btree (organization_id, update_index);
 

--- a/internal/server/debug_test.go
+++ b/internal/server/debug_test.go
@@ -10,7 +10,6 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/infrahq/infra/api"
-	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 )
@@ -65,10 +64,10 @@ func TestAPI_PProfHandler(t *testing.T) {
 			setupRequest: func(t *testing.T, req *http.Request) {
 				key, user := createAccessKey(t, s.DB(), "user2@example.com")
 				err := data.CreateGrant(s.DB(), &models.Grant{
-					Subject:   models.NewSubjectForUser(user.ID),
-					Privilege: models.InfraSupportAdminRole,
-					Resource:  access.ResourceInfraAPI,
-					CreatedBy: user.ID,
+					Subject:         models.NewSubjectForUser(user.ID),
+					Privilege:       models.InfraSupportAdminRole,
+					DestinationName: models.GrantDestinationInfra,
+					CreatedBy:       user.ID,
 				})
 				assert.NilError(t, err)
 

--- a/internal/server/destination_test.go
+++ b/internal/server/destination_test.go
@@ -197,19 +197,20 @@ func TestAPI_DeleteDestination(t *testing.T) {
 			setup: func(t *testing.T, req *http.Request) {
 				grants := []*models.Grant{
 					{
-						Subject:   models.NewSubjectForUser(7654321),
-						Privilege: "view",
-						Resource:  "wow",
+						Subject:         models.NewSubjectForUser(7654321),
+						Privilege:       "view",
+						DestinationName: "wow",
 					},
 					{
-						Subject:   models.NewSubjectForUser(7654321),
-						Privilege: "view",
-						Resource:  "wow.awesome",
+						Subject:             models.NewSubjectForUser(7654321),
+						Privilege:           "view",
+						DestinationName:     "wow",
+						DestinationResource: "awesome",
 					},
 					{
-						Subject:   models.NewSubjectForUser(7654321),
-						Privilege: "view",
-						Resource:  "anotherthing",
+						Subject:         models.NewSubjectForUser(7654321),
+						Privilege:       "view",
+						DestinationName: "anotherthing",
 					},
 				}
 				for _, g := range grants {

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -97,9 +97,9 @@ func createAdmin(t *testing.T, db data.WriteTxn) *models.Identity {
 	assert.NilError(t, err)
 
 	err = data.CreateGrant(db, &models.Grant{
-		Subject:   models.NewSubjectForUser(user.ID),
-		Resource:  "infra",
-		Privilege: models.InfraAdminRole,
+		Subject:         models.NewSubjectForUser(user.ID),
+		DestinationName: models.GrantDestinationInfra,
+		Privilege:       models.InfraAdminRole,
 	})
 	assert.NilError(t, err)
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -320,9 +320,9 @@ func TestHandleInfraDestinationHeader(t *testing.T) {
 	assert.NilError(t, err)
 
 	grant := models.Grant{
-		Subject:   models.NewSubjectForUser(connector.ID),
-		Privilege: models.InfraConnectorRole,
-		Resource:  "infra",
+		Subject:         models.NewSubjectForUser(connector.ID),
+		Privilege:       models.InfraConnectorRole,
+		DestinationName: models.GrantDestinationInfra,
 	}
 	err = data.CreateGrant(db, &grant)
 	assert.NilError(t, err)

--- a/internal/server/organizations_test.go
+++ b/internal/server/organizations_test.go
@@ -457,9 +457,9 @@ func TestAPI_UpdateOrganization(t *testing.T) {
 	assert.NilError(t, data.CreateIdentity(tx, admin))
 
 	adminGrant := &models.Grant{
-		Subject:   models.NewSubjectForUser(admin.ID),
-		Privilege: "admin",
-		Resource:  "infra",
+		Subject:         models.NewSubjectForUser(admin.ID),
+		Privilege:       "admin",
+		DestinationName: models.GrantDestinationInfra,
 	}
 	assert.NilError(t, data.CreateGrant(tx, adminGrant))
 

--- a/internal/server/signup.go
+++ b/internal/server/signup.go
@@ -312,10 +312,10 @@ func signupUser(rCtx access.RequestContext, keyExpiresAt time.Time, user *models
 	}
 
 	err = data.CreateGrant(tx, &models.Grant{
-		Subject:   models.NewSubjectForUser(identity.ID),
-		Privilege: models.InfraAdminRole,
-		Resource:  access.ResourceInfraAPI,
-		CreatedBy: identity.ID,
+		Subject:         models.NewSubjectForUser(identity.ID),
+		Privilege:       models.InfraAdminRole,
+		DestinationName: models.GrantDestinationInfra,
+		CreatedBy:       identity.ID,
 	})
 	if err != nil {
 		return nil, "", fmt.Errorf("create grant on sign-up: %w", err)

--- a/internal/server/signup_test.go
+++ b/internal/server/signup_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/internal"
-	"github.com/infrahq/infra/internal/access"
 	"github.com/infrahq/infra/internal/server/data"
 	"github.com/infrahq/infra/internal/server/models"
 	"github.com/infrahq/infra/internal/server/providers"
@@ -645,9 +644,9 @@ func validateSuccessfulSignup(t *testing.T, db *data.Transaction, testSignup val
 	// check the user is an admin
 	db = db.WithOrgID(respBody.Organization.ID)
 	_, err = data.GetGrant(db, data.GetGrantOptions{
-		BySubject:   models.NewSubjectForUser(userID),
-		ByResource:  access.ResourceInfraAPI,
-		ByPrivilege: api.InfraAdminRole,
+		BySubject:         models.NewSubjectForUser(userID),
+		ByDestinationName: models.GrantDestinationInfra,
+		ByPrivilege:       api.InfraAdminRole,
 	})
 	assert.NilError(t, err)
 

--- a/internal/server/users_test.go
+++ b/internal/server/users_test.go
@@ -943,7 +943,7 @@ func TestAPI_DeleteUser(t *testing.T) {
 				}
 				assert.NilError(t, data.CreateGroup(srv.DB(), group))
 				assert.NilError(t, data.AddUsersToGroup(srv.DB(), group.ID, []uid.ID{testUser.ID}))
-				assert.NilError(t, data.CreateGrant(srv.DB(), &models.Grant{Subject: models.NewSubjectForUser(testUser.ID), Privilege: "admin", Resource: "infra"}))
+				assert.NilError(t, data.CreateGrant(srv.DB(), &models.Grant{Subject: models.NewSubjectForUser(testUser.ID), Privilege: "admin", DestinationName: models.GrantDestinationInfra}))
 
 				// nolint:noctx
 				req := httptest.NewRequest(http.MethodDelete, "/api/users/"+testUser.ID.String(), nil)


### PR DESCRIPTION
Update the grant data model to split destination name from resource. This separation creates a clearer boundary between destinations and destination-specific resources. #4099, the API will be updated to follow this pattern which allows a future PR to allow dots in destination names.