### PR TITLE
api(grants): split resource into name and resource

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -352,16 +352,16 @@ func (c Client) DeleteProvider(ctx context.Context, id uid.ID) error {
 
 func (c Client) ListGrants(ctx context.Context, req ListGrantsRequest) (*ListResponse[Grant], error) {
 	return get[ListResponse[Grant]](ctx, c, "/api/grants", Query{
-		"user":            {req.User.String()},
-		"group":           {req.Group.String()},
-		"resource":        {req.Resource},
-		"destination":     {req.Destination},
-		"privilege":       {req.Privilege},
-		"showInherited":   {strconv.FormatBool(req.ShowInherited)},
-		"showSystem":      {strconv.FormatBool(req.ShowSystem)},
-		"page":            {strconv.Itoa(req.Page)},
-		"limit":           {strconv.Itoa(req.Limit)},
-		"lastUpdateIndex": {strconv.FormatInt(req.LastUpdateIndex, 10)},
+		"user":                {req.User.String()},
+		"group":               {req.Group.String()},
+		"destinationName":     {req.DestinationName},
+		"destinationResource": {req.DestinationResource},
+		"privilege":           {req.Privilege},
+		"showInherited":       {strconv.FormatBool(req.ShowInherited)},
+		"showSystem":          {strconv.FormatBool(req.ShowSystem)},
+		"page":                {strconv.Itoa(req.Page)},
+		"limit":               {strconv.Itoa(req.Limit)},
+		"lastUpdateIndex":     {strconv.FormatInt(req.LastUpdateIndex, 10)},
 	})
 }
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -205,7 +205,7 @@ func TestListGrants(t *testing.T) {
 
 	t.Run("sets value from Last-Update-Index header", func(t *testing.T) {
 		resp, err := c.ListGrants(ctx, ListGrantsRequest{
-			Resource:        "anything",
+			DestinationName: "anything",
 			BlockingRequest: BlockingRequest{LastUpdateIndex: 1234},
 		})
 		assert.NilError(t, err)
@@ -217,7 +217,7 @@ func TestListGrants(t *testing.T) {
 	})
 	t.Run("not modified", func(t *testing.T) {
 		_, err := c.ListGrants(ctx, ListGrantsRequest{
-			Resource:        "anything",
+			DestinationName: "anything",
 			BlockingRequest: BlockingRequest{LastUpdateIndex: 70000},
 		})
 		var apiError Error

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -66,6 +66,12 @@
             "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
             "type": "string"
           },
+          "destinationName": {
+            "type": "string"
+          },
+          "destinationResource": {
+            "type": "string"
+          },
           "group": {
             "description": "GroupID for a group being granted access",
             "example": "3zMaadcd2U",
@@ -83,11 +89,6 @@
           "privilege": {
             "description": "a role or permission",
             "example": "admin",
-            "type": "string"
-          },
-          "resource": {
-            "description": "a resource name in Infra's Universal Resource Notation",
-            "example": "production.namespace",
             "type": "string"
           },
           "updated": {
@@ -345,6 +346,12 @@
             "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
             "type": "string"
           },
+          "destinationName": {
+            "type": "string"
+          },
+          "destinationResource": {
+            "type": "string"
+          },
           "group": {
             "description": "GroupID for a group being granted access",
             "example": "3zMaadcd2U",
@@ -362,11 +369,6 @@
           "privilege": {
             "description": "a role or permission",
             "example": "admin",
-            "type": "string"
-          },
-          "resource": {
-            "description": "a resource name in Infra's Universal Resource Notation",
-            "example": "production.namespace",
             "type": "string"
           },
           "updated": {
@@ -680,6 +682,12 @@
                   "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
                   "type": "string"
                 },
+                "destinationName": {
+                  "type": "string"
+                },
+                "destinationResource": {
+                  "type": "string"
+                },
                 "group": {
                   "description": "GroupID for a group being granted access",
                   "example": "3zMaadcd2U",
@@ -697,11 +705,6 @@
                 "privilege": {
                   "description": "a role or permission",
                   "example": "admin",
-                  "type": "string"
-                },
-                "resource": {
-                  "description": "a resource name in Infra's Universal Resource Notation",
-                  "example": "production.namespace",
                   "type": "string"
                 },
                 "updated": {
@@ -3229,27 +3232,16 @@
             }
           },
           {
-            "description": "a resource name",
-            "example": "production.namespace",
             "in": "query",
-            "name": "resource",
+            "name": "destinationName",
             "schema": {
-              "description": "a resource name",
-              "example": "production.namespace",
               "type": "string"
             }
           },
           {
-            "description": "name of the destination where a connector is installed",
-            "example": "production",
             "in": "query",
-            "name": "destination",
+            "name": "destinationResource",
             "schema": {
-              "description": "name of the destination where a connector is installed",
-              "example": "production",
-              "format": "[a-zA-Z0-9\\-_]",
-              "maxLength": 256,
-              "minLength": 2,
               "type": "string"
             }
           },
@@ -3450,6 +3442,12 @@
                         }
                       ],
                       "properties": {
+                        "destinationName": {
+                          "type": "string"
+                        },
+                        "destinationResource": {
+                          "type": "string"
+                        },
                         "group": {
                           "description": "ID of the group granted access",
                           "example": "6Ti2p7r1h7",
@@ -3467,11 +3465,6 @@
                           "example": "view",
                           "type": "string"
                         },
-                        "resource": {
-                          "description": "a resource name in Infra's Universal Resource Notation",
-                          "example": "production",
-                          "type": "string"
-                        },
                         "user": {
                           "description": "ID of the user granted access",
                           "example": "6kdoMDd6PA",
@@ -3487,7 +3480,7 @@
                       },
                       "required": [
                         "privilege",
-                        "resource"
+                        "destinationName"
                       ],
                       "type": "object"
                     },
@@ -3520,6 +3513,12 @@
                         }
                       ],
                       "properties": {
+                        "destinationName": {
+                          "type": "string"
+                        },
+                        "destinationResource": {
+                          "type": "string"
+                        },
                         "group": {
                           "description": "ID of the group granted access",
                           "example": "6Ti2p7r1h7",
@@ -3537,11 +3536,6 @@
                           "example": "view",
                           "type": "string"
                         },
-                        "resource": {
-                          "description": "a resource name in Infra's Universal Resource Notation",
-                          "example": "production",
-                          "type": "string"
-                        },
                         "user": {
                           "description": "ID of the user granted access",
                           "example": "6kdoMDd6PA",
@@ -3557,7 +3551,7 @@
                       },
                       "required": [
                         "privilege",
-                        "resource"
+                        "destinationName"
                       ],
                       "type": "object"
                     },
@@ -3690,6 +3684,12 @@
                   }
                 ],
                 "properties": {
+                  "destinationName": {
+                    "type": "string"
+                  },
+                  "destinationResource": {
+                    "type": "string"
+                  },
                   "group": {
                     "description": "ID of the group granted access",
                     "example": "6Ti2p7r1h7",
@@ -3707,11 +3707,6 @@
                     "example": "view",
                     "type": "string"
                   },
-                  "resource": {
-                    "description": "a resource name in Infra's Universal Resource Notation",
-                    "example": "production",
-                    "type": "string"
-                  },
                   "user": {
                     "description": "ID of the user granted access",
                     "example": "6kdoMDd6PA",
@@ -3727,7 +3722,7 @@
                 },
                 "required": [
                   "privilege",
-                  "resource"
+                  "destinationName"
                 ],
                 "type": "object"
               }

