### PR TITLE
Revert "Merge pull request #4091 from infrahq/mxyng/rm-unused-grants-field"

### DIFF
--- a/api/grant.go
+++ b/api/grant.go
@@ -24,7 +24,7 @@ type Grant struct {
 
 type CreateGrantResponse struct {
 	*Grant     `json:",inline"`
-	WasCreated bool `json:"-" note:"Indicates that grant was successfully created, false it already existed beforehand" example:"true"`
+	WasCreated bool `json:"wasCreated" note:"Indicates that grant was successfully created, false it already existed beforehand" example:"true"`
 }
 
 func (r *CreateGrantResponse) StatusCode() int {

--- a/docs/api/openapi3.json
+++ b/docs/api/openapi3.json
@@ -102,6 +102,11 @@
             "format": "uid",
             "pattern": "[1-9a-km-zA-HJ-NP-Z]{1,11}",
             "type": "string"
+          },
+          "wasCreated": {
+            "description": "Indicates that grant was successfully created, false it already existed beforehand",
+            "example": "true",
+            "type": "boolean"
           }
         }
       },

--- a/internal/server/grants_test.go
+++ b/internal/server/grants_test.go
@@ -1055,7 +1055,8 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"resource": "some-cluster",
 					"user": "%[3]v",
 					"created": "%[4]v",
-					"updated": "%[4]v"
+					"updated": "%[4]v",
+					"wasCreated": true
 				}`,
 					accessKey.IssuedForID,
 					models.InfraAdminRole,
@@ -1086,7 +1087,8 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"resource": "some-big-cluster",
 					"user": "%[3]v",
 					"created": "%[4]v",
-					"updated": "%[4]v"
+					"updated": "%[4]v",
+					"wasCreated": true
 				}`,
 					accessKey.IssuedForID,
 					models.InfraAdminRole,
@@ -1138,7 +1140,8 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"resource": "some-resource",
 					"group": "%[3]v",
 					"created": "%[4]v",
-					"updated": "%[4]v"
+					"updated": "%[4]v",
+					"wasCreated": true
 				}`,
 					accessKey.IssuedForID,
 					models.InfraViewRole,
@@ -1203,7 +1206,8 @@ func TestAPI_CreateGrant(t *testing.T) {
 					"resource": "infra",
 					"user": "%[3]v",
 					"created": "%[4]v",
-					"updated": "%[4]v"
+					"updated": "%[4]v",
+					"wasCreated": true
 				}`,
 					supportAdmin.ID,
 					models.InfraSupportAdminRole,


### PR DESCRIPTION
This reverts commit 62fd302adc6464554c2753240e05ef51830210c7, reversing changes made to 9a7346f604427676e1dd512c41431d343192ec7d.

It appears I was a bit hasty removing this field. It's being used to let the caller of `api.CreateGrant` know if the grant is actually created. This is in lieu of checking the status code directly, which the API client does not expose. It's still a good idea to remove this field but some refactoring needs to be done first to all an API client user to check the status code.