### PR TITLE
FIX: paginate groups

### DIFF
--- a/ui/pages/groups/[id].js
+++ b/ui/pages/groups/[id].js
@@ -102,7 +102,7 @@ export default function GroupDetails() {
   const {
     data: { items: users, totalCount, totalPages } = {},
     mutate: mutateUsers,
-  } = useSWR(`/api/users?group=${group?.id}&limit=${limit}&p=${page}`)
+  } = useSWR(`/api/users?group=${group?.id}&limit=${limit}&page=${page}`)
   const { data: { items: allUsers } = {} } = useSWR(`/api/users?limit=1000`)
   const { data: { items: infraAdmins } = {} } = useSWR(
     '/api/grants?resource=infra&privilege=admin&limit=1000'


### PR DESCRIPTION
## Summary
Groups page was not paginating correctly, this was due to an incorrect query param.