--- a/internal/cmd/connector_test.go
+++ b/internal/cmd/connector_test.go
@@ -78,9 +78,9 @@ func TestConnector_Run_Kubernetes(t *testing.T) {
 	assert.NilError(t, err)
 
 	createGrants(t, srv.DB(),
-		api.GrantRequest{UserName: "user1@example.com", Resource: "testing.ns1", Privilege: "admin"},
-		api.GrantRequest{UserName: "user2@example.com", Resource: "testing", Privilege: "view"},
-		api.GrantRequest{GroupName: "group1@example.com", Resource: "testing.ns1", Privilege: "logs"},
+		api.GrantRequest{UserName: "user1@example.com", DestinationName: "testing", DestinationResource: "ns1", Privilege: "admin"},
+		api.GrantRequest{UserName: "user2@example.com", DestinationName: "testing", Privilege: "view"},
+		api.GrantRequest{GroupName: "group1@example.com", DestinationName: "testing", DestinationResource: "ns1", Privilege: "logs"},
 	)
 
 	kubeconfig := path.Join(dir, "kubeconfig")

--- a/internal/cmd/grants_test.go
+++ b/internal/cmd/grants_test.go
@@ -97,9 +97,9 @@ func TestGrantsAddCmd(t *testing.T) {
 
 		createReq := <-ch
 		expected := api.GrantRequest{
-			User:      3000,
-			Privilege: "connect",
-			Resource:  "the-destination",
+			User:            3000,
+			Privilege:       "connect",
+			DestinationName: "the-destination",
 		}
 		assert.DeepEqual(t, createReq, expected)
 	})
