### PR TITLE
fix: allow group names with commas

### DIFF
--- a/internal/server/data/identity_test.go
+++ b/internal/server/data/identity_test.go
@@ -768,6 +768,26 @@ func TestAssignIdentityToGroups(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:           "test where the group has a comma in its name",
+			StartingGroups: []string{"foo"},
+			ExistingGroups: []string{},
+			IncomingGroups: []string{"foo", "foo,2"},
+			ExpectedGroups: []models.Group{
+				{
+					Name: "foo",
+					OrganizationMember: models.OrganizationMember{
+						OrganizationID: 1000,
+					},
+				},
+				{
+					Name: "foo,2",
+					OrganizationMember: models.OrganizationMember{
+						OrganizationID: 1000,
+					},
+				},
+			},
+		},
 	}
 
 	runDBTests(t, func(t *testing.T, db *DB) {

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -1359,12 +1359,10 @@ func storeProviderUserGroupsArray() *migrator.Migration {
 			if err != nil {
 				return err
 			}
-			stmt := `
-				ALTER TABLE provider_users 
-				DROP COLUMN IF EXISTS groups
-				ADD COLUMN IF NOT EXISTS groups jsonb;
-			`
-			if _, err := tx.Exec(stmt); err != nil {
+			if _, err := tx.Exec(`ALTER TABLE provider_users DROP COLUMN IF EXISTS groups;`); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`ALTER TABLE provider_users ADD COLUMN IF NOT EXISTS groups jsonb;`); err != nil {
 				return err
 			}
 			for _, u := range users {

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -89,6 +89,7 @@ func migrations() []*migrator.Migration {
 		removeSettingsPasswordPolicy(),
 		moveSettingsJWKOrganizations(),
 		addAccessKeyIssuedForKind(),
+		storeProviderUserGroupsArray(),
 		// next one here, then run `go test -run TestMigrations ./internal/server/data -update`
 	}
 }
@@ -1326,6 +1327,55 @@ func addAccessKeyIssuedForKind() *migrator.Migration {
 				return fmt.Errorf("create access key issued_for index: %w", err)
 			}
 			return nil
+		},
+	}
+}
+
+func storeProviderUserGroupsArray() *migrator.Migration {
+	return &migrator.Migration{
+		ID: "2023-01-26T13:37",
+		Migrate: func(tx migrator.DB) error {
+			var groupType string
+			if err := tx.QueryRow(`SELECT pg_typeof(groups) FROM provider_users LIMIT 1;`).Scan(&groupType); err != nil {
+				return err
+			}
+			if groupType == "jsonb" {
+				// this migration has already been performed
+				return nil
+			}
+			if _, err := tx.Exec(`ALTER TABLE provider_users ADD COLUMN IF NOT EXISTS groups_json jsonb;`); err != nil {
+				return err
+			}
+			// copy the groups string to the new groupsArray column, this could be a large operation if there are a lot of users
+			type userGroups struct {
+				IdentityID uid.ID
+				ProviderID uid.ID
+				Groups     models.CommaSeparatedStrings
+			}
+			rows, err := tx.Query(`SELECT identity_id, provider_id, groups FROM provider_users`)
+			if err != nil {
+				return err
+			}
+			users, err := scanRows(rows, func(u *userGroups) []any {
+				return []any{&u.IdentityID, &u.ProviderID, &u.Groups}
+			})
+			if err != nil {
+				return err
+			}
+
+			for _, u := range users {
+				groups := models.JSONB(u.Groups)
+				if _, err := tx.Exec(`UPDATE provider_users SET groups_json = ? WHERE identity_id = ? AND provider_id = ?`, groups, u.IdentityID, u.ProviderID); err != nil {
+					return err
+				}
+			}
+
+			stmt := `
+				ALTER TABLE provider_users DROP COLUMN IF EXISTS groups;
+				ALTER TABLE provider_users RENAME COLUMN groups_json TO groups;
+			`
+			_, err = tx.Exec(stmt)
+			return err
 		},
 	}
 }

