### PR TITLE
maintain: specify when access key use fails due to timeout

### DIFF
--- a/internal/server/data/access_key.go
+++ b/internal/server/data/access_key.go
@@ -297,7 +297,7 @@ func ValidateRequestAccessKey(tx WriteTxn, authnKey string) (*models.AccessKey, 
 		t.InactivityTimeout = now.Add(t.InactivityExtension)
 	}
 
-	err = updateAccessKeyLastSeenAt(tx, t)
+	err = updateAccessKeyOnUse(tx, t)
 	return t, err
 }
 
@@ -307,14 +307,14 @@ func ValidateRequestAccessKey(tx WriteTxn, authnKey string) (*models.AccessKey, 
 // in a short period of time.
 const lastSeenUpdateThreshold = 2 * time.Second
 
-// updateAccessKeyLastSeenAt sets key.UpdatedAt to now and then updates the
-// user row in the database. Updates are throttled to once every 2 seconds.
+// updateAccessKeyOnUse sets key.UpdatedAt to now and then updates the
+// user row in the database to match the specified key. Updates are throttled to once every 2 seconds.
 // If the access key was updated recently, or the database row is already locked, the
 // update will be skipped.
 //
 // Unlike most functions in this package, this function uses key.OrganizationID
 // not tx.OrganizationID.
-func updateAccessKeyLastSeenAt(tx WriteTxn, key *models.AccessKey) error {
+func updateAccessKeyOnUse(tx WriteTxn, key *models.AccessKey) error {
 	if time.Since(key.UpdatedAt) < lastSeenUpdateThreshold {
 		return nil
 	}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -186,6 +186,9 @@ func requireAccessKey(c *gin.Context, db data.WriteTxn, srv *Server) (access.Aut
 
 	accessKey, err := data.ValidateRequestAccessKey(db, bearer)
 	if err != nil {
+		if errors.Is(err, data.ErrAccessInactivityTimeout) {
+			return u, AuthenticationError{Message: "access key has expired due to inactivity"}
+		}
 		if errors.Is(err, data.ErrAccessKeyExpired) {
 			return u, AuthenticationError{Message: "access key has expired"}
 		}


### PR DESCRIPTION
## Summary
It's hard to debug when an access key becomes invalid due to not being used. Add some extra context to error messages to help with that.

## Checklist

<!-- 
Checklists help us remember things. Change [ ] to [x] to show completion.
-->

- [x] Wrote appropriate unit tests
- [x] Considered security implications of the change
- [x] Change is backwards compatible if it needs to be (user can upgrade without manual steps?)
- [x] Nothing sensitive logged


## Related Issues

<!--
Link any related issues. Each issue should be on
its own line. For example:

Resolves #1234
Resolves #4321
-->

Resolves #4100