@@ -111,9 +111,10 @@ func TestGrantsAddCmd(t *testing.T) {
 
 		createReq := <-ch
 		expected := api.GrantRequest{
-			User:      3000,
-			Privilege: "connect",
-			Resource:  "the-destination.default",
+			User:                3000,
+			Privilege:           "connect",
+			DestinationName:     "the-destination",
+			DestinationResource: "default",
 		}
 		assert.DeepEqual(t, createReq, expected)
 	})
@@ -125,9 +126,9 @@ func TestGrantsAddCmd(t *testing.T) {
 
 		createReq := <-ch
 		expected := api.GrantRequest{
-			User:      3000,
-			Privilege: "role",
-			Resource:  "the-destination",
+			User:            3000,
+			Privilege:       "role",
+			DestinationName: "the-destination",
 		}
 		assert.DeepEqual(t, createReq, expected)
 	})
@@ -141,9 +142,9 @@ func TestGrantsAddCmd(t *testing.T) {
 
 		createReq := <-ch
 		expected := api.GrantRequest{
-			Group:     4000,
-			Privilege: "role",
-			Resource:  "the-destination",
+			Group:           4000,
+			Privilege:       "role",
+			DestinationName: "the-destination",
 		}
 		assert.DeepEqual(t, createReq, expected)
 	})