--- a/internal/server/data/migrations.go
+++ b/internal/server/data/migrations.go
@@ -1359,10 +1359,12 @@ func storeProviderUserGroupsArray() *migrator.Migration {
 			if err != nil {
 				return err
 			}
-			if _, err := tx.Exec(`ALTER TABLE provider_users DROP COLUMN IF EXISTS groups;`); err != nil {
-				return err
-			}
-			if _, err := tx.Exec(`ALTER TABLE provider_users ADD COLUMN IF NOT EXISTS groups jsonb;`); err != nil {
+			stmt := `
+				ALTER TABLE provider_users 
+				DROP COLUMN IF EXISTS groups
+				ADD COLUMN IF NOT EXISTS groups jsonb;
+			`
+			if _, err := tx.Exec(stmt); err != nil {
 				return err
 			}
 			for _, u := range users {

--- a/internal/server/data/provideruser_test.go
+++ b/internal/server/data/provideruser_test.go
@@ -108,7 +108,7 @@ func TestSyncProviderUser(t *testing.T) {
 
 					expected := models.ProviderUser{
 						Email:        "hello@example.com",
-						Groups:       models.CommaSeparatedStrings{"Developers", "Everyone"},
+						Groups:       []string{"Developers", "Everyone"},
 						ProviderID:   user.ProviderID,
 						IdentityID:   user.IdentityID,
 						RedirectURL:  "http://example.com",
@@ -170,7 +170,7 @@ func TestSyncProviderUser(t *testing.T) {
 
 					expected := models.ProviderUser{
 						Email:        "sync@example.com",
-						Groups:       models.CommaSeparatedStrings{"Developers", "Everyone"},
+						Groups:       []string{"Developers", "Everyone"},
 						ProviderID:   user.ProviderID,
 						IdentityID:   user.IdentityID,
 						RedirectURL:  "http://example.com",
@@ -276,7 +276,7 @@ func TestProvisionProviderUser(t *testing.T) {
 				GivenName:  "david",
 				FamilyName: "martinez",
 				ProviderID: InfraProvider(db).ID,
-				Groups:     models.CommaSeparatedStrings{},
+				Groups:     []string{},
 				Active:     true,
 			}
 
@@ -305,7 +305,7 @@ func TestProvisionProviderUser(t *testing.T) {
 				GivenName:  "lucy",
 				FamilyName: "",
 				ProviderID: InfraProvider(db).ID,
-				Groups:     models.CommaSeparatedStrings{},
+				Groups:     []string{},
 				Active:     true,
 			}
 
@@ -371,7 +371,7 @@ func TestUpdateProviderUser(t *testing.T) {
 				FamilyName: "martinez",
 				ProviderID: InfraProvider(db).ID,
 				Active:     true,
-				Groups:     models.CommaSeparatedStrings{},
+				Groups:     []string{},
 			}
 
 			err := ProvisionProviderUser(db, user)
@@ -407,7 +407,7 @@ func TestUpdateProviderUser(t *testing.T) {
 				GivenName:  "Lucy",
 				ProviderID: provider.ID,
 				Active:     true,
-				Groups:     models.CommaSeparatedStrings{},
+				Groups:     []string{},
 			}
 
 			err = ProvisionProviderUser(db, existing)
@@ -419,7 +419,7 @@ func TestUpdateProviderUser(t *testing.T) {
 				FamilyName: "",
 				ProviderID: InfraProvider(db).ID,
 				Active:     true,
-				Groups:     models.CommaSeparatedStrings{},
+				Groups:     []string{},
 			}
 
 			err = ProvisionProviderUser(db, user)
@@ -441,7 +441,7 @@ func TestGetProviderUser(t *testing.T) {
 				GivenName:  "david",
 				FamilyName: "martinez",
 				ProviderID: InfraProvider(db).ID,
-				Groups:     models.CommaSeparatedStrings{},
+				Groups:     []string{},
 				Active:     true,
 			}
 
@@ -467,7 +467,7 @@ func TestGetProviderUser(t *testing.T) {
 				GivenName:  "lucy",
 				FamilyName: "",
 				ProviderID: InfraProvider(db).ID,
-				Groups:     models.CommaSeparatedStrings{},
+				Groups:     []string{},
 				Active:     true,
 			}
 
@@ -742,8 +742,6 @@ func createTestProviderUser(t *testing.T, tx *Transaction, provider *models.Prov
 
 	pu, err := CreateProviderUser(tx, provider, user)
 	assert.NilError(t, err)
-
-	pu.Groups = models.CommaSeparatedStrings{}
 
 	return *pu
 }

--- a/internal/server/data/schema.sql
+++ b/internal/server/data/schema.sql
@@ -259,7 +259,6 @@ CREATE TABLE provider_users (
     identity_id bigint NOT NULL,
     provider_id bigint NOT NULL,
     email text,
-    groups text,
     last_update timestamp with time zone,
     redirect_url text,
     access_token text,
@@ -267,7 +266,8 @@ CREATE TABLE provider_users (
     expires_at timestamp with time zone,
     given_name text DEFAULT ''::text,
     family_name text DEFAULT ''::text,
-    active boolean DEFAULT true
+    active boolean DEFAULT true,
+    groups jsonb
 );
 
 CREATE TABLE providers (

--- a/internal/server/models/provideruser.go
+++ b/internal/server/models/provideruser.go
@@ -15,7 +15,7 @@ type ProviderUser struct {
 	Email      string
 	GivenName  string
 	FamilyName string
-	Groups     CommaSeparatedStrings
+	Groups     JSONB
 	LastUpdate time.Time
 
 	RedirectURL string // needs to match the redirect URL specified when the token was issued for refreshing

--- a/internal/server/models/types.go
+++ b/internal/server/models/types.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -35,10 +36,6 @@ func (s *CommaSeparatedStrings) Scan(v interface{}) error {
 	return nil
 }
 
-func (f CommaSeparatedStrings) GormDataType() string {
-	return "text"
-}
-
 func (s *CommaSeparatedStrings) Includes(str string) bool {
 	if s == nil {
 		return false
@@ -51,4 +48,24 @@ func (s *CommaSeparatedStrings) Includes(str string) bool {
 	}
 
 	return false
+}
+
+// JSONB represents a JSON binary stored in Postgres
+type JSONB []string
+
+func (j JSONB) Value() (driver.Value, error) {
+	marshalled, err := json.Marshal(j)
+	if err != nil {
+		return nil, fmt.Errorf("convert object to json")
+	}
+	return string(marshalled), nil
+}
+
+// Scan implements the sql.Scanner interface.
+func (j *JSONB) Scan(src interface{}) error {
+	s, ok := src.([]uint8)
+	if !ok {
+		return fmt.Errorf("cannot scan values which are not a byte array to a JSON blob")
+	}
+	return json.Unmarshal([]byte(s), &j)
 }


### PR DESCRIPTION
## Summary
Update group tracking to use a JSON binary in the database, rather than a text field separated by commas. This allows for storing group commas.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Updated associated docs where necessary
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged
- [x] Considered data migrations for smooth upgrades


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #3138