@@ -167,9 +168,9 @@ func TestGrantsAddCmd(t *testing.T) {
 
 		actual := <-ch
 		expected := api.GrantRequest{
-			User:      3002,
-			Privilege: "connect",
-			Resource:  "destination",
+			User:            3002,
+			Privilege:       "connect",
+			DestinationName: "destination",
 		}
 
 		assert.DeepEqual(t, actual, expected)
@@ -182,9 +183,9 @@ func TestGrantsAddCmd(t *testing.T) {
 
 		actual := <-ch
 		expected := api.GrantRequest{
-			Group:     4001,
-			Privilege: "connect",
-			Resource:  "destination",
+			Group:           4001,
+			Privilege:       "connect",
+			DestinationName: "destination",
 		}
 
 		assert.DeepEqual(t, actual, expected)
@@ -218,9 +219,9 @@ func TestGrantsAddCmd(t *testing.T) {
 
 		actual := <-ch
 		expected := api.GrantRequest{
-			User:      3000,
-			Privilege: "connect",
-			Resource:  "nonexistent",
+			User:            3000,
+			Privilege:       "connect",
+			DestinationName: "nonexistent",
 		}
 
 		assert.DeepEqual(t, actual, expected)
@@ -233,9 +234,10 @@ func TestGrantsAddCmd(t *testing.T) {
 
 		actual := <-ch
 		expected := api.GrantRequest{
-			User:      3000,
-			Privilege: "connect",
-			Resource:  "the-destination.nonexistent",
+			User:                3000,
+			Privilege:           "connect",
+			DestinationName:     "the-destination",
+			DestinationResource: "nonexistent",
 		}
 
 		assert.DeepEqual(t, actual, expected)
@@ -248,9 +250,9 @@ func TestGrantsAddCmd(t *testing.T) {
 
 		actual := <-ch
 		expected := api.GrantRequest{
-			User:      3000,
-			Privilege: "nonexistent",
-			Resource:  "the-destination",
+			User:            3000,
+			Privilege:       "nonexistent",
+			DestinationName: "the-destination",
 		}
 
 		assert.DeepEqual(t, actual, expected)
@@ -296,7 +298,7 @@ func TestGrantRemoveCmd(t *testing.T) {
 
 			if requestMatches(req, http.MethodGet, "/api/grants") {
 				resp.WriteHeader(http.StatusOK)
-				if query.Get("resource") != "the-destination" {
+				if query.Get("destinationName") != "the-destination" {
 					writeResponse(t, resp, api.ListResponse[api.Grant]{})
 					return
 				}

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -30,11 +29,10 @@ func createGrants(t *testing.T, tx data.WriteTxn, grants ...api.GrantRequest) {
 			subject = models.NewSubjectForGroup(group.ID)
 		}
 
-		destinationName, destinationResource, _ := strings.Cut(g.Resource, ".")
 		err := data.CreateGrant(tx, &models.Grant{
 			Subject:             subject,
-			DestinationName:     destinationName,
-			DestinationResource: destinationResource,
+			DestinationName:     g.DestinationName,
+			DestinationResource: g.DestinationResource,
 			Privilege:           g.Privilege,
 		})
 		assert.NilError(t, err, "grant %v", i)

--- a/internal/cmd/kubernetes.go
+++ b/internal/cmd/kubernetes.go
@@ -82,26 +82,19 @@ func writeKubeconfig(user *api.User, destinations []api.Destination, grants []ap
 	infraContexts := make(map[string]clusterContext)
 
 	for _, g := range grants {
-		parts := strings.Split(g.Resource, ".")
-		cluster := parts[0]
-
-		var namespace string
-		if len(parts) > 1 {
-			namespace = parts[1]
-		}
-
+		namespace := g.DestinationResource
 		if namespace == "default" {
 			namespace = ""
 		}
 
-		contextName := "infra:" + cluster
+		contextName := "infra:" + g.DestinationName
 		if _, ok := infraContexts[contextName]; ok && namespace != "" {
 			continue
 		}
 
 		var infraContext clusterContext
 		for _, d := range destinations {
-			if !isResourceForDestination(g.Resource, d.Name) {
+			if g.DestinationName != d.Name {
 				continue
 			}
 

--- a/internal/cmd/kubernetes_test.go
+++ b/internal/cmd/kubernetes_test.go
@@ -35,8 +35,8 @@ func TestUpdateKubeconfig(t *testing.T) {
 	assert.NilError(t, err)
 
 	createGrants(t, srv.DB(),
-		api.GrantRequest{UserName: "admin@local", Resource: "my-first-kubernetes-cluster", Privilege: "connect"},
-		api.GrantRequest{UserName: "admin@local", Resource: "my-first-ssh-server", Privilege: "connect"})
+		api.GrantRequest{UserName: "admin@local", DestinationName: "my-first-kubernetes-cluster", Privilege: "connect"},
+		api.GrantRequest{UserName: "admin@local", DestinationName: "my-first-ssh-server", Privilege: "connect"})
 
 	ctx := context.Background()
 	runAndWait(ctx, t, srv.Run)
@@ -177,7 +177,7 @@ func TestWriteKubeconfig(t *testing.T) {
 			},
 		}
 
-		actual := run(t, api.Grant{Resource: "connected.namespace"})
+		actual := run(t, api.Grant{DestinationName: "connected", DestinationResource: "namespace"})
 
 		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
 		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
@@ -194,9 +194,9 @@ func TestWriteKubeconfig(t *testing.T) {
 		}
 
 		grants := []api.Grant{
-			{Resource: "connected.namespace"},
-			{Resource: "connected.namespace2"},
-			{Resource: "connected.namespace3"},
+			{DestinationName: "connected", DestinationResource: "namespace"},
+			{DestinationName: "connected", DestinationResource: "namespace2"},
+			{DestinationName: "connected", DestinationResource: "namespace3"},
 		}
 
 		actual := run(t, grants...)
@@ -215,7 +215,7 @@ func TestWriteKubeconfig(t *testing.T) {
 		}
 
 		grants := []api.Grant{
-			{Resource: "connected.default"},
+			{DestinationName: "connected", DestinationResource: "default"},
 		}
 
 		actual := run(t, grants...)
@@ -234,10 +234,10 @@ func TestWriteKubeconfig(t *testing.T) {
 		}
 
 		grants := []api.Grant{
-			{Resource: "connected.namespace"},
-			{Resource: "connected.namespace2"},
-			{Resource: "connected.default"},
-			{Resource: "connected.namespace3"},
+			{DestinationName: "connected", DestinationResource: "namespace"},
+			{DestinationName: "connected", DestinationResource: "namespace2"},
+			{DestinationName: "connected", DestinationResource: "default"},
+			{DestinationName: "connected", DestinationResource: "namespace3"},
 		}
 
 		actual := run(t, grants...)
@@ -255,7 +255,7 @@ func TestWriteKubeconfig(t *testing.T) {
 			},
 		}
 
-		actual := run(t, api.Grant{Resource: "connected"})
+		actual := run(t, api.Grant{DestinationName: "connected"})
 
 		assert.DeepEqual(t, actual.Contexts, expectedContexts, cmpKubeconfig)
 		assert.DeepEqual(t, actual.Clusters, expectedClusters, cmpKubeconfig)
@@ -271,8 +271,8 @@ func TestWriteKubeconfig(t *testing.T) {
 		}
 
 		grants := []api.Grant{
-			{Resource: "connected.default"},
-			{Resource: "connected"},
+			{DestinationName: "connected", DestinationResource: "default"},
+			{DestinationName: "connected"},
 		}
 
 		actual := run(t, grants...)
@@ -291,10 +291,10 @@ func TestWriteKubeconfig(t *testing.T) {
 		}
 
 		grants := []api.Grant{
-			{Resource: "connected.namespace"},
-			{Resource: "connected.namespace2"},
-			{Resource: "connected.namespace3"},
-			{Resource: "connected"},
+			{DestinationName: "connected", DestinationResource: "namespace"},
+			{DestinationName: "connected", DestinationResource: "namespace2"},
+			{DestinationName: "connected", DestinationResource: "namespace3"},
+			{DestinationName: "connected"},
 		}
 
 		actual := run(t, grants...)
@@ -313,9 +313,9 @@ func TestWriteKubeconfig(t *testing.T) {
 		}
 
 		grants := []api.Grant{
-			{Resource: "connected"},
-			{Resource: "disconnected"},
-			{Resource: "pending"},
+			{DestinationName: "connected"},
+			{DestinationName: "disconnected"},
+			{DestinationName: "pending"},
 		}
 
 		actual := run(t, grants...)
@@ -369,7 +369,7 @@ func TestWriteKubeconfig_UserNamespaceOverride(t *testing.T) {
 	}
 	grants := []api.Grant{
 		{
-			Resource: "cluster",
+			DestinationName: "cluster",
 		},
 	}
 

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -38,20 +38,21 @@ func list(cli *CLI) error {
 	grantsByResource := make(map[string]map[string]struct{})
 	resources := []string{}
 	for _, g := range grants {
-		if isResourceForDestination(g.Resource, "infra") {
+		if g.DestinationName == "infra" {
 			continue
 		}
 
-		if !destinationForResourceExists(g.Resource, destinations) {
+		if !destinationForResourceExists(g.DestinationName, destinations) {
 			continue
 		}
 
-		if grantsByResource[g.Resource] == nil {
-			grantsByResource[g.Resource] = make(map[string]struct{})
-			resources = append(resources, g.Resource)
+		resource := api.FormatResourceURN(g.DestinationName, g.DestinationResource)
+		if grantsByResource[resource] == nil {
+			grantsByResource[resource] = make(map[string]struct{})
+			resources = append(resources, resource)
 		}
 
-		grantsByResource[g.Resource][g.Privilege] = struct{}{}
+		grantsByResource[resource][g.Privilege] = struct{}{}
 	}
 	sort.Strings(resources)
 

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -38,9 +38,9 @@ func TestListCmd(t *testing.T) {
 	runAndWait(ctx, t, srv.Run)
 
 	createGrants(t, srv.DB(),
-		api.GrantRequest{UserName: "manygrants@example.com", Resource: "space", Privilege: "explorer"},
-		api.GrantRequest{UserName: "manygrants@example.com", Resource: "moon", Privilege: "inhabitant"},
-		api.GrantRequest{UserName: "manygrants@example.com", Resource: "infra-this-is-not", Privilege: "view"},
+		api.GrantRequest{UserName: "manygrants@example.com", DestinationName: "space", Privilege: "explorer"},
+		api.GrantRequest{UserName: "manygrants@example.com", DestinationName: "moon", Privilege: "inhabitant"},
+		api.GrantRequest{UserName: "manygrants@example.com", DestinationName: "infra-this-is-not", Privilege: "view"},
 	)
 
 	clientOpts := &APIClientOpts{

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -50,7 +50,7 @@ func TestSSHHostsCmd(t *testing.T) {
 	runAndWait(ctx, t, srv.Run)
 
 	createGrants(t, srv.DB(),
-		api.GrantRequest{UserName: "anyuser@example.com", Resource: "prodhost", Privilege: "connect"})
+		api.GrantRequest{UserName: "anyuser@example.com", DestinationName: "prodhost", Privilege: "connect"})
 
 	client, err := NewAPIClient(&APIClientOpts{
 		AccessKey: "0000000001.adminadminadminadmin1234",

--- a/internal/cmd/sshauthkeys.go
+++ b/internal/cmd/sshauthkeys.go
@@ -160,9 +160,9 @@ func authorizeUserForDestination(
 	name string,
 ) error {
 	grants, err := client.ListGrants(ctx, api.ListGrantsRequest{
-		User:          user.ID,
-		Destination:   name,
-		ShowInherited: true,
+		User:            user.ID,
+		DestinationName: name,
+		ShowInherited:   true,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/sshauthkeys_test.go
+++ b/internal/cmd/sshauthkeys_test.go
@@ -51,9 +51,9 @@ func TestSSHDAuthKeysCmd(t *testing.T) {
 	runAndWait(ctx, t, srv.Run)
 
 	createGrants(t, srv.DB(),
-		api.GrantRequest{UserName: "anyuser@example.com", Resource: "prodhost", Privilege: "connect"},
-		api.GrantRequest{UserName: "otheruser@example.com", Resource: "prodhost", Privilege: "connect"},
-		api.GrantRequest{UserName: "nogrant@example.com", Resource: "otherhost", Privilege: "connect"},
+		api.GrantRequest{UserName: "anyuser@example.com", DestinationName: "prodhost", Privilege: "connect"},
+		api.GrantRequest{UserName: "otheruser@example.com", DestinationName: "prodhost", Privilege: "connect"},
+		api.GrantRequest{UserName: "nogrant@example.com", DestinationName: "otherhost", Privilege: "connect"},
 	)
 
 	pubKey := `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCxB1cFqocoje6xEGj3UOlNMo4b51ff7F7V4FzVsVyGk2iDYy/ZwuFfdAnKVQETCY/jwpKw6UQp7Sg1E5R9YljyCRjSGJXY1Tv07HJsYF8z4vVXpV15Sp4md9ExB0EGkdtagb10pX3lnj5vZSur6NvdsXWYh8ikZZydB3KKCV3ylgb2OOzGpSHD9MEc4b1LUyFAqB7zZeiccDYgIqwZ3spuX7Kt3vrC46H1Fv9yWjnZ4S1xJYHVgDwBTJE3rszVzX5ZHCbdvWMKBbvnzZlh8GBwxgoH4MEPnhTZSCk26BtFjSGyVG3CXsI0o4uJERw+oqSG/A45LN+qa0e+0O54VylIgploM0+inWDL7tInUjkFIFd6qhqxELGVpE8BOrw8ucW8xfmWyCISI9W9Z482HK2/SCuFWCJaPxHEOgLjYwB4aTEMbLSewRRRBUC1J4hmIp23Hu2yYuE7kC8w7zWptw43qLvWy4SAdCZFEpR+hSRD77nnsgabz4HGGnECAFwRXA0=`

--- a/internal/cmd/use.go
+++ b/internal/cmd/use.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/infrahq/infra/api"
 )
 
 func newUseCmd(cli *CLI) *cobra.Command {
@@ -60,7 +62,8 @@ func getUseCompletion(cmd *cobra.Command, args []string, toComplete string) ([]s
 	resources := make(map[string]struct{}, len(grants))
 
 	for _, g := range grants {
-		resources[g.Resource] = struct{}{}
+		resource := api.FormatResourceURN(g.DestinationName, g.DestinationResource)
+		resources[resource] = struct{}{}
 	}
 
 	validArgs := make([]string, 0, len(resources))

--- a/internal/cmd/use_test.go
+++ b/internal/cmd/use_test.go
@@ -56,16 +56,17 @@ func TestUse(t *testing.T) {
 				grants := api.ListResponse[api.Grant]{
 					Items: []api.Grant{
 						{
-							ID:        uid.New(),
-							User:      userID,
-							Resource:  "cluster",
-							Privilege: "admin",
+							ID:              uid.New(),
+							User:            userID,
+							DestinationName: "cluster",
+							Privilege:       "admin",
 						},
 						{
-							ID:        uid.New(),
-							User:      userID,
-							Resource:  "cluster.namespace",
-							Privilege: "admin",
+							ID:                  uid.New(),
+							User:                userID,
+							DestinationName:     "cluster",
+							DestinationResource: "namespace",
+							Privilege:           "admin",
 						},
 					},
 				}

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -409,10 +409,10 @@ func isUserSelf(name string) (bool, error) {
 func hasAccessToChangePasswordsForOtherUsers(client *api.Client, config *ClientHostConfig) (bool, error) {
 	ctx := context.TODO()
 	grants, err := client.ListGrants(ctx, api.ListGrantsRequest{
-		User:          config.UserID,
-		Privilege:     api.InfraAdminRole,
-		Resource:      "infra",
-		ShowInherited: true,
+		User:            config.UserID,
+		Privilege:       api.InfraAdminRole,
+		DestinationName: "infra",
+		ShowInherited:   true,
 	})
 	if err != nil {
 		return false, err

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -291,8 +291,8 @@ func TestSyncGrantsToDestination_KubeBindings(t *testing.T) {
 			fakeAPI: &fakeAPIClient{
 				listGrantsResult: &api.ListResponse[api.Grant]{
 					Items: []api.Grant{
-						{User: uid.ID(123), Resource: "the-test", Privilege: "view"},
-						{User: uid.ID(124), Resource: "the-test.ns1", Privilege: "logs"},
+						{User: uid.ID(123), DestinationName: "the-test", Privilege: "view"},
+						{User: uid.ID(124), DestinationName: "the-test", DestinationResource: "ns1", Privilege: "logs"},
 					},
 					LastUpdateIndex: api.LastUpdateIndex{Index: 42},
 				},
@@ -320,7 +320,7 @@ func TestSyncGrantsToDestination_KubeBindings(t *testing.T) {
 			fakeAPI: &fakeAPIClient{
 				listGrantsResult: &api.ListResponse[api.Grant]{
 					Items: []api.Grant{
-						{User: uid.ID(123), Resource: "the-test", Privilege: "view"},
+						{User: uid.ID(123), DestinationName: "the-test", Privilege: "view"},
 					},
 					LastUpdateIndex: api.LastUpdateIndex{Index: 42},
 				},

--- a/internal/server/data/grant.go
+++ b/internal/server/data/grant.go
@@ -329,7 +329,7 @@ func validateGrant(grant *models.Grant) error {
 	case grant.Privilege == "":
 		return fmt.Errorf("privilege is required")
 	case grant.DestinationName == "":
-		return fmt.Errorf("resource name is required")
+		return fmt.Errorf("destination name is required")
 	}
 	return nil
 }

--- a/internal/server/models/grant.go
+++ b/internal/server/models/grant.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	"fmt"
-
 	"github.com/infrahq/infra/api"
 	"github.com/infrahq/infra/uid"
 )
@@ -59,18 +57,13 @@ const (
 
 func (r *Grant) ToAPI() *api.Grant {
 	grant := &api.Grant{
-		ID:        r.ID,
-		Created:   api.Time(r.CreatedAt),
-		Updated:   api.Time(r.UpdatedAt),
-		CreatedBy: r.CreatedBy,
-		Privilege: r.Privilege,
-	}
-
-	switch {
-	case r.DestinationResource != "":
-		grant.Resource = fmt.Sprintf("%s.%s", r.DestinationName, r.DestinationResource)
-	default:
-		grant.Resource = r.DestinationName
+		ID:                  r.ID,
+		Created:             api.Time(r.CreatedAt),
+		Updated:             api.Time(r.UpdatedAt),
+		CreatedBy:           r.CreatedBy,
+		Privilege:           r.Privilege,
+		DestinationName:     r.DestinationName,
+		DestinationResource: r.DestinationResource,
 	}
 
 	switch r.Subject.Kind {

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -150,9 +150,9 @@ func TestTrimWhitespace(t *testing.T) {
 	userID := uid.New()
 	// nolint:noctx
 	req := httptest.NewRequest(http.MethodPost, "/api/grants", jsonBody(t, api.GrantRequest{
-		User:      userID,
-		Privilege: "admin   ",
-		Resource:  " kubernetes.production.*",
+		User:            userID,
+		Privilege:       "admin   ",
+		DestinationName: "production",
 	}))
 	req.Header.Add("Authorization", "Bearer "+adminAccessKey(srv))
 	req.Header.Add("Infra-Version", apiVersionLatest)
@@ -176,9 +176,9 @@ func TestTrimWhitespace(t *testing.T) {
 
 	assert.Equal(t, len(rb.Items), 2, rb.Items)
 	expected := api.Grant{
-		User:      userID,
-		Privilege: "admin",
-		Resource:  "kubernetes.production.*",
+		User:            userID,
+		Privilege:       "admin",
+		DestinationName: "production",
 	}
 	assert.DeepEqual(t, rb.Items[1], expected, cmpAPIGrantShallow)
 }


### PR DESCRIPTION
## Summary

<!-- Include a summary of the change and/or why it's necessary. -->

Follow up to #4096. This PR updates the API to separate out grant `resource` into `destinationName` and `destinationResource` where `destinationName` is the real destination the grant applies to and `destinationResource` is the destination-specific resource, e.g. Kubernetes namespace.